### PR TITLE
fix(router): fall back to default model when router model is unavailable

### DIFF
--- a/core/router.py
+++ b/core/router.py
@@ -1,5 +1,10 @@
+import logging
+import httpx
+import ollama
 from config import MODELS
 from core.ollama_client import client
+
+logger = logging.getLogger(__name__)
 
 ROUTER_PROMPT = """Classify this request with ONE word only.
 
@@ -29,9 +34,13 @@ FALLBACK_MODEL = MODELS["default"]
 def route(user_input: str) -> str:
     """Choisit le bon modèle selon la complexité de la requête."""
     prompt = ROUTER_PROMPT.format(query=user_input)
-    response = client.chat(
-        model=MODELS["router"],
-        messages=[{"role": "user", "content": prompt}]
-    )
-    category = response["message"]["content"].strip().lower().split()[0]
-    return MODEL_MAP.get(category, FALLBACK_MODEL)
+    try:
+        response = client.chat(
+            model=MODELS["router"],
+            messages=[{"role": "user", "content": prompt}]
+        )
+        category = response["message"]["content"].strip().lower().split()[0]
+        return MODEL_MAP.get(category, FALLBACK_MODEL)
+    except (ollama.ResponseError, httpx.HTTPError) as e:
+        logger.warning("Router model unavailable, falling back to default: %s", e)
+        return FALLBACK_MODEL


### PR DESCRIPTION
## Summary

- Wraps `client.chat()` in `route()` with a try/except for `ollama.ResponseError` and `httpx.HTTPError`
- On any router failure, logs a `WARNING` and returns `FALLBACK_MODEL` (`MODELS["default"]`) so the conversation continues normally
- `httpx` is already a transitive dependency of `ollama` — no new dependency added

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Router model works | Routes correctly | Unchanged |
| Model not pulled / not found (`ResponseError`) | Crashes request | Falls back to `gemma4`, logs warning |
| Ollama daemon down (`ConnectError`) | Crashes request | Falls back to `gemma4`, logs warning |
| Request timeout (`ReadTimeout`) | Crashes request | Falls back to `gemma4`, logs warning |

## Test plan

- [ ] Auto mode routes normally when `gemma3:1b` is available
- [ ] Auto mode returns a response (not an error) when `gemma3:1b` is removed or Ollama is restarted without it
- [ ] `WARNING core.router: Router model unavailable...` appears in logs on fallback, not on success

Closes #14

https://claude.ai/code/session_01GSR7V8T51Pz4Q4tiJ3brwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSR7V8T51Pz4Q4tiJ3brwN)_