### PR TITLE
security: sanitize search result content

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -1,5 +1,15 @@
+import html
+import re
 import httpx
 from ddgs import DDGS
+
+
+def sanitize_search_text(text: str, max_length: int = 500) -> str:
+    """Strip HTML, decode entities, normalize whitespace, and cap length."""
+    text = html.unescape(text)
+    text = re.sub(r'<[^>]+>', ' ', text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text[:max_length]
 
 
 def clean_query(query: str) -> str:
@@ -24,7 +34,9 @@ def web_search(query: str, max_results: int = 5) -> str:
 
         formatted = []
         for i, r in enumerate(results, 1):
-            formatted.append(f"[{i}] {r['title']}\n{r['href']}\n{r['body']}")
+            title = sanitize_search_text(r['title'], max_length=200)
+            body = sanitize_search_text(r['body'], max_length=500)
+            formatted.append(f"[{i}] {title}\n{r['href']}\n{body}")
 
         return "\n\n".join(formatted)
 


### PR DESCRIPTION
## Summary

Adds a `sanitize_search_text()` helper in `core/search.py` that cleans DuckDuckGo search result content before it is injected into the LLM system prompt. Uses stdlib only (`html`, `re`) — no new dependencies.

The helper:
- Decodes HTML entities (`html.unescape`)
- Strips HTML tags via regex
- Normalizes whitespace
- Caps length to a configurable `max_length`

## Changes

- Result **titles** are sanitized and capped at **200 characters**
- Result **snippets/bodies** are sanitized and capped at **500 characters**
- **URLs** (`href`) are passed through unchanged
- No changes to search provider, chat/routing logic, README, or LICENSE

Closes #28

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX6FP9LvgTov1adX8CDDJ4)_