### PR TITLE
feat: release channel UI + Alpha GitHub OAuth gate

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,10 @@ load_dotenv()
 
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 
+_raw_channel = os.getenv("NOVA_CHANNEL", "stable").lower()
+NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else "stable"
+NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")
+
 MODELS = {
     "router":   "gemma3:1b",        # lightweight classifier, learner
     "default":  "gemma4",           # general chat, vision, memory extraction

--- a/config.py
+++ b/config.py
@@ -10,6 +10,15 @@ NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else 
 NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")
 NOVA_ADMIN_UI = os.getenv("NOVA_ADMIN_UI", "false").lower() == "true"
 
+GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "")
+GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET", "")
+GITHUB_OAUTH_REDIRECT_URI = os.getenv("GITHUB_OAUTH_REDIRECT_URI", "")
+NOVA_ALPHA_ALLOWED_USERS: frozenset[str] = frozenset(
+    u.strip().lower()
+    for u in os.getenv("NOVA_ALPHA_ALLOWED_USERS", "").split(",")
+    if u.strip()
+)
+
 MODELS = {
     "router":   "gemma3:1b",        # lightweight classifier, learner
     "default":  "gemma4",           # general chat, vision, memory extraction

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 _raw_channel = os.getenv("NOVA_CHANNEL", "stable").lower()
 NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else "stable"
 NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")
+NOVA_ADMIN_UI = os.getenv("NOVA_ADMIN_UI", "false").lower() == "true"
 
 MODELS = {
     "router":   "gemma3:1b",        # lightweight classifier, learner

--- a/core/github_oauth.py
+++ b/core/github_oauth.py
@@ -1,0 +1,59 @@
+import httpx
+from urllib.parse import urlencode
+
+from config import (
+    GITHUB_CLIENT_ID,
+    GITHUB_CLIENT_SECRET,
+    GITHUB_OAUTH_REDIRECT_URI,
+    NOVA_ALPHA_ALLOWED_USERS,
+)
+
+_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+_TOKEN_URL = "https://github.com/login/oauth/access_token"
+_USER_URL = "https://api.github.com/user"
+
+
+def build_auth_url(state: str) -> str:
+    return _AUTHORIZE_URL + "?" + urlencode({
+        "client_id": GITHUB_CLIENT_ID,
+        "redirect_uri": GITHUB_OAUTH_REDIRECT_URI,
+        "scope": "read:user",
+        "state": state,
+    })
+
+
+async def exchange_code(code: str) -> str | None:
+    """Exchange an OAuth code for an access token. Returns the token or None."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            _TOKEN_URL,
+            data={
+                "client_id": GITHUB_CLIENT_ID,
+                "client_secret": GITHUB_CLIENT_SECRET,
+                "code": code,
+                "redirect_uri": GITHUB_OAUTH_REDIRECT_URI,
+            },
+            headers={"Accept": "application/json"},
+        )
+    if resp.status_code != 200:
+        return None
+    return resp.json().get("access_token") or None
+
+
+async def fetch_username(token: str) -> str | None:
+    """Return the GitHub login for the given access token, or None on failure."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            _USER_URL,
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    if resp.status_code != 200:
+        return None
+    return resp.json().get("login") or None
+
+
+def is_allowed(username: str) -> bool:
+    return username.lower() in NOVA_ALPHA_ALLOWED_USERS

--- a/static/index.html
+++ b/static/index.html
@@ -820,6 +820,89 @@
         ::-webkit-scrollbar { width: 4px; }
         ::-webkit-scrollbar-track { background: transparent; }
         ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+        /* ── CHANNEL BADGE ── */
+        #channel-wrapper {
+            position: relative;
+            flex-shrink: 0;
+        }
+
+        #channel-btn {
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            padding: 0;
+            display: flex;
+            align-items: center;
+        }
+
+        .channel-badge {
+            font-size: 0.65rem;
+            font-family: monospace;
+            font-weight: bold;
+            letter-spacing: 1px;
+            padding: 3px 8px;
+            border-radius: 10px;
+            border: 1px solid;
+            text-transform: uppercase;
+            transition: opacity 0.2s;
+        }
+
+        .channel-badge:hover { opacity: 0.8; }
+
+        .channel-stable { color: var(--cyan); border-color: var(--cyan); background: rgba(0,188,212,0.08); }
+        .channel-beta   { color: #ffb74d;    border-color: #ffb74d;    background: rgba(255,183,77,0.08); }
+        .channel-alpha  { color: #ce93d8;    border-color: #ce93d8;    background: rgba(206,147,216,0.08); }
+
+        #channel-dropdown {
+            display: none;
+            position: absolute;
+            top: calc(100% + 8px);
+            right: 0;
+            background: var(--bg2);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 210px;
+            z-index: 100;
+            overflow: hidden;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+        }
+
+        #channel-dropdown.open { display: block; }
+
+        .channel-option a {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 14px;
+            text-decoration: none;
+            color: var(--text);
+            font-size: 0.85rem;
+            font-family: monospace;
+            transition: background 0.15s;
+        }
+
+        .channel-option a:hover { background: var(--bg3); }
+        .channel-option.active a { background: var(--bg3); color: var(--cyan); }
+
+        .channel-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+
+        .channel-dot.stable { background: var(--cyan); }
+        .channel-dot.beta   { background: #ffb74d; }
+        .channel-dot.alpha  { background: #ce93d8; }
+
+        .channel-opt-url {
+            margin-left: auto;
+            font-size: 0.7rem;
+            color: var(--text-dim);
+        }
+
+        .channel-option.active .channel-opt-url { color: var(--cyan-dim); }
     </style>
 </head>
 <body>
@@ -865,6 +948,34 @@
             <div id="chat-header">
                 <button id="menu-toggle" onclick="toggleSidebar()">☰</button>
                 <span id="chat-title">Discute avec Nova</span>
+                <div id="channel-wrapper">
+                    <button id="channel-btn" onclick="toggleChannelDropdown()" title="Release channel">
+                        <span id="channel-badge" class="channel-badge channel-stable">STABLE</span>
+                    </button>
+                    <div id="channel-dropdown">
+                        <div class="channel-option" data-channel="stable">
+                            <a href="https://nova.borealnode.ca">
+                                <span class="channel-dot stable"></span>
+                                Stable
+                                <span class="channel-opt-url">nova.borealnode.ca</span>
+                            </a>
+                        </div>
+                        <div class="channel-option" data-channel="beta">
+                            <a href="https://beta.nova.borealnode.ca">
+                                <span class="channel-dot beta"></span>
+                                Beta
+                                <span class="channel-opt-url">beta.nova.borealnode.ca</span>
+                            </a>
+                        </div>
+                        <div class="channel-option" data-channel="alpha">
+                            <a href="https://alpha.nova.borealnode.ca">
+                                <span class="channel-dot alpha"></span>
+                                Alpha
+                                <span class="channel-opt-url">alpha.nova.borealnode.ca</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <span id="model-badge">—</span>
             </div>
 
@@ -1188,12 +1299,43 @@
         location.reload();
     }
 
+    // ── CHANNEL ──
+    async function loadChannelInfo() {
+        try {
+            const res = await fetch("/channel");
+            if (res.ok) {
+                const data = await res.json();
+                const channel = (data.channel || "stable").toLowerCase();
+                const badge = document.getElementById("channel-badge");
+                if (badge) {
+                    badge.textContent = channel.toUpperCase();
+                    badge.className = "channel-badge channel-" + channel;
+                }
+                document.querySelectorAll(".channel-option").forEach(opt => {
+                    opt.classList.toggle("active", opt.dataset.channel === channel);
+                });
+            }
+        } catch (e) {}
+    }
+
+    function toggleChannelDropdown() {
+        document.getElementById("channel-dropdown").classList.toggle("open");
+    }
+
+    document.addEventListener("click", function(e) {
+        const wrapper = document.getElementById("channel-wrapper");
+        if (wrapper && !wrapper.contains(e.target)) {
+            document.getElementById("channel-dropdown").classList.remove("open");
+        }
+    });
+
     // ── INIT ──
     function initApp() {
         document.getElementById("login-screen").style.display = "none";
         document.getElementById("app").style.display = "flex";
         setMode(currentMode);
         loadConversations();
+        loadChannelInfo();
     }
 
     // ── SIDEBAR ──

--- a/static/index.html
+++ b/static/index.html
@@ -903,6 +903,17 @@
         }
 
         .channel-option.active .channel-opt-url { color: var(--cyan-dim); }
+
+        #channel-branch-row {
+            display: none;
+            padding: 7px 14px 9px;
+            border-top: 1px solid var(--border);
+            font-size: 0.7rem;
+            color: var(--text-dim);
+            font-family: monospace;
+        }
+
+        #channel-branch-row.show { display: block; }
     </style>
 </head>
 <body>
@@ -967,13 +978,14 @@
                                 <span class="channel-opt-url">beta.nova.borealnode.ca</span>
                             </a>
                         </div>
-                        <div class="channel-option" data-channel="alpha">
+                        <div class="channel-option" id="channel-alpha-opt" data-channel="alpha" style="display:none">
                             <a href="https://alpha.nova.borealnode.ca">
                                 <span class="channel-dot alpha"></span>
                                 Alpha
                                 <span class="channel-opt-url">alpha.nova.borealnode.ca</span>
                             </a>
                         </div>
+                        <div id="channel-branch-row"></div>
                     </div>
                 </div>
                 <span id="model-badge">—</span>
@@ -1306,14 +1318,30 @@
             if (res.ok) {
                 const data = await res.json();
                 const channel = (data.channel || "stable").toLowerCase();
+                const admin = !!data.admin_ui_enabled;
+
                 const badge = document.getElementById("channel-badge");
                 if (badge) {
                     badge.textContent = channel.toUpperCase();
                     badge.className = "channel-badge channel-" + channel;
                 }
+
                 document.querySelectorAll(".channel-option").forEach(opt => {
                     opt.classList.toggle("active", opt.dataset.channel === channel);
                 });
+
+                const alphaOpt = document.getElementById("channel-alpha-opt");
+                if (alphaOpt) alphaOpt.style.display = admin ? "" : "none";
+
+                const branchRow = document.getElementById("channel-branch-row");
+                if (branchRow) {
+                    if (admin && data.branch) {
+                        branchRow.textContent = "branch: " + data.branch;
+                        branchRow.classList.add("show");
+                    } else {
+                        branchRow.classList.remove("show");
+                    }
+                }
             }
         } catch (e) {}
     }

--- a/tests/test_alpha_auth.py
+++ b/tests/test_alpha_auth.py
@@ -1,0 +1,233 @@
+"""
+Tests for the Alpha channel GitHub OAuth guard.
+
+Automated tests cover the middleware logic; the manual steps below are for
+verifying a live deployment end-to-end.
+
+Manual test steps
+-----------------
+1. Alpha without login
+   - Visit https://alpha.nova.borealnode.ca
+   - Expected: browser is redirected to GitHub OAuth, Nova UI is never shown
+
+2. Alpha with a non-allowed GitHub account
+   - Complete the GitHub OAuth flow as any account that is NOT in NOVA_ALPHA_ALLOWED_USERS
+   - Expected: 403 "ACCESS DENIED" page with the GitHub username shown
+
+3. Alpha with TheZupZup
+   - Complete the GitHub OAuth flow as TheZupZup
+   - Expected: Nova login screen appears normally
+
+4. Stable / Beta (no GitHub gate)
+   - Visit https://nova.borealnode.ca or https://beta.nova.borealnode.ca
+   - Expected: Nova login screen appears with no GitHub redirect
+
+Limitation: sessions are stored in process memory. They are lost on server
+restart and are not shared across multiple workers or containers. For a
+single-process Alpha instance this is acceptable. A persistent session
+store (e.g. Redis) would be needed for multi-worker deployments.
+"""
+
+import contextlib
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import web
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _alpha_stack(stack: contextlib.ExitStack) -> None:
+    """Enter patches that simulate NOVA_CHANNEL=alpha with stub OAuth credentials."""
+    stack.enter_context(patch("web.NOVA_CHANNEL", "alpha"))
+    stack.enter_context(patch("web.GITHUB_CLIENT_ID", "test-client-id"))
+    stack.enter_context(patch("web.GITHUB_CLIENT_SECRET", "test-client-secret"))
+    _suppress_startup(stack)
+
+
+def _suppress_startup(stack: contextlib.ExitStack) -> None:
+    """Suppress DB init, background learning, and the APScheduler."""
+    stack.enter_context(patch("web.initialize_db"))
+    stack.enter_context(patch("web.learn_from_feeds"))
+    stack.enter_context(patch("web.scheduler", MagicMock()))
+
+
+def _inject_session(github_user: str) -> str:
+    """Insert an authenticated GitHub session directly into the store, return SID."""
+    sid = f"test-sid-{github_user}"
+    web._sessions[sid] = {
+        "data": {"github_user": github_user},
+        "exp": time.time() + 3600,
+    }
+    return sid
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def alpha_client():
+    """TestClient with NOVA_CHANNEL=alpha and stub OAuth credentials."""
+    with contextlib.ExitStack() as stack:
+        _alpha_stack(stack)
+        web._sessions.clear()
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+@pytest.fixture()
+def stable_client():
+    """TestClient with NOVA_CHANNEL=stable — guard must not activate."""
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.NOVA_CHANNEL", "stable"))
+        _suppress_startup(stack)
+        web._sessions.clear()
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+# ── is_allowed() ───────────────────────────────────────────────────────────────
+
+class TestIsAllowed:
+    def test_listed_user_is_allowed(self):
+        with patch("core.github_oauth.NOVA_ALPHA_ALLOWED_USERS", frozenset({"thezupzup"})):
+            from core.github_oauth import is_allowed
+            assert is_allowed("TheZupZup") is True
+
+    def test_match_is_case_insensitive(self):
+        with patch("core.github_oauth.NOVA_ALPHA_ALLOWED_USERS", frozenset({"thezupzup"})):
+            from core.github_oauth import is_allowed
+            assert is_allowed("THEZUPZUP") is True
+            assert is_allowed("thezupzup") is True
+
+    def test_unlisted_user_is_denied(self):
+        with patch("core.github_oauth.NOVA_ALPHA_ALLOWED_USERS", frozenset({"thezupzup"})):
+            from core.github_oauth import is_allowed
+            assert is_allowed("attacker") is False
+            assert is_allowed("") is False
+
+    def test_empty_allowlist_denies_everyone(self):
+        with patch("core.github_oauth.NOVA_ALPHA_ALLOWED_USERS", frozenset()):
+            from core.github_oauth import is_allowed
+            assert is_allowed("TheZupZup") is False
+
+
+# ── Alpha channel guard ─────────────────────────────────────────────────────────
+
+class TestAlphaGuard:
+    def test_unauthenticated_browser_redirects_to_oauth(self, alpha_client):
+        """Alpha without any session → redirect to the GitHub OAuth initiation route."""
+        resp = alpha_client.get("/", follow_redirects=False)
+        assert resp.status_code in (302, 307)
+        assert "/auth/github" in resp.headers["location"]
+
+    def test_unauthenticated_api_call_returns_401_json(self, alpha_client):
+        """Bearer-token API calls without a session get a JSON 401, not an HTML redirect."""
+        resp = alpha_client.get(
+            "/health",
+            headers={"Authorization": "Bearer some.jwt.token"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["detail"] == "GitHub authentication required."
+
+    def test_non_allowed_github_user_gets_403(self, alpha_client):
+        """A GitHub user not in NOVA_ALPHA_ALLOWED_USERS receives an access-denied page."""
+        sid = _inject_session("notallowed")
+        with patch("web.is_allowed", return_value=False):
+            resp = alpha_client.get(
+                "/",
+                cookies={web._SESSION_COOKIE: sid},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 403
+        assert "ACCESS DENIED" in resp.text
+        assert "@notallowed" in resp.text
+
+    def test_allowed_user_reaches_app(self, alpha_client):
+        """An allowed GitHub user passes the guard and the underlying handler responds."""
+        sid = _inject_session("thezupzup")
+        with patch("web.is_allowed", return_value=True):
+            resp = alpha_client.get(
+                "/health",
+                cookies={web._SESSION_COOKIE: sid},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_auth_paths_bypass_guard(self, alpha_client):
+        """/auth/* routes are always reachable so the OAuth flow can complete."""
+        resp = alpha_client.get("/auth/github", follow_redirects=False)
+        # Must redirect toward GitHub, not loop back to itself
+        assert resp.status_code in (302, 307)
+        assert "github.com" in resp.headers.get("location", "")
+
+    def test_missing_oauth_config_returns_503(self):
+        """Alpha with empty GITHUB_CLIENT_ID/SECRET returns 503 instead of crashing."""
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("web.NOVA_CHANNEL", "alpha"))
+            stack.enter_context(patch("web.GITHUB_CLIENT_ID", ""))
+            stack.enter_context(patch("web.GITHUB_CLIENT_SECRET", ""))
+            _suppress_startup(stack)
+            web._sessions.clear()
+            with TestClient(web.app, raise_server_exceptions=True) as client:
+                resp = client.get("/", follow_redirects=False)
+        assert resp.status_code == 503
+
+    def test_expired_session_redirects_to_oauth(self, alpha_client):
+        """A session whose TTL has passed is treated as unauthenticated."""
+        sid = "expired-session"
+        web._sessions[sid] = {
+            "data": {"github_user": "thezupzup"},
+            "exp": time.time() - 1,  # already expired
+        }
+        resp = alpha_client.get(
+            "/",
+            cookies={web._SESSION_COOKIE: sid},
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 307)
+        assert "/auth/github" in resp.headers["location"]
+
+
+# ── Stable and Beta are unaffected ─────────────────────────────────────────────
+
+class TestPublicChannels:
+    def test_stable_health_is_public(self, stable_client):
+        """Stable channel: /health is reachable with no GitHub session."""
+        resp = stable_client.get("/health")
+        assert resp.status_code == 200
+
+    def test_beta_health_is_public(self):
+        """Beta channel: /health is reachable with no GitHub session."""
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("web.NOVA_CHANNEL", "beta"))
+            _suppress_startup(stack)
+            web._sessions.clear()
+            with TestClient(web.app, raise_server_exceptions=True) as client:
+                resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_stable_index_is_not_gated(self, stable_client):
+        """Stable channel: the root path must not redirect to /auth/github."""
+        resp = stable_client.get("/", follow_redirects=False)
+        location = resp.headers.get("location", "")
+        assert "/auth/github" not in location
+
+
+# ── Session cookie security properties ─────────────────────────────────────────
+
+class TestSessionCookieProperties:
+    def test_cookie_is_httponly(self, alpha_client):
+        """/auth/github must set a cookie with the HttpOnly flag."""
+        resp = alpha_client.get("/auth/github", follow_redirects=False)
+        assert "httponly" in resp.headers.get("set-cookie", "").lower()
+
+    def test_cookie_has_samesite_lax(self, alpha_client):
+        """/auth/github must set a cookie with SameSite=Lax."""
+        resp = alpha_client.get("/auth/github", follow_redirects=False)
+        assert "samesite=lax" in resp.headers.get("set-cookie", "").lower()

--- a/web.py
+++ b/web.py
@@ -33,8 +33,11 @@ from config import (
 from core.github_oauth import build_auth_url, exchange_code, fetch_username, is_allowed
 
 # ── ALPHA CHANNEL: SESSION STORE ──────────────────────────────────────────────
-# In-memory store keyed by a random, opaque session ID.
+# In-memory store keyed by a random, opaque session ID (256-bit entropy).
 # Only the GitHub username is persisted — the OAuth token is never stored.
+# Limitation: sessions are cleared on server restart and are not shared
+# across multiple workers or containers. Acceptable for a single-process
+# Alpha instance; replace with a persistent store for multi-worker setups.
 _sessions: dict[str, dict] = {}
 _SESSION_COOKIE = "nova_alpha_sess"
 _SESSION_TTL = 28800  # 8 hours

--- a/web.py
+++ b/web.py
@@ -22,7 +22,7 @@ from memory.store import (
     list_memories as list_natural_memories,
     delete_memories_matching,
 )
-from config import MODELS, ALLOWED_SETTINGS
+from config import MODELS, ALLOWED_SETTINGS, NOVA_CHANNEL, NOVA_BRANCH
 
 security = HTTPBearer()
 
@@ -240,6 +240,11 @@ def update_settings(data: SettingsUpdateRequest, _: bool = Depends(get_current_u
     if data.ram_budget is not None:
         save_setting("ram_budget", str(data.ram_budget))
     return {"ok": True}
+
+
+@app.get("/channel")
+def get_channel():
+    return {"channel": NOVA_CHANNEL, "branch": NOVA_BRANCH}
 
 
 @app.get("/health")

--- a/web.py
+++ b/web.py
@@ -22,7 +22,7 @@ from memory.store import (
     list_memories as list_natural_memories,
     delete_memories_matching,
 )
-from config import MODELS, ALLOWED_SETTINGS, NOVA_CHANNEL, NOVA_BRANCH
+from config import MODELS, ALLOWED_SETTINGS, NOVA_CHANNEL, NOVA_BRANCH, NOVA_ADMIN_UI
 
 security = HTTPBearer()
 
@@ -244,7 +244,7 @@ def update_settings(data: SettingsUpdateRequest, _: bool = Depends(get_current_u
 
 @app.get("/channel")
 def get_channel():
-    return {"channel": NOVA_CHANNEL, "branch": NOVA_BRANCH}
+    return {"channel": NOVA_CHANNEL, "branch": NOVA_BRANCH, "admin_ui_enabled": NOVA_ADMIN_UI}
 
 
 @app.get("/health")

--- a/web.py
+++ b/web.py
@@ -1,6 +1,9 @@
+import time
+import secrets as _secrets
 import uvicorn
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException, Depends
+from fastapi import FastAPI, HTTPException, Depends, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field, field_validator
@@ -22,7 +25,73 @@ from memory.store import (
     list_memories as list_natural_memories,
     delete_memories_matching,
 )
-from config import MODELS, ALLOWED_SETTINGS, NOVA_CHANNEL, NOVA_BRANCH, NOVA_ADMIN_UI
+from config import (
+    MODELS, ALLOWED_SETTINGS,
+    NOVA_CHANNEL, NOVA_BRANCH, NOVA_ADMIN_UI,
+    GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_REDIRECT_URI,
+)
+from core.github_oauth import build_auth_url, exchange_code, fetch_username, is_allowed
+
+# ── ALPHA CHANNEL: SESSION STORE ──────────────────────────────────────────────
+# In-memory store keyed by a random, opaque session ID.
+# Only the GitHub username is persisted — the OAuth token is never stored.
+_sessions: dict[str, dict] = {}
+_SESSION_COOKIE = "nova_alpha_sess"
+_SESSION_TTL = 28800  # 8 hours
+_SECURE_COOKIE = GITHUB_OAUTH_REDIRECT_URI.startswith("https://")
+
+
+def _session_read(request: Request) -> dict | None:
+    sid = request.cookies.get(_SESSION_COOKIE)
+    if not sid:
+        return None
+    entry = _sessions.get(sid)
+    if not entry or entry["exp"] < time.time():
+        _sessions.pop(sid, None)
+        return None
+    return entry["data"]
+
+
+def _session_create(data: dict) -> str:
+    sid = _secrets.token_urlsafe(32)
+    _sessions[sid] = {"data": data, "exp": time.time() + _SESSION_TTL}
+    return sid
+
+
+def _session_destroy(request: Request) -> None:
+    sid = request.cookies.get(_SESSION_COOKIE)
+    if sid:
+        _sessions.pop(sid, None)
+
+
+def _set_cookie(response, sid: str) -> None:
+    response.set_cookie(
+        _SESSION_COOKIE, sid,
+        httponly=True,
+        secure=_SECURE_COOKIE,
+        samesite="lax",
+        max_age=_SESSION_TTL,
+    )
+
+
+def _access_denied_page(username: str) -> str:
+    return (
+        "<!DOCTYPE html><html><head><title>Access Denied — Nova</title>"
+        "<style>*{box-sizing:border-box;margin:0;padding:0}"
+        "body{background:#0d0d0d;color:#e0e0e0;font-family:monospace;"
+        "display:flex;align-items:center;justify-content:center;height:100dvh}"
+        ".box{text-align:center;border:1px solid #222;border-radius:12px;"
+        "padding:32px 40px;background:#111}"
+        "h1{color:#f44336;font-size:1rem;letter-spacing:2px;margin-bottom:12px}"
+        "p{color:#666;font-size:0.85rem;margin:6px 0}"
+        "a{color:#00bcd4;text-decoration:none;font-size:0.8rem}"
+        "</style></head><body><div class='box'>"
+        "<h1>⬡ ACCESS DENIED</h1>"
+        f"<p>@{username} is not authorised to access this instance.</p>"
+        "<p style='margin-top:16px'><a href='/auth/logout'>← Sign out</a></p>"
+        "</div></body></html>"
+    )
+
 
 security = HTTPBearer()
 
@@ -48,6 +117,85 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(docs_url=None, redoc_url=None, lifespan=lifespan)
+
+
+# ── ALPHA CHANNEL GUARD ────────────────────────────────────────────────────────
+@app.middleware("http")
+async def alpha_channel_guard(request: Request, call_next):
+    if NOVA_CHANNEL != "alpha":
+        return await call_next(request)
+
+    # OAuth flow paths are always open
+    if request.url.path.startswith("/auth/"):
+        return await call_next(request)
+
+    if not GITHUB_CLIENT_ID or not GITHUB_CLIENT_SECRET:
+        return HTMLResponse(
+            "<h1 style='font-family:monospace;color:#f44336'>"
+            "Alpha channel requires GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET.</h1>",
+            status_code=503,
+        )
+
+    sess = _session_read(request)
+    github_user = sess.get("github_user") if sess else None
+
+    if not github_user:
+        # API callers with a Bearer token get a JSON 401, not a redirect
+        if request.headers.get("authorization"):
+            return JSONResponse({"detail": "GitHub authentication required."}, status_code=401)
+        return RedirectResponse("/auth/github")
+
+    if not is_allowed(github_user):
+        return HTMLResponse(_access_denied_page(github_user), status_code=403)
+
+    return await call_next(request)
+
+
+# ── GITHUB OAUTH ROUTES ────────────────────────────────────────────────────────
+@app.get("/auth/github")
+async def auth_github(request: Request):
+    state = _secrets.token_urlsafe(16)
+    sid = _session_create({"oauth_state": state})
+    response = RedirectResponse(build_auth_url(state), status_code=302)
+    _set_cookie(response, sid)
+    return response
+
+
+@app.get("/auth/github/callback")
+async def auth_github_callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+):
+    sess = _session_read(request)
+    if not sess or not state or sess.get("oauth_state") != state:
+        return HTMLResponse("Invalid or expired OAuth state. Please try again.", status_code=400)
+
+    token = await exchange_code(code)
+    if not token:
+        return HTMLResponse("Failed to obtain access token from GitHub.", status_code=400)
+
+    username = await fetch_username(token)
+    # Token is used once and immediately discarded — never stored or logged
+    if not username:
+        return HTMLResponse("Failed to verify GitHub identity.", status_code=400)
+
+    # Upgrade the pending session to an authenticated one
+    sid = request.cookies.get(_SESSION_COOKIE, "")
+    if sid in _sessions:
+        _sessions[sid]["data"] = {"github_user": username}
+        _sessions[sid]["exp"] = time.time() + _SESSION_TTL
+
+    response = RedirectResponse("/", status_code=302)
+    return response
+
+
+@app.get("/auth/logout")
+async def auth_logout(request: Request):
+    _session_destroy(request)
+    response = RedirectResponse("/auth/github" if NOVA_CHANNEL == "alpha" else "/", status_code=302)
+    response.delete_cookie(_SESSION_COOKIE)
+    return response
 
 
 class LoginRequest(BaseModel):


### PR DESCRIPTION
## Summary

- Adds a channel badge in the chat header (Stable / Beta / Alpha) driven by `NOVA_CHANNEL` env var
- Channel dropdown links to each deployment URL; Alpha option and branch name are hidden unless `NOVA_ADMIN_UI=true`
- Alpha channel is protected server-side by GitHub OAuth: every request is intercepted by middleware before the Nova UI or any API endpoint is served
- Only GitHub usernames listed in `NOVA_ALPHA_ALLOWED_USERS` are admitted; all others get a 403 page
- OAuth access token is used once to fetch the GitHub username, then immediately discarded — never stored or logged
- Stable and Beta instances are completely unaffected (middleware no-ops on the first line)

## Security checklist

- [x] Session cookie is `HttpOnly`
- [x] Session cookie is `SameSite=Lax`
- [x] Cookie `Secure` flag derived from `GITHUB_OAUTH_REDIRECT_URI` scheme (auto-enabled on HTTPS)
- [x] GitHub access token is never stored or logged
- [x] Alpha guard runs in middleware — enforced before static files, the web UI, and all API routes
- [x] CSRF state parameter verified on OAuth callback
- [x] Session IDs are 256-bit random (`secrets.token_urlsafe(32)`)
- [x] PR targets `dev/thezupzup-private`, not `main`

## In-memory session note

Sessions live in a process-level dict. They are cleared on server restart and are not shared across workers or containers. This is acceptable for a single-process Alpha instance. A persistent store (e.g. Redis) would be needed for multi-worker deployments — documented in `web.py` and in the test file.

## New env vars (Alpha instance only)

```env
NOVA_CHANNEL=alpha
NOVA_BRANCH=dev/Thezupzup-private
NOVA_ADMIN_UI=true
GITHUB_CLIENT_ID=<from GitHub OAuth App settings>
GITHUB_CLIENT_SECRET=<from GitHub OAuth App settings>
GITHUB_OAUTH_REDIRECT_URI=https://alpha.nova.borealnode.ca/auth/github/callback
NOVA_ALPHA_ALLOWED_USERS=TheZupZup
```

## Test plan

Automated (`pytest tests/test_alpha_auth.py`):
- [ ] `TestIsAllowed` — allowlist filtering, case-insensitivity, empty list
- [ ] `TestAlphaGuard` — unauthenticated browser → redirect, unauthenticated API → 401 JSON, non-allowed user → 403, allowed user → 200, `/auth/*` bypass, missing credentials → 503, expired session → redirect
- [ ] `TestPublicChannels` — Stable and Beta health endpoint is public, Stable root not gated
- [ ] `TestSessionCookieProperties` — HttpOnly present, SameSite=Lax present

Manual (live Alpha deployment):
- [ ] Visit `https://alpha.nova.borealnode.ca` without a session → redirected to GitHub
- [ ] Complete OAuth as a non-allowed account → 403 access-denied page
- [ ] Complete OAuth as TheZupZup → Nova login screen shown normally
- [ ] Visit `https://nova.borealnode.ca` (Stable) → loads with no GitHub gate

https://claude.ai/code/session_01DwCx1kxnqPCxLrA3yki84C

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwCx1kxnqPCxLrA3yki84C)_