### PR TITLE
feat: users-table-backed auth + JWT identity (#104)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -1,10 +1,36 @@
-import jwt
-import bcrypt
+"""
+JWT authentication backed by the `users` table (issue #104).
+
+Identity flow:
+  * `authenticate(u, p)` looks up the user, verifies bcrypt, refuses
+    disabled accounts, and returns a `CurrentUser`.
+  * `create_token(user)` issues a JWT carrying user_id, username, role,
+    and the user's current `token_version`.
+  * `verify_token(t)` decodes + validates the signature/expiry and the
+    presence of required identity claims, returning the payload.
+  * `load_current_user(t)` re-loads the row referenced by the token and
+    rejects tokens whose `token_version` is stale or whose user has been
+    disabled — this is the dependency used by protected endpoints.
+
+Conversation- and memory-level scoping by user_id are out of scope for
+#104; they are addressed in #105 / #106.
+"""
+
+from __future__ import annotations
+
 import logging
-import secrets
-from datetime import datetime, timedelta, timezone
-from dotenv import load_dotenv
 import os
+import secrets
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import bcrypt
+import jwt
+from dotenv import load_dotenv
+
+from core import users as _users
 
 load_dotenv()
 
@@ -19,30 +45,121 @@ if _secret_key_env is None:
     SECRET_KEY = secrets.token_hex(32)
 else:
     SECRET_KEY = _secret_key_env
+
 TOKEN_EXPIRY_HOURS = 24
+JWT_ALGORITHM = "HS256"
+_REQUIRED_CLAIMS = ("sub", "username", "role", "tv")
 
 
-VALID_USERNAME = os.getenv("NOVA_USERNAME", "nova")
-HASHED_PASSWORD = bcrypt.hashpw(
-    os.getenv("NOVA_PASSWORD", "nova").encode(),
-    bcrypt.gensalt()
-)
+@dataclass(frozen=True)
+class CurrentUser:
+    """Identity object resolved from a valid JWT for a non-disabled user."""
+
+    id: int
+    username: str
+    role: str
+    token_version: int
+    is_restricted: bool
 
 
-def verify_credentials(username: str, password: str) -> bool:
-    if username != VALID_USERNAME:
-        return False
-    return bcrypt.checkpw(password.encode(), HASHED_PASSWORD)
+def _open_conn() -> sqlite3.Connection:
+    # Late import: core.memory wires up the entire data layer, and importing
+    # it at module level pulls in heavier deps than `auth` actually needs.
+    from core.memory import DB_PATH
+    return sqlite3.connect(DB_PATH)
 
 
-def create_token() -> str:
-    payload = {"exp": datetime.now(timezone.utc) + timedelta(hours=TOKEN_EXPIRY_HOURS)}
-    return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+def _user_from_row(row: sqlite3.Row) -> CurrentUser:
+    return CurrentUser(
+        id=int(row["id"]),
+        username=row["username"],
+        role=row["role"],
+        token_version=int(row["token_version"]),
+        is_restricted=bool(row["is_restricted"]),
+    )
 
 
-def verify_token(token: str) -> bool:
+def _check_password(plain: str, hashed: str) -> bool:
     try:
-        jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
-        return True
-    except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
+        return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    except (ValueError, TypeError):
         return False
+
+
+def authenticate(username: str, password: str) -> Optional[CurrentUser]:
+    """
+    Verify (username, password) against the users table.
+
+    Returns the user on success; None for unknown user, wrong password,
+    or a disabled account (`disabled_at IS NOT NULL`).
+    """
+    if not username or not password:
+        return None
+    try:
+        with _open_conn() as conn:
+            row = _users.get_user_by_username(conn, username)
+    except sqlite3.DatabaseError:
+        return None
+    if row is None or row["disabled_at"] is not None:
+        return None
+    if not _check_password(password, row["password_hash"]):
+        return None
+    return _user_from_row(row)
+
+
+def create_token(user: CurrentUser) -> str:
+    """Issue a JWT carrying the user's identity, role and token version."""
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": str(user.id),
+        "username": user.username,
+        "role": user.role,
+        "tv": user.token_version,
+        "iat": int(now.timestamp()),
+        "exp": now + timedelta(hours=TOKEN_EXPIRY_HOURS),
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+
+def verify_token(token: str) -> Optional[dict]:
+    """
+    Decode and validate a JWT signed by Nova.
+
+    Returns the payload on success, or None on expiry, signature failure,
+    malformed input, or a payload missing any required identity claim.
+    """
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM])
+    except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
+        return None
+    if not all(k in payload for k in _REQUIRED_CLAIMS):
+        return None
+    return payload
+
+
+def load_current_user(token: str) -> Optional[CurrentUser]:
+    """
+    Validate `token` and confirm the underlying user still exists, is not
+    disabled, and has the same `token_version` as the token claims.
+
+    A bumped `token_version` (e.g. after a password reset or revocation)
+    immediately invalidates every previously-issued token for that user.
+    """
+    payload = verify_token(token)
+    if payload is None:
+        return None
+    try:
+        with _open_conn() as conn:
+            row = _users.get_user_by_username(conn, payload["username"])
+    except sqlite3.DatabaseError:
+        return None
+    if row is None or row["disabled_at"] is not None:
+        return None
+    try:
+        if int(row["id"]) != int(payload["sub"]):
+            return None
+        if int(row["token_version"]) != int(payload["tv"]):
+            return None
+    except (TypeError, ValueError):
+        return None
+    return _user_from_row(row)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,306 @@
+"""
+Tests for core/auth.py — users-table-backed login + JWT identity (issue #104).
+
+Conversation/memory scoping by user_id is intentionally out of scope; those
+behaviours land in #105 / #106.
+"""
+
+import contextlib
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from core import auth, users
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """A fresh nova.db with the users table created. core.memory.DB_PATH is
+    redirected at it so core.auth picks it up automatically."""
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr("core.memory.DB_PATH", path)
+    with sqlite3.connect(path) as conn:
+        users.create_users_table(conn)
+    return path
+
+
+def _create(db_path, username="admin", password="pw", role=users.ROLE_ADMIN):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password, role=role)
+
+
+def _disable(db_path, username):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE users SET disabled_at = ? WHERE username = ?",
+            ("2026-01-01T00:00:00+00:00", username),
+        )
+
+
+# ── authenticate() ────────────────────────────────────────────────────────────
+
+class TestAuthenticate:
+    def test_success_returns_current_user(self, db_path):
+        uid = _create(db_path, "admin", "pw")
+        user = auth.authenticate("admin", "pw")
+        assert user is not None
+        assert user.id == uid
+        assert user.username == "admin"
+        assert user.role == "admin"
+        assert user.token_version == 1
+        assert user.is_restricted is False
+
+    def test_wrong_password_returns_none(self, db_path):
+        _create(db_path, "admin", "pw")
+        assert auth.authenticate("admin", "wrong") is None
+
+    def test_unknown_user_returns_none(self, db_path):
+        assert auth.authenticate("ghost", "x") is None
+
+    def test_disabled_user_cannot_authenticate(self, db_path):
+        _create(db_path, "admin", "pw")
+        _disable(db_path, "admin")
+        assert auth.authenticate("admin", "pw") is None
+
+    def test_empty_inputs_return_none(self, db_path):
+        assert auth.authenticate("", "x") is None
+        assert auth.authenticate("admin", "") is None
+
+    def test_role_user_authenticates_as_user(self, db_path):
+        _create(db_path, "alice", "pw", role=users.ROLE_USER)
+        user = auth.authenticate("alice", "pw")
+        assert user is not None
+        assert user.role == "user"
+
+
+# ── create_token() ────────────────────────────────────────────────────────────
+
+class TestCreateToken:
+    def test_token_includes_user_id_and_role(self, db_path):
+        uid = _create(db_path, "admin", "pw")
+        user = auth.authenticate("admin", "pw")
+        token = auth.create_token(user)
+        payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.JWT_ALGORITHM])
+        assert payload["sub"] == str(uid)
+        assert payload["username"] == "admin"
+        assert payload["role"] == "admin"
+        assert payload["tv"] == 1
+        assert "exp" in payload
+        assert "iat" in payload
+
+
+# ── verify_token() ────────────────────────────────────────────────────────────
+
+class TestVerifyToken:
+    def test_valid_token_returns_payload(self, db_path):
+        _create(db_path, "admin", "pw")
+        user = auth.authenticate("admin", "pw")
+        payload = auth.verify_token(auth.create_token(user))
+        assert payload is not None
+        assert payload["username"] == "admin"
+        assert payload["role"] == "admin"
+
+    def test_malformed_token_returns_none(self):
+        assert auth.verify_token("not.a.jwt") is None
+        assert auth.verify_token("") is None
+
+    def test_signature_mismatch_returns_none(self):
+        token = jwt.encode(
+            {
+                "sub": "1", "username": "x", "role": "user", "tv": 1,
+                "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            },
+            "different-secret",
+            algorithm="HS256",
+        )
+        assert auth.verify_token(token) is None
+
+    def test_expired_token_returns_none(self):
+        token = jwt.encode(
+            {
+                "sub": "1", "username": "x", "role": "user", "tv": 1,
+                "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+            },
+            auth.SECRET_KEY,
+            algorithm=auth.JWT_ALGORITHM,
+        )
+        assert auth.verify_token(token) is None
+
+    def test_payload_missing_required_claim_returns_none(self):
+        # Missing "username".
+        token = jwt.encode(
+            {
+                "sub": "1", "role": "user", "tv": 1,
+                "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            },
+            auth.SECRET_KEY,
+            algorithm=auth.JWT_ALGORITHM,
+        )
+        assert auth.verify_token(token) is None
+
+
+# ── load_current_user() ───────────────────────────────────────────────────────
+
+class TestLoadCurrentUser:
+    def test_valid_token_returns_user(self, db_path):
+        _create(db_path, "admin", "pw")
+        token = auth.create_token(auth.authenticate("admin", "pw"))
+        loaded = auth.load_current_user(token)
+        assert loaded is not None
+        assert loaded.username == "admin"
+        assert loaded.role == "admin"
+
+    def test_stale_token_version_is_rejected(self, db_path):
+        _create(db_path, "admin", "pw")
+        token = auth.create_token(auth.authenticate("admin", "pw"))
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE users SET token_version = token_version + 1 "
+                "WHERE username = 'admin'"
+            )
+        assert auth.load_current_user(token) is None
+
+    def test_disabled_user_cannot_use_existing_token(self, db_path):
+        _create(db_path, "admin", "pw")
+        token = auth.create_token(auth.authenticate("admin", "pw"))
+        _disable(db_path, "admin")
+        assert auth.load_current_user(token) is None
+
+    def test_invalid_token_returns_none(self, db_path):
+        assert auth.load_current_user("not.a.jwt") is None
+
+
+# ── /login + protected-endpoint integration ──────────────────────────────────
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    """A TestClient backed by the temp DB, with background jobs suppressed."""
+    monkeypatch.setattr("core.memory.DB_PATH", db_path)
+    # The login limiter is a module-level singleton keyed by client IP.
+    # TestClient always presents itself as "testclient", so successive
+    # tests share the same bucket; reset it before each test.
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+class TestLoginEndpoint:
+    def test_login_succeeds_for_default_admin(self, db_path, web_client):
+        _create(db_path, "nova", "nova")
+        resp = web_client.post(
+            "/login", json={"username": "nova", "password": "nova"}
+        )
+        assert resp.status_code == 200
+        token = resp.json()["token"]
+        assert token
+
+        payload = jwt.decode(
+            token, auth.SECRET_KEY, algorithms=[auth.JWT_ALGORITHM]
+        )
+        assert payload["username"] == "nova"
+        assert payload["role"] == "admin"
+        assert "sub" in payload
+        assert payload["tv"] == 1
+
+    def test_login_response_has_only_token_field(self, db_path, web_client):
+        """Login response shape stays {"token": ...} — no breaking additions."""
+        _create(db_path, "nova", "nova")
+        resp = web_client.post(
+            "/login", json={"username": "nova", "password": "nova"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"token"}
+
+    def test_login_rejects_invalid_password(self, db_path, web_client):
+        _create(db_path, "nova", "nova")
+        resp = web_client.post(
+            "/login", json={"username": "nova", "password": "wrong"}
+        )
+        assert resp.status_code == 401
+
+    def test_login_rejects_unknown_user(self, db_path, web_client):
+        resp = web_client.post(
+            "/login", json={"username": "ghost", "password": "x"}
+        )
+        assert resp.status_code == 401
+
+    def test_login_rejects_disabled_user(self, db_path, web_client):
+        _create(db_path, "nova", "nova")
+        _disable(db_path, "nova")
+        resp = web_client.post(
+            "/login", json={"username": "nova", "password": "nova"}
+        )
+        assert resp.status_code == 401
+
+
+class TestProtectedEndpoint:
+    def test_protected_endpoint_accepts_valid_token(self, db_path, web_client):
+        _create(db_path, "nova", "nova")
+        # /memories is protected by get_current_user — it must accept the
+        # bearer token issued by /login. The endpoint reads from the
+        # memories table, which doesn't exist on this temp DB, so we patch
+        # the data accessor.
+        login = web_client.post(
+            "/login", json={"username": "nova", "password": "nova"}
+        )
+        token = login.json()["token"]
+
+        with patch("web.list_memories", return_value=[]):
+            resp = web_client.get(
+                "/memories", headers={"Authorization": f"Bearer {token}"}
+            )
+        assert resp.status_code == 200
+
+    def test_protected_endpoint_rejects_invalid_token(self, db_path, web_client):
+        resp = web_client.get(
+            "/memories", headers={"Authorization": "Bearer not.a.jwt"}
+        )
+        assert resp.status_code == 401
+
+    def test_protected_endpoint_rejects_token_after_version_bump(
+        self, db_path, web_client
+    ):
+        _create(db_path, "nova", "nova")
+        login = web_client.post(
+            "/login", json={"username": "nova", "password": "nova"}
+        )
+        token = login.json()["token"]
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE users SET token_version = token_version + 1 "
+                "WHERE username = 'nova'"
+            )
+
+        resp = web_client.get(
+            "/memories", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 401
+
+    def test_get_current_user_returns_current_user_object(self, db_path):
+        """Direct unit check: the dependency must yield a CurrentUser."""
+        from fastapi.security import HTTPAuthorizationCredentials
+        import web as web_mod
+
+        _create(db_path, "nova", "nova")
+        token = auth.create_token(auth.authenticate("nova", "nova"))
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        result = web_mod.get_current_user(creds)
+        assert isinstance(result, auth.CurrentUser)
+        assert result.username == "nova"
+        assert result.role == "admin"

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -207,7 +207,8 @@ def _post_login(client, username="nova", password="nova", ip="1.2.3.4"):
 
 class TestLoginRateLimiting:
     def test_successful_login_within_limit(self, client):
-        with patch("web.verify_credentials", return_value=True), \
+        fake_user = MagicMock()
+        with patch("web.authenticate", return_value=fake_user), \
              patch("web.create_token", return_value="tok"), \
              patch("core.rate_limiter._login_limiter.is_allowed", return_value=(True, 0)):
             resp = _post_login(client, ip="10.0.0.1")
@@ -245,7 +246,7 @@ class TestLoginRateLimiting:
         # collapse onto the single key "testclient".
         with patch("core.rate_limiter._login_limiter.is_allowed", side_effect=side_effect), \
              patch("core.rate_limiter._TRUSTED_PROXIES", frozenset({"testclient"})), \
-             patch("web.verify_credentials", return_value=False):
+             patch("web.authenticate", return_value=None):
             # Exhaust IP A
             _post_login(client, ip="192.168.0.1")
             _post_login(client, ip="192.168.0.1")

--- a/web.py
+++ b/web.py
@@ -8,7 +8,12 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field, field_validator
 
-from core.auth import verify_credentials, create_token, verify_token
+from core.auth import (
+    CurrentUser,
+    authenticate,
+    create_token,
+    load_current_user,
+)
 from core.rate_limiter import check_login_rate_limit
 from apscheduler.schedulers.background import BackgroundScheduler
 from core.learner import learn_from_feeds
@@ -269,17 +274,21 @@ class SettingsUpdateRequest(BaseModel):
         return v
 
 
-def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    if not verify_token(credentials.credentials):
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> CurrentUser:
+    user = load_current_user(credentials.credentials)
+    if user is None:
         raise HTTPException(status_code=401, detail="Token invalide ou expiré.")
-    return True
+    return user
 
 
 @app.post("/login")
 def login(request: LoginRequest, _: None = Depends(check_login_rate_limit)):
-    if not verify_credentials(request.username, request.password):
+    user = authenticate(request.username, request.password)
+    if user is None:
         raise HTTPException(status_code=401, detail="Identifiants incorrects.")
-    return {"token": create_token()}
+    return {"token": create_token(user)}
 
 
 @app.get("/conversations")


### PR DESCRIPTION
Closes #104.

Adds users-table-backed authentication and identity-aware JWT sessions.

## Changes
- Adds `CurrentUser` identity object
- Authenticates login against the `users` table
- Rejects disabled users
- Adds `user_id`, `username`, `role`, `token_version`, issued-at, and expiration claims to JWTs
- Revalidates `token_version` and disabled status against the live `users` table on every protected request
- Updates the protected dependency to return `CurrentUser`
- Updates rate-limiter tests for the new auth entrypoint
- Adds focused auth/session tests

This does not enable multi-user data isolation yet.

## Not included
- No conversation scoping (#105)
- No memory scoping (#106)
- No user settings split (#107)
- No family controls (#108)
- No admin user-management UI (#109)
- No model registry or model permissions (#110–#112)
- No frontend changes

## Test plan
- [x] `pytest tests/` — 288 passed
- [x] `tests/test_auth.py` — 25 new tests (authenticate, create_token, verify_token, load_current_user, /login + protected-endpoint integration, token-version revocation)
- [x] `tests/test_rate_limiter.py` — rate-limit behaviour unchanged
- [x] `tests/test_alpha_auth.py` — alpha-channel guard unaffected
- [x] `tests/test_users.py` / `tests/test_migration.py` — schema/seed from #103 unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01TCeW3iTpUJYRrT2Mz7Qwgb)_