### PR TITLE
feat: add Nova model override option to Settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,6 +26,8 @@ MODELS = {
     "advanced": "qwen2.5:32b",
 }
 
+NOVA_MODEL_DEFAULT_NAME = "nova-assistant"
+
 NOVA_SYSTEM_PROMPT = """Tu es Nova, un assistant personnel intelligent créé par TheZupZup.
 Tu fonctionnes localement via Ollama sur la machine de l'utilisateur.
 Tu n'es pas ChatGPT, pas Gemini, pas un modèle Google et pas OpenAI.
@@ -99,4 +101,6 @@ CHAT_HISTORY_LIMIT = 20
 
 ALLOWED_SETTINGS = {
     "ram_budget": {"type": int, "min": 256, "max": 16384},
+    "nova_model_enabled": {"type": str, "allowed": ["true", "false"]},
+    "nova_model_name": {"type": str, "max_len": 100},
 }

--- a/static/index.html
+++ b/static/index.html
@@ -1090,6 +1090,25 @@
                     </button>
                 </div>
             </div>
+            <div id="settings-section-title" style="margin-top:12px;">Nova Model</div>
+            <div class="memory-item" style="flex-direction:column;gap:10px;">
+                <div style="display:flex;align-items:center;justify-content:space-between;">
+                    <div style="display:flex;flex-direction:column;gap:3px;">
+                        <span style="font-size:0.85rem;">Use Nova model</span>
+                        <span style="font-size:0.72rem;color:var(--text-dim);">Override all routing with a single model</span>
+                    </div>
+                    <button id="nova-model-toggle-btn" onclick="toggleNovaModel()"
+                        style="font-family:monospace;font-size:0.75rem;padding:4px 12px;border-radius:6px;cursor:pointer;border:1px solid var(--border);background:var(--bg);color:var(--text-dim);min-width:52px;">
+                        OFF
+                    </button>
+                </div>
+                <div id="nova-model-name-div" style="display:none;flex-direction:column;gap:4px;">
+                    <input id="nova-model-name-input" type="text" placeholder="nova-assistant"
+                        style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:monospace;font-size:0.8rem;padding:6px 10px;outline:none;box-sizing:border-box;"
+                        onblur="saveNovaModelName()" onkeydown="if(event.key==='Enter')saveNovaModelName()" />
+                    <div style="font-size:0.7rem;color:var(--text-dim);">Ollama model name (e.g. nova-assistant, llama3:8b)</div>
+                </div>
+            </div>
             <div id="settings-section-title" style="margin-top:12px;">Memories</div>
             <div id="memories-list"></div>
             <div id="add-memory-form">
@@ -1638,9 +1657,14 @@
         }
         const lastUpdate = document.getElementById("last-update-text");
         if (lastUpdate && data.last_model_update) {
-            const date = data.last_model_update === "Never" ? "Never" : 
+            const date = data.last_model_update === "Never" ? "Never" :
                 new Date(data.last_model_update).toLocaleDateString();
             lastUpdate.textContent = `Last update: ${date}`;
+        }
+        applyNovaModelUI(!!data.nova_model_enabled);
+        const nameInput = document.getElementById("nova-model-name-input");
+        if (nameInput && data.nova_model_name) {
+            nameInput.value = data.nova_model_name;
         }
     }
 
@@ -1687,6 +1711,37 @@
                 "Authorization": `Bearer ${token}`
             },
             body: JSON.stringify({ ram_budget: value })
+        });
+    }
+
+    async function toggleNovaModel() {
+        const btn = document.getElementById("nova-model-toggle-btn");
+        const isOn = btn.textContent.trim() === "ON";
+        const newVal = !isOn;
+        await fetch("/settings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify({ nova_model_enabled: newVal })
+        });
+        applyNovaModelUI(newVal);
+    }
+
+    function applyNovaModelUI(enabled) {
+        const btn = document.getElementById("nova-model-toggle-btn");
+        const nameDiv = document.getElementById("nova-model-name-div");
+        btn.textContent = enabled ? "ON" : "OFF";
+        btn.style.color = enabled ? "var(--cyan)" : "var(--text-dim)";
+        btn.style.borderColor = enabled ? "var(--cyan)" : "var(--border)";
+        nameDiv.style.display = enabled ? "flex" : "none";
+    }
+
+    async function saveNovaModelName() {
+        const value = document.getElementById("nova-model-name-input").value.trim();
+        if (!value) return;
+        await fetch("/settings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify({ nova_model_name: value })
         });
     }
 

--- a/web.py
+++ b/web.py
@@ -26,7 +26,7 @@ from memory.store import (
     delete_memories_matching,
 )
 from config import (
-    MODELS, ALLOWED_SETTINGS,
+    MODELS, ALLOWED_SETTINGS, NOVA_MODEL_DEFAULT_NAME,
     NOVA_CHANNEL, NOVA_BRANCH, NOVA_ADMIN_UI,
     GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_REDIRECT_URI,
 )
@@ -240,6 +240,8 @@ class SettingsUpdateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
     ram_budget: int | None = None
+    nova_model_enabled: bool | None = None
+    nova_model_name: str | None = None
 
     @field_validator("ram_budget")
     @classmethod
@@ -248,6 +250,17 @@ class SettingsUpdateRequest(BaseModel):
             spec = ALLOWED_SETTINGS["ram_budget"]
             if not (spec["min"] <= v <= spec["max"]):
                 raise ValueError(f"must be between {spec['min']} and {spec['max']}")
+        return v
+
+    @field_validator("nova_model_name")
+    @classmethod
+    def validate_nova_model_name(cls, v):
+        if v is not None:
+            v = v.strip()
+            if not v:
+                raise ValueError("model name cannot be empty")
+            if len(v) > ALLOWED_SETTINGS["nova_model_name"]["max_len"]:
+                raise ValueError("model name too long (max 100 characters)")
         return v
 
 
@@ -333,7 +346,11 @@ def chat_endpoint(request: ChatRequest, _: bool = Depends(get_current_user)):
         for m in load_conversation_messages(conversation_id)
     ]
 
-    forced_model = MODE_MAP.get(request.mode)
+    nova_enabled = get_setting("nova_model_enabled", "false") == "true"
+    if nova_enabled:
+        forced_model = get_setting("nova_model_name", NOVA_MODEL_DEFAULT_NAME)
+    else:
+        forced_model = MODE_MAP.get(request.mode)
     print(f"IMAGE RECEIVED: {bool(request.image)} - Length: {len(request.image) if request.image else 0}")
     response, model_used = chat(history, request.message, memories, forced_model=forced_model, force_search=request.search, image=request.image)
 
@@ -380,7 +397,9 @@ def get_settings(_: bool = Depends(get_current_user)):
     return {
         "ram_budget": get_setting("ram_budget", "2048"),
         "last_model_update": get_setting("last_model_update", "Never"),
-        "last_updated_models": get_setting("last_updated_models", "")
+        "last_updated_models": get_setting("last_updated_models", ""),
+        "nova_model_enabled": get_setting("nova_model_enabled", "false") == "true",
+        "nova_model_name": get_setting("nova_model_name", NOVA_MODEL_DEFAULT_NAME),
     }
 
 
@@ -398,6 +417,10 @@ def trigger_model_update(_: bool = Depends(get_current_user)):
 def update_settings(data: SettingsUpdateRequest, _: bool = Depends(get_current_user)):
     if data.ram_budget is not None:
         save_setting("ram_budget", str(data.ram_budget))
+    if data.nova_model_enabled is not None:
+        save_setting("nova_model_enabled", "true" if data.nova_model_enabled else "false")
+    if data.nova_model_name is not None:
+        save_setting("nova_model_name", data.nova_model_name)
     return {"ok": True}
 
 


### PR DESCRIPTION
## Summary

- Adds a **"Use Nova model"** toggle in the Settings panel
- When enabled, all model routing (auto-router + Chat/Code/Deep mode selector) is bypassed and the configured model name is used for every request
- When disabled, existing routing behaviour is 100% unchanged
- Default model name: `nova-assistant` (configurable via text input in Settings)

## Files Changed

| File | What changed |
|---|---|
| `config.py` | Added `NOVA_MODEL_DEFAULT_NAME = "nova-assistant"` constant; extended `ALLOWED_SETTINGS` with `nova_model_enabled` and `nova_model_name` |
| `web.py` | `SettingsUpdateRequest` accepts `nova_model_enabled` (bool) and `nova_model_name` (str); `GET /settings` returns both values; `POST /settings` persists them; `chat_endpoint` checks the setting before mode routing |
| `static/index.html` | New "Nova Model" section in Settings panel with ON/OFF toggle button and model name input; `loadSystemSettings()` restores saved state on panel open; `toggleNovaModel()`, `applyNovaModelUI()`, `saveNovaModelName()` JS helpers added |

## Routing Behaviour

```
Every ChatRequest
  ↓
nova_model_enabled? (from SQLite settings)
  ├─ YES → forced_model = nova_model_name  (bypasses everything else)
  └─ NO  → MODE_MAP.get(request.mode)
              ├─ chat/code/deep → fixed model
              └─ auto           → route() classifier → MODEL_MAP[category]
```

## Edge Cases & Risks

- **Model not in Ollama**: if the configured name doesn't match any pulled model, Ollama returns an error — the existing error-handling in `core/chat.py` surfaces this cleanly to the user
- **Empty model name**: validated server-side (`nova_model_name` cannot be blank or exceed 100 chars); the input is also guarded client-side before posting
- **Toggle off while name is set**: the name is preserved in the DB so it is restored if the user re-enables later
- **Auto-router unchanged**: `core/router.py` is not modified; the override lives entirely in the `chat_endpoint`, keeping the router reusable
- **No training / no dataset**: this feature only routes to a model name string — it does not create, modify, or train any model

## Existing Behaviour Preserved

When `nova_model_enabled = false` (the default), the code path through `chat_endpoint` is byte-for-byte identical to the previous version.

https://claude.ai/code/session_01AVYHn2UFYxKMPJ8sbBdbn8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVYHn2UFYxKMPJ8sbBdbn8)_