### PR TITLE
feat(identity): add Nova identity contract injected before every mode…

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -4,6 +4,7 @@ import ollama
 from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
 from core.ollama_client import client
 from core.memory import format_memories_for_prompt, parse_and_save
+from core.identity import IDENTITY_CONTRACT
 from core.router import route
 from core.search import web_search, should_search
 from core.weather import detect_weather_city, get_weather
@@ -85,7 +86,7 @@ def build_messages(history: list[dict], user_input: str, memories: list[dict], e
         combined = "\n\n".join(filter(None, [memory_text, natural_text]))
         system_prompt = NOVA_SYSTEM_PROMPT.format(memories=combined)
 
-    messages = [{"role": "system", "content": system_prompt}]
+    messages = [{"role": "system", "content": IDENTITY_CONTRACT + "\n\n" + system_prompt}]
     messages += history[-CHAT_HISTORY_LIMIT:]
     messages.append({"role": "user", "content": user_input})
     return messages

--- a/core/identity.py
+++ b/core/identity.py
@@ -1,0 +1,6 @@
+IDENTITY_CONTRACT = """IDENTITÉ — règle absolue:
+Tu t'appelles Nova. "Nova" te désigne TOI, cet assistant IA local créé par TheZupZup.
+Quand un utilisateur dit "Nova", il parle de toi.
+Si on te demande "Nova c'est qui ?", réponds : "C'est moi. Je suis Nova, ton assistant IA local."
+Ne mentionne jamais le nom du modèle sous-jacent (ex: gemma4, gemma3, deepseek, qwen) sauf si l'utilisateur pose explicitement une question technique sur l'implémentation.
+N'utilise le sens astronomique ou tout autre sens externe de "Nova" que si l'utilisateur le demande explicitement."""

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,40 @@
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+# Stub heavy deps before importing core.chat
+for _mod in ("ddgs", "ollama"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.identity import IDENTITY_CONTRACT  # noqa: E402
+from core.chat import build_messages         # noqa: E402
+
+
+class TestIdentityContract:
+    def test_contract_is_non_empty(self):
+        assert IDENTITY_CONTRACT.strip()
+
+    def test_contract_names_nova(self):
+        assert "Nova" in IDENTITY_CONTRACT
+
+    def test_contract_hides_model_name(self):
+        # gemma4 should appear only as an example of what NOT to reveal
+        assert "gemma4" in IDENTITY_CONTRACT
+
+    def test_contract_covers_identity_question(self):
+        assert "Nova c'est qui" in IDENTITY_CONTRACT
+
+
+class TestBuildMessagesInjectsIdentity:
+    def test_normal_context_starts_with_contract(self):
+        messages = build_messages([], "bonjour", [], None, None, None)
+        assert messages[0]["content"].startswith(IDENTITY_CONTRACT)
+
+    def test_weather_context_contains_contract(self):
+        messages = build_messages([], "météo ?", [], "temp: 20°C", "weather", None)
+        assert IDENTITY_CONTRACT in messages[0]["content"]
+
+    def test_search_context_contains_contract(self):
+        messages = build_messages([], "qui est Einstein ?", [], "résultats…", "search", None)
+        assert IDENTITY_CONTRACT in messages[0]["content"]


### PR DESCRIPTION
…l call

Creates core/identity.py with an IDENTITY_CONTRACT that establishes Nova as the assistant's primary identity, hides underlying model names by default, and reserves external meanings of "Nova" for explicit user requests. Prepends the contract to all system prompts in build_messages (chat, weather, search paths). Adds 7 focused tests in tests/test_identity.py.

https://claude.ai/code/session_01QibiCYdW8zm4nL5XZBqvEy