### PR TITLE
fix(weather): handle unknown and ambiguous cities safely

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -42,12 +42,6 @@ Données météo:
 {weather_data}"""
 
 
-def is_weather_query(text: str) -> bool:
-    """Détecte si la requête concerne la météo."""
-    keywords = ["météo", "temperature", "température", "weather", "il fait combien"]
-    lower = text.lower()
-    return any(k in lower for k in keywords)
-
 
 def extract_and_save_memory(user_message: str, assistant_response: str):
     """Extrait automatiquement les infos importantes et les sauvegarde."""
@@ -106,18 +100,20 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
         model = forced_model if forced_model else route(user_input)
 
         # Météo en temps réel
-        weather_city = detect_weather_city(user_input)
-        if weather_city:
-            lat, lon, city = weather_city
+        weather_result = detect_weather_city(user_input)
+        if isinstance(weather_result, tuple):
+            lat, lon, city = weather_result
             weather_data = get_weather(lat, lon, city)
             messages = build_messages(history, user_input, memories, weather_data, "weather")
             response = client.chat(model=model, messages=messages)
             reply = response["message"]["content"]
             return reply, model
 
-        # Weather query but no city recognized → short clarification, no LLM
-        if is_weather_query(user_input):
+        if weather_result in ("no_city", "multiple"):
             return "Quelle ville ?", model
+
+        if weather_result == "unknown_city":
+            return "Je n'ai pas accès à la météo pour cette ville.", model
 
         # Web search
         if force_search or should_search(user_input):

--- a/core/chat.py
+++ b/core/chat.py
@@ -42,7 +42,6 @@ Données météo:
 {weather_data}"""
 
 
-
 def extract_and_save_memory(user_message: str, assistant_response: str):
     """Extrait automatiquement les infos importantes et les sauvegarde."""
     prompt = MEMORY_EXTRACTION_PROMPT.format(

--- a/core/weather.py
+++ b/core/weather.py
@@ -51,7 +51,7 @@ _NOISE = {
     "quel", "quelle", "quels", "quelles", "fait", "il", "y", "a", "à",
     "de", "du", "des", "la", "le", "les", "un", "une", "pour", "en",
     "et", "ou", "je", "tu", "nous", "vous", "comment", "est", "c",
-    "qu", "combien", "quand", "où",
+    "qu", "combien", "quand", "où", "ce", "cet", "cette", "ces",
     # common contextual words
     "actuelle", "actuel", "aujourd", "hui", "maintenant",
     # English function words
@@ -61,11 +61,22 @@ _NOISE = {
     "s", "d", "l", "m", "n", "j", "t",
 }
 
+# Time/context words that look like content but are not city names
+_TIME_WORDS = {
+    # French
+    "demain", "aujourd'hui", "maintenant", "hier", "matin", "soir",
+    "midi", "nuit", "semaine", "weekend", "week-end", "prochain",
+    "prochaine", "après-midi", "aprem",
+    # English
+    "today", "tomorrow", "yesterday", "morning", "evening", "night",
+    "afternoon", "now", "soon", "later", "week", "weekend", "next",
+}
+
 
 def _has_unrecognized_city(lower_input: str) -> bool:
     """Returns True if the input contains a word that looks like an unsupported city name."""
     words = re.sub(r"[^\w\s]", " ", lower_input).split()
-    return any(w not in _NOISE and len(w) > 1 for w in words)
+    return any(w not in _NOISE and w not in _TIME_WORDS and len(w) > 1 for w in words)
 
 
 def detect_weather_city(user_input: str):

--- a/core/weather.py
+++ b/core/weather.py
@@ -72,11 +72,26 @@ _TIME_WORDS = {
     "afternoon", "now", "soon", "later", "week", "weekend", "next",
 }
 
+# Weather descriptors and conditions that are not city names
+_WEATHER_CONTEXT_WORDS = {
+    # French
+    "froid", "chaud", "pluie", "neige", "soleil", "vent", "nuage", "nuageux",
+    "ensoleillé", "pluvieux", "orageux", "brouillard", "brume", "gel", "verglas",
+    "humide", "sec", "doux", "frais", "frisquet", "glacial", "tempête",
+    "beau", "mauvais", "prévision", "prévisions",
+    # English
+    "rain", "rainy", "snow", "snowy", "sun", "sunny", "wind", "windy",
+    "cloud", "cloudy", "cold", "hot", "warm", "cool", "fog", "foggy",
+    "stormy", "storm", "forecast", "hail",
+}
+
+_CITY_IGNORED = _NOISE | _TIME_WORDS | _WEATHER_CONTEXT_WORDS
+
 
 def _has_unrecognized_city(lower_input: str) -> bool:
-    """Returns True if the input contains a word that looks like an unsupported city name."""
+    """Returns True if the input contains a token that realistically looks like a city name."""
     words = re.sub(r"[^\w\s]", " ", lower_input).split()
-    return any(w not in _NOISE and w not in _TIME_WORDS and len(w) > 1 for w in words)
+    return any(w not in _CITY_IGNORED and len(w) > 1 for w in words)
 
 
 def detect_weather_city(user_input: str):

--- a/core/weather.py
+++ b/core/weather.py
@@ -1,6 +1,7 @@
 import urllib.request
 import urllib.error
 import json
+import re
 
 
 def get_weather(lat: float, lon: float, city: str) -> str:
@@ -37,17 +38,68 @@ CITIES = {
     "vancouver": (49.2827, -123.1207, "Vancouver"),
 }
 
+_WEATHER_KEYWORDS = [
+    "météo", "meteo", "température", "temperature",
+    "temps qu'il fait", "weather", "il fait combien",
+]
+
+# Words that cannot be city names — used to detect whether a city was mentioned
+_NOISE = {
+    # weather keywords
+    "météo", "meteo", "température", "temperature", "temps", "weather",
+    # French function words
+    "quel", "quelle", "quels", "quelles", "fait", "il", "y", "a", "à",
+    "de", "du", "des", "la", "le", "les", "un", "une", "pour", "en",
+    "et", "ou", "je", "tu", "nous", "vous", "comment", "est", "c",
+    "qu", "combien", "quand", "où",
+    # common contextual words
+    "actuelle", "actuel", "aujourd", "hui", "maintenant",
+    # English function words
+    "what", "is", "the", "it", "like", "how", "at", "in", "for",
+    "are", "me", "can", "you", "tell",
+    # single-letter fragments left after punctuation stripping
+    "s", "d", "l", "m", "n", "j", "t",
+}
+
+
+def _has_unrecognized_city(lower_input: str) -> bool:
+    """Returns True if the input contains a word that looks like an unsupported city name."""
+    words = re.sub(r"[^\w\s]", " ", lower_input).split()
+    return any(w not in _NOISE and len(w) > 1 for w in words)
+
 
 def detect_weather_city(user_input: str):
-    """Détecte si la requête est une demande météo et retourne la ville."""
-    lower = user_input.lower()
-    weather_words = ["météo", "meteo", "température", "temperature", "temps qu'il fait", "weather"]
+    """
+    Détecte si la requête concerne la météo et identifie la ville.
 
-    if not any(w in lower for w in weather_words):
+    Returns:
+      (lat, lon, city_name)  — single recognized city
+      "multiple"             — multiple distinct recognized cities
+      "no_city"              — weather query but no city mentioned
+      "unknown_city"         — weather query with an unrecognized city
+      None                   — not a weather query at all
+    """
+    lower = user_input.lower()
+
+    if not any(w in lower for w in _WEATHER_KEYWORDS):
         return None
 
+    # Collect all matching cities, deduplicated by coordinates
+    seen: set = set()
+    matches = []
     for key, value in CITIES.items():
-        if key in lower:
-            return value
+        if key in lower and value[:2] not in seen:
+            seen.add(value[:2])
+            matches.append(value)
 
-    return None
+    if len(matches) == 1:
+        return matches[0]
+
+    if len(matches) > 1:
+        return "multiple"
+
+    # No recognized city — check if a city name was mentioned anyway
+    if _has_unrecognized_city(lower):
+        return "unknown_city"
+
+    return "no_city"

--- a/core/weather.py
+++ b/core/weather.py
@@ -51,7 +51,7 @@ _NOISE = {
     "quel", "quelle", "quels", "quelles", "fait", "il", "y", "a", "à",
     "de", "du", "des", "la", "le", "les", "un", "une", "pour", "en",
     "et", "ou", "je", "tu", "nous", "vous", "comment", "est", "c",
-    "qu", "combien", "quand", "où", "ce", "cet", "cette", "ces",
+    "qu", "combien", "quand", "où", "ce", "cet", "cette", "ces", "dans", "sur",
     # common contextual words
     "actuelle", "actuel", "aujourd", "hui", "maintenant",
     # English function words
@@ -66,7 +66,8 @@ _TIME_WORDS = {
     # French
     "demain", "aujourd'hui", "maintenant", "hier", "matin", "soir",
     "midi", "nuit", "semaine", "weekend", "week-end", "prochain",
-    "prochaine", "après-midi", "aprem",
+    "prochaine", "après-midi", "aprem", "jours", "jour", "heures", "heure",
+    "minutes", "minute",
     # English
     "today", "tomorrow", "yesterday", "morning", "evening", "night",
     "afternoon", "now", "soon", "later", "week", "weekend", "next",
@@ -91,7 +92,7 @@ _CITY_IGNORED = _NOISE | _TIME_WORDS | _WEATHER_CONTEXT_WORDS
 def _has_unrecognized_city(lower_input: str) -> bool:
     """Returns True if the input contains a token that realistically looks like a city name."""
     words = re.sub(r"[^\w\s]", " ", lower_input).split()
-    return any(w not in _CITY_IGNORED and len(w) > 1 for w in words)
+    return any(w not in _CITY_IGNORED and len(w) > 1 and not w[0].isdigit() for w in words)
 
 
 def detect_weather_city(user_input: str):

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch
 from core.memory import parse_and_save
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,6 +1,5 @@
 import httpx
 import ollama
-import pytest
 from unittest.mock import patch
 from config import MODELS
 from core.router import route, FALLBACK_MODEL

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -85,3 +85,31 @@ def test_time_word_soir_is_no_city():
 
 def test_time_word_cette_semaine_is_no_city():
     assert detect_weather_city("météo cette semaine") == "no_city"
+
+
+def test_weather_adjective_froid_is_no_city():
+    assert detect_weather_city("météo froid") == "no_city"
+
+
+def test_weather_adjective_pluie_is_no_city():
+    assert detect_weather_city("météo pluie") == "no_city"
+
+
+def test_weather_adjective_neige_is_no_city():
+    assert detect_weather_city("météo neige") == "no_city"
+
+
+def test_weather_adjective_ensoleille_is_no_city():
+    assert detect_weather_city("météo ensoleillé") == "no_city"
+
+
+def test_weather_adjective_cold_is_no_city():
+    assert detect_weather_city("weather cold") == "no_city"
+
+
+def test_weather_adjective_sunny_is_no_city():
+    assert detect_weather_city("weather sunny") == "no_city"
+
+
+def test_weather_adjective_forecast_is_no_city():
+    assert detect_weather_city("weather forecast") == "no_city"

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -65,3 +65,23 @@ def test_non_weather_query_returns_none():
 def test_non_weather_query_with_city_name_returns_none():
     # mentioning a city without a weather keyword is not a weather query
     assert detect_weather_city("je suis à Montréal") is None
+
+
+def test_time_word_demain_is_no_city():
+    assert detect_weather_city("météo demain") == "no_city"
+
+
+def test_time_word_today_is_no_city():
+    assert detect_weather_city("weather today") == "no_city"
+
+
+def test_time_word_tomorrow_is_no_city():
+    assert detect_weather_city("weather tomorrow") == "no_city"
+
+
+def test_time_word_soir_is_no_city():
+    assert detect_weather_city("météo ce soir") == "no_city"
+
+
+def test_time_word_cette_semaine_is_no_city():
+    assert detect_weather_city("météo cette semaine") == "no_city"

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,67 @@
+from core.weather import detect_weather_city
+
+
+def test_recognized_city_returns_tuple():
+    result = detect_weather_city("Météo à Montréal")
+    assert isinstance(result, tuple)
+    assert result[2] == "Montréal"
+
+
+def test_recognized_city_no_accent():
+    result = detect_weather_city("météo montreal")
+    assert isinstance(result, tuple)
+    assert result[2] == "Montréal"
+
+
+def test_recognized_city_toronto():
+    result = detect_weather_city("weather in Toronto")
+    assert isinstance(result, tuple)
+    assert result[2] == "Toronto"
+
+
+def test_no_city_bare_keyword():
+    assert detect_weather_city("météo") == "no_city"
+
+
+def test_no_city_question():
+    assert detect_weather_city("quelle météo ?") == "no_city"
+
+
+def test_no_city_il_fait_combien():
+    assert detect_weather_city("il fait combien") == "no_city"
+
+
+def test_unknown_city_returns_unknown_city():
+    assert detect_weather_city("météo à Paris") == "unknown_city"
+
+
+def test_unknown_city_english():
+    assert detect_weather_city("weather in London") == "unknown_city"
+
+
+def test_unknown_city_il_fait_combien():
+    assert detect_weather_city("il fait combien à Lyon") == "unknown_city"
+
+
+def test_multiple_cities_returns_multiple():
+    assert detect_weather_city("météo à Montréal et Toronto") == "multiple"
+
+
+def test_multiple_cities_vancouver_quebec():
+    assert detect_weather_city("météo Vancouver et Québec") == "multiple"
+
+
+def test_same_city_dual_spelling_is_single():
+    # montreal and montréal refer to the same city — should count as one
+    result = detect_weather_city("météo montreal montréal")
+    assert isinstance(result, tuple)
+    assert result[2] == "Montréal"
+
+
+def test_non_weather_query_returns_none():
+    assert detect_weather_city("bonjour comment vas-tu") is None
+
+
+def test_non_weather_query_with_city_name_returns_none():
+    # mentioning a city without a weather keyword is not a weather query
+    assert detect_weather_city("je suis à Montréal") is None

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -113,3 +113,15 @@ def test_weather_adjective_sunny_is_no_city():
 
 def test_weather_adjective_forecast_is_no_city():
     assert detect_weather_city("weather forecast") == "no_city"
+
+
+def test_numeric_token_is_no_city():
+    assert detect_weather_city("météo dans 5 jours") == "no_city"
+
+
+def test_numeric_mixed_token_is_no_city():
+    assert detect_weather_city("weather in 2h") == "no_city"
+
+
+def test_numeric_unit_token_is_no_city():
+    assert detect_weather_city("météo 10km") == "no_city"


### PR DESCRIPTION
## Summary

- `detect_weather_city` now returns a discriminated result with four states instead of a plain tuple-or-None:
  - `(lat, lon, city)` — single recognized city → use the internal weather tool
  - `"multiple"` — two or more distinct supported cities detected → ask "Quelle ville ?"
  - `"no_city"` — weather keyword present but no city mentioned → ask "Quelle ville ?"
  - `"unknown_city"` — city-like word detected but not in the supported list → fixed refusal message
  - `None` — not a weather query → normal search/chat flow continues
- `chat()` dispatches all four states immediately and returns before reaching `should_search` or the LLM, so weather queries are fully contained.
- Removes `is_weather_query()`, which is now subsumed by `detect_weather_city`.
- Adds `tests/test_weather.py` covering all outcome branches, including dual-spelling deduplication (`montreal` / `montréal` treated as one city).

## Unsupported cities no longer hallucinate weather

Previously, a query like "météo à Paris" fell through to `is_weather_query`, which returned the generic "Quelle ville ?" — as if no city had been mentioned at all. Now it returns:

> Je n'ai pas accès à la météo pour cette ville.

No LLM is involved and no weather data is invented.

## Weather queries never fall back to web search or LLM guesses

All non-`None` returns from `detect_weather_city` are handled with an early `return` in `chat()`, before `should_search` or the normal chat path is reached. A weather query can no longer be routed to a web search or answered speculatively by the model.

Closes #19

---
_Generated by [Claude Code](https://claude.ai/code/session_0144tjDVZb2aRmdetoJ311kk)_