### PR TITLE
Add GET /health endpoint for monitoring

### DIFF
--- a/web.py
+++ b/web.py
@@ -210,6 +210,11 @@ def update_settings(data: SettingsUpdateRequest, _: bool = Depends(get_current_u
     return {"ok": True}
 
 
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
 app.mount("/", StaticFiles(directory="static", html=True), name="static")
 
 


### PR DESCRIPTION
## Summary

- Adds a public `GET /health` endpoint to `web.py`
- Returns `{"status": "ok"}` with no authentication required
- No dependencies added, no existing routes affected

## Test plan

- [ ] `GET /health` returns `{"status": "ok"}` with HTTP 200
- [ ] Existing routes (`/login`, `/chat`, `/conversations`, etc.) still work as expected
- [ ] Unauthenticated request to `/health` succeeds (no token required)

Closes #43

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXx8CGEPoovnE27sTzuerQ)_