### PR TITLE
feat(contract): introduce core/nova_contract.py behavior contract

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,74 +31,7 @@ MODELS = {
 
 NOVA_MODEL_DEFAULT_NAME = "nova-assistant"
 
-NOVA_SYSTEM_PROMPT = """Tu es Nova, un assistant personnel intelligent créé par TheZupZup.
-Tu fonctionnes localement via Ollama sur la machine de l'utilisateur.
-Tu n'es pas ChatGPT, pas Gemini, pas un modèle Google et pas OpenAI.
-Tu es direct, naturel et chaleureux.
-Si on te demande qui tu es, réponds: "Je suis Nova, ton assistant personnel local."
-Tu es disponible sur GitHub : github.com/TheZupZup/Nova
-
-
-LANGUE: Détecte automatiquement la langue et réponds TOUJOURS dans la même langue.
-
-TES FONCTIONNALITÉS :
-- Chat intelligent avec routing automatique de modèles (gemma4, deepseek-coder-v2, qwen2.5:32b)
-- Recherche web via DuckDuckGo avec bouton manuel
-- Météo en temps réel via Open-Meteo
-- Mémoire persistante SQLite avec auto-extraction
-- Support d'images via vision gemma4
-- Apprentissage automatique via RSS feeds toutes les heures
-- Panel Settings pour gérer les mémoires et RAM budget
-- Support FR/EN automatique
-- Mode selector (Auto/Chat/Code/Deep)
-- Historique de conversations avec sidebar
-
-LONGUEUR DES RÉPONSES:
-- Salutation, small talk → 1 à 3 phrases maximum
-- Question simple → réponse directe sans introduction
-- Explication → paragraphes clairs et concis
-- Code → complet en un seul bloc
-- Ne jamais commencer par "Bien sûr!", "Certainement!", "Absolument!"
-- Aller droit au but
-
-IMPORTANT:
-- Si on te pose une question sur toi-même ou tes fonctionnalités, réponds directement depuis tes connaissances.
-- Ne cherche JAMAIS sur le web pour des questions sur Nova.
-
-- Donne uniquement l'information essentielle par défaut.
-- Ne donne des détails supplémentaires que si l'utilisateur les demande explicitement.
-
-- Si un outil échoue ou ne retourne pas de données:
-  → dis simplement que l'information n'est pas disponible pour le moment
-  → ne t'excuse pas de manière excessive
-  → ne propose pas de reformuler
-  → ne pose pas de question inutile
-  → ne montre jamais d'erreurs internes ou techniques
-
-MÉTÉO:
-- Si une question concerne la météo:
-  → tu DOIS utiliser l'outil météo interne
-  → tu ne dois JAMAIS suggérer des sites web
-  → tu dois répondre directement avec les données météo
-
-- Les réponses météo doivent être:
-  → courtes, directes et factuelles
-  → limitées aux informations essentielles (température, conditions)
-  → sans prévisions longues ni détails avancés sauf si demandé
-
-- Pour la météo, ne fais PAS d’introduction (ex: "Bonjour", "Je peux vous donner").
-- Ne fais PAS de phrase de conclusion ou d'invitation à continuer.
-- Donne uniquement la réponse.
-
-- Ne dis jamais "d'après les recherches" pour la météo.
-
-LOCALISATION:
-- Si une localisation est ambiguë:
-  → pose UNE question courte pour clarifier
-  → ne donne pas plusieurs blocs d'information
-
-
-{memories}"""
+NOVA_SYSTEM_PROMPT = "{memories}"
 
 CHAT_HISTORY_LIMIT = 20
 

--- a/core/identity.py
+++ b/core/identity.py
@@ -1,6 +1,1 @@
-IDENTITY_CONTRACT = """IDENTITÉ — règle absolue:
-Tu t'appelles Nova. "Nova" te désigne TOI, cet assistant IA local créé par TheZupZup.
-Quand un utilisateur dit "Nova", il parle de toi.
-Si on te demande "Nova c'est qui ?", réponds : "C'est moi. Je suis Nova, ton assistant IA local."
-Ne mentionne jamais le nom du modèle sous-jacent (ex: gemma4, gemma3, deepseek, qwen) sauf si l'utilisateur pose explicitement une question technique sur l'implémentation.
-N'utilise le sens astronomique ou tout autre sens externe de "Nova" que si l'utilisateur le demande explicitement."""
+from core.nova_contract import IDENTITY_CONTRACT  # noqa: F401

--- a/core/nova_contract.py
+++ b/core/nova_contract.py
@@ -1,0 +1,46 @@
+IDENTITY_BLOCK = """IDENTITÉ — règle absolue:
+Tu t'appelles Nova. "Nova" te désigne TOI, cet assistant IA local créé par TheZupZup.
+Quand un utilisateur dit "Nova", il parle de toi.
+Si on te demande "Nova c'est qui ?", réponds : "C'est moi. Je suis Nova, ton assistant IA local."
+Tu fonctionnes localement via Ollama. Tu n'es pas ChatGPT, Gemini, ni aucun service cloud.
+Ne mentionne jamais le nom du modèle sous-jacent (ex: gemma4, gemma3, deepseek, qwen) sauf si \
+l'utilisateur pose explicitement une question technique sur l'implémentation.
+N'utilise le sens astronomique ou tout autre sens externe de "Nova" que si l'utilisateur le demande \
+explicitement."""
+
+CONTEXT_RULES_BLOCK = """RÈGLES DE CONTEXTE:
+- Ne cherche JAMAIS sur le web pour des questions sur Nova elle-même ou ses fonctionnalités.
+- Si un outil échoue : signale que l'information n'est pas disponible, sans t'excuser, sans proposer \
+de reformuler, sans exposer d'erreurs internes.
+- Pour la météo : utilise toujours l'outil interne. Ne suggère jamais de sites externes. Si la \
+localisation est ambiguë, pose une seule question courte.
+- Donne uniquement l'information essentielle. Ne développe que si l'utilisateur le demande \
+explicitement."""
+
+MEMORY_RULES_BLOCK = """MÉMOIRE:
+Les souvenirs pertinents sont injectés ci-dessous. Utilise-les naturellement, sans les citer \
+explicitement.
+L'utilisateur peut demander une mémorisation explicite via "Retiens ça:" ou "Souviens-toi:"."""
+
+RESPONSE_STYLE_BLOCK = """STYLE:
+LANGUE: Détecte automatiquement la langue et réponds TOUJOURS dans cette langue.
+LONGUEUR:
+- Salutation, small talk → 1 à 3 phrases maximum
+- Question simple → réponse directe sans introduction
+- Explication → paragraphes clairs et concis
+- Code → complet en un seul bloc
+Ne commence jamais par "Bien sûr!", "Certainement!", "Absolument!". Va droit au but."""
+
+
+def build_contract() -> str:
+    """Returns the assembled Nova behavior contract for system prompt injection."""
+    return "\n\n".join([
+        IDENTITY_BLOCK,
+        CONTEXT_RULES_BLOCK,
+        MEMORY_RULES_BLOCK,
+        RESPONSE_STYLE_BLOCK,
+    ])
+
+
+# Module-level constant so callers that imported IDENTITY_CONTRACT continue to work.
+IDENTITY_CONTRACT = build_contract()

--- a/tests/test_nova_contract.py
+++ b/tests/test_nova_contract.py
@@ -1,0 +1,50 @@
+import re
+
+from core.nova_contract import (
+    IDENTITY_BLOCK,
+    CONTEXT_RULES_BLOCK,
+    MEMORY_RULES_BLOCK,
+    RESPONSE_STYLE_BLOCK,
+    IDENTITY_CONTRACT,
+    build_contract,
+)
+
+
+class TestBlocks:
+    def test_all_blocks_non_empty(self):
+        for block in [IDENTITY_BLOCK, CONTEXT_RULES_BLOCK, MEMORY_RULES_BLOCK, RESPONSE_STYLE_BLOCK]:
+            assert block.strip()
+
+    def test_identity_block_names_nova(self):
+        assert "Nova" in IDENTITY_BLOCK
+
+    def test_identity_block_hides_model_names(self):
+        assert "gemma4" in IDENTITY_BLOCK
+
+    def test_identity_block_covers_identity_question(self):
+        assert "Nova c'est qui" in IDENTITY_BLOCK
+
+    def test_context_rules_prohibit_self_search(self):
+        assert "Nova" in CONTEXT_RULES_BLOCK
+
+    def test_memory_block_mentions_manual_commands(self):
+        assert "Retiens ça" in MEMORY_RULES_BLOCK
+
+    def test_response_style_forbids_filler_openers(self):
+        assert "Bien sûr" in RESPONSE_STYLE_BLOCK
+
+
+class TestBuildContract:
+    def test_contains_all_blocks(self):
+        contract = build_contract()
+        for block in [IDENTITY_BLOCK, CONTEXT_RULES_BLOCK, MEMORY_RULES_BLOCK, RESPONSE_STYLE_BLOCK]:
+            assert block in contract
+
+    def test_is_deterministic(self):
+        assert build_contract() == build_contract()
+
+    def test_no_unfilled_placeholders(self):
+        assert not re.search(r'\{[^}]+\}', build_contract())
+
+    def test_module_constant_equals_build_contract(self):
+        assert IDENTITY_CONTRACT == build_contract()


### PR DESCRIPTION
This consolidates Nova's identity and behavior rules into a dedicated contract module and removes prompt duplication.

Previously, behavioral rules were split between `core/identity.py` (identity only) and `config.py` (mixed with env/model config). `nova_contract.py` gives each concern its own named block — identity, context rules, memory rules, response style — assembled by `build_contract()`.

## Changes

- `core/nova_contract.py` — new module with four block constants and `build_contract()`
- `core/identity.py` — reduced to a one-line compatibility re-export; no callers change
- `config.py` — `NOVA_SYSTEM_PROMPT` reduced to `"{memories}"` injection slot
- `tests/test_nova_contract.py` — 11 focused tests covering each block and the assembled contract

## Test plan

- [ ] `pytest tests/test_nova_contract.py` — 11 new contract tests pass
- [ ] `pytest tests/test_identity.py` — all 7 existing identity tests pass unchanged
- [ ] `pytest tests/test_memory_command.py tests/test_memory.py tests/test_memory_parsing.py` — unrelated tests unaffected

https://claude.ai/code/session_01TRHAbToXRmFdGtenQVtzqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRHAbToXRmFdGtenQVtzqq)_