### PR TITLE
ci: enforce flake8 — remove || true and fix lint violations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         run: |
           pip install flake8
-          flake8 . || true
+          flake8 .
 
       - name: Import test
         run: |

--- a/config.py
+++ b/config.py
@@ -14,7 +14,7 @@ MODELS = {
 
 NOVA_SYSTEM_PROMPT = """Tu es Nova, un assistant personnel intelligent créé par TheZupZup.
 Tu fonctionnes localement via Ollama sur la machine de l'utilisateur.
-Tu n'es pas ChatGPT, pas Gemini, pas un modèle Google et pas OpenAI. 
+Tu n'es pas ChatGPT, pas Gemini, pas un modèle Google et pas OpenAI.
 Tu es direct, naturel et chaleureux.
 Si on te demande qui tu es, réponds: "Je suis Nova, ton assistant personnel local."
 Tu es disponible sur GitHub : github.com/TheZupZup/Nova

--- a/core/search.py
+++ b/core/search.py
@@ -14,7 +14,7 @@ def sanitize_search_text(text: str, max_length: int = 500) -> str:
 
 def clean_query(query: str) -> str:
     """Nettoie la requête pour une meilleure recherche."""
-    stop_words = ["cherche", "trouve", "dis-moi", "quelle", "quelles", "est-ce que", 
+    stop_words = ["cherche", "trouve", "dis-moi", "quelle", "quelles", "est-ce que",
                   "je veux savoir", "peux-tu", "pourrait-tu", "s'il te plait"]
     q = query.lower()
     for word in stop_words:

--- a/core/updater.py
+++ b/core/updater.py
@@ -1,7 +1,6 @@
 import logging
 import sqlite3
 import subprocess
-import json
 import httpx
 import ollama
 from datetime import datetime

--- a/core/weather.py
+++ b/core/weather.py
@@ -42,7 +42,7 @@ def detect_weather_city(user_input: str):
     """Détecte si la requête est une demande météo et retourne la ville."""
     lower = user_input.lower()
     weather_words = ["météo", "meteo", "température", "temperature", "temps qu'il fait", "weather"]
-    
+
     if not any(w in lower for w in weather_words):
         return None
 

--- a/web.py
+++ b/web.py
@@ -33,6 +33,7 @@ scheduler = BackgroundScheduler()
 scheduler.add_job(learn_from_feeds, "interval", hours=1)
 scheduler.add_job(check_and_update_models, "interval", weeks=1)
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     initialize_db()


### PR DESCRIPTION
Closes #18

## Summary
- Removes `|| true` from the flake8 CI step so lint failures now fail the build
- Adds `.flake8` config with `max-line-length = 200` to avoid mass-reformatting existing long lines
- Fixes the 5 real violations that would have blocked CI: W291 ×2, W293, F401, E302

## Lint fixes
| File | Line | Code | Fix |
|---|---|---|---|
| `config.py` | 17 | W291 | Removed trailing whitespace |
| `core/search.py` | 17 | W291 | Removed trailing whitespace |
| `core/weather.py` | 45 | W293 | Removed whitespace from blank line |
| `core/updater.py` | 4 | F401 | Removed unused `import json` |
| `web.py` | 36 | E302 | Added missing blank line before function |

---
_Generated by [Claude Code](https://claude.ai/code/session_018TwnSeJMGxqxgfGwr42VUH)_