### PR TITLE
Improve mode descriptions and hide model IDs from user-facing labels

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1007,15 +1007,15 @@
                         </div>
                         <div class="mode-option" data-mode="chat" onclick="setMode('chat')">
                             Chat
-                            <span class="mode-desc">Forces gemma4</span>
+                            <span class="mode-desc">Everyday chat and questions</span>
                         </div>
                         <div class="mode-option" data-mode="code" onclick="setMode('code')">
                             Code
-                            <span class="mode-desc">Forces deepseek-coder-v2</span>
+                            <span class="mode-desc">Code, refactoring, debugging</span>
                         </div>
                         <div class="mode-option" data-mode="deep" onclick="setMode('deep')">
                             Deep
-                            <span class="mode-desc">Forces qwen2.5:32b</span>
+                            <span class="mode-desc">Long, careful reasoning</span>
                         </div>
                     </div>
                 </div>
@@ -1142,10 +1142,10 @@
             copy: "copier",
             copied: "copié!",
             mode: "Mode",
-            mode_auto_desc: "Router decides automatically",
-            mode_chat_desc: "Forces gemma4",
-            mode_code_desc: "Forces deepseek-coder-v2",
-            mode_deep_desc: "Forces qwen2.5:32b",
+            mode_auto_desc: "Choisit automatiquement le bon mode",
+            mode_chat_desc: "Conversation et questions du jour",
+            mode_code_desc: "Code, refactor et débogage",
+            mode_deep_desc: "Réflexion approfondie et longue",
         },
         en: {
             never_checked: "Never checked",
@@ -1170,10 +1170,10 @@
             copy: "copy",
             copied: "copied!",
             mode: "Mode",
-            mode_auto_desc: "Router decides automatically",
-            mode_chat_desc: "Forces gemma4",
-            mode_code_desc: "Forces deepseek-coder-v2",
-            mode_deep_desc: "Forces qwen2.5:32b",
+            mode_auto_desc: "Picks the right mode automatically",
+            mode_chat_desc: "Everyday chat and questions",
+            mode_code_desc: "Code, refactoring, debugging",
+            mode_deep_desc: "Long, careful reasoning",
         }
     };
 
@@ -1537,10 +1537,13 @@
         const messagesEl = document.getElementById("messages");
         const row = document.createElement("div");
         row.className = `message-row ${role}`;
+        // Raw model id is kept on the row for devtools-only inspection;
+        // it is intentionally not rendered in the user-facing label.
+        if (model) row.dataset.model = model;
 
         const label = document.createElement("div");
         label.className = "message-label";
-        label.textContent = role === "user" ? "Toi" : `Nova${model ? ` · ${model}` : ""}`;
+        label.textContent = role === "user" ? "Toi" : "Nova";
 
         const bubble = document.createElement("div");
         bubble.className = `message ${role}`;
@@ -1595,7 +1598,11 @@
         messagesEl.appendChild(row);
         messagesEl.scrollTop = messagesEl.scrollHeight;
 
-        if (model) document.getElementById("model-badge").textContent = model;
+        if (model) {
+            const badge = document.getElementById("model-badge");
+            badge.textContent = "Nova";
+            badge.dataset.model = model;
+        }
         return bubble;
     }
 


### PR DESCRIPTION
## Summary
This PR improves the user experience by making mode descriptions more user-friendly and hiding internal model identifiers from the chat interface while preserving them for developer inspection.

## Key Changes
- **Updated mode descriptions** to be more descriptive and user-centric:
  - Chat: "Everyday chat and questions" (was "Forces gemma4")
  - Code: "Code, refactoring, debugging" (was "Forces deepseek-coder-v2")
  - Deep: "Long, careful reasoning" (was "Forces qwen2.5:32b")
  - Auto: "Picks the right mode automatically" (was "Router decides automatically")

- **Localized French translations** for all mode descriptions with appropriate French phrasing

- **Refactored message labeling** to hide model IDs from user-facing labels:
  - Message labels now show only "Nova" instead of "Nova · model-name"
  - Raw model IDs are stored in `data-model` attributes for developer inspection via devtools
  - Model badge now displays "Nova" with the model ID stored in `dataset.model`

## Implementation Details
- Model identifiers are preserved in `data-model` attributes on both message rows and the model badge for debugging purposes
- The change maintains a clean user interface while keeping technical details accessible to developers
- All changes are backward compatible with existing functionality

https://claude.ai/code/session_01GF7i5GSDs2q5kCPmoyFrzh