### PR TITLE
Fix timezone-aware datetime handling in token creation

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -2,7 +2,7 @@ import jwt
 import bcrypt
 import logging
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 import os
 
@@ -36,7 +36,7 @@ def verify_credentials(username: str, password: str) -> bool:
 
 
 def create_token() -> str:
-    payload = {"exp": datetime.utcnow() + timedelta(hours=TOKEN_EXPIRY_HOURS)}
+    payload = {"exp": datetime.now(timezone.utc) + timedelta(hours=TOKEN_EXPIRY_HOURS)}
     return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 
 


### PR DESCRIPTION
## Summary
Updated the token creation function to use timezone-aware datetime objects instead of naive UTC datetimes, improving compatibility with modern Python datetime best practices and JWT libraries.

## Key Changes
- Added `timezone` import from the `datetime` module
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc)` in the `create_token()` function

## Implementation Details
The change addresses a deprecation in Python's datetime module. `datetime.utcnow()` returns a naive datetime object (without timezone information), while `datetime.now(timezone.utc)` returns a timezone-aware datetime object. This is the recommended approach for handling UTC times and ensures better compatibility with JWT token expiration validation, which expects timezone-aware datetime objects.

https://claude.ai/code/session_01WzrCK7jJzP6erFnsV7S9vM