### PR TITLE
Add memory import preview functionality without database writes (#89)

### DIFF
--- a/core/memory_importer.py
+++ b/core/memory_importer.py
@@ -12,6 +12,64 @@ class MemoryImportCandidate:
     priority: str = field(default="normal")
 
 
+@dataclass
+class MemoryImportPreview:
+    candidates: List[MemoryImportCandidate]
+    total: int
+    categories: List[str]
+    warnings: List[str]
+
+
+def build_memory_import_preview(text: str) -> MemoryImportPreview:
+    """Return a preview of what would be imported without writing to the database."""
+    warnings: List[str] = []
+
+    if not text or not text.strip():
+        warnings.append("empty input")
+        return MemoryImportPreview(candidates=[], total=0, categories=[], warnings=warnings)
+
+    rejected = _count_short_entries(text)
+    candidates = parse_markdown_memory_pack(text)
+
+    if not candidates:
+        warnings.append("no valid memory candidates found")
+
+    if rejected:
+        warnings.append(f"{rejected} entr{'y' if rejected == 1 else 'ies'} rejected for being too short")
+
+    seen: dict[str, int] = {}
+    for c in candidates:
+        seen.setdefault(c.category, 0)
+        seen[c.category] += 1
+    categories = list(seen.keys())
+
+    return MemoryImportPreview(
+        candidates=candidates,
+        total=len(candidates),
+        categories=categories,
+        warnings=warnings,
+    )
+
+
+def _count_short_entries(text: str) -> int:
+    """Count bullet entries that exist but are rejected for being too short."""
+    count = 0
+    in_category = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("## "):
+            in_category = True
+            continue
+        if line.startswith("# "):
+            in_category = False
+            continue
+        if in_category and line.startswith("- "):
+            content = line[2:].strip()
+            if content and len(content) < MIN_CONTENT_LENGTH:
+                count += 1
+    return count
+
+
 def parse_markdown_memory_pack(text: str) -> List[MemoryImportCandidate]:
     """Parse a Markdown memory pack into structured memory candidates.
 

--- a/tests/test_memory_importer.py
+++ b/tests/test_memory_importer.py
@@ -1,4 +1,9 @@
-from core.memory_importer import MemoryImportCandidate, parse_markdown_memory_pack
+from core.memory_importer import (
+    MemoryImportCandidate,
+    MemoryImportPreview,
+    build_memory_import_preview,
+    parse_markdown_memory_pack,
+)
 
 
 SAMPLE_PACK = """
@@ -91,3 +96,75 @@ def test_top_level_heading_does_not_become_category():
     results = parse_markdown_memory_pack(text)
     assert all(r.category != "Top Level" for r in results)
     assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: build_memory_import_preview
+# ---------------------------------------------------------------------------
+
+def test_preview_returns_candidates_from_valid_markdown():
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    assert isinstance(preview, MemoryImportPreview)
+    assert len(preview.candidates) == 4
+    assert all(isinstance(c, MemoryImportCandidate) for c in preview.candidates)
+
+
+def test_preview_total_count():
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    assert preview.total == len(preview.candidates)
+    assert preview.total == 4
+
+
+def test_preview_lists_categories():
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    assert "Git workflow" in preview.categories
+    assert "Response style" in preview.categories
+    assert len(preview.categories) == 2
+
+
+def test_preview_empty_input_warning():
+    for empty in ("", "   ", "\n\n"):
+        preview = build_memory_import_preview(empty)
+        assert "empty input" in preview.warnings
+        assert preview.total == 0
+        assert preview.candidates == []
+        assert preview.categories == []
+
+
+def test_preview_no_valid_candidates_warning():
+    # Every bullet is too short → no valid candidates
+    text_no_valid = "## Info\n- ok\n- hi\n"
+    preview = build_memory_import_preview(text_no_valid)
+    assert "no valid memory candidates found" in preview.warnings
+    assert preview.total == 0
+
+
+def test_preview_short_entries_warning():
+    text = "## Info\n- ok\n- hi\n- This entry is long enough.\n"
+    preview = build_memory_import_preview(text)
+    short_warnings = [w for w in preview.warnings if "rejected for being too short" in w]
+    assert len(short_warnings) == 1
+    assert "2" in short_warnings[0]
+
+
+def test_preview_does_not_save_anything():
+    import core.memory_importer as mod
+    # The module must not expose a save_memory callable — confirming no DB writes are wired in.
+    assert not hasattr(mod, "save_memory")
+    # Calling preview must not raise and must return data without side effects.
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    assert preview.total > 0
+
+
+def test_preview_is_deterministic():
+    preview_a = build_memory_import_preview(SAMPLE_PACK)
+    preview_b = build_memory_import_preview(SAMPLE_PACK)
+    assert preview_a.total == preview_b.total
+    assert preview_a.categories == preview_b.categories
+    assert preview_a.warnings == preview_b.warnings
+    assert [c.content for c in preview_a.candidates] == [c.content for c in preview_b.candidates]
+
+
+def test_preview_no_warnings_on_clean_input():
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    assert preview.warnings == []


### PR DESCRIPTION
* Add MemoryImportPreview and build_memory_import_preview (Phase 2)

Introduces a preview layer for Markdown memory import candidates:
- MemoryImportPreview dataclass (candidates, total, categories, warnings)
- build_memory_import_preview() parses input and returns structured preview
- _count_short_entries() private helper for rejected-entry warnings
- Warnings for empty input, no valid candidates, and too-short entries
- 9 new tests covering all preview behaviours; all 21 tests pass

No database writes, no save_memory calls, no external dependencies.

https://claude.ai/code/session_01PwCUXVueRq8RSahQCev5Y9

* Fix F841: remove unused variable in test_preview_no_valid_candidates_warning

https://claude.ai/code/session_01PwCUXVueRq8RSahQCev5Y9

---------