### PR TITLE
fix: disable automatic web/RSS learning by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_OAUTH_REDIRECT_URI=https://your-alpha-domain/auth/github/callback
 NOVA_ALPHA_ALLOWED_USERS=githubusername1,githubusername2
+
+# ── Automatic web/RSS learning ─────────────────────────────────────────
+# Set to "true" to enable background RSS feed learning every hour.
+# Disabled by default to prevent low-value entries from polluting the memory DB.
+NOVA_AUTO_WEB_LEARNING=false

--- a/config.py
+++ b/config.py
@@ -9,6 +9,9 @@ _raw_channel = os.getenv("NOVA_CHANNEL", "stable").lower()
 NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else "stable"
 NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")
 NOVA_ADMIN_UI = os.getenv("NOVA_ADMIN_UI", "false").lower() == "true"
+# Automatic background RSS/web learning is off by default to avoid polluting the memory DB.
+# Set NOVA_AUTO_WEB_LEARNING=true in .env to re-enable it.
+NOVA_AUTO_WEB_LEARNING = os.getenv("NOVA_AUTO_WEB_LEARNING", "false").lower() == "true"
 
 GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "")
 GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET", "")

--- a/web.py
+++ b/web.py
@@ -30,6 +30,7 @@ from config import (
     MODELS, ALLOWED_SETTINGS, NOVA_MODEL_DEFAULT_NAME,
     NOVA_CHANNEL, NOVA_BRANCH,
     GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_OAUTH_REDIRECT_URI,
+    NOVA_AUTO_WEB_LEARNING,
 )
 from core.github_oauth import build_auth_url, exchange_code, fetch_username, is_allowed
 
@@ -115,7 +116,8 @@ MODE_MAP = {
 
 
 scheduler = BackgroundScheduler()
-scheduler.add_job(learn_from_feeds, "interval", hours=1)
+if NOVA_AUTO_WEB_LEARNING:
+    scheduler.add_job(learn_from_feeds, "interval", hours=1)
 scheduler.add_job(check_and_update_models, "interval", weeks=1)
 
 
@@ -123,7 +125,8 @@ scheduler.add_job(check_and_update_models, "interval", weeks=1)
 async def lifespan(app: FastAPI):
     initialize_db()
     scheduler.start()
-    learn_from_feeds()
+    if NOVA_AUTO_WEB_LEARNING:
+        learn_from_feeds()
     yield
     scheduler.shutdown()
 


### PR DESCRIPTION
- Adds `NOVA_AUTO_WEB_LEARNING` config flag, default `false`
- Prevents startup `learn_from_feeds()` from running unless enabled
- Prevents scheduled RSS/web learning unless enabled
- Keeps manual web search/tools unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcNbPY8M8bziTuDWKywhqG)_