### PR TITLE
fix: remove unused identity test imports

### DIFF
--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,6 +1,5 @@
 import sys
-from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # Stub heavy deps before importing core.chat
 for _mod in ("ddgs", "ollama"):


### PR DESCRIPTION
Fixes CI lint failure from the Nova identity contract tests.

Changes:
- Removes unused ModuleType import
- Removes unused patch import
- Keeps MagicMock import because it is used for dependency stubs

No behavior changes.