### PR TITLE
feat: add capabilities block to Nova contract (#99)

### DIFF
--- a/core/nova_contract.py
+++ b/core/nova_contract.py
@@ -8,6 +8,26 @@ l'utilisateur pose explicitement une question technique sur l'implémentation.
 N'utilise le sens astronomique ou tout autre sens externe de "Nova" que si l'utilisateur le demande \
 explicitement."""
 
+CAPABILITIES_BLOCK = """CAPACITÉS — ce que Nova peut et ne peut pas faire:
+Cœur (toujours actif):
+- Conversation locale via Ollama, sur la machine de l'utilisateur
+- Mémoire persistante locale, avec commandes manuelles "Retiens ça:" et "Souviens-toi:"
+- Interface web locale accessible depuis le navigateur
+- Météo en temps réel via un outil interne
+- Recherche web manuelle, uniquement quand l'utilisateur la déclenche
+- Aide au code et aux flux de travail techniques courants
+
+En cours / expérimental (à signaler si l'utilisateur demande le détail):
+- Import de mémoire: socle en place, encore en cours de validation (expérimental)
+
+Ce que Nova ne fait pas:
+- Aucun appel à un LLM cloud, aucune synchronisation externe
+- Pas d'action automatique sur des comptes ou services tiers
+- Ne révèle pas les noms des modèles internes
+
+Quand l'utilisateur demande ce que tu sais faire, résume cette liste en quelques points clairs, \
+sans inventer de fonctionnalité."""
+
 CONTEXT_RULES_BLOCK = """RÈGLES DE CONTEXTE:
 - Ne cherche JAMAIS sur le web pour des questions sur Nova elle-même ou ses fonctionnalités.
 - Si un outil échoue : signale que l'information n'est pas disponible, sans t'excuser, sans proposer \
@@ -36,6 +56,7 @@ def build_contract() -> str:
     """Returns the assembled Nova behavior contract for system prompt injection."""
     return "\n\n".join([
         IDENTITY_BLOCK,
+        CAPABILITIES_BLOCK,
         CONTEXT_RULES_BLOCK,
         MEMORY_RULES_BLOCK,
         RESPONSE_STYLE_BLOCK,

--- a/tests/test_nova_contract.py
+++ b/tests/test_nova_contract.py
@@ -2,6 +2,7 @@ import re
 
 from core.nova_contract import (
     IDENTITY_BLOCK,
+    CAPABILITIES_BLOCK,
     CONTEXT_RULES_BLOCK,
     MEMORY_RULES_BLOCK,
     RESPONSE_STYLE_BLOCK,
@@ -12,7 +13,13 @@ from core.nova_contract import (
 
 class TestBlocks:
     def test_all_blocks_non_empty(self):
-        for block in [IDENTITY_BLOCK, CONTEXT_RULES_BLOCK, MEMORY_RULES_BLOCK, RESPONSE_STYLE_BLOCK]:
+        for block in [
+            IDENTITY_BLOCK,
+            CAPABILITIES_BLOCK,
+            CONTEXT_RULES_BLOCK,
+            MEMORY_RULES_BLOCK,
+            RESPONSE_STYLE_BLOCK,
+        ]:
             assert block.strip()
 
     def test_identity_block_names_nova(self):
@@ -34,11 +41,70 @@ class TestBlocks:
         assert "Bien sûr" in RESPONSE_STYLE_BLOCK
 
 
+class TestCapabilitiesBlock:
+    def test_has_capabilities_label(self):
+        assert "CAPACITÉS" in CAPABILITIES_BLOCK
+
+    def test_mentions_local_ollama_chat(self):
+        assert "Ollama" in CAPABILITIES_BLOCK
+
+    def test_mentions_persistent_memory(self):
+        assert "Mémoire persistante" in CAPABILITIES_BLOCK
+
+    def test_mentions_manual_memory_commands(self):
+        assert "Retiens ça" in CAPABILITIES_BLOCK
+        assert "Souviens-toi" in CAPABILITIES_BLOCK
+
+    def test_mentions_local_web_ui(self):
+        text = CAPABILITIES_BLOCK.lower()
+        assert "interface web" in text
+        assert "navigateur" in text
+
+    def test_mentions_weather_tool(self):
+        assert "Météo" in CAPABILITIES_BLOCK
+
+    def test_mentions_manual_web_search(self):
+        text = CAPABILITIES_BLOCK.lower()
+        assert "recherche web" in text
+        assert "manuelle" in text
+
+    def test_mentions_coding_help(self):
+        assert "code" in CAPABILITIES_BLOCK.lower()
+
+    def test_marks_memory_import_experimental(self):
+        text = CAPABILITIES_BLOCK.lower()
+        assert "import de mémoire" in text
+        assert "expérimental" in text
+
+    def test_lists_things_nova_does_not_do(self):
+        assert "Nova ne fait pas" in CAPABILITIES_BLOCK
+        assert "cloud" in CAPABILITIES_BLOCK.lower()
+
+    def test_does_not_expose_raw_model_names(self):
+        text = CAPABILITIES_BLOCK.lower()
+        for name in ("gemma4", "gemma3", "deepseek", "qwen"):
+            assert name not in text
+
+    def test_block_stays_short(self):
+        # Issue #99 targets ~25 lines of contract text for this block.
+        assert CAPABILITIES_BLOCK.count("\n") < 25
+
+
 class TestBuildContract:
     def test_contains_all_blocks(self):
         contract = build_contract()
-        for block in [IDENTITY_BLOCK, CONTEXT_RULES_BLOCK, MEMORY_RULES_BLOCK, RESPONSE_STYLE_BLOCK]:
+        for block in [
+            IDENTITY_BLOCK,
+            CAPABILITIES_BLOCK,
+            CONTEXT_RULES_BLOCK,
+            MEMORY_RULES_BLOCK,
+            RESPONSE_STYLE_BLOCK,
+        ]:
             assert block in contract
+
+    def test_capabilities_block_appears_after_identity(self):
+        contract = build_contract()
+        assert contract.index(IDENTITY_BLOCK) < contract.index(CAPABILITIES_BLOCK)
 
     def test_is_deterministic(self):
         assert build_contract() == build_contract()


### PR DESCRIPTION
## Summary

Closes #99.

Adds a concise `CAPABILITIES_BLOCK` to `core/nova_contract.py` and injects it right after the identity block in `build_contract()`. The block tells the model what Nova can and cannot do, so when a user asks "what can you do?" Nova answers from a fixed, accurate list rather than improvising.

The block is in French (consistent with the existing contract blocks), 18 lines long, and split into three sections:

- **Cœur (toujours actif)**: local Ollama chat, persistent local memory + manual commands (`Retiens ça:` / `Souviens-toi:`), local web UI, weather tool, manual web search, coding/workflow help.
- **En cours / expérimental**: memory import flagged as experimental / in validation.
- **Ce que Nova ne fait pas**: no cloud LLM calls, no automatic actions on third-party services, never exposes raw internal model names.

Closes with a directive: when asked about capabilities, summarize this list — do not invent features.

## Scope

- Touches only `core/nova_contract.py` and `tests/test_nova_contract.py`.
- No changes to memory logic, routing, `web.py`, `static/index.html`, or model config.
- No new runtime capability is introduced.

## Test plan

- [x] New `TestCapabilitiesBlock` class covers content (Ollama, memory, web UI, weather, manual search, coding, experimental import), absence of raw model names (`gemma4`, `gemma3`, `deepseek`, `qwen`), and length bound (< 25 lines).
- [x] `TestBuildContract` extended to assert the capabilities block is included and appears after the identity block.
- [x] Existing `tests/test_nova_contract.py` and `tests/test_identity.py` pass — 31/31.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug1AbzTirqTBgVeNpbfeWR)_