### PR TITLE
security: validate and restrict POST /settings to known keys

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,3 +82,7 @@ LOCALISATION:
 {memories}"""
 
 CHAT_HISTORY_LIMIT = 20
+
+ALLOWED_SETTINGS = {
+    "ram_budget": {"type": int, "min": 256, "max": 16384},
+}

--- a/web.py
+++ b/web.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from core.auth import verify_credentials, create_token, verify_token
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -18,7 +18,7 @@ from core.memory import (
     get_setting, save_setting,
     list_memories, update_memory, delete_memory,
 )
-from config import MODELS
+from config import MODELS, ALLOWED_SETTINGS
 
 security = HTTPBearer()
 
@@ -70,6 +70,21 @@ class MemoryUpdateRequest(BaseModel):
 class MemoryAddRequest(BaseModel):
     category: str
     content: str
+
+
+class SettingsUpdateRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    ram_budget: int | None = None
+
+    @field_validator("ram_budget")
+    @classmethod
+    def validate_ram_budget(cls, v):
+        if v is not None:
+            spec = ALLOWED_SETTINGS["ram_budget"]
+            if not (spec["min"] <= v <= spec["max"]):
+                raise ValueError(f"must be between {spec['min']} and {spec['max']}")
+        return v
 
 
 def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
@@ -188,9 +203,9 @@ def trigger_model_update(_: bool = Depends(get_current_user)):
 
 
 @app.post("/settings")
-def update_settings(data: dict, _: bool = Depends(get_current_user)):
-    for key, value in data.items():
-        save_setting(key, str(value))
+def update_settings(data: SettingsUpdateRequest, _: bool = Depends(get_current_user)):
+    if data.ram_budget is not None:
+        save_setting("ram_budget", str(data.ram_budget))
     return {"ok": True}
 
 


### PR DESCRIPTION
## Summary

- Adds `ALLOWED_SETTINGS` to `config.py` as the single source of truth for valid settings keys and their constraints
- Replaces the open-ended `data: dict` parameter on `POST /settings` with a typed `SettingsUpdateRequest` Pydantic model
- Unknown keys are rejected with HTTP 422 before the handler body runs (`extra = "forbid"`)
- `ram_budget` is validated as an integer in the range 256–16384

## Validation behaviour

| Request | Result |
|---|---|
| `{"ram_budget": 2048}` | 200 — saved |
| `{"ram_budget": 100}` | 422 — below minimum |
| `{"ram_budget": 99999}` | 422 — above maximum |
| `{"ram_budget": "hello"}` | 422 — wrong type |
| `{"unknown_key": "x"}` | 422 — extra fields forbidden |
| `{}` | 200 — no-op |

## What did not change

- `updater.py` calls `save_setting()` directly and is unaffected
- GET `/settings` response shape is unchanged
- All existing valid `ram_budget` values continue to work

## Test plan

- [ ] `POST /settings` with `{"ram_budget": 2048}` returns `{"ok": true}`
- [ ] `POST /settings` with `{"ram_budget": 100}` returns HTTP 422
- [ ] `POST /settings` with `{"evil": "x"}` returns HTTP 422
- [ ] Model update check still writes `last_model_update` correctly via `updater.py`

Closes #20

https://claude.ai/code/session_01GSR7V8T51Pz4Q4tiJ3brwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSR7V8T51Pz4Q4tiJ3brwN)_