### PR TITLE
fix(chat): limit image upload size

### DIFF
--- a/web.py
+++ b/web.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from core.auth import verify_credentials, create_token, verify_token
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -55,7 +55,7 @@ class ChatRequest(BaseModel):
     conversation_id: int | None = None
     mode: str = "auto"
     search: bool = False
-    image: str | None = None  # base64 encoded image
+    image: str | None = Field(default=None, max_length=13_000_000)
 
 
 class NewConversationRequest(BaseModel):


### PR DESCRIPTION
## Summary

- Added `max_length=13_000_000` (~10 MB base64) constraint to the `image` field in `ChatRequest` using Pydantic's `Field`
- Added `Field` to the existing `pydantic` import — no new dependencies introduced
- Two-line change total

## Behavior

- **Oversized payloads** (image string > 13M characters) are rejected by Pydantic before reaching the handler — FastAPI returns **HTTP 422** automatically
- **Valid image handling is unchanged** — requests within the limit follow the exact same code path as before
- No modifications to `/chat` logic, no manual try/except added

Closes #27

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxzDBRSVt6e1GupFjVVF2k)_