### PR TITLE
Add pytest coverage for router classification and memory parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,7 @@ jobs:
           python -c "import config"
           python -c "import core.chat"
           python -c "import core.memory"
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v

--- a/core/chat.py
+++ b/core/chat.py
@@ -3,7 +3,7 @@ import httpx
 import ollama
 from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
 from core.ollama_client import client
-from core.memory import format_memories_for_prompt, save_memory
+from core.memory import format_memories_for_prompt, parse_and_save
 from core.router import route
 from core.search import web_search, should_search
 from core.weather import detect_weather_city, get_weather
@@ -63,10 +63,7 @@ def extract_and_save_memory(user_message: str, assistant_response: str):
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError):
         return
     result = response["message"]["content"].strip()
-    if result.startswith("SAVE:"):
-        parts = result[5:].split(":", 1)
-        if len(parts) == 2:
-            save_memory(parts[0].strip(), parts[1].strip())
+    parse_and_save(result)
 
 
 def build_messages(history: list[dict], user_input: str, memories: list[dict], extra_context: str = None, context_type: str = None) -> list[dict]:

--- a/core/learner.py
+++ b/core/learner.py
@@ -3,7 +3,7 @@ import httpx
 import ollama
 import sqlite3
 from config import MODELS
-from core.memory import save_memory, cleanup_old_knowledge
+from core.memory import cleanup_old_knowledge, parse_and_save
 from core.ollama_client import client
 
 SOURCES = [
@@ -53,10 +53,7 @@ def learn_from_feeds():
                     messages=[{"role": "user", "content": prompt}]
                 )
                 result = response["message"]["content"].strip()
-                if result.startswith("SAVE:"):
-                    parts = result[5:].split(":", 1)
-                    if len(parts) == 2:
-                        save_memory(parts[0].strip(), parts[1].strip())
+                parse_and_save(result)
         except (ollama.ResponseError, ConnectionError, httpx.HTTPError,
                 KeyError, sqlite3.OperationalError, sqlite3.DatabaseError) as e:
             print(f"Error learning from {url}: {e}")

--- a/core/memory.py
+++ b/core/memory.py
@@ -94,6 +94,20 @@ def save_memory(category: str, content: str):
         )
 
 
+def parse_and_save(result: str) -> bool:
+    """Parses a 'SAVE:category:content' string and saves to memory. Returns True if saved."""
+    if not result:
+        return False
+    text = result.strip()
+    if not text.startswith("SAVE:"):
+        return False
+    parts = text[5:].split(":", 1)
+    if len(parts) != 2:
+        return False
+    save_memory(parts[0].strip(), parts[1].strip())
+    return True
+
+
 def load_memories() -> list[dict]:
     """Charge tous les souvenirs existants."""
     with _get_connection() as conn:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 annotated-doc==0.0.4
+pytest
 annotated-types==0.7.0
 anyio==4.13.0
 APScheduler==3.11.2

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch
+from core.memory import parse_and_save
+
+
+class TestParseAndSave:
+    def test_valid_save_format_saves_memory(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("SAVE:preferences:likes coffee")
+        assert result is True
+        mock_save.assert_called_once_with("preferences", "likes coffee")
+
+    def test_nothing_response_returns_false(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("NOTHING")
+        assert result is False
+        mock_save.assert_not_called()
+
+    def test_invalid_text_returns_false(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("random text")
+        assert result is False
+        mock_save.assert_not_called()
+
+    def test_extra_colons_in_content_preserved(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("SAVE:preferences:likes coffee:with milk")
+        assert result is True
+        mock_save.assert_called_once_with("preferences", "likes coffee:with milk")
+
+    def test_missing_content_returns_false(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("SAVE:preferences")
+        assert result is False
+        mock_save.assert_not_called()
+
+    def test_empty_input_returns_false(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("")
+        assert result is False
+        mock_save.assert_not_called()
+
+    def test_whitespace_input_returns_false(self):
+        with patch("core.memory.save_memory") as mock_save:
+            result = parse_and_save("   ")
+        assert result is False
+        mock_save.assert_not_called()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,32 @@
+import httpx
+import ollama
+import pytest
+from unittest.mock import patch
+from config import MODELS
+from core.router import route, FALLBACK_MODEL
+
+
+def _mock_response(content):
+    return {"message": {"content": content}}
+
+
+class TestRoute:
+    def test_code_category_returns_code_model(self):
+        with patch("core.router.client.chat", return_value=_mock_response("code")):
+            assert route("write a python script") == MODELS["code"]
+
+    def test_unknown_category_returns_fallback(self):
+        with patch("core.router.client.chat", return_value=_mock_response("banana")):
+            assert route("some input") == FALLBACK_MODEL
+
+    def test_connection_error_returns_fallback(self):
+        with patch("core.router.client.chat", side_effect=ConnectionError("unreachable")):
+            assert route("some input") == FALLBACK_MODEL
+
+    def test_ollama_response_error_returns_fallback(self):
+        with patch("core.router.client.chat", side_effect=ollama.ResponseError("bad")):
+            assert route("some input") == FALLBACK_MODEL
+
+    def test_httpx_error_returns_fallback(self):
+        with patch("core.router.client.chat", side_effect=httpx.HTTPError("timeout")):
+            assert route("some input") == FALLBACK_MODEL


### PR DESCRIPTION
- Extract inline SAVE: parsing from chat.py and learner.py into core.memory.parse_and_save(), making the logic unit-testable
- Add tests/test_router.py: 5 tests covering code model selection, unknown category fallback, and connection/Ollama/httpx error fallback
- Add tests/test_memory_parsing.py: 7 tests covering valid save, NOTHING response, invalid text, extra colons, missing content, empty and whitespace input — all mocking core.memory.save_memory
- Add pytest to requirements.txt
- Add 'pytest tests/ -v' step to CI workflow

No production behavior changed; parse_and_save() is a pure extraction of the existing parsing logic.

https://claude.ai/code/session_01FyC745ZyXZ6paNQzxUjAhc