### PR TITLE
Add multi-user support with users table and default admin migration

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -3,6 +3,7 @@ import shutil
 import os
 from datetime import datetime
 from memory.store import initialize_memory_database as _init_natural_memory
+from core import users as _users
 
 DB_PATH = "nova.db"
 
@@ -84,6 +85,7 @@ def initialize_db():
             )
         """)
     _init_natural_memory(DB_PATH)
+    _users.migrate(DB_PATH)
 
 
 def save_memory(category: str, content: str):

--- a/core/users.py
+++ b/core/users.py
@@ -1,0 +1,238 @@
+"""
+Users table and default-admin migration.
+
+This is the schema-and-seed foundation for multi-user support
+(see docs/multi-user-architecture.md, issue #103).
+
+Scope of this module is intentionally narrow:
+  * Create the `users` table if missing.
+  * Seed a single admin row from NOVA_USERNAME / NOVA_PASSWORD when the
+    table is empty.
+  * Mark schema_version=2 in the existing global `settings` table.
+
+Anything else from the architecture doc — JWT identity, per-user data
+scoping, family controls, model registry, admin endpoints, UI — is
+deferred to issues #104 and beyond. Login behavior is unchanged: this
+module only adds rows; it does not alter `core/auth.py`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sqlite3
+from datetime import datetime, timezone
+from typing import Optional
+
+import bcrypt
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 2
+SCHEMA_VERSION_KEY = "schema_version"
+ROLE_ADMIN = "admin"
+ROLE_USER = "user"
+
+
+_USERS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    username        TEXT    NOT NULL UNIQUE,
+    password_hash   TEXT    NOT NULL,
+    role            TEXT    NOT NULL CHECK (role IN ('admin', 'user')),
+    is_restricted   INTEGER NOT NULL DEFAULT 0,
+    token_version   INTEGER NOT NULL DEFAULT 1,
+    created_at      TEXT    NOT NULL,
+    disabled_at     TEXT
+)
+"""
+
+_USERS_USERNAME_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_users_username ON users(username)"
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def _ensure_settings_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS settings ("
+        "key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+    )
+
+
+def _read_schema_version(conn: sqlite3.Connection) -> int:
+    row = conn.execute(
+        "SELECT value FROM settings WHERE key = ?", (SCHEMA_VERSION_KEY,)
+    ).fetchone()
+    if row is None:
+        return 1
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return 1
+
+
+def _write_schema_version(conn: sqlite3.Connection, version: int) -> None:
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (SCHEMA_VERSION_KEY, str(version)),
+    )
+
+
+def create_users_table(conn: sqlite3.Connection) -> None:
+    """Create the users table and its index. Idempotent."""
+    conn.execute(_USERS_TABLE_SQL)
+    conn.execute(_USERS_USERNAME_INDEX_SQL)
+
+
+def count_users(conn: sqlite3.Connection) -> int:
+    return conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+
+
+def get_user_by_username(
+    conn: sqlite3.Connection, username: str
+) -> Optional[sqlite3.Row]:
+    prev_factory = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM users WHERE username = ?", (username,)
+        ).fetchone()
+    finally:
+        conn.row_factory = prev_factory
+
+
+def create_user(
+    conn: sqlite3.Connection,
+    username: str,
+    password: str,
+    role: str = ROLE_USER,
+    is_restricted: bool = False,
+) -> int:
+    if role not in (ROLE_ADMIN, ROLE_USER):
+        raise ValueError(f"invalid role: {role!r}")
+    if not username:
+        raise ValueError("username must be non-empty")
+    if not password:
+        raise ValueError("password must be non-empty")
+
+    cur = conn.execute(
+        "INSERT INTO users (username, password_hash, role, is_restricted, "
+        "token_version, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            username,
+            _hash_password(password),
+            role,
+            1 if is_restricted else 0,
+            1,
+            _now_iso(),
+        ),
+    )
+    return cur.lastrowid
+
+
+def seed_default_admin(
+    conn: sqlite3.Connection,
+    username: str,
+    password: str,
+) -> Optional[int]:
+    """
+    Insert the legacy admin row when the users table is empty.
+
+    Returns the new user id, or None if the table already had at least one
+    row (in which case this is a no-op — the seed has already run).
+    """
+    if count_users(conn) > 0:
+        return None
+    user_id = create_user(conn, username, password, role=ROLE_ADMIN)
+    logger.info("Seeded default admin user '%s' (id=%d)", username, user_id)
+    return user_id
+
+
+def _backup_db(db_path: str) -> Optional[str]:
+    """
+    Copy nova.db to nova.db.preupgrade-<UTC timestamp> before a schema bump.
+
+    Returns the backup path, or None if the source DB does not exist yet
+    (fresh install — nothing to back up). Raises OSError on failure so the
+    caller can refuse to proceed.
+    """
+    if not os.path.exists(db_path):
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = f"{db_path}.preupgrade-{stamp}"
+    shutil.copy2(db_path, backup_path)
+    return backup_path
+
+
+def migrate(
+    db_path: str,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+) -> None:
+    """
+    Run the users-table + default-admin migration.
+
+    Idempotent:
+      * If schema_version >= 2 and the admin row already exists, this is a
+        no-op (no backup, no writes).
+      * If the table exists but is empty, the admin is re-seeded.
+      * If schema_version is missing it is treated as 1.
+
+    Backup:
+      * A timestamped copy of the DB is taken before any schema change,
+        only when the DB file already exists. A failure to back up aborts
+        the migration before any write.
+
+    Login behavior is not affected — `core/auth.py` continues to read
+    NOVA_USERNAME / NOVA_PASSWORD from the environment.
+    """
+    if admin_username is None:
+        admin_username = os.getenv("NOVA_USERNAME", "nova")
+    if admin_password is None:
+        admin_password = os.getenv("NOVA_PASSWORD", "nova")
+
+    needs_backup = os.path.exists(db_path)
+    with sqlite3.connect(db_path) as probe:
+        _ensure_settings_table(probe)
+        current_version = _read_schema_version(probe)
+        users_table_exists = probe.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='users'"
+        ).fetchone() is not None
+        admin_row_exists = False
+        if users_table_exists:
+            admin_row_exists = probe.execute(
+                "SELECT 1 FROM users LIMIT 1"
+            ).fetchone() is not None
+
+    if (
+        current_version >= SCHEMA_VERSION
+        and users_table_exists
+        and admin_row_exists
+    ):
+        return
+
+    if needs_backup:
+        try:
+            backup_path = _backup_db(db_path)
+        except OSError as exc:
+            raise RuntimeError(
+                f"refusing to migrate: backup of {db_path} failed: {exc}"
+            ) from exc
+        if backup_path is not None:
+            logger.info("Pre-migration backup written to %s", backup_path)
+
+    with sqlite3.connect(db_path) as conn:
+        _ensure_settings_table(conn)
+        create_users_table(conn)
+        seed_default_admin(conn, admin_username, admin_password)
+        _write_schema_version(conn, SCHEMA_VERSION)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,150 @@
+"""Tests for the users-table + default-admin migration (issue #103)."""
+
+import glob
+import os
+import sqlite3
+
+import bcrypt
+import pytest
+
+from core import users
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "nova.db")
+
+
+def _table_exists(path: str, name: str) -> bool:
+    with sqlite3.connect(path) as conn:
+        return conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone() is not None
+
+
+def _schema_version(path: str) -> int:
+    with sqlite3.connect(path) as conn:
+        row = conn.execute(
+            "SELECT value FROM settings WHERE key = 'schema_version'"
+        ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def test_migrate_on_fresh_db_creates_table_and_seeds_admin(db_path):
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+
+    assert _table_exists(db_path, "users")
+    assert _schema_version(db_path) == users.SCHEMA_VERSION
+
+    with sqlite3.connect(db_path) as conn:
+        row = users.get_user_by_username(conn, "admin")
+    assert row is not None
+    assert row["role"] == "admin"
+    assert bcrypt.checkpw(b"pw", row["password_hash"].encode())
+
+
+def test_migrate_is_idempotent(db_path):
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+
+    with sqlite3.connect(db_path) as conn:
+        n = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+    assert n == 1
+
+
+def test_migrate_creates_pre_upgrade_backup_when_db_exists(tmp_path):
+    db_path = str(tmp_path / "nova.db")
+
+    # Pre-existing DB with some legacy content.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO settings(key, value) VALUES ('legacy_key', 'legacy_value')"
+        )
+
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+
+    backups = glob.glob(str(tmp_path / "nova.db.preupgrade-*"))
+    assert len(backups) == 1, f"expected one backup, found {backups!r}"
+
+    # Backup preserves the legacy row exactly as it was pre-migration.
+    with sqlite3.connect(backups[0]) as conn:
+        row = conn.execute(
+            "SELECT value FROM settings WHERE key='legacy_key'"
+        ).fetchone()
+    assert row is not None and row[0] == "legacy_value"
+
+
+def test_migrate_skips_backup_when_already_at_target_version(tmp_path):
+    db_path = str(tmp_path / "nova.db")
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+
+    # Remove any backup created on the first run.
+    for b in glob.glob(str(tmp_path / "nova.db.preupgrade-*")):
+        os.remove(b)
+
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+
+    backups = glob.glob(str(tmp_path / "nova.db.preupgrade-*"))
+    assert backups == []
+
+
+def test_migrate_does_not_overwrite_existing_admin_password(db_path):
+    users.migrate(db_path, admin_username="admin", admin_password="original")
+    # Re-run with a different password — should NOT overwrite.
+    users.migrate(db_path, admin_username="admin", admin_password="changed")
+
+    with sqlite3.connect(db_path) as conn:
+        row = users.get_user_by_username(conn, "admin")
+    assert bcrypt.checkpw(b"original", row["password_hash"].encode())
+    assert not bcrypt.checkpw(b"changed", row["password_hash"].encode())
+
+
+def test_migrate_preserves_existing_legacy_tables(tmp_path):
+    """The migration must not touch existing single-user data."""
+    db_path = str(tmp_path / "nova.db")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE memories ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "category TEXT NOT NULL, content TEXT NOT NULL, "
+            "created TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO memories(category, content, created) "
+            "VALUES (?, ?, ?)",
+            ("knowledge", "the sky is blue", "2024-01-01T00:00:00Z"),
+        )
+
+    users.migrate(db_path, admin_username="admin", admin_password="pw")
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT category, content FROM memories"
+        ).fetchall()
+    assert rows == [("knowledge", "the sky is blue")]
+
+
+def test_initialize_db_runs_migration(tmp_path, monkeypatch):
+    """core.memory.initialize_db should pick up the users migration."""
+    db_path = str(tmp_path / "nova.db")
+    monkeypatch.setenv("NOVA_USERNAME", "envadmin")
+    monkeypatch.setenv("NOVA_PASSWORD", "envpw")
+
+    from core import memory as core_memory
+    from memory import store as natural_store
+
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+
+    core_memory.initialize_db()
+
+    assert _table_exists(db_path, "users")
+    with sqlite3.connect(db_path) as conn:
+        row = users.get_user_by_username(conn, "envadmin")
+    assert row is not None
+    assert row["role"] == "admin"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,95 @@
+import sqlite3
+
+import bcrypt
+import pytest
+
+from core import users
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "nova.db")
+
+
+def _connect(path):
+    return sqlite3.connect(path)
+
+
+def test_create_users_table_is_idempotent(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        users.create_users_table(conn)  # second call must not raise
+
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(users)").fetchall()}
+    assert {
+        "id",
+        "username",
+        "password_hash",
+        "role",
+        "is_restricted",
+        "token_version",
+        "created_at",
+        "disabled_at",
+    } <= cols
+
+
+def test_create_user_hashes_password_and_returns_id(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        uid = users.create_user(conn, "alice", "s3cret", role=users.ROLE_USER)
+
+        row = users.get_user_by_username(conn, "alice")
+    assert uid > 0
+    assert row is not None
+    assert row["username"] == "alice"
+    assert row["role"] == "user"
+    assert row["is_restricted"] == 0
+    assert row["token_version"] == 1
+    # password_hash is a bcrypt hash, not the plaintext
+    assert row["password_hash"] != "s3cret"
+    assert bcrypt.checkpw(b"s3cret", row["password_hash"].encode())
+
+
+def test_create_user_rejects_invalid_role(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        with pytest.raises(ValueError):
+            users.create_user(conn, "x", "y", role="superuser")
+
+
+def test_create_user_rejects_empty_credentials(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        with pytest.raises(ValueError):
+            users.create_user(conn, "", "p")
+        with pytest.raises(ValueError):
+            users.create_user(conn, "u", "")
+
+
+def test_username_uniqueness_enforced(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        users.create_user(conn, "dup", "a")
+        with pytest.raises(sqlite3.IntegrityError):
+            users.create_user(conn, "dup", "b")
+
+
+def test_seed_default_admin_only_when_empty(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        first = users.seed_default_admin(conn, "admin", "pw")
+        second = users.seed_default_admin(conn, "admin", "pw")
+        third = users.seed_default_admin(conn, "other", "pw2")
+
+        rows = conn.execute("SELECT username, role FROM users").fetchall()
+
+    assert first is not None
+    assert second is None
+    assert third is None
+    assert rows == [("admin", "admin")]
+
+
+def test_get_user_by_username_returns_none_for_missing(db_path):
+    with _connect(db_path) as conn:
+        users.create_users_table(conn)
+        assert users.get_user_by_username(conn, "ghost") is None


### PR DESCRIPTION
## Summary
This PR implements the foundational schema and seeding for multi-user support as described in the architecture document (issue #103). It introduces a new `users` table with admin/user roles, password hashing via bcrypt, and an idempotent migration system that creates the table and seeds a default admin user from environment variables.

## Key Changes

- **New `core/users.py` module**: Provides the complete users table schema and migration logic
  - `users` table with columns for id, username, password_hash, role, is_restricted, token_version, created_at, and disabled_at
  - Role-based access control (admin/user roles with CHECK constraint)
  - Password hashing using bcrypt
  - Index on username for efficient lookups
  - Helper functions: `create_user()`, `seed_default_admin()`, `get_user_by_username()`, `count_users()`

- **Idempotent migration system** (`migrate()` function):
  - Creates users table and settings table if missing
  - Seeds a single default admin user from `NOVA_USERNAME`/`NOVA_PASSWORD` environment variables (defaults to "nova"/"nova")
  - Updates schema_version to 2 in the settings table
  - Creates timestamped database backups before any schema changes (only when DB already exists)
  - Skips all operations if already at target version with admin row present
  - Refuses to proceed if backup creation fails

- **Integration with `core/memory.py`**: 
  - Calls `users.migrate()` during `initialize_db()` to ensure users table exists on startup

- **Comprehensive test coverage**:
  - `tests/test_users.py`: Unit tests for user creation, password hashing, role validation, uniqueness constraints
  - `tests/test_migration.py`: Integration tests for migration idempotency, backup creation, schema versioning, and preservation of existing data

## Notable Implementation Details

- Password hashing is performed immediately on user creation; plaintext passwords are never stored
- The migration is fully idempotent: running it multiple times is safe and produces no side effects
- Pre-upgrade backups are only created when migrating an existing database, not on fresh installs
- The migration reads environment variables for admin credentials but does not modify `core/auth.py` — login behavior remains unchanged
- Schema version tracking uses the existing `settings` table to support future migrations
- Username uniqueness is enforced at the database level via UNIQUE constraint

https://claude.ai/code/session_0126pPjFtBrpkxivHpT4hZMt