### PR TITLE
Refactor manual memory commands into dedicated module (#76)

### DIFF
--- a/core/memory_command.py
+++ b/core/memory_command.py
@@ -1,0 +1,27 @@
+from core.memory import save_memory
+
+_MANUAL_PREFIXES = (
+    "retiens ça:",
+    "souviens-toi de ça:",
+    "souviens-toi:",
+)
+
+
+def handle_manual_memory_command(message: str) -> str | None:
+    """
+    Detects explicit manual memory commands and saves their content.
+
+    Matches "Retiens ça:", "Souviens-toi de ça:", or "Souviens-toi:" (case-insensitive).
+    Saves everything after the first colon as-is under the "manual" category.
+    Returns a confirmation string if matched, None if the message is not a memory command.
+    """
+    stripped = message.lstrip()
+    lower = stripped.lower()
+    for prefix in _MANUAL_PREFIXES:
+        if lower.startswith(prefix):
+            content = stripped[len(prefix):].strip()
+            if not content:
+                return "Rien à sauvegarder : le contenu est vide."
+            save_memory("manual", content)
+            return f"Souvenir sauvegardé : {content}"
+    return None

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from rich.console import Console
 from rich.prompt import Prompt
 from core.chat import chat
-from core.memory import initialize_db, load_memories, save_memory
+from core.memory import initialize_db, load_memories
+from core.memory_command import handle_manual_memory_command
 from memory.store import list_memories as list_natural_memories, delete_memories_matching
 
 console = Console()
@@ -22,13 +23,11 @@ def run():
             console.print("[bold cyan]Nova hors ligne.[/bold cyan]")
             break
 
-        if user_input.lower().startswith("souviens-toi:"):
-            parts = user_input[13:].strip().split(":", 1)
-            if len(parts) == 2:
-                save_memory(parts[0].strip(), parts[1].strip())
-                memories = load_memories()
-                console.print("[dim]Souvenir sauvegardé.[/dim]\n")
-                continue
+        reply = handle_manual_memory_command(user_input)
+        if reply is not None:
+            memories = load_memories()
+            console.print(f"[dim]{reply}[/dim]\n")
+            continue
 
         low = user_input.lower().strip()
 

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch
+from core.memory_command import handle_manual_memory_command
+
+
+def test_retiens_ca_saves():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("Retiens ça: mon âge est 25")
+        mock_save.assert_called_once_with("manual", "mon âge est 25")
+        assert result is not None
+        assert "mon âge est 25" in result
+
+
+def test_souviens_toi_de_ca_saves():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("Souviens-toi de ça: je préfère le dark mode")
+        mock_save.assert_called_once_with("manual", "je préfère le dark mode")
+        assert result is not None
+        assert "je préfère le dark mode" in result
+
+
+def test_souviens_toi_legacy_saves():
+    """Legacy "souviens-toi:" still works; content is preserved as-is (no category split)."""
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("souviens-toi: préférence:vim")
+        mock_save.assert_called_once_with("manual", "préférence:vim")
+        assert result is not None
+
+
+def test_case_insensitive():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("RETIENS ÇA: test majuscules")
+        mock_save.assert_called_once_with("manual", "test majuscules")
+        assert result is not None
+
+
+def test_leading_whitespace_ignored():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("  Retiens ça: avec espace avant")
+        mock_save.assert_called_once_with("manual", "avec espace avant")
+        assert result is not None
+
+
+def test_empty_content_no_save():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("Retiens ça:")
+        mock_save.assert_not_called()
+        assert result is not None
+        assert "vide" in result
+
+
+def test_empty_content_with_spaces_no_save():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("Retiens ça:   ")
+        mock_save.assert_not_called()
+        assert result is not None
+
+
+def test_normal_message_returns_none():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("Comment tu vas ?")
+        mock_save.assert_not_called()
+        assert result is None
+
+
+def test_partial_prefix_returns_none():
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("souviens")
+        mock_save.assert_not_called()
+        assert result is None
+
+
+def test_confirmation_contains_full_content():
+    with patch("core.memory_command.save_memory"):
+        result = handle_manual_memory_command("Retiens ça: foo bar baz")
+        assert "foo bar baz" in result
+
+
+def test_content_with_colon_preserved():
+    """Colons inside the content must not be split further."""
+    with patch("core.memory_command.save_memory") as mock_save:
+        result = handle_manual_memory_command("Retiens ça: Python 3.12: plus rapide")
+        mock_save.assert_called_once_with("manual", "Python 3.12: plus rapide")
+        assert result is not None

--- a/web.py
+++ b/web.py
@@ -14,6 +14,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from core.learner import learn_from_feeds
 from core.updater import check_and_update_models
 from core.chat import chat
+from core.memory_command import handle_manual_memory_command
 from core.memory import (
     initialize_db, load_memories, save_memory,
     create_conversation, load_conversations,
@@ -307,11 +308,9 @@ def remove_conversation(conversation_id: int, _: bool = Depends(get_current_user
 def chat_endpoint(request: ChatRequest, _: bool = Depends(get_current_user)):
     memories = load_memories()
 
-    if request.message.lower().startswith("souviens-toi:"):
-        parts = request.message[13:].strip().split(":", 1)
-        if len(parts) == 2:
-            save_memory(parts[0].strip(), parts[1].strip())
-            return {"response": "Souvenir sauvegardé.", "model": "system", "conversation_id": request.conversation_id}
+    reply = handle_manual_memory_command(request.message)
+    if reply is not None:
+        return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
 
     msg_lower = request.message.lower().strip()
 
@@ -322,7 +321,6 @@ def chat_endpoint(request: ChatRequest, _: bool = Depends(get_current_user)):
         return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
 
     if msg_lower.startswith("forget everything about ") or msg_lower.startswith("oublie tout sur "):
-        parts = msg_lower.split(" ", 3)
         query = request.message.split(" ", 3)[-1].strip()
         count = delete_memories_matching(query)
         reply = f"Done. Removed {count} memory(ies) about '{query}'." if count else "No matching memories found."


### PR DESCRIPTION
* fix: handle "Retiens ça:" and "Souviens-toi de ça:" as manual memory commands

The chat flow only matched "souviens-toi:" and required a CATEGORY:CONTENT split, silently dropping messages that didn't contain a second colon and falling through to automatic LLM extraction (which could truncate content).

Introduces handle_manual_memory_command() in core/memory_command.py that matches all three trigger phrases case-insensitively, preserves the full content after the first colon, and saves it under the "manual" category. Returns None for non-commands so they reach normal chat unchanged.

https://claude.ai/code/session_01EPbv8rajAQQkbLoVaSaACT

* fix: remove unused variable `parts` (F841)

https://claude.ai/code/session_01EPbv8rajAQQkbLoVaSaACT

---------