### PR TITLE
feat(memory): add Natural Memory v1 system

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -7,6 +7,10 @@ from core.memory import format_memories_for_prompt, parse_and_save
 from core.router import route
 from core.search import web_search, should_search
 from core.weather import detect_weather_city, get_weather
+from memory.extractor import extract_memories
+from memory.policy import is_memory_allowed
+from memory.retriever import get_relevant_memories, format_for_prompt
+from memory.store import save_memory as save_natural_memory
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +46,16 @@ Données météo:
 {weather_data}"""
 
 
+def _extract_and_save_natural_memories(user_message: str):
+    """Runs the rule-based extractor on the user message and persists allowed memories."""
+    try:
+        for mem in extract_memories(user_message):
+            if is_memory_allowed(mem):
+                save_natural_memory(mem)
+    except Exception:
+        pass  # never let memory extraction break the chat flow
+
+
 def extract_and_save_memory(user_message: str, assistant_response: str):
     """Extrait automatiquement les infos importantes et les sauvegarde."""
     prompt = MEMORY_EXTRACTION_PROMPT.format(
@@ -59,7 +73,7 @@ def extract_and_save_memory(user_message: str, assistant_response: str):
     parse_and_save(result)
 
 
-def build_messages(history: list[dict], user_input: str, memories: list[dict], extra_context: str = None, context_type: str = None) -> list[dict]:
+def build_messages(history: list[dict], user_input: str, memories: list[dict], extra_context: str = None, context_type: str = None, natural_memories=None) -> list[dict]:
     """Construit la liste de messages à envoyer à Ollama."""
     if context_type == "weather":
         system_prompt = WEATHER_SYSTEM_PROMPT.format(weather_data=extra_context)
@@ -67,7 +81,9 @@ def build_messages(history: list[dict], user_input: str, memories: list[dict], e
         system_prompt = SEARCH_SYSTEM_PROMPT.format(search_results=extra_context)
     else:
         memory_text = format_memories_for_prompt(memories)
-        system_prompt = NOVA_SYSTEM_PROMPT.format(memories=memory_text)
+        natural_text = format_for_prompt(natural_memories) if natural_memories else ""
+        combined = "\n\n".join(filter(None, [memory_text, natural_text]))
+        system_prompt = NOVA_SYSTEM_PROMPT.format(memories=combined)
 
     messages = [{"role": "system", "content": system_prompt}]
     messages += history[-CHAT_HISTORY_LIMIT:]
@@ -98,6 +114,8 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
 
         model = forced_model if forced_model else route(user_input)
 
+        natural_mems = get_relevant_memories(user_input)
+
         # Météo en temps réel
         weather_result = detect_weather_city(user_input)
         if isinstance(weather_result, tuple):
@@ -122,8 +140,8 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
             reply = response["message"]["content"]
             return reply, model
 
-        # Chat normal
-        messages = build_messages(history, user_input, memories)
+        # Chat normal — inject relevant natural memories into context
+        messages = build_messages(history, user_input, memories, natural_memories=natural_mems)
         response = client.chat(model=model, messages=messages)
         reply = response["message"]["content"]
 
@@ -144,6 +162,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
                 reply = response["message"]["content"]
 
         extract_and_save_memory(user_input, reply)
+        _extract_and_save_natural_memories(user_input)
         return reply, model
 
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:

--- a/core/memory.py
+++ b/core/memory.py
@@ -2,6 +2,7 @@ import sqlite3
 import shutil
 import os
 from datetime import datetime
+from memory.store import initialize_memory_database as _init_natural_memory
 
 DB_PATH = "nova.db"
 
@@ -82,6 +83,7 @@ def initialize_db():
                 FOREIGN KEY (conversation_id) REFERENCES conversations(id)
             )
         """)
+    _init_natural_memory(DB_PATH)
 
 
 def save_memory(category: str, content: str):

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from rich.console import Console
 from rich.prompt import Prompt
 from core.chat import chat
 from core.memory import initialize_db, load_memories, save_memory
+from memory.store import list_memories as list_natural_memories, delete_memories_matching
 
 console = Console()
 history = []
@@ -28,6 +29,35 @@ def run():
                 memories = load_memories()
                 console.print("[dim]Souvenir sauvegardé.[/dim]\n")
                 continue
+
+        low = user_input.lower().strip()
+
+        if low.startswith("forget that ") or low.startswith("oublie que "):
+            query = user_input.split(" ", 2)[2].strip()
+            count = delete_memories_matching(query)
+            console.print(f"[dim]Removed {count} memory(ies) matching '{query}'.[/dim]\n")
+            continue
+
+        if low.startswith("forget everything about ") or low.startswith("oublie tout sur "):
+            query = user_input.split(" ", 3)[-1].strip()
+            count = delete_memories_matching(query)
+            console.print(f"[dim]Removed {count} memory(ies) about '{query}'.[/dim]\n")
+            continue
+
+        if low in (
+            "what do you remember about me?", "show my memories", "show memories",
+            "what do you know about me?", "que sais-tu de moi ?", "que sais-tu de moi?",
+            "montre mes souvenirs", "montre-moi mes souvenirs",
+        ):
+            mems = list_natural_memories()
+            if not mems:
+                console.print("[dim]No natural memories stored yet.[/dim]\n")
+            else:
+                console.print("\n[bold cyan]Memories:[/bold cyan]")
+                for m in mems:
+                    console.print(f"  [dim][{m.kind}/{m.topic}][/dim] {m.content}")
+                console.print()
+            continue
 
         response, model_used = chat(history, user_input, memories)
 

--- a/memory/extractor.py
+++ b/memory/extractor.py
@@ -1,0 +1,86 @@
+import re
+from memory.schema import Memory
+
+# Maps topic labels to representative keywords found in content.
+_TOPIC_KEYWORDS: dict[str, list[str]] = {
+    "linux_distribution": ["linux", "fedora", "ubuntu", "debian", "arch", "mint", "kde", "gnome", "wayland", "x11", "distro"],
+    "editor": ["vim", "neovim", "nvim", "vscode", "emacs", "sublime", "nano", "helix", "cursor"],
+    "terminal": ["terminal", "alacritty", "kitty", "konsole", "tmux", "wezterm", "bash", "zsh", "fish"],
+    "language": ["python", "javascript", "typescript", "rust", "golang", "java", "php", "ruby", "swift", "kotlin", "c++", "c#"],
+    "framework": ["fastapi", "django", "flask", "react", "vue", "angular", "svelte", "nextjs", "express", "rails", "spring"],
+    "hardware": ["cpu", "gpu", "ram", "ssd", "nvme", "hdd", "monitor", "keyboard", "mouse", "nvidia", "amd", "intel", "ryzen"],
+    "workflow": ["workflow", "setup", "config", "configuration", "automate", "script", "pipeline", "makefile"],
+    "coding_style": ["indent", "tabs", "spaces", "formatting", "linter", "formatter", "black", "prettier", "pylint", "eslint"],
+    "ai_tools": ["ollama", "llm", "gpt", "claude", "gemini", "llama", "mistral", "openai"],
+}
+
+# Each entry: (compiled regex, kind, confidence, human-readable prefix for content)
+_TRIGGERS: list[tuple[re.Pattern, str, float, str]] = [
+    # Explicit memory requests
+    (re.compile(r"(?:remember that|note that|souviens-toi que|n'oublie pas que)\s+(.+)", re.I), "general", 0.85, "User noted:"),
+
+    # Workflow / habits
+    (re.compile(r"(?:from now on|dorénavant|à partir de maintenant)\s*,?\s*(.+)", re.I), "workflow", 0.85, "User prefers:"),
+
+    # Positive preferences
+    (re.compile(r"i (?:really )?(?:prefer|love|enjoy|like)\s+(.+?)(?=\s+and\s+i|\s+but\s+|[.!?]|$)", re.I), "preference", 0.9, "User prefers"),
+    (re.compile(r"je (?:préfère|adore|aime|aime bien)\s+(.+?)(?=\s+et\s+je|\s+mais\s+|[.!?]|$)", re.I), "preference", 0.9, "User prefers"),
+    (re.compile(r"i(?:'m a)? (?:big )?fan of\s+(.+?)(?=\s+and\s+|\s+but\s+|[.!?]|$)", re.I), "preference", 0.85, "User is a fan of"),
+
+    # Negative preferences / avoidances
+    (re.compile(r"i (?:don't like|hate|dislike|can't stand|avoid)\s+(.+?)(?=\s+and\s+i|\s+but\s+|[.!?]|$)", re.I), "avoid", 0.9, "User dislikes"),
+    (re.compile(r"(?:j'aime pas|je déteste|je n'aime pas|j'évite|je supporte pas)\s+(.+?)(?=\s+et\s+je|\s+mais\s+|[.!?]|$)", re.I), "avoid", 0.9, "User dislikes"),
+
+    # Project descriptions  ("my project Nova uses FastAPI and Ollama")
+    (re.compile(r"my project\s+(\w+)\s+(?:uses?|is built with|runs? on)\s+(.+?)(?=[.!?]|$)", re.I), "project", 0.9, None),
+    (re.compile(r"mon projet\s+(\w+)\s+(?:utilise|est fait avec|tourne sur)\s+(.+?)(?=[.!?]|$)", re.I), "project", 0.9, None),
+
+    # Hardware
+    (re.compile(r"my (?:pc|computer|machine|laptop|desktop)\s+(?:has|runs?|is running)\s+(.+?)(?=[.!?]|$)", re.I), "hardware", 0.85, "User's machine has"),
+    (re.compile(r"mon (?:pc|ordinateur|machine|laptop)\s+(?:a|tourne|fait tourner)\s+(.+?)(?=[.!?]|$)", re.I), "hardware", 0.85, "User's machine has"),
+    (re.compile(r"i have\s+(?:a\s+)?(\d+\s*(?:gb|tb|mb)\s+(?:of\s+)?(?:ram|ssd|storage|vram).+?)(?=[.!?]|$)", re.I), "hardware", 0.85, "User has"),
+
+    # Software / tool usage
+    (re.compile(r"i use\s+(.+?)(?:\s+for\s+.+)?(?=[.!?]|$)", re.I), "software", 0.8, "User uses"),
+    (re.compile(r"j'utilise\s+(.+?)(?:\s+pour\s+.+)?(?=[.!?]|$)", re.I), "software", 0.8, "User uses"),
+]
+
+
+def _infer_topic(text: str, fallback: str) -> str:
+    """Returns a topic label based on keyword matches in text, or the fallback."""
+    lowered = text.lower()
+    for topic, keywords in _TOPIC_KEYWORDS.items():
+        if any(kw in lowered for kw in keywords):
+            return topic
+    return fallback
+
+
+def extract_memories(message: str) -> list[Memory]:
+    """
+    Scans `message` for known trigger phrases and returns a list of Memory
+    objects. No LLM is involved — purely rule-based for speed and reliability.
+    """
+    results: list[Memory] = []
+
+    for pattern, kind, confidence, prefix in _TRIGGERS:
+        for match in pattern.finditer(message):
+            groups = [g.strip() for g in match.groups() if g]
+            if not groups:
+                continue
+
+            # Project pattern has two groups: name + stack
+            if kind == "project" and len(groups) == 2:
+                project_name, stack = groups
+                content = f"{project_name} uses {stack}."
+                topic = project_name.lower()
+            elif prefix:
+                raw = groups[0]
+                content = f"{prefix} {raw}."
+                topic = _infer_topic(raw, kind)
+            else:
+                content = groups[0]
+                topic = _infer_topic(content, kind)
+
+            results.append(Memory(kind=kind, topic=topic, content=content, confidence=confidence))
+
+    return results

--- a/memory/policy.py
+++ b/memory/policy.py
@@ -1,0 +1,49 @@
+import re
+from memory.schema import Memory
+
+# Credentials, tokens, financial details, and personal identifiers
+_SENSITIVE_PATTERNS = [
+    r"\b(password|mot de passe|passwd|passphrase)\b",
+    r"\b(token|api[_\s-]?key|access[_\s-]?key|secret[_\s-]?key|private[_\s-]?key)\b",
+    r"\b\d{13,19}\b",                    # raw card numbers
+    r"\b(credit card|carte de crédit|carte bancaire|cvv|cvc|iban|swift|bic)\b",
+    r"\b(social security|numéro de sécurité sociale|ssn|sin number)\b",
+    r"[A-Za-z0-9+/]{32,}={0,2}\b",      # base64-encoded secrets / long tokens
+]
+
+# Health, politics, religion, relationships — sensitive identity information
+_IDENTITY_PATTERNS = [
+    r"\b(depression|anxiety|cancer|diabetes|hiv|sida|antidépresseur|medication|médicament|therapist|thérapie)\b",
+    r"\b(republican|democrat|liberal|conservative|trump|biden|macron|le pen|political party|parti politique)\b",
+    r"\b(vote for|voted for|my religion|my faith|my church|ma religion|ma foi)\b",
+]
+
+# Transient, short-lived details that are not worth persisting
+_TRANSIENT_PATTERNS = [
+    r"\b(right now|en ce moment|tonight|ce soir|this morning|ce matin)\b",
+    r"\b(i feel|je me sens|i'm (sad|angry|depressed|happy today)|je suis (triste|en colère))\b",
+    r"\b(my ex|mon ex|breakup|rupture|divorce|cheated|trompé|cheating)\b",
+    r"\b(\d+\s+(?:rue|avenue|boulevard|street|drive|lane|road))\b",  # private addresses
+]
+
+
+def is_memory_allowed(memory: Memory) -> bool:
+    """
+    Returns True if the memory is safe and durable enough to store.
+    Rejects credentials, sensitive identity info, and transient emotions.
+    """
+    combined = f"{memory.topic} {memory.content}".lower()
+
+    for pattern in _SENSITIVE_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            return False
+
+    for pattern in _IDENTITY_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            return False
+
+    for pattern in _TRANSIENT_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            return False
+
+    return True

--- a/memory/retriever.py
+++ b/memory/retriever.py
@@ -1,0 +1,20 @@
+from memory.store import search_memories, DB_PATH
+from memory.schema import Memory
+
+
+def get_relevant_memories(message: str, limit: int = 8, db_path: str = DB_PATH) -> list[Memory]:
+    """
+    Returns up to `limit` memories relevant to the given user message.
+    Uses keyword matching against memory topic and content.
+    """
+    return search_memories(message, limit=limit, db_path=db_path)
+
+
+def format_for_prompt(memories: list[Memory]) -> str:
+    """Formats a list of memories into the context block injected into the system prompt."""
+    if not memories:
+        return ""
+    lines = ["Relevant user memory:"]
+    for m in memories:
+        lines.append(f"- [{m.kind}/{m.topic}] {m.content}")
+    return "\n".join(lines)

--- a/memory/schema.py
+++ b/memory/schema.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+VALID_KINDS = frozenset({
+    "preference", "project", "hardware", "software",
+    "workflow", "constraint", "avoid", "general",
+})
+
+
+class Memory(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    kind: str
+    topic: str
+    content: str
+    confidence: float = 0.8
+    source: str = "extractor"
+    created_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    updated_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    last_seen_at: str = Field(default_factory=lambda: datetime.now().isoformat())

--- a/memory/store.py
+++ b/memory/store.py
@@ -1,0 +1,127 @@
+import sqlite3
+from datetime import datetime
+from memory.schema import Memory
+
+DB_PATH = "nova.db"
+
+
+def initialize_memory_database(db_path: str = DB_PATH):
+    """Creates the natural_memories table if it doesn't already exist."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS natural_memories (
+                id           TEXT PRIMARY KEY,
+                kind         TEXT NOT NULL,
+                topic        TEXT NOT NULL,
+                content      TEXT NOT NULL,
+                confidence   REAL NOT NULL,
+                source       TEXT NOT NULL,
+                created_at   TEXT NOT NULL,
+                updated_at   TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            )
+        """)
+
+
+def save_memory(memory: Memory, db_path: str = DB_PATH):
+    """Inserts a new memory or replaces an existing one with the same id."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO natural_memories
+            (id, kind, topic, content, confidence, source, created_at, updated_at, last_seen_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                memory.id, memory.kind, memory.topic, memory.content,
+                memory.confidence, memory.source,
+                memory.created_at, memory.updated_at, memory.last_seen_at,
+            ),
+        )
+
+
+def update_memory(memory: Memory, db_path: str = DB_PATH):
+    """Updates mutable fields of an existing memory and refreshes timestamps."""
+    now = datetime.now().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE natural_memories
+            SET kind=?, topic=?, content=?, confidence=?, updated_at=?, last_seen_at=?
+            WHERE id=?
+            """,
+            (memory.kind, memory.topic, memory.content, memory.confidence, now, now, memory.id),
+        )
+
+
+def delete_memory(memory_id: str, db_path: str = DB_PATH):
+    """Deletes a single memory by its id."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM natural_memories WHERE id = ?", (memory_id,))
+
+
+def list_memories(db_path: str = DB_PATH) -> list[Memory]:
+    """Returns all stored memories, newest first."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM natural_memories ORDER BY created_at DESC"
+        ).fetchall()
+    finally:
+        conn.close()
+    return [_row_to_memory(r) for r in rows]
+
+
+def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[Memory]:
+    """
+    Returns up to `limit` memories scored by keyword overlap with `query`.
+    Matches are checked against topic + content (case-insensitive).
+    """
+    if not query.strip():
+        return []
+    words = [w.lower() for w in query.split() if len(w) > 2]
+    if not words:
+        return []
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM natural_memories ORDER BY created_at DESC"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    scored: list[tuple[int, Memory]] = []
+    for row in rows:
+        mem = _row_to_memory(row)
+        haystack = f"{mem.topic} {mem.content}".lower()
+        score = sum(1 for w in words if w in haystack)
+        if score > 0:
+            scored.append((score, mem))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [m for _, m in scored[:limit]]
+
+
+def delete_memories_matching(query: str, db_path: str = DB_PATH) -> int:
+    """Deletes all memories matching the query keywords. Returns the count deleted."""
+    matches = search_memories(query, limit=200, db_path=db_path)
+    for mem in matches:
+        delete_memory(mem.id, db_path=db_path)
+    return len(matches)
+
+
+def _row_to_memory(row: sqlite3.Row) -> Memory:
+    return Memory(
+        id=row["id"],
+        kind=row["kind"],
+        topic=row["topic"],
+        content=row["content"],
+        confidence=float(row["confidence"]),
+        source=row["source"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        last_seen_at=row["last_seen_at"],
+    )

--- a/memory/store.py
+++ b/memory/store.py
@@ -73,14 +73,18 @@ def list_memories(db_path: str = DB_PATH) -> list[Memory]:
     return [_row_to_memory(r) for r in rows]
 
 
+def _tokenize(text: str) -> list[str]:
+    """Lowercases, splits on non-alphanumeric characters (including underscores), returns tokens > 2 chars."""
+    import re
+    return [t for t in re.split(r"[\W_]+", text.lower()) if len(t) > 2]
+
+
 def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[Memory]:
     """
-    Returns up to `limit` memories scored by keyword overlap with `query`.
-    Matches are checked against topic + content (case-insensitive).
+    Returns up to `limit` memories scored by token overlap with `query`.
+    Tokens are normalized (lowercased, punctuation stripped) before matching.
     """
-    if not query.strip():
-        return []
-    words = [w.lower() for w in query.split() if len(w) > 2]
+    words = _tokenize(query)
     if not words:
         return []
 
@@ -96,8 +100,8 @@ def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[
     scored: list[tuple[int, Memory]] = []
     for row in rows:
         mem = _row_to_memory(row)
-        haystack = f"{mem.topic} {mem.content}".lower()
-        score = sum(1 for w in words if w in haystack)
+        haystack_tokens = set(_tokenize(f"{mem.topic} {mem.content}"))
+        score = sum(1 for w in words if w in haystack_tokens)
         if score > 0:
             scored.append((score, mem))
 
@@ -106,11 +110,28 @@ def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[
 
 
 def delete_memories_matching(query: str, db_path: str = DB_PATH) -> int:
-    """Deletes all memories matching the query keywords. Returns the count deleted."""
-    matches = search_memories(query, limit=200, db_path=db_path)
-    for mem in matches:
-        delete_memory(mem.id, db_path=db_path)
-    return len(matches)
+    """Deletes ALL memories matching the query keywords. Returns the count deleted."""
+    words = _tokenize(query)
+    if not words:
+        return 0
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT * FROM natural_memories").fetchall()
+    finally:
+        conn.close()
+
+    to_delete = []
+    for row in rows:
+        mem = _row_to_memory(row)
+        haystack_tokens = set(_tokenize(f"{mem.topic} {mem.content}"))
+        if any(w in haystack_tokens for w in words):
+            to_delete.append(mem.id)
+
+    for memory_id in to_delete:
+        delete_memory(memory_id, db_path=db_path)
+    return len(to_delete)
 
 
 def _row_to_memory(row: sqlite3.Row) -> Memory:

--- a/tests/test_natural_memory.py
+++ b/tests/test_natural_memory.py
@@ -7,8 +7,6 @@ Tests for Natural Memory v1:
   - retriever: return relevant memories
   - forget command: delete matching memories
 """
-import os
-import tempfile
 import pytest
 
 from memory.schema import Memory

--- a/tests/test_natural_memory.py
+++ b/tests/test_natural_memory.py
@@ -1,0 +1,306 @@
+"""
+Tests for Natural Memory v1:
+  - DB initialisation
+  - save / list / search memories
+  - policy: reject sensitive content
+  - extractor: detect preferences, projects, hardware
+  - retriever: return relevant memories
+  - forget command: delete matching memories
+"""
+import os
+import tempfile
+import pytest
+
+from memory.schema import Memory
+from memory.store import (
+    initialize_memory_database,
+    save_memory,
+    update_memory,
+    delete_memory,
+    list_memories,
+    search_memories,
+    delete_memories_matching,
+)
+from memory.policy import is_memory_allowed
+from memory.extractor import extract_memories
+from memory.retriever import get_relevant_memories, format_for_prompt
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Provides a fresh, isolated SQLite database for each test."""
+    db = str(tmp_path / "test_memory.db")
+    initialize_memory_database(db)
+    return db
+
+
+def _mem(**kwargs) -> Memory:
+    defaults = dict(kind="general", topic="test", content="test content", confidence=0.9)
+    defaults.update(kwargs)
+    return Memory(**defaults)
+
+
+# ── DB initialisation ──────────────────────────────────────────────────────────
+
+class TestDatabaseInit:
+    def test_initialise_creates_table(self, tmp_db):
+        mems = list_memories(db_path=tmp_db)
+        assert isinstance(mems, list)
+        assert mems == []
+
+    def test_initialise_is_idempotent(self, tmp_db):
+        # Calling twice must not raise or duplicate the table
+        initialize_memory_database(tmp_db)
+        mems = list_memories(db_path=tmp_db)
+        assert mems == []
+
+
+# ── save / list / search ───────────────────────────────────────────────────────
+
+class TestSaveAndList:
+    def test_save_and_list_single(self, tmp_db):
+        m = _mem(kind="preference", topic="editor", content="User prefers neovim.")
+        save_memory(m, db_path=tmp_db)
+        result = list_memories(db_path=tmp_db)
+        assert len(result) == 1
+        assert result[0].content == "User prefers neovim."
+        assert result[0].kind == "preference"
+
+    def test_save_multiple_returns_all(self, tmp_db):
+        for i in range(3):
+            save_memory(_mem(content=f"content {i}"), db_path=tmp_db)
+        assert len(list_memories(db_path=tmp_db)) == 3
+
+    def test_list_returns_newest_first(self, tmp_db):
+        m1 = _mem(content="first", created_at="2024-01-01T00:00:00")
+        m2 = _mem(content="second", created_at="2024-06-01T00:00:00")
+        save_memory(m1, db_path=tmp_db)
+        save_memory(m2, db_path=tmp_db)
+        result = list_memories(db_path=tmp_db)
+        assert result[0].content == "second"
+
+    def test_delete_removes_memory(self, tmp_db):
+        m = _mem()
+        save_memory(m, db_path=tmp_db)
+        delete_memory(m.id, db_path=tmp_db)
+        assert list_memories(db_path=tmp_db) == []
+
+    def test_update_changes_content(self, tmp_db):
+        m = _mem(content="original")
+        save_memory(m, db_path=tmp_db)
+        m.content = "updated"
+        update_memory(m, db_path=tmp_db)
+        result = list_memories(db_path=tmp_db)
+        assert result[0].content == "updated"
+
+
+class TestSearchMemories:
+    def test_search_returns_matching(self, tmp_db):
+        save_memory(_mem(topic="linux_distribution", content="User prefers Fedora KDE."), db_path=tmp_db)
+        save_memory(_mem(topic="editor", content="User uses neovim."), db_path=tmp_db)
+        results = search_memories("fedora linux", db_path=tmp_db)
+        assert len(results) == 1
+        assert "Fedora" in results[0].content
+
+    def test_search_empty_query_returns_nothing(self, tmp_db):
+        save_memory(_mem(), db_path=tmp_db)
+        assert search_memories("", db_path=tmp_db) == []
+
+    def test_search_no_match_returns_empty(self, tmp_db):
+        save_memory(_mem(content="User prefers dark mode."), db_path=tmp_db)
+        assert search_memories("kubernetes docker swarm", db_path=tmp_db) == []
+
+    def test_search_respects_limit(self, tmp_db):
+        for i in range(10):
+            save_memory(_mem(topic="python", content=f"User writes python {i}"), db_path=tmp_db)
+        results = search_memories("python", limit=3, db_path=tmp_db)
+        assert len(results) <= 3
+
+    def test_search_ranks_by_keyword_overlap(self, tmp_db):
+        save_memory(_mem(topic="linux", content="User uses linux fedora kde"), db_path=tmp_db)
+        save_memory(_mem(topic="linux2", content="User uses linux"), db_path=tmp_db)
+        results = search_memories("linux fedora kde", db_path=tmp_db)
+        assert "fedora" in results[0].content.lower()
+
+
+# ── policy ─────────────────────────────────────────────────────────────────────
+
+class TestPolicy:
+    def test_allows_normal_preference(self):
+        m = _mem(kind="preference", topic="editor", content="User prefers neovim.")
+        assert is_memory_allowed(m) is True
+
+    def test_allows_project_info(self):
+        m = _mem(kind="project", topic="nova", content="Nova uses FastAPI and Ollama.")
+        assert is_memory_allowed(m) is True
+
+    def test_allows_hardware_info(self):
+        m = _mem(kind="hardware", topic="hardware", content="User has 32GB RAM and an Nvidia GPU.")
+        assert is_memory_allowed(m) is True
+
+    def test_allows_linux_distro_preference(self):
+        m = _mem(kind="preference", topic="linux_distribution", content="User prefers Fedora KDE.")
+        assert is_memory_allowed(m) is True
+
+    def test_rejects_password(self):
+        m = _mem(content="User's password is hunter2.")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_api_key(self):
+        m = _mem(content="The api_key is sk-abc123.")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_token(self):
+        m = _mem(content="token=abcdef1234567890abcdef1234567890")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_credit_card(self):
+        m = _mem(content="credit card 4111111111111111")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_medical_info(self):
+        m = _mem(content="User has diabetes and takes medication.")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_political_identity(self):
+        m = _mem(content="User voted for Trump in the last election.")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_transient_emotion(self):
+        m = _mem(content="User is feeling sad right now.")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_ex_relationship_drama(self):
+        m = _mem(content="User's ex cheated on them.")
+        assert is_memory_allowed(m) is False
+
+
+# ── extractor ──────────────────────────────────────────────────────────────────
+
+class TestExtractor:
+    def test_extracts_preference(self):
+        mems = extract_memories("I prefer Fedora KDE.")
+        assert len(mems) >= 1
+        kinds = [m.kind for m in mems]
+        assert "preference" in kinds
+
+    def test_extracts_avoid(self):
+        mems = extract_memories("I hate Ubuntu.")
+        assert any(m.kind == "avoid" for m in mems)
+
+    def test_extracts_project(self):
+        mems = extract_memories("My project Nova uses FastAPI and Ollama.")
+        assert any(m.kind == "project" for m in mems)
+        project_mems = [m for m in mems if m.kind == "project"]
+        assert any("Nova" in m.content or "nova" in m.topic for m in project_mems)
+
+    def test_project_content_includes_stack(self):
+        mems = extract_memories("My project Nova uses FastAPI and Ollama.")
+        project_mems = [m for m in mems if m.kind == "project"]
+        assert any("FastAPI" in m.content for m in project_mems)
+
+    def test_extracts_hardware(self):
+        mems = extract_memories("My PC has 32GB RAM and an Nvidia GPU.")
+        assert any(m.kind == "hardware" for m in mems)
+
+    def test_extracts_software_usage(self):
+        mems = extract_memories("I use neovim for coding.")
+        assert any(m.kind == "software" for m in mems)
+
+    def test_extracts_workflow(self):
+        mems = extract_memories("From now on, always use type hints in Python.")
+        assert any(m.kind == "workflow" for m in mems)
+
+    def test_returns_list_for_empty_input(self):
+        assert extract_memories("") == []
+
+    def test_returns_list_for_no_trigger(self):
+        mems = extract_memories("What is the weather today?")
+        assert isinstance(mems, list)
+
+    def test_infers_linux_topic(self):
+        mems = extract_memories("I prefer Fedora KDE.")
+        pref_mems = [m for m in mems if m.kind == "preference"]
+        assert any(m.topic == "linux_distribution" for m in pref_mems)
+
+    def test_confidence_is_positive(self):
+        mems = extract_memories("I prefer dark themes.")
+        assert all(m.confidence > 0 for m in mems)
+
+    def test_extracts_french_preference(self):
+        mems = extract_memories("Je préfère utiliser neovim.")
+        assert any(m.kind == "preference" for m in mems)
+
+    def test_extracts_multiple_triggers_in_one_message(self):
+        mems = extract_memories("I prefer Fedora KDE and I hate Ubuntu.")
+        kinds = [m.kind for m in mems]
+        assert "preference" in kinds
+        assert "avoid" in kinds
+
+
+# ── retriever ──────────────────────────────────────────────────────────────────
+
+class TestRetriever:
+    def test_returns_relevant_memories(self, tmp_db):
+        save_memory(_mem(topic="linux_distribution", content="User prefers Fedora."), db_path=tmp_db)
+        save_memory(_mem(topic="editor", content="User uses neovim."), db_path=tmp_db)
+        results = get_relevant_memories("which linux distro", db_path=tmp_db)
+        assert any("Fedora" in m.content for m in results)
+
+    def test_empty_message_returns_empty(self, tmp_db):
+        save_memory(_mem(), db_path=tmp_db)
+        assert get_relevant_memories("", db_path=tmp_db) == []
+
+    def test_respects_limit(self, tmp_db):
+        for i in range(20):
+            save_memory(_mem(topic="python", content=f"User likes python {i}"), db_path=tmp_db)
+        results = get_relevant_memories("python", limit=5, db_path=tmp_db)
+        assert len(results) <= 5
+
+
+class TestFormatForPrompt:
+    def test_empty_list_returns_empty_string(self):
+        assert format_for_prompt([]) == ""
+
+    def test_formats_single_memory(self):
+        m = _mem(kind="preference", topic="editor", content="User prefers neovim.")
+        text = format_for_prompt([m])
+        assert "Relevant user memory:" in text
+        assert "preference/editor" in text
+        assert "User prefers neovim." in text
+
+    def test_formats_multiple_memories(self):
+        mems = [
+            _mem(kind="preference", topic="editor", content="User prefers neovim."),
+            _mem(kind="hardware", topic="hardware", content="User has 32GB RAM."),
+        ]
+        text = format_for_prompt(mems)
+        assert text.count("-") >= 2
+
+
+# ── forget command ─────────────────────────────────────────────────────────────
+
+class TestForgetCommand:
+    def test_forget_deletes_matching(self, tmp_db):
+        save_memory(_mem(topic="fedora", content="User prefers Fedora KDE."), db_path=tmp_db)
+        save_memory(_mem(topic="neovim", content="User uses neovim."), db_path=tmp_db)
+        count = delete_memories_matching("fedora", db_path=tmp_db)
+        assert count == 1
+        remaining = list_memories(db_path=tmp_db)
+        assert all("Fedora" not in m.content for m in remaining)
+
+    def test_forget_all_about_topic(self, tmp_db):
+        save_memory(_mem(topic="ubuntu", content="User tried Ubuntu once."), db_path=tmp_db)
+        save_memory(_mem(topic="ubuntu2", content="User disliked Ubuntu."), db_path=tmp_db)
+        save_memory(_mem(topic="fedora", content="User prefers Fedora."), db_path=tmp_db)
+        count = delete_memories_matching("ubuntu", db_path=tmp_db)
+        assert count == 2
+        remaining = list_memories(db_path=tmp_db)
+        assert len(remaining) == 1
+        assert "Fedora" in remaining[0].content
+
+    def test_forget_nonexistent_returns_zero(self, tmp_db):
+        count = delete_memories_matching("kubernetes", db_path=tmp_db)
+        assert count == 0

--- a/web.py
+++ b/web.py
@@ -18,6 +18,10 @@ from core.memory import (
     get_setting, save_setting,
     list_memories, update_memory, delete_memory,
 )
+from memory.store import (
+    list_memories as list_natural_memories,
+    delete_memories_matching,
+)
 from config import MODELS, ALLOWED_SETTINGS
 
 security = HTTPBearer()
@@ -132,6 +136,34 @@ def chat_endpoint(request: ChatRequest, _: bool = Depends(get_current_user)):
         if len(parts) == 2:
             save_memory(parts[0].strip(), parts[1].strip())
             return {"response": "Souvenir sauvegardé.", "model": "system", "conversation_id": request.conversation_id}
+
+    msg_lower = request.message.lower().strip()
+
+    if msg_lower.startswith("forget that ") or msg_lower.startswith("oublie que "):
+        query = request.message.split(" ", 2)[2].strip()
+        count = delete_memories_matching(query)
+        reply = f"Done. Removed {count} memory(ies) matching '{query}'." if count else "No matching memories found."
+        return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
+
+    if msg_lower.startswith("forget everything about ") or msg_lower.startswith("oublie tout sur "):
+        parts = msg_lower.split(" ", 3)
+        query = request.message.split(" ", 3)[-1].strip()
+        count = delete_memories_matching(query)
+        reply = f"Done. Removed {count} memory(ies) about '{query}'." if count else "No matching memories found."
+        return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
+
+    if msg_lower in (
+        "what do you remember about me?", "show my memories", "show memories",
+        "what do you know about me?", "que sais-tu de moi ?", "que sais-tu de moi?",
+        "montre mes souvenirs", "montre-moi mes souvenirs",
+    ):
+        mems = list_natural_memories()
+        if not mems:
+            return {"response": "I don't have any natural memories stored yet.", "model": "system", "conversation_id": request.conversation_id}
+        lines = ["Here's what I remember about you:\n"]
+        for m in mems:
+            lines.append(f"- [{m.kind}/{m.topic}] {m.content}")
+        return {"response": "\n".join(lines), "model": "system", "conversation_id": request.conversation_id}
 
     conversation_id = request.conversation_id
     if not conversation_id:


### PR DESCRIPTION
## Summary

- Adds a new `memory/` package implementing a structured, rule-based persistent memory layer for Nova
- Memories are extracted automatically from user messages without any LLM calls (fast, offline-safe)
- A policy layer rejects credentials, sensitive identity details, and transient content before anything is stored
- Relevant memories are injected into the system prompt context on every normal-chat turn
- User commands (`forget that X`, `show my memories`) are handled in both the web API and the CLI

---

## File Structure

```
memory/
├── __init__.py       — empty package marker
├── schema.py         — Memory pydantic model (id, kind, topic, content, confidence, source, timestamps)
├── store.py          — SQLite CRUD: initialize, save, update, delete, list, search, delete_matching
├── policy.py         — Regex rules rejecting passwords/tokens/health/politics/transient emotions
├── extractor.py      — Rule-based trigger detection (EN + FR patterns)
└── retriever.py      — Keyword-scored relevance search + prompt formatter
```

Modified files:
- `core/memory.py` — `initialize_db()` now also creates the `natural_memories` table
- `core/chat.py` — retrieves relevant memories before building context; runs rule-based extraction after each user message
- `web.py` — handles `forget that`, `forget everything about`, `show my memories` commands
- `main.py` — same user commands in the CLI loop

---

## How Memory Extraction Works

After each user message, `extractor.extract_memories()` scans for trigger phrases using compiled regexes:

| Trigger pattern | Kind |
|---|---|
| `I prefer / I love / je préfère` | `preference` |
| `I hate / I don't like / je déteste` | `avoid` |
| `My project X uses Y` | `project` |
| `My PC has / Mon PC a` | `hardware` |
| `I use / j'utilise` | `software` |
| `From now on / dorénavant` | `workflow` |
| `Remember that / souviens-toi que` | `general` |

Each match produces a `Memory` object with a normalised content string and an inferred topic (e.g. `linux_distribution`, `editor`, `framework`). Before saving, `policy.is_memory_allowed()` rejects anything containing passwords, tokens, card numbers, medical info, political identity, or transient emotions.

---

## How Retrieval Works

Before generating a response, `retriever.get_relevant_memories(user_message)` runs `store.search_memories()`:

1. Tokenises the query into words longer than 2 characters
2. Scores each stored memory by keyword overlap against `topic + content`
3. Returns up to 8 highest-scoring memories

The results are formatted as a `Relevant user memory:` block and appended to the system prompt alongside the existing legacy memories. Weather and search routes are unaffected.

---

## How to Test

```bash
# Run the full natural memory test suite (46 tests)
python3 -m pytest tests/test_natural_memory.py -v

# Run all project tests
python3 -m pytest tests/ -v
```

**Manual CLI smoke test:**
```
I prefer Fedora KDE.
→ (memory saved automatically)

show my memories
→ Lists stored natural memories

forget that fedora
→ Removes matching memories

My project Nova uses FastAPI and Ollama.
→ Memory(kind="project", topic="nova", content="Nova uses FastAPI and Ollama.")
```

---

## Limitations of v1

- **Keyword-only search** — no semantic similarity; unrelated words won't surface related memories
- **No deduplication** — similar memories can accumulate (e.g. "User prefers neovim" saved multiple times)
- **Regex patterns are brittle** — unusual phrasings or mid-sentence triggers may be missed or over-matched
- **No embeddings** — by design for v1; planned for v2
- **English + French only** — other languages are not covered by current trigger patterns
- **No memory merging/updating** — two contradictory preferences are both kept; latest wins at retrieval time only by rank

https://claude.ai/code/session_0113aaMgsbh4PYGh2cGUtni2

---
_Generated by [Claude Code](https://claude.ai/code/session_0113aaMgsbh4PYGh2cGUtni2)_