### PR TITLE
fix(chat): show actionable error when Ollama is unreachable

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -1,9 +1,16 @@
+import logging
+import httpx
+import ollama
 from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
 from core.ollama_client import client
 from core.memory import format_memories_for_prompt, save_memory
 from core.router import route
 from core.search import web_search, should_search
 from core.weather import detect_weather_city, get_weather
+
+logger = logging.getLogger(__name__)
+
+OLLAMA_UNAVAILABLE = "Ollama is unreachable. Make sure Ollama is running, then try again."
 
 MEMORY_EXTRACTION_PROMPT = """Analyse cette conversation et extrait UNIQUEMENT les informations personnelles importantes sur l'utilisateur.
 
@@ -48,10 +55,13 @@ def extract_and_save_memory(user_message: str, assistant_response: str):
         user_message=user_message,
         assistant_response=assistant_response
     )
-    response = client.chat(
-        model=MODELS["default"],
-        messages=[{"role": "user", "content": prompt}]
-    )
+    try:
+        response = client.chat(
+            model=MODELS["default"],
+            messages=[{"role": "user", "content": prompt}]
+        )
+    except (ollama.ResponseError, httpx.HTTPError):
+        return
     result = response["message"]["content"].strip()
     if result.startswith("SAVE:"):
         parts = result[5:].split(":", 1)
@@ -86,63 +96,67 @@ def build_image_messages(user_input: str, image: str) -> list[dict]:
 
 def chat(history: list[dict], user_input: str, memories: list[dict], forced_model: str = None, force_search: bool = False, image: str = None) -> tuple[str, str]:
     """Envoie un message à Nova et retourne sa réponse et le modèle utilisé."""
+    try:
+        # Image → vision model, no routing
+        if image:
+            print(f"CHAT IMAGE: True len={len(image)}")
+            messages = build_image_messages(user_input, image)
+            response = client.chat(model=MODELS["default"], messages=messages)
+            reply = response["message"]["content"]
+            extract_and_save_memory(user_input or "image", reply)
+            return reply, MODELS["default"]
 
-    # Image → vision model, no routing
-    if image:
-        print(f"CHAT IMAGE: True len={len(image)}")
-        messages = build_image_messages(user_input, image)
-        response = client.chat(model=MODELS["default"], messages=messages)
-        reply = response["message"]["content"]
-        extract_and_save_memory(user_input or "image", reply)
-        return reply, MODELS["default"]
+        model = forced_model if forced_model else route(user_input)
 
-    model = forced_model if forced_model else route(user_input)
+        # Météo en temps réel
+        weather_city = detect_weather_city(user_input)
+        if weather_city:
+            lat, lon, city = weather_city
+            weather_data = get_weather(lat, lon, city)
+            messages = build_messages(history, user_input, memories, weather_data, "weather")
+            response = client.chat(model=model, messages=messages)
+            reply = response["message"]["content"]
+            return reply, model
 
-    # Météo en temps réel
-    weather_city = detect_weather_city(user_input)
-    if weather_city:
-        lat, lon, city = weather_city
-        weather_data = get_weather(lat, lon, city)
-        messages = build_messages(history, user_input, memories, weather_data, "weather")
-        response = client.chat(model=model, messages=messages)
-        reply = response["message"]["content"]
-        return reply, model
+        # Weather query but no city recognized → short clarification, no LLM
+        if is_weather_query(user_input):
+            return "Quelle ville ?", model
 
-    # Weather query but no city recognized → short clarification, no LLM
-    if is_weather_query(user_input):
-        return "Quelle ville ?", model
-
-    # Web search
-    if force_search or should_search(user_input):
-        search_results = web_search(user_input)
-        messages = build_messages(history, user_input, memories, search_results, "search")
-        response = client.chat(model=model, messages=messages)
-        reply = response["message"]["content"]
-        return reply, model
-
-    # Chat normal
-    messages = build_messages(history, user_input, memories)
-    response = client.chat(model=model, messages=messages)
-    reply = response["message"]["content"]
-
-    # Si Nova sait pas → cherche sur le web automatiquement
-    uncertainty_triggers = [
-        "je ne sais pas", "je n'ai pas", "je n'ai aucune",
-        "je ne peux pas", "je ne dispose pas", "je n'ai pas accès",
-        "i don't know", "i don't have", "i cannot",
-        "je ne trouve pas", "aucune information",
-        "je ne suis pas sûr", "je ne suis pas certain",
-    ]
-    
-    if any(t in reply.lower() for t in uncertainty_triggers):
-        search_results = web_search(user_input)
-        if search_results and "Aucun résultat" not in search_results:
+        # Web search
+        if force_search or should_search(user_input):
+            search_results = web_search(user_input)
             messages = build_messages(history, user_input, memories, search_results, "search")
             response = client.chat(model=model, messages=messages)
             reply = response["message"]["content"]
+            return reply, model
 
-    extract_and_save_memory(user_input, reply)
-    return reply, model
+        # Chat normal
+        messages = build_messages(history, user_input, memories)
+        response = client.chat(model=model, messages=messages)
+        reply = response["message"]["content"]
+
+        # Si Nova sait pas → cherche sur le web automatiquement
+        uncertainty_triggers = [
+            "je ne sais pas", "je n'ai pas", "je n'ai aucune",
+            "je ne peux pas", "je ne dispose pas", "je n'ai pas accès",
+            "i don't know", "i don't have", "i cannot",
+            "je ne trouve pas", "aucune information",
+            "je ne suis pas sûr", "je ne suis pas certain",
+        ]
+
+        if any(t in reply.lower() for t in uncertainty_triggers):
+            search_results = web_search(user_input)
+            if search_results and "Aucun résultat" not in search_results:
+                messages = build_messages(history, user_input, memories, search_results, "search")
+                response = client.chat(model=model, messages=messages)
+                reply = response["message"]["content"]
+
+        extract_and_save_memory(user_input, reply)
+        return reply, model
+
+    except (ollama.ResponseError, httpx.HTTPError) as e:
+        logger.warning("Ollama unreachable during chat: %s", e)
+        return OLLAMA_UNAVAILABLE, MODELS["default"]
 
 
 def get_history_limit() -> int:

--- a/core/chat.py
+++ b/core/chat.py
@@ -60,7 +60,7 @@ def extract_and_save_memory(user_message: str, assistant_response: str):
             model=MODELS["default"],
             messages=[{"role": "user", "content": prompt}]
         )
-    except (ollama.ResponseError, httpx.HTTPError):
+    except (ollama.ResponseError, ConnectionError, httpx.HTTPError):
         return
     result = response["message"]["content"].strip()
     if result.startswith("SAVE:"):
@@ -154,7 +154,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
         extract_and_save_memory(user_input, reply)
         return reply, model
 
-    except (ollama.ResponseError, httpx.HTTPError) as e:
+    except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
         logger.warning("Ollama unreachable during chat: %s", e)
         return OLLAMA_UNAVAILABLE, MODELS["default"]
 

--- a/core/ollama_client.py
+++ b/core/ollama_client.py
@@ -1,4 +1,10 @@
+import httpx
 import ollama
 from config import OLLAMA_HOST
 
-client = ollama.Client(host=OLLAMA_HOST)
+# Short connect timeout so unreachable Ollama fails fast.
+# No read timeout — large models can take minutes to generate.
+client = ollama.Client(
+    host=OLLAMA_HOST,
+    timeout=httpx.Timeout(5.0, read=None),
+)

--- a/core/router.py
+++ b/core/router.py
@@ -41,6 +41,6 @@ def route(user_input: str) -> str:
         )
         category = response["message"]["content"].strip().lower().split()[0]
         return MODEL_MAP.get(category, FALLBACK_MODEL)
-    except (ollama.ResponseError, httpx.HTTPError) as e:
+    except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
         logger.warning("Router model unavailable, falling back to default: %s", e)
         return FALLBACK_MODEL

--- a/static/index.html
+++ b/static/index.html
@@ -1404,37 +1404,41 @@
         messagesEl.scrollTop = messagesEl.scrollHeight;
 
         console.log("Sending image:", currentImage ? "YES (" + currentImage.substring(0,20) + "...)" : "NO");
-        const res = await fetch("/chat", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${token}`
-            },
-            body: JSON.stringify({
-                message: text,
-                conversation_id: currentConvId,
-                mode: currentMode,
-                search: searchEnabled,
-                image: currentImage
-            })
-        });
+        try {
+            const res = await fetch("/chat", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${token}`
+                },
+                body: JSON.stringify({
+                    message: text,
+                    conversation_id: currentConvId,
+                    mode: currentMode,
+                    search: searchEnabled,
+                    image: currentImage
+                })
+            });
 
-        thinkingRow.remove();
+            thinkingRow.remove();
 
-        if (res.status === 401) { logout(); return; }
+            if (res.status === 401) { logout(); return; }
 
-        const data = await res.json();
-        currentConvId = data.conversation_id;
-        appendMessage("nova", data.response, data.model);
-
-        isThinking = false;
-        btn.disabled = false;
-        searchEnabled = false;
-        document.getElementById("search-btn").classList.remove("active");
-        removeImage();
-        input.focus();
-
-        loadConversations();
+            const data = await res.json();
+            currentConvId = data.conversation_id;
+            appendMessage("nova", data.response, data.model);
+            loadConversations();
+        } catch (e) {
+            thinkingRow.remove();
+            appendMessage("nova", "Ollama is unreachable. Make sure Ollama is running, then try again.");
+        } finally {
+            isThinking = false;
+            btn.disabled = false;
+            searchEnabled = false;
+            document.getElementById("search-btn").classList.remove("active");
+            removeImage();
+            input.focus();
+        }
     }
 
     // ── SETTINGS ──


### PR DESCRIPTION
## Summary

- Adds a 5s connect timeout to the Ollama client so a stopped Ollama fails fast instead of hanging indefinitely
- Wraps `chat()` in `core/chat.py` with `try/except` — returns a clear user-facing message on any connectivity failure
- Guards `extract_and_save_memory()` separately so a background extraction failure cannot replace a reply the user already received
- Wraps `sendMessage()` in `static/index.html` with `try/catch/finally` — displays the error in the chat window and unconditionally re-enables the send button
- Adds `ConnectionError` to all except clauses after discovering the ollama client wraps `httpx.ConnectError` into Python's built-in `ConnectionError` before re-raising

## Files changed

| File | Change |
|---|---|
| `core/ollama_client.py` | `httpx.Timeout(connect=5.0, read=None)` — fast failure, no read timeout |
| `core/chat.py` | `try/except (ollama.ResponseError, ConnectionError, httpx.HTTPError)` in `chat()` and `extract_and_save_memory()` |
| `core/router.py` | Same exception tuple updated for consistency |
| `static/index.html` | `sendMessage()` wrapped in `try/catch/finally` |

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Ollama running | Normal response | Unchanged |
| Ollama stopped | UI freezes, hangs indefinitely | Error shown in ≤5s, send button re-enabled |
| Network timeout | UI freezes | Same as above |
| Memory extraction fails after reply | Crash | Silently ignored, reply preserved |

## Test plan

- [ ] Send a message with Ollama running — response appears normally
- [ ] Stop Ollama, send a message — `"Ollama is unreachable. Make sure Ollama is running, then try again."` appears in the chat within ~5 seconds
- [ ] Send button is re-enabled after the error message appears
- [ ] No stack trace or internal error detail is visible in the UI
- [ ] Large model responses (qwen2.5:32b) are not cut off — read timeout is `None`

Closes #16

https://claude.ai/code/session_01GSR7V8T51Pz4Q4tiJ3brwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSR7V8T51Pz4Q4tiJ3brwN)_