### PR TITLE
Add ability to stop in-progress chat requests and toggle send/stop button

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1247,6 +1247,39 @@
     let currentMode = localStorage.getItem("nova_mode") || "auto";
     let searchEnabled = false;
     let currentImage = null;
+    let activeChatController = null;
+    let activeThinkingRow = null;
+
+    function setSendButtonToSend() {
+        const btn = document.getElementById("send-btn");
+        if (!btn) return;
+        btn.disabled = false;
+        btn.textContent = t("send");
+        btn.onclick = sendMessage;
+    }
+
+    function setSendButtonToStop() {
+        const btn = document.getElementById("send-btn");
+        if (!btn) return;
+        btn.disabled = false;
+        btn.textContent = "Stop";
+        btn.onclick = stopMessage;
+    }
+
+    function stopMessage() {
+        if (!isThinking) return;
+        if (activeChatController) {
+            activeChatController.abort();
+        }
+        if (activeThinkingRow && activeThinkingRow.isConnected) {
+            activeThinkingRow.remove();
+        }
+        activeThinkingRow = null;
+        isThinking = false;
+        activeChatController = null;
+        setSendButtonToSend();
+        document.getElementById("user-input")?.focus();
+    }
 
     function handleImageSelect(event) {
         const file = event.target.files[0];
@@ -1576,7 +1609,7 @@
 
         input.value = "";
         isThinking = true;
-        btn.disabled = true;
+        setSendButtonToStop();
 
         appendMessage("user", text || "", null, currentImage);
 
@@ -1589,6 +1622,8 @@
         `;
         messagesEl.appendChild(thinkingRow);
         messagesEl.scrollTop = messagesEl.scrollHeight;
+        activeThinkingRow = thinkingRow;
+        activeChatController = new AbortController();
 
         console.log("Sending image:", currentImage ? "YES (" + currentImage.substring(0,20) + "...)" : "NO");
         try {
@@ -1604,10 +1639,14 @@
                     mode: currentMode,
                     search: searchEnabled,
                     image: currentImage
-                })
+                }),
+                signal: activeChatController.signal
             });
 
-            thinkingRow.remove();
+            if (thinkingRow.isConnected) {
+                thinkingRow.remove();
+            }
+            activeThinkingRow = null;
 
             if (res.status === 401) { logout(); return; }
 
@@ -1616,11 +1655,17 @@
             appendMessage("nova", data.response, data.model);
             loadConversations();
         } catch (e) {
-            thinkingRow.remove();
-            appendMessage("nova", "Ollama is unreachable. Make sure Ollama is running, then try again.");
+            if (thinkingRow.isConnected) {
+                thinkingRow.remove();
+            }
+            activeThinkingRow = null;
+            if (e?.name !== "AbortError") {
+                appendMessage("nova", "Ollama is unreachable. Make sure Ollama is running, then try again.");
+            }
         } finally {
             isThinking = false;
-            btn.disabled = false;
+            activeChatController = null;
+            setSendButtonToSend();
             searchEnabled = false;
             document.getElementById("search-btn").classList.remove("active");
             removeImage();


### PR DESCRIPTION
### Motivation
- Allow users to abort long-running or stuck chat requests and remove leftover "thinking" UI elements.
- Improve UX by toggling the send button between `Send` and `Stop` while a request is in progress.
- Prevent appending misleading network error messages when a request is intentionally aborted.

### Description
- Introduce `activeChatController` and `activeThinkingRow` state variables to track the in-flight request and its placeholder row.
- Add `setSendButtonToSend`, `setSendButtonToStop`, and `stopMessage` functions and wire the send button to toggle between sending and stopping.
- Use an `AbortController` and pass its `signal` to the `fetch` call for `POST /chat`, and only show the unreachable error when the exception is not an `AbortError`.
- Safely remove the thinking row only when it is still connected (`isConnected`) and reset state and UI in the `finally` block.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4182b69b8832d8cc473a58c0f846d)