### PR TITLE
Fix updater crash when model entries are missing fields

### DIFF
--- a/core/updater.py
+++ b/core/updater.py
@@ -18,7 +18,12 @@ def get_local_model_digest(model_name: str) -> str:
     try:
         models = client.list()
         for model in models.get("models", []):
-            if model["name"].startswith(model_name):
+            if not isinstance(model, dict):
+                continue
+            model_entry_name = model.get("name")
+            if not model_entry_name:
+                continue
+            if model_entry_name.startswith(model_name):
                 return model.get("digest", "")
     except (ConnectionError, OSError, ollama.ResponseError, httpx.HTTPError):
         pass


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError: 'name'` crash when `client.list()` yields malformed or incomplete model entries by hardening `get_local_model_digest`.

### Description
- In `core/updater.py` update `get_local_model_digest` to skip entries that are not dictionaries, fetch the model name with `model.get("name")`, and skip entries where `name` is missing or empty, while preserving the existing digest lookup for valid entries.
- No other files or external behavior were changed and no new dependencies were added.

### Testing
- Ran `python -m py_compile core/updater.py` which succeeded.
- Code inspection confirms there is no remaining direct `model["name"]` access, removing the previous `KeyError` crash path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12411b50c832d8d47201b51452e78)