### PR TITLE
fix: guard against IndexError in route() when response is empty

### DIFF
--- a/core/router.py
+++ b/core/router.py
@@ -39,7 +39,8 @@ def route(user_input: str) -> str:
             model=MODELS["router"],
             messages=[{"role": "user", "content": prompt}]
         )
-        category = response["message"]["content"].strip().lower().split()[0]
+        content = response["message"]["content"].strip().lower()
+        category = content.split()[0] if content else ""
         return MODEL_MAP.get(category, FALLBACK_MODEL)
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
         logger.warning("Router model unavailable, falling back to default: %s", e)


### PR DESCRIPTION
## Summary

- Fixes #41
- Extracts `content` before calling `.split()[0]` so an empty or whitespace-only router response no longer raises `IndexError`
- Empty/invalid responses now safely return `FALLBACK_MODEL`
- Normal routing behavior is unchanged; existing exception handling untouched

## Test plan

- [ ] Router returns valid category (`"code"`, `"simple"`, etc.) → correct model selected
- [ ] Router returns empty string → `FALLBACK_MODEL` returned, no exception
- [ ] Router returns whitespace-only string → `FALLBACK_MODEL` returned, no exception
- [ ] Router raises `ollama.ResponseError` / `ConnectionError` / `httpx.HTTPError` → existing fallback still triggers

https://claude.ai/code/session_01TSHPF1LXUKiMpyHdoUK6KF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSHPF1LXUKiMpyHdoUK6KF)_