### PR TITLE
feat: scope memories by user (#106)

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -47,18 +47,18 @@ Données météo:
 {weather_data}"""
 
 
-def _extract_and_save_natural_memories(user_message: str):
-    """Runs the rule-based extractor on the user message and persists allowed memories."""
+def _extract_and_save_natural_memories(user_message: str, user_id: int):
+    """Runs the rule-based extractor on the user message and persists allowed memories under `user_id`."""
     try:
         for mem in extract_memories(user_message):
             if is_memory_allowed(mem):
-                save_natural_memory(mem)
+                save_natural_memory(mem, user_id)
     except Exception:
         pass  # never let memory extraction break the chat flow
 
 
-def extract_and_save_memory(user_message: str, assistant_response: str):
-    """Extrait automatiquement les infos importantes et les sauvegarde."""
+def extract_and_save_memory(user_message: str, assistant_response: str, user_id: int):
+    """Extrait automatiquement les infos importantes et les sauvegarde sous `user_id`."""
     prompt = MEMORY_EXTRACTION_PROMPT.format(
         user_message=user_message,
         assistant_response=assistant_response
@@ -71,7 +71,7 @@ def extract_and_save_memory(user_message: str, assistant_response: str):
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError):
         return
     result = response["message"]["content"].strip()
-    parse_and_save(result)
+    parse_and_save(result, user_id)
 
 
 def build_messages(history: list[dict], user_input: str, memories: list[dict], extra_context: str = None, context_type: str = None, natural_memories=None) -> list[dict]:
@@ -101,8 +101,14 @@ def build_image_messages(user_input: str, image: str) -> list[dict]:
     }]
 
 
-def chat(history: list[dict], user_input: str, memories: list[dict], forced_model: str = None, force_search: bool = False, image: str = None) -> tuple[str, str]:
-    """Envoie un message à Nova et retourne sa réponse et le modèle utilisé."""
+def chat(history: list[dict], user_input: str, memories: list[dict], user_id: int, forced_model: str = None, force_search: bool = False, image: str = None) -> tuple[str, str]:
+    """
+    Envoie un message à Nova et retourne sa réponse et le modèle utilisé.
+
+    Toutes les opérations mémoire (récupération, extraction, sauvegarde)
+    sont scopées à `user_id` — un utilisateur ne voit jamais les souvenirs
+    d'un autre.
+    """
     try:
         # Image → vision model, no routing
         if image:
@@ -110,12 +116,12 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
             messages = build_image_messages(user_input, image)
             response = client.chat(model=MODELS["default"], messages=messages)
             reply = response["message"]["content"]
-            extract_and_save_memory(user_input or "image", reply)
+            extract_and_save_memory(user_input or "image", reply, user_id)
             return reply, MODELS["default"]
 
         model = forced_model if forced_model else route(user_input)
 
-        natural_mems = get_relevant_memories(user_input)
+        natural_mems = get_relevant_memories(user_input, user_id)
 
         # Météo en temps réel
         weather_result = detect_weather_city(user_input)
@@ -162,8 +168,8 @@ def chat(history: list[dict], user_input: str, memories: list[dict], forced_mode
                 response = client.chat(model=model, messages=messages)
                 reply = response["message"]["content"]
 
-        extract_and_save_memory(user_input, reply)
-        _extract_and_save_natural_memories(user_input)
+        extract_and_save_memory(user_input, reply, user_id)
+        _extract_and_save_natural_memories(user_input, user_id)
         return reply, model
 
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:

--- a/core/learner.py
+++ b/core/learner.py
@@ -4,8 +4,9 @@ import httpx
 import ollama
 import sqlite3
 from config import MODELS
-from core.memory import cleanup_old_knowledge, parse_and_save
+from core.memory import DB_PATH, cleanup_old_knowledge, parse_and_save
 from core.ollama_client import client
+from core.users import get_legacy_admin_id
 
 SOURCES = [
     # Tech & IA
@@ -42,7 +43,19 @@ logger = logging.getLogger(__name__)
 
 
 def learn_from_feeds():
-    """Scanne les flux RSS et sauvegarde les infos importantes."""
+    """
+    Scanne les flux RSS et sauvegarde les infos importantes.
+
+    Les souvenirs "knowledge" appris automatiquement sont attribués au
+    default admin migré (issue #106) : la tâche tourne en arrière-plan
+    sans utilisateur authentifié, et l'admin est l'héritier naturel
+    des données pré-multi-utilisateur.
+    """
+    user_id = get_legacy_admin_id(DB_PATH)
+    if user_id is None:
+        logger.warning("Skipping web learning: no admin user available.")
+        return
+
     logger.info("Nova learning from web...")
     for url in SOURCES:
         try:
@@ -56,9 +69,9 @@ def learn_from_feeds():
                     messages=[{"role": "user", "content": prompt}]
                 )
                 result = response["message"]["content"].strip()
-                parse_and_save(result)
+                parse_and_save(result, user_id)
         except (ollama.ResponseError, ConnectionError, httpx.HTTPError,
                 KeyError, sqlite3.OperationalError, sqlite3.DatabaseError) as e:
             logger.warning("Error learning from %s: %s", url, e)
-    cleanup_old_knowledge(MAX_KNOWLEDGE_MEMORIES)
+    cleanup_old_knowledge(user_id, MAX_KNOWLEDGE_MEMORIES)
     logger.info("Nova learning done.")

--- a/core/memory.py
+++ b/core/memory.py
@@ -86,25 +86,28 @@ def initialize_db():
                 FOREIGN KEY (conversation_id) REFERENCES conversations(id)
             )
         """)
-    _init_natural_memory(DB_PATH)
     _users.migrate(DB_PATH)
     _migrate_conversation_ownership(DB_PATH)
+    _migrate_memories_ownership(DB_PATH)
+    _init_natural_memory(DB_PATH)
 
 
-def save_memory(category: str, content: str):
-    """Sauvegarde un nouveau souvenir dans la base."""
+def save_memory(category: str, content: str, user_id: int):
+    """Sauvegarde un nouveau souvenir attribué à `user_id`."""
     backup_db()
     with _get_connection() as conn:
         conn.execute(
-            "INSERT INTO memories (category, content, created) VALUES (?, ?, ?)",
-            (category, content, datetime.now().isoformat())
+            "INSERT INTO memories (category, content, created, user_id) "
+            "VALUES (?, ?, ?, ?)",
+            (category, content, datetime.now().isoformat(), user_id)
         )
 
 
-def parse_and_save(result: str) -> bool:
+def parse_and_save(result: str, user_id: int) -> bool:
     """
     Parse un résultat de l'LLM et sauvegarde la mémoire si le format est valide.
     Retourne True si une mémoire a été sauvegardée, False sinon.
+    Le souvenir est attribué à `user_id`.
     """
     if not result or not isinstance(result, str):
         return False
@@ -123,15 +126,17 @@ def parse_and_save(result: str) -> bool:
     if not category or not content:
         return False
 
-    save_memory(category, content)
+    save_memory(category, content, user_id)
     return True
 
 
-def load_memories() -> list[dict]:
-    """Charge tous les souvenirs existants."""
+def load_memories(user_id: int) -> list[dict]:
+    """Charge les souvenirs appartenant à `user_id`."""
     with _get_connection() as conn:
         rows = conn.execute(
-            "SELECT category, content FROM memories ORDER BY created ASC"
+            "SELECT category, content FROM memories "
+            "WHERE user_id = ? ORDER BY created ASC",
+            (user_id,)
         ).fetchall()
     return [{"category": row["category"], "content": row["content"]} for row in rows]
 
@@ -144,6 +149,54 @@ def format_memories_for_prompt(memories: list[dict]) -> str:
     for m in memories:
         lines.append(f"- [{m['category']}] {m['content']}")
     return "\n".join(lines)
+
+
+def _migrate_memories_ownership(db_path: str) -> None:
+    """
+    Add a user_id column to the memories table and backfill existing rows
+    to the legacy admin (issue #106).
+
+    Idempotent: returns immediately if the column is already present (after
+    ensuring the index exists).
+
+    The column is nullable for the migration itself, mirroring the
+    conversations migration; all application paths set user_id explicitly
+    via save_memory().
+    """
+    with sqlite3.connect(db_path) as conn:
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(memories)").fetchall()
+        }
+        if "user_id" in cols:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memories_user_id "
+                "ON memories(user_id)"
+            )
+            return
+
+        row = conn.execute(
+            "SELECT id FROM users ORDER BY id ASC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(
+                "cannot scope memories: users table is empty; "
+                "users.migrate() must run first"
+            )
+        legacy_owner_id = row[0]
+
+        conn.execute(
+            "ALTER TABLE memories "
+            "ADD COLUMN user_id INTEGER REFERENCES users(id)"
+        )
+        conn.execute(
+            "UPDATE memories SET user_id = ? WHERE user_id IS NULL",
+            (legacy_owner_id,),
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memories_user_id "
+            "ON memories(user_id)"
+        )
 
 
 def _migrate_conversation_ownership(db_path: str) -> None:
@@ -294,43 +347,57 @@ def delete_conversation(conversation_id: int, user_id: int) -> bool:
     return True
 
 
-def list_memories() -> list[dict]:
-    """Charge tous les souvenirs avec id et created — pour l'interface web (pas pour les prompts)."""
+def list_memories(user_id: int) -> list[dict]:
+    """Liste les souvenirs de `user_id` avec id et created — pour l'interface web."""
     with _get_connection() as conn:
         rows = conn.execute(
-            "SELECT id, category, content, created FROM memories ORDER BY created DESC"
+            "SELECT id, category, content, created FROM memories "
+            "WHERE user_id = ? ORDER BY created DESC",
+            (user_id,)
         ).fetchall()
     return [{"id": r["id"], "category": r["category"], "content": r["content"], "created": r["created"]} for r in rows]
 
 
-def update_memory(memory_id: int, category: str, content: str):
-    """Met à jour la catégorie et le contenu d'un souvenir."""
+def update_memory(memory_id: int, category: str, content: str, user_id: int) -> bool:
+    """
+    Met à jour un souvenir s'il appartient à `user_id`.
+    Retourne True si une ligne a été modifiée, False sinon.
+    """
     backup_db()
     with _get_connection() as conn:
-        conn.execute(
-            "UPDATE memories SET category = ?, content = ? WHERE id = ?",
-            (category, content, memory_id)
+        cursor = conn.execute(
+            "UPDATE memories SET category = ?, content = ? "
+            "WHERE id = ? AND user_id = ?",
+            (category, content, memory_id, user_id)
         )
+    return cursor.rowcount > 0
 
 
-def delete_memory(memory_id: int):
-    """Supprime un souvenir par son id."""
+def delete_memory(memory_id: int, user_id: int) -> bool:
+    """
+    Supprime un souvenir s'il appartient à `user_id`.
+    Retourne True si une ligne a été supprimée, False sinon.
+    """
     backup_db()
     with _get_connection() as conn:
-        conn.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
+        cursor = conn.execute(
+            "DELETE FROM memories WHERE id = ? AND user_id = ?",
+            (memory_id, user_id)
+        )
+    return cursor.rowcount > 0
 
 
-def cleanup_old_knowledge(max_count: int = 500):
-    """Garde seulement les max_count dernières mémoires de type knowledge."""
+def cleanup_old_knowledge(user_id: int, max_count: int = 500):
+    """Garde seulement les max_count dernières mémoires de type knowledge pour `user_id`."""
     backup_db()
     with _get_connection() as conn:
         conn.execute("""
             DELETE FROM memories
-            WHERE category = 'knowledge'
+            WHERE category = 'knowledge' AND user_id = ?
             AND id NOT IN (
                 SELECT id FROM memories
-                WHERE category = 'knowledge'
+                WHERE category = 'knowledge' AND user_id = ?
                 ORDER BY created DESC
                 LIMIT ?
             )
-        """, (max_count,))
+        """, (user_id, user_id, max_count))

--- a/core/memory_command.py
+++ b/core/memory_command.py
@@ -7,12 +7,13 @@ _MANUAL_PREFIXES = (
 )
 
 
-def handle_manual_memory_command(message: str) -> str | None:
+def handle_manual_memory_command(message: str, user_id: int) -> str | None:
     """
-    Detects explicit manual memory commands and saves their content.
+    Detects explicit manual memory commands and saves their content for `user_id`.
 
     Matches "Retiens ça:", "Souviens-toi de ça:", or "Souviens-toi:" (case-insensitive).
-    Saves everything after the first colon as-is under the "manual" category.
+    Saves everything after the first colon as-is under the "manual" category,
+    attributed to `user_id`.
     Returns a confirmation string if matched, None if the message is not a memory command.
     """
     stripped = message.lstrip()
@@ -22,6 +23,6 @@ def handle_manual_memory_command(message: str) -> str | None:
             content = stripped[len(prefix):].strip()
             if not content:
                 return "Rien à sauvegarder : le contenu est vide."
-            save_memory("manual", content)
+            save_memory("manual", content, user_id)
             return f"Souvenir sauvegardé : {content}"
     return None

--- a/core/users.py
+++ b/core/users.py
@@ -140,6 +140,26 @@ def create_user(
     return cur.lastrowid
 
 
+def get_legacy_admin_id(db_path: str) -> Optional[int]:
+    """
+    Return the user_id of the first user in the table — the seeded admin.
+
+    Used by code paths that have no authenticated user (CLI in main.py,
+    background learner) to attribute writes to the migrated default admin,
+    preserving single-user behaviour after the multi-user migration.
+
+    Returns None if the users table is empty or missing.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT id FROM users ORDER BY id ASC LIMIT 1"
+            ).fetchone()
+    except sqlite3.DatabaseError:
+        return None
+    return int(row[0]) if row else None
+
+
 def seed_default_admin(
     conn: sqlite3.Connection,
     username: str,

--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
 from rich.console import Console
 from rich.prompt import Prompt
 from core.chat import chat
-from core.memory import initialize_db, load_memories
+from core.memory import DB_PATH, initialize_db, load_memories
 from core.memory_command import handle_manual_memory_command
+from core.users import get_legacy_admin_id
 from memory.store import list_memories as list_natural_memories, delete_memories_matching
 
 console = Console()
@@ -11,7 +12,14 @@ history = []
 
 def run():
     initialize_db()
-    memories = load_memories()
+    # The CLI has no auth context — attribute everything to the migrated
+    # default admin so single-user behaviour is preserved (issue #106).
+    user_id = get_legacy_admin_id(DB_PATH)
+    if user_id is None:
+        console.print("[bold red]No admin user available — cannot start CLI.[/bold red]")
+        return
+
+    memories = load_memories(user_id)
 
     console.print("[bold cyan]Nova en ligne.[/bold cyan] (tape 'exit' pour quitter)\n")
     console.print(f"[dim]{len(memories)} souvenir(s) chargé(s)[/dim]\n")
@@ -23,9 +31,9 @@ def run():
             console.print("[bold cyan]Nova hors ligne.[/bold cyan]")
             break
 
-        reply = handle_manual_memory_command(user_input)
+        reply = handle_manual_memory_command(user_input, user_id)
         if reply is not None:
-            memories = load_memories()
+            memories = load_memories(user_id)
             console.print(f"[dim]{reply}[/dim]\n")
             continue
 
@@ -33,13 +41,13 @@ def run():
 
         if low.startswith("forget that ") or low.startswith("oublie que "):
             query = user_input.split(" ", 2)[2].strip()
-            count = delete_memories_matching(query)
+            count = delete_memories_matching(query, user_id)
             console.print(f"[dim]Removed {count} memory(ies) matching '{query}'.[/dim]\n")
             continue
 
         if low.startswith("forget everything about ") or low.startswith("oublie tout sur "):
             query = user_input.split(" ", 3)[-1].strip()
-            count = delete_memories_matching(query)
+            count = delete_memories_matching(query, user_id)
             console.print(f"[dim]Removed {count} memory(ies) about '{query}'.[/dim]\n")
             continue
 
@@ -48,7 +56,7 @@ def run():
             "what do you know about me?", "que sais-tu de moi ?", "que sais-tu de moi?",
             "montre mes souvenirs", "montre-moi mes souvenirs",
         ):
-            mems = list_natural_memories()
+            mems = list_natural_memories(user_id)
             if not mems:
                 console.print("[dim]No natural memories stored yet.[/dim]\n")
             else:
@@ -58,7 +66,7 @@ def run():
                 console.print()
             continue
 
-        response, model_used = chat(history, user_input, memories)
+        response, model_used = chat(history, user_input, memories, user_id)
 
         history.append({"role": "user", "content": user_input})
         history.append({"role": "assistant", "content": response})

--- a/memory/retriever.py
+++ b/memory/retriever.py
@@ -1,14 +1,18 @@
 from memory.embeddings import generate_embedding, cosine_similarity
-from memory.store import search_memories, list_memories, DB_PATH
+from memory import store as _store
+from memory.store import search_memories, list_memories
 from memory.schema import Memory
 
 # Memories with a cosine score below this threshold are considered irrelevant.
 _COSINE_THRESHOLD = 0.40
 
 
-def get_relevant_memories(message: str, limit: int = 8, db_path: str = DB_PATH) -> list[Memory]:
+def get_relevant_memories(message: str, user_id: int, limit: int = 8, db_path: str | None = None) -> list[Memory]:
     """
-    Returns up to `limit` memories relevant to `message`.
+    Returns up to `limit` memories owned by `user_id` and relevant to `message`.
+
+    Cross-user retrieval is impossible by construction — every read goes
+    through the user-scoped store layer.
 
     Strategy:
     - If Ollama is reachable, use cosine similarity for memories that have
@@ -16,11 +20,13 @@ def get_relevant_memories(message: str, limit: int = 8, db_path: str = DB_PATH) 
     - If Ollama is unreachable (generate_embedding returns None), fall back
       entirely to keyword search (v1 behaviour).
     """
+    if db_path is None:
+        db_path = _store.DB_PATH
     query_emb = generate_embedding(message)
     if query_emb is None:
-        return search_memories(message, limit=limit, db_path=db_path)
+        return search_memories(message, user_id, limit=limit, db_path=db_path)
 
-    all_mems = list_memories(db_path=db_path)
+    all_mems = list_memories(user_id, db_path=db_path)
 
     scored: list[tuple[float, Memory]] = []
     without_embedding: list[Memory] = []
@@ -36,7 +42,7 @@ def get_relevant_memories(message: str, limit: int = 8, db_path: str = DB_PATH) 
 
     # Fill remaining slots with keyword matches for legacy memories (no embedding).
     if without_embedding and len(results) < limit:
-        kw = search_memories(message, limit=limit - len(results), db_path=db_path)
+        kw = search_memories(message, user_id, limit=limit - len(results), db_path=db_path)
         seen = {m.id for m in results}
         results += [m for m in kw if m.id not in seen]
 

--- a/memory/store.py
+++ b/memory/store.py
@@ -15,8 +15,18 @@ _EMBED_THRESHOLD = 0.85
 _KEYWORD_THRESHOLD = 0.50
 
 
-def initialize_memory_database(db_path: str = DB_PATH):
+def _resolve_db_path(db_path: str | None) -> str:
+    """Return the explicit `db_path` if given, else the current module DB_PATH.
+
+    Resolving at call time (rather than as a default arg) lets tests
+    monkeypatch `memory.store.DB_PATH` and have every call honour the patch.
+    """
+    return db_path if db_path is not None else DB_PATH
+
+
+def initialize_memory_database(db_path: str | None = None):
     """Creates the natural_memories table and runs any pending schema migrations."""
+    db_path = _resolve_db_path(db_path)
     with sqlite3.connect(db_path) as conn:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS natural_memories (
@@ -36,27 +46,83 @@ def initialize_memory_database(db_path: str = DB_PATH):
             conn.execute("ALTER TABLE natural_memories ADD COLUMN embedding TEXT")
         except sqlite3.OperationalError:
             pass  # column already exists
+    _migrate_natural_memories_ownership(db_path)
 
 
-def save_memory(memory: Memory, db_path: str = DB_PATH):
+def _migrate_natural_memories_ownership(db_path: str) -> None:
     """
-    Saves a memory, deduplicating against existing memories with the same
-    kind + topic. If a sufficiently similar memory already exists it is updated
-    in place (preserving created_at) rather than inserting a duplicate.
+    Add a user_id column to natural_memories and backfill existing rows
+    to the legacy admin (issue #106).
+
+    Idempotent: if user_id is already present, only the index is ensured.
+    Requires the users table to exist with at least one row.
     """
+    with sqlite3.connect(db_path) as conn:
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(natural_memories)").fetchall()
+        }
+        if "user_id" in cols:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_natural_memories_user_id "
+                "ON natural_memories(user_id)"
+            )
+            return
+
+        users_table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='users'"
+        ).fetchone() is not None
+        if not users_table_exists:
+            raise RuntimeError(
+                "cannot scope natural_memories: users table is missing; "
+                "users.migrate() must run first"
+            )
+        row = conn.execute(
+            "SELECT id FROM users ORDER BY id ASC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(
+                "cannot scope natural_memories: users table is empty; "
+                "users.migrate() must run first"
+            )
+        legacy_owner_id = row[0]
+
+        conn.execute(
+            "ALTER TABLE natural_memories "
+            "ADD COLUMN user_id INTEGER REFERENCES users(id)"
+        )
+        conn.execute(
+            "UPDATE natural_memories SET user_id = ? WHERE user_id IS NULL",
+            (legacy_owner_id,),
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_natural_memories_user_id "
+            "ON natural_memories(user_id)"
+        )
+
+
+def save_memory(memory: Memory, user_id: int, db_path: str | None = None):
+    """
+    Saves a memory for `user_id`, deduplicating only against that user's
+    existing memories with the same kind + topic. If a sufficiently similar
+    memory already exists it is updated in place (preserving created_at)
+    rather than inserting a duplicate.
+    """
+    db_path = _resolve_db_path(db_path)
     if memory.embedding is None:
         memory = memory.model_copy(update={"embedding": generate_embedding(memory.content)})
 
-    duplicate = _find_duplicate(memory, db_path)
+    duplicate = _find_duplicate(memory, user_id, db_path)
     if duplicate:
         to_save = memory.model_copy(update={"id": duplicate.id, "created_at": duplicate.created_at})
-        update_memory(to_save, db_path)
+        update_memory(to_save, user_id, db_path)
     else:
-        _insert_memory(memory, db_path)
+        _insert_memory(memory, user_id, db_path)
 
 
-def update_memory(memory: Memory, db_path: str = DB_PATH):
-    """Updates all mutable fields of an existing memory and refreshes timestamps."""
+def update_memory(memory: Memory, user_id: int, db_path: str | None = None):
+    """Updates all mutable fields of an existing memory owned by `user_id`."""
+    db_path = _resolve_db_path(db_path)
     now = datetime.now().isoformat()
     emb_json = json.dumps(memory.embedding) if memory.embedding is not None else None
     with sqlite3.connect(db_path) as conn:
@@ -65,37 +131,46 @@ def update_memory(memory: Memory, db_path: str = DB_PATH):
             UPDATE natural_memories
             SET kind=?, topic=?, content=?, confidence=?, embedding=?,
                 updated_at=?, last_seen_at=?
-            WHERE id=?
+            WHERE id=? AND user_id=?
             """,
             (memory.kind, memory.topic, memory.content, memory.confidence,
-             emb_json, now, now, memory.id),
+             emb_json, now, now, memory.id, user_id),
         )
 
 
-def delete_memory(memory_id: str, db_path: str = DB_PATH):
-    """Deletes a single memory by its id."""
+def delete_memory(memory_id: str, user_id: int, db_path: str | None = None):
+    """Deletes a memory by id, but only if owned by `user_id`."""
+    db_path = _resolve_db_path(db_path)
     with sqlite3.connect(db_path) as conn:
-        conn.execute("DELETE FROM natural_memories WHERE id = ?", (memory_id,))
+        conn.execute(
+            "DELETE FROM natural_memories WHERE id = ? AND user_id = ?",
+            (memory_id, user_id),
+        )
 
 
-def list_memories(db_path: str = DB_PATH) -> list[Memory]:
-    """Returns all stored memories, newest first."""
+def list_memories(user_id: int, db_path: str | None = None) -> list[Memory]:
+    """Returns all memories owned by `user_id`, newest first."""
+    db_path = _resolve_db_path(db_path)
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
-            "SELECT * FROM natural_memories ORDER BY created_at DESC"
+            "SELECT * FROM natural_memories WHERE user_id = ? "
+            "ORDER BY created_at DESC",
+            (user_id,),
         ).fetchall()
     finally:
         conn.close()
     return [_row_to_memory(r) for r in rows]
 
 
-def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[Memory]:
+def search_memories(query: str, user_id: int, limit: int = 8, db_path: str | None = None) -> list[Memory]:
     """
-    Returns up to `limit` memories scored by token overlap with `query`.
-    Tokens are normalized (lowercased, punctuation and underscores stripped).
+    Returns up to `limit` memories owned by `user_id`, scored by token
+    overlap with `query`. Tokens are normalized (lowercased, punctuation
+    and underscores stripped).
     """
+    db_path = _resolve_db_path(db_path)
     words = _tokenize(query)
     if not words:
         return []
@@ -104,7 +179,9 @@ def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
-            "SELECT * FROM natural_memories ORDER BY created_at DESC"
+            "SELECT * FROM natural_memories WHERE user_id = ? "
+            "ORDER BY created_at DESC",
+            (user_id,),
         ).fetchall()
     finally:
         conn.close()
@@ -121,8 +198,13 @@ def search_memories(query: str, limit: int = 8, db_path: str = DB_PATH) -> list[
     return [m for _, m in scored[:limit]]
 
 
-def delete_memories_matching(query: str, db_path: str = DB_PATH) -> int:
-    """Deletes ALL memories matching the query keywords. Returns the count deleted."""
+def delete_memories_matching(query: str, user_id: int, db_path: str | None = None) -> int:
+    """
+    Deletes ALL of `user_id`'s memories matching the query keywords.
+    Returns the count deleted. Memories belonging to other users are
+    never touched.
+    """
+    db_path = _resolve_db_path(db_path)
     words = _tokenize(query)
     if not words:
         return 0
@@ -130,7 +212,10 @@ def delete_memories_matching(query: str, db_path: str = DB_PATH) -> int:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
-        rows = conn.execute("SELECT * FROM natural_memories").fetchall()
+        rows = conn.execute(
+            "SELECT * FROM natural_memories WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
     finally:
         conn.close()
 
@@ -140,36 +225,37 @@ def delete_memories_matching(query: str, db_path: str = DB_PATH) -> int:
         if any(w in set(_tokenize(f"{r['topic']} {r['content']}")) for w in words)
     ]
     for memory_id in to_delete:
-        delete_memory(memory_id, db_path=db_path)
+        delete_memory(memory_id, user_id, db_path=db_path)
     return len(to_delete)
 
 
 # ── private helpers ────────────────────────────────────────────────────────────
 
-def _insert_memory(memory: Memory, db_path: str = DB_PATH):
+def _insert_memory(memory: Memory, user_id: int, db_path: str):
     emb_json = json.dumps(memory.embedding) if memory.embedding is not None else None
     with sqlite3.connect(db_path) as conn:
         conn.execute(
             """
             INSERT OR REPLACE INTO natural_memories
             (id, kind, topic, content, confidence, source,
-             created_at, updated_at, last_seen_at, embedding)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             created_at, updated_at, last_seen_at, embedding, user_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (memory.id, memory.kind, memory.topic, memory.content,
              memory.confidence, memory.source,
              memory.created_at, memory.updated_at, memory.last_seen_at,
-             emb_json),
+             emb_json, user_id),
         )
 
 
-def _find_duplicate(memory: Memory, db_path: str) -> Memory | None:
+def _find_duplicate(memory: Memory, user_id: int, db_path: str) -> Memory | None:
     """
-    Returns the most recent existing memory with the same kind + topic that is
-    similar enough to be treated as the same logical memory, or None if no
-    such memory exists.
+    Returns the most recent memory owned by `user_id` with the same kind +
+    topic that is similar enough to be treated as the same logical memory,
+    or None if no such memory exists. Cross-user dedup is intentionally
+    avoided so distinct users keep distinct memories.
     """
-    candidates = _get_by_kind_topic(memory.kind, memory.topic, db_path)
+    candidates = _get_by_kind_topic(memory.kind, memory.topic, user_id, db_path)
     for candidate in candidates:
         if memory.embedding and candidate.embedding:
             if cosine_similarity(memory.embedding, candidate.embedding) >= _EMBED_THRESHOLD:
@@ -179,13 +265,14 @@ def _find_duplicate(memory: Memory, db_path: str) -> Memory | None:
     return None
 
 
-def _get_by_kind_topic(kind: str, topic: str, db_path: str) -> list[Memory]:
+def _get_by_kind_topic(kind: str, topic: str, user_id: int, db_path: str) -> list[Memory]:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
-            "SELECT * FROM natural_memories WHERE kind=? AND topic=? ORDER BY created_at DESC",
-            (kind, topic),
+            "SELECT * FROM natural_memories "
+            "WHERE kind=? AND topic=? AND user_id=? ORDER BY created_at DESC",
+            (kind, topic, user_id),
         ).fetchall()
     finally:
         conn.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,45 +1,48 @@
 from unittest.mock import patch
 from core.memory import parse_and_save
 
+# Arbitrary stand-in user_id; these tests only check parsing logic.
+_UID = 7
+
 
 def test_valid_input_returns_true():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("SAVE:knowledge:GPT-4o now supports video")
+        result = parse_and_save("SAVE:knowledge:GPT-4o now supports video", _UID)
         assert result is True
-        mock_save.assert_called_once_with("knowledge", "GPT-4o now supports video")
+        mock_save.assert_called_once_with("knowledge", "GPT-4o now supports video", _UID)
 
 
 def test_nothing_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("NOTHING")
+        result = parse_and_save("NOTHING", _UID)
         assert result is False
         mock_save.assert_not_called()
 
 
 def test_missing_second_colon_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("SAVE:onlyone")
+        result = parse_and_save("SAVE:onlyone", _UID)
         assert result is False
         mock_save.assert_not_called()
 
 
 def test_empty_category_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("SAVE::some content here")
+        result = parse_and_save("SAVE::some content here", _UID)
         assert result is False
         mock_save.assert_not_called()
 
 
 def test_empty_content_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("SAVE:knowledge:")
+        result = parse_and_save("SAVE:knowledge:", _UID)
         assert result is False
         mock_save.assert_not_called()
 
 
 def test_whitespace_only_content_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("SAVE:knowledge:   ")
+        result = parse_and_save("SAVE:knowledge:   ", _UID)
         assert result is False
         mock_save.assert_not_called()
 
@@ -47,20 +50,20 @@ def test_whitespace_only_content_returns_false():
 def test_content_with_colons_preserved():
     """Colons inside content must not be split further."""
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("SAVE:knowledge:Python 3.12: faster and better")
+        result = parse_and_save("SAVE:knowledge:Python 3.12: faster and better", _UID)
         assert result is True
-        mock_save.assert_called_once_with("knowledge", "Python 3.12: faster and better")
+        mock_save.assert_called_once_with("knowledge", "Python 3.12: faster and better", _UID)
 
 
 def test_empty_string_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("")
+        result = parse_and_save("", _UID)
         assert result is False
         mock_save.assert_not_called()
 
 
 def test_whitespace_input_returns_false():
     with patch("core.memory.save_memory") as mock_save:
-        result = parse_and_save("   ")
+        result = parse_and_save("   ", _UID)
         assert result is False
         mock_save.assert_not_called()

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -1,19 +1,22 @@
 from unittest.mock import patch
 from core.memory_command import handle_manual_memory_command
 
+# Arbitrary stand-in user_id used in mocked tests.
+_UID = 1
+
 
 def test_retiens_ca_saves():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("Retiens ça: mon âge est 25")
-        mock_save.assert_called_once_with("manual", "mon âge est 25")
+        result = handle_manual_memory_command("Retiens ça: mon âge est 25", _UID)
+        mock_save.assert_called_once_with("manual", "mon âge est 25", _UID)
         assert result is not None
         assert "mon âge est 25" in result
 
 
 def test_souviens_toi_de_ca_saves():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("Souviens-toi de ça: je préfère le dark mode")
-        mock_save.assert_called_once_with("manual", "je préfère le dark mode")
+        result = handle_manual_memory_command("Souviens-toi de ça: je préfère le dark mode", _UID)
+        mock_save.assert_called_once_with("manual", "je préfère le dark mode", _UID)
         assert result is not None
         assert "je préfère le dark mode" in result
 
@@ -21,28 +24,28 @@ def test_souviens_toi_de_ca_saves():
 def test_souviens_toi_legacy_saves():
     """Legacy "souviens-toi:" still works; content is preserved as-is (no category split)."""
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("souviens-toi: préférence:vim")
-        mock_save.assert_called_once_with("manual", "préférence:vim")
+        result = handle_manual_memory_command("souviens-toi: préférence:vim", _UID)
+        mock_save.assert_called_once_with("manual", "préférence:vim", _UID)
         assert result is not None
 
 
 def test_case_insensitive():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("RETIENS ÇA: test majuscules")
-        mock_save.assert_called_once_with("manual", "test majuscules")
+        result = handle_manual_memory_command("RETIENS ÇA: test majuscules", _UID)
+        mock_save.assert_called_once_with("manual", "test majuscules", _UID)
         assert result is not None
 
 
 def test_leading_whitespace_ignored():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("  Retiens ça: avec espace avant")
-        mock_save.assert_called_once_with("manual", "avec espace avant")
+        result = handle_manual_memory_command("  Retiens ça: avec espace avant", _UID)
+        mock_save.assert_called_once_with("manual", "avec espace avant", _UID)
         assert result is not None
 
 
 def test_empty_content_no_save():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("Retiens ça:")
+        result = handle_manual_memory_command("Retiens ça:", _UID)
         mock_save.assert_not_called()
         assert result is not None
         assert "vide" in result
@@ -50,34 +53,34 @@ def test_empty_content_no_save():
 
 def test_empty_content_with_spaces_no_save():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("Retiens ça:   ")
+        result = handle_manual_memory_command("Retiens ça:   ", _UID)
         mock_save.assert_not_called()
         assert result is not None
 
 
 def test_normal_message_returns_none():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("Comment tu vas ?")
+        result = handle_manual_memory_command("Comment tu vas ?", _UID)
         mock_save.assert_not_called()
         assert result is None
 
 
 def test_partial_prefix_returns_none():
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("souviens")
+        result = handle_manual_memory_command("souviens", _UID)
         mock_save.assert_not_called()
         assert result is None
 
 
 def test_confirmation_contains_full_content():
     with patch("core.memory_command.save_memory"):
-        result = handle_manual_memory_command("Retiens ça: foo bar baz")
+        result = handle_manual_memory_command("Retiens ça: foo bar baz", _UID)
         assert "foo bar baz" in result
 
 
 def test_content_with_colon_preserved():
     """Colons inside the content must not be split further."""
     with patch("core.memory_command.save_memory") as mock_save:
-        result = handle_manual_memory_command("Retiens ça: Python 3.12: plus rapide")
-        mock_save.assert_called_once_with("manual", "Python 3.12: plus rapide")
+        result = handle_manual_memory_command("Retiens ça: Python 3.12: plus rapide", _UID)
+        mock_save.assert_called_once_with("manual", "Python 3.12: plus rapide", _UID)
         assert result is not None

--- a/tests/test_memory_parsing.py
+++ b/tests/test_memory_parsing.py
@@ -1,46 +1,49 @@
 from unittest.mock import patch
 from core.memory import parse_and_save
 
+# Arbitrary stand-in user_id; these tests only check parsing logic.
+_UID = 42
+
 
 class TestParseAndSave:
     def test_valid_save_format_saves_memory(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("SAVE:preferences:likes coffee")
+            result = parse_and_save("SAVE:preferences:likes coffee", _UID)
         assert result is True
-        mock_save.assert_called_once_with("preferences", "likes coffee")
+        mock_save.assert_called_once_with("preferences", "likes coffee", _UID)
 
     def test_nothing_response_returns_false(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("NOTHING")
+            result = parse_and_save("NOTHING", _UID)
         assert result is False
         mock_save.assert_not_called()
 
     def test_invalid_text_returns_false(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("random text")
+            result = parse_and_save("random text", _UID)
         assert result is False
         mock_save.assert_not_called()
 
     def test_extra_colons_in_content_preserved(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("SAVE:preferences:likes coffee:with milk")
+            result = parse_and_save("SAVE:preferences:likes coffee:with milk", _UID)
         assert result is True
-        mock_save.assert_called_once_with("preferences", "likes coffee:with milk")
+        mock_save.assert_called_once_with("preferences", "likes coffee:with milk", _UID)
 
     def test_missing_content_returns_false(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("SAVE:preferences")
+            result = parse_and_save("SAVE:preferences", _UID)
         assert result is False
         mock_save.assert_not_called()
 
     def test_empty_input_returns_false(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("")
+            result = parse_and_save("", _UID)
         assert result is False
         mock_save.assert_not_called()
 
     def test_whitespace_input_returns_false(self):
         with patch("core.memory.save_memory") as mock_save:
-            result = parse_and_save("   ")
+            result = parse_and_save("   ", _UID)
         assert result is False
         mock_save.assert_not_called()

--- a/tests/test_memory_scoping.py
+++ b/tests/test_memory_scoping.py
@@ -1,0 +1,649 @@
+"""
+Tests for per-user memory scoping (issue #106).
+
+Covers the migration that adds user_id to `memories` and `natural_memories`
+plus the data-layer and HTTP-endpoint behaviours that prevent one user
+from reading, retrieving, or deleting another user's memories.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, users
+from core.memory_command import handle_manual_memory_command
+from memory import store as natural_store
+from memory.retriever import get_relevant_memories
+from memory.schema import Memory
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """Initialise a fresh nova.db with all tables and the users migration run."""
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password, role=role)
+
+
+def _mem(**kwargs) -> Memory:
+    defaults = dict(kind="general", topic="test", content="test content", confidence=0.9)
+    defaults.update(kwargs)
+    return Memory(**defaults)
+
+
+# ── Migration ───────────────────────────────────────────────────────────────
+
+class TestMigration:
+    def test_fresh_db_has_user_id_column_on_memories(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(memories)").fetchall()}
+        assert "user_id" in cols
+
+    def test_fresh_db_has_user_id_column_on_natural_memories(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(natural_memories)").fetchall()}
+        assert "user_id" in cols
+
+    def test_existing_memories_are_backfilled_to_legacy_admin(self, tmp_path, monkeypatch):
+        """A pre-multi-user DB with manual memories is migrated to the default admin."""
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        monkeypatch.setenv("NOVA_USERNAME", "legacyadmin")
+        monkeypatch.setenv("NOVA_PASSWORD", "legacypw")
+
+        # Simulate the legacy single-user DB shape: memories table without user_id.
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                "CREATE TABLE memories ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "category TEXT NOT NULL, content TEXT NOT NULL, created TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO memories (category, content, created) "
+                "VALUES ('manual', 'legacy memory', '2024-01-01T00:00:00')"
+            )
+
+        core_memory.initialize_db()
+
+        with sqlite3.connect(path) as conn:
+            row = conn.execute(
+                "SELECT user_id, content FROM memories"
+            ).fetchone()
+            admin = conn.execute(
+                "SELECT id FROM users WHERE username = 'legacyadmin'"
+            ).fetchone()
+        assert admin is not None
+        assert row[0] == admin[0]
+        assert row[1] == "legacy memory"
+
+    def test_existing_natural_memories_are_backfilled_to_legacy_admin(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        monkeypatch.setenv("NOVA_USERNAME", "legacyadmin")
+        monkeypatch.setenv("NOVA_PASSWORD", "legacypw")
+
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                "CREATE TABLE natural_memories ("
+                "id TEXT PRIMARY KEY, kind TEXT NOT NULL, topic TEXT NOT NULL, "
+                "content TEXT NOT NULL, confidence REAL NOT NULL, source TEXT NOT NULL, "
+                "created_at TEXT NOT NULL, updated_at TEXT NOT NULL, "
+                "last_seen_at TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO natural_memories "
+                "(id, kind, topic, content, confidence, source, "
+                " created_at, updated_at, last_seen_at) "
+                "VALUES ('legacy-id', 'preference', 'editor', "
+                "        'User prefers neovim.', 0.9, 'extractor', "
+                "        '2024-01-01', '2024-01-01', '2024-01-01')"
+            )
+
+        core_memory.initialize_db()
+
+        with sqlite3.connect(path) as conn:
+            row = conn.execute(
+                "SELECT user_id, content FROM natural_memories WHERE id = 'legacy-id'"
+            ).fetchone()
+            admin = conn.execute(
+                "SELECT id FROM users WHERE username = 'legacyadmin'"
+            ).fetchone()
+        assert admin is not None
+        assert row[0] == admin[0]
+
+    def test_migration_is_idempotent(self, db_path):
+        # Running initialize_db a second time must not raise or duplicate work.
+        core_memory.initialize_db()
+        core_memory.initialize_db()
+        with sqlite3.connect(db_path) as conn:
+            cols = [
+                r[1] for r in conn.execute("PRAGMA table_info(memories)").fetchall()
+            ]
+            nat_cols = [
+                r[1] for r in conn.execute("PRAGMA table_info(natural_memories)").fetchall()
+            ]
+        assert cols.count("user_id") == 1
+        assert nat_cols.count("user_id") == 1
+
+    def test_legacy_admin_still_sees_their_memories(self, tmp_path, monkeypatch):
+        """End-to-end: legacy single-user manual memories remain visible to the admin."""
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        monkeypatch.setenv("NOVA_USERNAME", "nova")
+        monkeypatch.setenv("NOVA_PASSWORD", "nova")
+
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                "CREATE TABLE memories ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "category TEXT NOT NULL, content TEXT NOT NULL, created TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO memories (category, content, created) "
+                "VALUES ('manual', 'old fact', '2024-01-01')"
+            )
+
+        core_memory.initialize_db()
+
+        with sqlite3.connect(path) as conn:
+            admin_id = conn.execute(
+                "SELECT id FROM users WHERE username = 'nova'"
+            ).fetchone()[0]
+
+        loaded = core_memory.load_memories(admin_id)
+        assert any(m["content"] == "old fact" for m in loaded)
+
+
+# ── Manual memory data-layer scoping ────────────────────────────────────────
+
+class TestManualMemoryScoping:
+    def test_save_memory_records_user_id(self, db_path):
+        a = _make_user(db_path, "alice")
+        core_memory.save_memory("manual", "alice's secret", a)
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT user_id, content FROM memories WHERE content = 'alice''s secret'"
+            ).fetchone()
+        assert row[0] == a
+
+    def test_load_memories_filters_by_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        core_memory.save_memory("manual", "alice fact", a)
+        core_memory.save_memory("manual", "bob fact", b)
+
+        a_mems = core_memory.load_memories(a)
+        b_mems = core_memory.load_memories(b)
+        assert [m["content"] for m in a_mems] == ["alice fact"]
+        assert [m["content"] for m in b_mems] == ["bob fact"]
+
+    def test_list_memories_filters_by_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        core_memory.save_memory("manual", "alice fact", a)
+        core_memory.save_memory("manual", "bob fact", b)
+
+        a_mems = core_memory.list_memories(a)
+        b_mems = core_memory.list_memories(b)
+        assert [m["content"] for m in a_mems] == ["alice fact"]
+        assert [m["content"] for m in b_mems] == ["bob fact"]
+
+    def test_delete_memory_refuses_other_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        core_memory.save_memory("manual", "alice secret", a)
+        with sqlite3.connect(db_path) as conn:
+            mid = conn.execute(
+                "SELECT id FROM memories WHERE content = 'alice secret'"
+            ).fetchone()[0]
+
+        # Bob trying to delete Alice's memory must be denied.
+        assert core_memory.delete_memory(mid, b) is False
+        # Alice's memory still exists.
+        assert any(m["content"] == "alice secret" for m in core_memory.load_memories(a))
+
+        # Alice can delete her own memory.
+        assert core_memory.delete_memory(mid, a) is True
+        assert core_memory.load_memories(a) == []
+
+    def test_update_memory_refuses_other_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        core_memory.save_memory("manual", "alice fact", a)
+        with sqlite3.connect(db_path) as conn:
+            mid = conn.execute(
+                "SELECT id FROM memories WHERE content = 'alice fact'"
+            ).fetchone()[0]
+
+        assert core_memory.update_memory(mid, "manual", "hijacked", b) is False
+        assert any(m["content"] == "alice fact" for m in core_memory.load_memories(a))
+
+        assert core_memory.update_memory(mid, "manual", "renamed", a) is True
+        assert any(m["content"] == "renamed" for m in core_memory.load_memories(a))
+
+    def test_manual_memory_command_writes_for_current_user_only(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        handle_manual_memory_command("Retiens ça: alice prefers tea", a)
+        handle_manual_memory_command("Retiens ça: bob prefers coffee", b)
+
+        a_mems = [m["content"] for m in core_memory.load_memories(a)]
+        b_mems = [m["content"] for m in core_memory.load_memories(b)]
+        assert a_mems == ["alice prefers tea"]
+        assert b_mems == ["bob prefers coffee"]
+
+    def test_parse_and_save_attributes_to_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        core_memory.parse_and_save("SAVE:knowledge:alice fact", a)
+        core_memory.parse_and_save("SAVE:knowledge:bob fact", b)
+
+        a_mems = [m["content"] for m in core_memory.load_memories(a)]
+        b_mems = [m["content"] for m in core_memory.load_memories(b)]
+        assert a_mems == ["alice fact"]
+        assert b_mems == ["bob fact"]
+
+    def test_cleanup_old_knowledge_only_affects_target_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        # Alice has 3 knowledge rows, bob has 2.
+        for i in range(3):
+            core_memory.save_memory("knowledge", f"alice fact {i}", a)
+        for i in range(2):
+            core_memory.save_memory("knowledge", f"bob fact {i}", b)
+
+        # Trim Alice down to 1 knowledge row; Bob's must be untouched.
+        core_memory.cleanup_old_knowledge(a, max_count=1)
+
+        a_mems = [m["content"] for m in core_memory.load_memories(a)]
+        b_mems = [m["content"] for m in core_memory.load_memories(b)]
+        assert len(a_mems) == 1
+        assert len(b_mems) == 2
+
+
+# ── Natural memory data-layer scoping ───────────────────────────────────────
+
+class TestNaturalMemoryScoping:
+    @pytest.fixture(autouse=True)
+    def _no_ollama(self, monkeypatch):
+        monkeypatch.setattr("memory.store.generate_embedding", lambda _: None)
+        monkeypatch.setattr("memory.retriever.generate_embedding", lambda _: None)
+
+    def test_list_returns_only_owned_memories(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        natural_store.save_memory(
+            _mem(kind="preference", topic="editor", content="User A prefers vim."),
+            a,
+        )
+        natural_store.save_memory(
+            _mem(kind="preference", topic="editor", content="User B prefers emacs."),
+            b,
+        )
+
+        a_mems = natural_store.list_memories(a)
+        b_mems = natural_store.list_memories(b)
+        assert [m.content for m in a_mems] == ["User A prefers vim."]
+        assert [m.content for m in b_mems] == ["User B prefers emacs."]
+
+    def test_search_returns_only_owned_memories(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        natural_store.save_memory(
+            _mem(kind="preference", topic="editor", content="User A prefers vim editor."),
+            a,
+        )
+        natural_store.save_memory(
+            _mem(kind="preference", topic="editor", content="User B prefers vim editor."),
+            b,
+        )
+
+        a_mems = natural_store.search_memories("vim editor", a)
+        b_mems = natural_store.search_memories("vim editor", b)
+        assert len(a_mems) == 1
+        assert "User A" in a_mems[0].content
+        assert len(b_mems) == 1
+        assert "User B" in b_mems[0].content
+
+    def test_get_relevant_memories_isolated_per_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        natural_store.save_memory(
+            _mem(kind="preference", topic="distro", content="Alice prefers Fedora KDE."),
+            a,
+        )
+        natural_store.save_memory(
+            _mem(kind="preference", topic="distro", content="Bob prefers Ubuntu GNOME."),
+            b,
+        )
+
+        a_results = get_relevant_memories("which linux distro", a)
+        b_results = get_relevant_memories("which linux distro", b)
+        a_text = " ".join(m.content for m in a_results)
+        b_text = " ".join(m.content for m in b_results)
+        assert "Alice" in a_text
+        assert "Bob" not in a_text
+        assert "Bob" in b_text
+        assert "Alice" not in b_text
+
+    def test_delete_memory_refuses_other_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        m = _mem(kind="preference", topic="editor", content="User A prefers vim.")
+        natural_store.save_memory(m, a)
+
+        # Bob tries to delete Alice's memory — silently no-op.
+        natural_store.delete_memory(m.id, b)
+        assert any(x.id == m.id for x in natural_store.list_memories(a))
+
+        natural_store.delete_memory(m.id, a)
+        assert natural_store.list_memories(a) == []
+
+    def test_delete_memories_matching_only_deletes_owned(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        natural_store.save_memory(
+            _mem(kind="preference", topic="distro", content="Alice prefers Fedora."),
+            a,
+        )
+        natural_store.save_memory(
+            _mem(kind="preference", topic="distro", content="Bob prefers Fedora."),
+            b,
+        )
+
+        count = natural_store.delete_memories_matching("fedora", a)
+        assert count == 1
+        # Alice's row gone, Bob's row preserved.
+        assert natural_store.list_memories(a) == []
+        assert len(natural_store.list_memories(b)) == 1
+
+    def test_dedup_is_per_user(self, db_path):
+        """Two users with identical content+topic are NOT deduped against each other."""
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+
+        m_a = _mem(kind="preference", topic="editor", content="User prefers neovim.")
+        m_a.embedding = [1.0, 0.0]
+        natural_store.save_memory(m_a, a)
+
+        m_b = _mem(kind="preference", topic="editor", content="User prefers neovim.")
+        m_b.embedding = [1.0, 0.0]
+        natural_store.save_memory(m_b, b)
+
+        assert len(natural_store.list_memories(a)) == 1
+        assert len(natural_store.list_memories(b)) == 1
+
+
+# ── HTTP endpoint scoping ───────────────────────────────────────────────────
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    """A TestClient backed by the temp DB, with background jobs suppressed."""
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestMemoryEndpoints:
+    def test_list_memories_returns_only_current_users(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+        b_token = _login(web_client, "bob")
+
+        web_client.post("/memories", json={"category": "manual", "content": "alice fact"}, headers=_h(a_token))
+        web_client.post("/memories", json={"category": "manual", "content": "bob fact"}, headers=_h(b_token))
+
+        a_list = web_client.get("/memories", headers=_h(a_token)).json()
+        b_list = web_client.get("/memories", headers=_h(b_token)).json()
+        assert sorted(m["content"] for m in a_list) == ["alice fact"]
+        assert sorted(m["content"] for m in b_list) == ["bob fact"]
+
+    def test_post_memory_attributes_to_current_user(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        web_client.post(
+            "/memories",
+            json={"category": "manual", "content": "mine"},
+            headers=_h(token),
+        )
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT user_id FROM memories WHERE content = 'mine'"
+            ).fetchone()
+        assert row[0] == uid
+
+    def test_user_a_cannot_delete_user_b_memory_returns_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+        b_token = _login(web_client, "bob")
+
+        web_client.post(
+            "/memories", json={"category": "manual", "content": "alice's fact"}, headers=_h(a_token)
+        )
+        with sqlite3.connect(db_path) as conn:
+            mid = conn.execute(
+                "SELECT id FROM memories WHERE content = 'alice''s fact'"
+            ).fetchone()[0]
+
+        resp = web_client.delete(f"/memories/{mid}", headers=_h(b_token))
+        assert resp.status_code == 404
+
+        # Memory still exists for Alice.
+        with sqlite3.connect(db_path) as conn:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM memories WHERE id = ?", (mid,)
+            ).fetchone()[0] == 1
+
+    def test_user_a_cannot_update_user_b_memory_returns_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+        b_token = _login(web_client, "bob")
+
+        web_client.post(
+            "/memories", json={"category": "manual", "content": "alice fact"}, headers=_h(a_token)
+        )
+        with sqlite3.connect(db_path) as conn:
+            mid = conn.execute(
+                "SELECT id FROM memories WHERE content = 'alice fact'"
+            ).fetchone()[0]
+
+        resp = web_client.put(
+            f"/memories/{mid}",
+            json={"category": "manual", "content": "hijacked"},
+            headers=_h(b_token),
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_memory_id_returns_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        assert web_client.delete(
+            "/memories/99999", headers=_h(token)
+        ).status_code == 404
+        assert web_client.put(
+            "/memories/99999",
+            json={"category": "manual", "content": "anything"},
+            headers=_h(token),
+        ).status_code == 404
+
+
+class TestChatMemoryCommands:
+    def test_show_my_memories_lists_only_current_user(self, db_path, web_client, monkeypatch):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+        b_token = _login(web_client, "bob")
+
+        # Stub embeddings so dedup doesn't get tangled.
+        monkeypatch.setattr("memory.store.generate_embedding", lambda _: None)
+
+        natural_store.save_memory(
+            _mem(kind="preference", topic="editor", content="Alice prefers vim."),
+            a,
+        )
+        natural_store.save_memory(
+            _mem(kind="preference", topic="editor", content="Bob prefers emacs."),
+            b,
+        )
+
+        a_resp = web_client.post(
+            "/chat",
+            json={"message": "show my memories", "mode": "chat"},
+            headers=_h(a_token),
+        )
+        b_resp = web_client.post(
+            "/chat",
+            json={"message": "show my memories", "mode": "chat"},
+            headers=_h(b_token),
+        )
+        assert "Alice prefers vim." in a_resp.json()["response"]
+        assert "Bob prefers emacs." not in a_resp.json()["response"]
+        assert "Bob prefers emacs." in b_resp.json()["response"]
+        assert "Alice prefers vim." not in b_resp.json()["response"]
+
+    def test_forget_command_only_deletes_current_users_memories(self, db_path, web_client, monkeypatch):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+
+        monkeypatch.setattr("memory.store.generate_embedding", lambda _: None)
+
+        natural_store.save_memory(
+            _mem(kind="preference", topic="distro", content="Alice prefers Fedora."),
+            a,
+        )
+        natural_store.save_memory(
+            _mem(kind="preference", topic="distro", content="Bob prefers Fedora."),
+            b,
+        )
+
+        resp = web_client.post(
+            "/chat",
+            json={"message": "forget that fedora", "mode": "chat"},
+            headers=_h(a_token),
+        )
+        assert resp.status_code == 200
+        # Alice's memory is gone, Bob's remains.
+        assert natural_store.list_memories(a) == []
+        assert any("Bob" in m.content for m in natural_store.list_memories(b))
+
+    def test_manual_memory_command_through_chat_attributes_to_current_user(
+        self, db_path, web_client
+    ):
+        a = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        web_client.post(
+            "/chat",
+            json={"message": "Retiens ça: alice prefers tea", "mode": "chat"},
+            headers=_h(token),
+        )
+        mems = core_memory.load_memories(a)
+        assert any(m["content"] == "alice prefers tea" for m in mems)
+
+    def test_chat_memory_injection_uses_current_users_memories(
+        self, db_path, web_client, monkeypatch
+    ):
+        """Verify the chat handler hands the current user's memories to the model."""
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+
+        core_memory.save_memory("manual", "alice fact", a)
+        core_memory.save_memory("manual", "bob fact", b)
+
+        captured = {}
+
+        def fake_chat(history, user_input, memories, user_id, **kwargs):
+            captured["memories"] = memories
+            captured["user_id"] = user_id
+            return ("ok", "stub-model")
+
+        monkeypatch.setattr("web.chat", fake_chat)
+
+        web_client.post(
+            "/chat",
+            json={"message": "hi", "mode": "chat"},
+            headers=_h(a_token),
+        )
+        assert captured["user_id"] == a
+        contents = [m["content"] for m in captured["memories"]]
+        assert "alice fact" in contents
+        assert "bob fact" not in contents
+
+
+class TestSingleUserBehaviorPreserved:
+    def test_default_admin_sees_migrated_memories(self, tmp_path, monkeypatch):
+        """Single-user upgrade path: legacy memories remain visible to nova/nova."""
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        monkeypatch.setenv("NOVA_USERNAME", "nova")
+        monkeypatch.setenv("NOVA_PASSWORD", "nova")
+
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                "CREATE TABLE memories ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "category TEXT NOT NULL, content TEXT NOT NULL, created TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO memories (category, content, created) "
+                "VALUES ('manual', 'I prefer tea', '2024-01-01')"
+            )
+
+        core_memory.initialize_db()
+
+        from core.rate_limiter import _login_limiter
+        _login_limiter._store.clear()
+
+        import web
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("web.initialize_db"))
+            stack.enter_context(patch("web.learn_from_feeds"))
+            stack.enter_context(patch("web.scheduler", MagicMock()))
+            with TestClient(web.app, raise_server_exceptions=True) as client:
+                token = _login(client, "nova", "nova")
+                resp = client.get("/memories", headers=_h(token))
+        assert resp.status_code == 200
+        contents = [m["content"] for m in resp.json()]
+        assert "I prefer tea" in contents

--- a/tests/test_natural_memory.py
+++ b/tests/test_natural_memory.py
@@ -9,10 +9,15 @@ Tests for Natural Memory v1 + v2:
   - embedding generation (mocked)
   - deduplication on write
   - preference overwrite
+
+Per issue #106 every store-layer call requires a `user_id`. The fixture
+seeds a single admin row and exposes its id as `uid`.
 """
+import sqlite3
 import pytest
 from unittest.mock import patch
 
+from core import users
 from memory.embeddings import generate_embedding, cosine_similarity
 from memory.schema import Memory
 from memory.store import (
@@ -33,10 +38,20 @@ from memory.retriever import get_relevant_memories, format_for_prompt
 
 @pytest.fixture
 def tmp_db(tmp_path):
-    """Provides a fresh, isolated SQLite database for each test."""
+    """Provides a fresh DB with users + natural_memories tables and one admin user."""
     db = str(tmp_path / "test_memory.db")
+    with sqlite3.connect(db) as conn:
+        users.create_users_table(conn)
+        users.create_user(conn, "admin", "pw", role=users.ROLE_ADMIN)
     initialize_memory_database(db)
     return db
+
+
+@pytest.fixture
+def uid(tmp_db):
+    """Returns the admin user_id for the current `tmp_db`."""
+    with sqlite3.connect(tmp_db) as conn:
+        return conn.execute("SELECT id FROM users LIMIT 1").fetchone()[0]
 
 
 def _mem(**kwargs) -> Memory:
@@ -48,85 +63,85 @@ def _mem(**kwargs) -> Memory:
 # ── DB initialisation ──────────────────────────────────────────────────────────
 
 class TestDatabaseInit:
-    def test_initialise_creates_table(self, tmp_db):
-        mems = list_memories(db_path=tmp_db)
+    def test_initialise_creates_table(self, tmp_db, uid):
+        mems = list_memories(uid, db_path=tmp_db)
         assert isinstance(mems, list)
         assert mems == []
 
-    def test_initialise_is_idempotent(self, tmp_db):
+    def test_initialise_is_idempotent(self, tmp_db, uid):
         # Calling twice must not raise or duplicate the table
         initialize_memory_database(tmp_db)
-        mems = list_memories(db_path=tmp_db)
+        mems = list_memories(uid, db_path=tmp_db)
         assert mems == []
 
 
 # ── save / list / search ───────────────────────────────────────────────────────
 
 class TestSaveAndList:
-    def test_save_and_list_single(self, tmp_db):
+    def test_save_and_list_single(self, tmp_db, uid):
         m = _mem(kind="preference", topic="editor", content="User prefers neovim.")
-        save_memory(m, db_path=tmp_db)
-        result = list_memories(db_path=tmp_db)
+        save_memory(m, uid, db_path=tmp_db)
+        result = list_memories(uid, db_path=tmp_db)
         assert len(result) == 1
         assert result[0].content == "User prefers neovim."
         assert result[0].kind == "preference"
 
-    def test_save_multiple_returns_all(self, tmp_db):
+    def test_save_multiple_returns_all(self, tmp_db, uid):
         # Use distinct kind+topic combinations so dedup doesn't consolidate them.
-        save_memory(_mem(kind="preference", topic="editor", content="User prefers neovim."), db_path=tmp_db)
-        save_memory(_mem(kind="software", topic="terminal", content="User uses alacritty."), db_path=tmp_db)
-        save_memory(_mem(kind="hardware", topic="hardware_setup", content="User has 32GB RAM."), db_path=tmp_db)
-        assert len(list_memories(db_path=tmp_db)) == 3
+        save_memory(_mem(kind="preference", topic="editor", content="User prefers neovim."), uid, db_path=tmp_db)
+        save_memory(_mem(kind="software", topic="terminal", content="User uses alacritty."), uid, db_path=tmp_db)
+        save_memory(_mem(kind="hardware", topic="hardware_setup", content="User has 32GB RAM."), uid, db_path=tmp_db)
+        assert len(list_memories(uid, db_path=tmp_db)) == 3
 
-    def test_list_returns_newest_first(self, tmp_db):
+    def test_list_returns_newest_first(self, tmp_db, uid):
         m1 = _mem(content="first", created_at="2024-01-01T00:00:00")
         m2 = _mem(content="second", created_at="2024-06-01T00:00:00")
-        save_memory(m1, db_path=tmp_db)
-        save_memory(m2, db_path=tmp_db)
-        result = list_memories(db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
+        result = list_memories(uid, db_path=tmp_db)
         assert result[0].content == "second"
 
-    def test_delete_removes_memory(self, tmp_db):
+    def test_delete_removes_memory(self, tmp_db, uid):
         m = _mem()
-        save_memory(m, db_path=tmp_db)
-        delete_memory(m.id, db_path=tmp_db)
-        assert list_memories(db_path=tmp_db) == []
+        save_memory(m, uid, db_path=tmp_db)
+        delete_memory(m.id, uid, db_path=tmp_db)
+        assert list_memories(uid, db_path=tmp_db) == []
 
-    def test_update_changes_content(self, tmp_db):
+    def test_update_changes_content(self, tmp_db, uid):
         m = _mem(content="original")
-        save_memory(m, db_path=tmp_db)
+        save_memory(m, uid, db_path=tmp_db)
         m.content = "updated"
-        update_memory(m, db_path=tmp_db)
-        result = list_memories(db_path=tmp_db)
+        update_memory(m, uid, db_path=tmp_db)
+        result = list_memories(uid, db_path=tmp_db)
         assert result[0].content == "updated"
 
 
 class TestSearchMemories:
-    def test_search_returns_matching(self, tmp_db):
-        save_memory(_mem(topic="linux_distribution", content="User prefers Fedora KDE."), db_path=tmp_db)
-        save_memory(_mem(topic="editor", content="User uses neovim."), db_path=tmp_db)
-        results = search_memories("fedora linux", db_path=tmp_db)
+    def test_search_returns_matching(self, tmp_db, uid):
+        save_memory(_mem(topic="linux_distribution", content="User prefers Fedora KDE."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="editor", content="User uses neovim."), uid, db_path=tmp_db)
+        results = search_memories("fedora linux", uid, db_path=tmp_db)
         assert len(results) == 1
         assert "Fedora" in results[0].content
 
-    def test_search_empty_query_returns_nothing(self, tmp_db):
-        save_memory(_mem(), db_path=tmp_db)
-        assert search_memories("", db_path=tmp_db) == []
+    def test_search_empty_query_returns_nothing(self, tmp_db, uid):
+        save_memory(_mem(), uid, db_path=tmp_db)
+        assert search_memories("", uid, db_path=tmp_db) == []
 
-    def test_search_no_match_returns_empty(self, tmp_db):
-        save_memory(_mem(content="User prefers dark mode."), db_path=tmp_db)
-        assert search_memories("kubernetes docker swarm", db_path=tmp_db) == []
+    def test_search_no_match_returns_empty(self, tmp_db, uid):
+        save_memory(_mem(content="User prefers dark mode."), uid, db_path=tmp_db)
+        assert search_memories("kubernetes docker swarm", uid, db_path=tmp_db) == []
 
-    def test_search_respects_limit(self, tmp_db):
+    def test_search_respects_limit(self, tmp_db, uid):
         for i in range(10):
-            save_memory(_mem(topic="python", content=f"User writes python {i}"), db_path=tmp_db)
-        results = search_memories("python", limit=3, db_path=tmp_db)
+            save_memory(_mem(topic="python", content=f"User writes python {i}"), uid, db_path=tmp_db)
+        results = search_memories("python", uid, limit=3, db_path=tmp_db)
         assert len(results) <= 3
 
-    def test_search_ranks_by_keyword_overlap(self, tmp_db):
-        save_memory(_mem(topic="linux", content="User uses linux fedora kde"), db_path=tmp_db)
-        save_memory(_mem(topic="linux2", content="User uses linux"), db_path=tmp_db)
-        results = search_memories("linux fedora kde", db_path=tmp_db)
+    def test_search_ranks_by_keyword_overlap(self, tmp_db, uid):
+        save_memory(_mem(topic="linux", content="User uses linux fedora kde"), uid, db_path=tmp_db)
+        save_memory(_mem(topic="linux2", content="User uses linux"), uid, db_path=tmp_db)
+        results = search_memories("linux fedora kde", uid, db_path=tmp_db)
         assert "fedora" in results[0].content.lower()
 
 
@@ -248,20 +263,20 @@ class TestExtractor:
 # ── retriever ──────────────────────────────────────────────────────────────────
 
 class TestRetriever:
-    def test_returns_relevant_memories(self, tmp_db):
-        save_memory(_mem(topic="linux_distribution", content="User prefers Fedora."), db_path=tmp_db)
-        save_memory(_mem(topic="editor", content="User uses neovim."), db_path=tmp_db)
-        results = get_relevant_memories("which linux distro", db_path=tmp_db)
+    def test_returns_relevant_memories(self, tmp_db, uid):
+        save_memory(_mem(topic="linux_distribution", content="User prefers Fedora."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="editor", content="User uses neovim."), uid, db_path=tmp_db)
+        results = get_relevant_memories("which linux distro", uid, db_path=tmp_db)
         assert any("Fedora" in m.content for m in results)
 
-    def test_empty_message_returns_empty(self, tmp_db):
-        save_memory(_mem(), db_path=tmp_db)
-        assert get_relevant_memories("", db_path=tmp_db) == []
+    def test_empty_message_returns_empty(self, tmp_db, uid):
+        save_memory(_mem(), uid, db_path=tmp_db)
+        assert get_relevant_memories("", uid, db_path=tmp_db) == []
 
-    def test_respects_limit(self, tmp_db):
+    def test_respects_limit(self, tmp_db, uid):
         for i in range(20):
-            save_memory(_mem(topic="python", content=f"User likes python {i}"), db_path=tmp_db)
-        results = get_relevant_memories("python", limit=5, db_path=tmp_db)
+            save_memory(_mem(topic="python", content=f"User likes python {i}"), uid, db_path=tmp_db)
+        results = get_relevant_memories("python", uid, limit=5, db_path=tmp_db)
         assert len(results) <= 5
 
 
@@ -288,26 +303,26 @@ class TestFormatForPrompt:
 # ── forget command ─────────────────────────────────────────────────────────────
 
 class TestForgetCommand:
-    def test_forget_deletes_matching(self, tmp_db):
-        save_memory(_mem(topic="fedora", content="User prefers Fedora KDE."), db_path=tmp_db)
-        save_memory(_mem(topic="neovim", content="User uses neovim."), db_path=tmp_db)
-        count = delete_memories_matching("fedora", db_path=tmp_db)
+    def test_forget_deletes_matching(self, tmp_db, uid):
+        save_memory(_mem(topic="fedora", content="User prefers Fedora KDE."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="neovim", content="User uses neovim."), uid, db_path=tmp_db)
+        count = delete_memories_matching("fedora", uid, db_path=tmp_db)
         assert count == 1
-        remaining = list_memories(db_path=tmp_db)
+        remaining = list_memories(uid, db_path=tmp_db)
         assert all("Fedora" not in m.content for m in remaining)
 
-    def test_forget_all_about_topic(self, tmp_db):
-        save_memory(_mem(topic="ubuntu", content="User tried Ubuntu once."), db_path=tmp_db)
-        save_memory(_mem(topic="ubuntu2", content="User disliked Ubuntu."), db_path=tmp_db)
-        save_memory(_mem(topic="fedora", content="User prefers Fedora."), db_path=tmp_db)
-        count = delete_memories_matching("ubuntu", db_path=tmp_db)
+    def test_forget_all_about_topic(self, tmp_db, uid):
+        save_memory(_mem(topic="ubuntu", content="User tried Ubuntu once."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="ubuntu2", content="User disliked Ubuntu."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="fedora", content="User prefers Fedora."), uid, db_path=tmp_db)
+        count = delete_memories_matching("ubuntu", uid, db_path=tmp_db)
         assert count == 2
-        remaining = list_memories(db_path=tmp_db)
+        remaining = list_memories(uid, db_path=tmp_db)
         assert len(remaining) == 1
         assert "Fedora" in remaining[0].content
 
-    def test_forget_nonexistent_returns_zero(self, tmp_db):
-        count = delete_memories_matching("kubernetes", db_path=tmp_db)
+    def test_forget_nonexistent_returns_zero(self, tmp_db, uid):
+        count = delete_memories_matching("kubernetes", uid, db_path=tmp_db)
         assert count == 0
 
 
@@ -341,15 +356,15 @@ class TestEmbeddings:
 # ── v2: schema migration ───────────────────────────────────────────────────────
 
 class TestSchemaMigration:
-    def test_embedding_column_created_on_init(self, tmp_db):
-        mems = list_memories(db_path=tmp_db)
+    def test_embedding_column_created_on_init(self, tmp_db, uid):
+        mems = list_memories(uid, db_path=tmp_db)
         assert isinstance(mems, list)
 
-    def test_init_is_idempotent_with_embedding_column(self, tmp_db):
+    def test_init_is_idempotent_with_embedding_column(self, tmp_db, uid):
         # Calling initialize twice must not raise even if column already exists.
         initialize_memory_database(tmp_db)
         initialize_memory_database(tmp_db)
-        assert list_memories(db_path=tmp_db) == []
+        assert list_memories(uid, db_path=tmp_db) == []
 
 
 # ── v2: embedding storage and retrieval ───────────────────────────────────────
@@ -359,16 +374,16 @@ class TestEmbeddingStorage:
     def no_ollama(self, monkeypatch):
         monkeypatch.setattr("memory.store.generate_embedding", lambda _: None)
 
-    def test_embedding_persisted_and_loaded(self, tmp_db):
+    def test_embedding_persisted_and_loaded(self, tmp_db, uid):
         m = _mem()
         m.embedding = [0.1, 0.2, 0.3]
-        save_memory(m, db_path=tmp_db)
-        loaded = list_memories(db_path=tmp_db)
+        save_memory(m, uid, db_path=tmp_db)
+        loaded = list_memories(uid, db_path=tmp_db)
         assert loaded[0].embedding == pytest.approx([0.1, 0.2, 0.3])
 
-    def test_null_embedding_round_trips_as_none(self, tmp_db):
-        save_memory(_mem(), db_path=tmp_db)
-        loaded = list_memories(db_path=tmp_db)
+    def test_null_embedding_round_trips_as_none(self, tmp_db, uid):
+        save_memory(_mem(), uid, db_path=tmp_db)
+        loaded = list_memories(uid, db_path=tmp_db)
         assert loaded[0].embedding is None
 
 
@@ -380,74 +395,74 @@ class TestDeduplication:
         # Tests set embeddings directly; prevent accidental Ollama calls.
         monkeypatch.setattr("memory.store.generate_embedding", lambda _: None)
 
-    def test_high_cosine_similarity_updates_existing(self, tmp_db):
+    def test_high_cosine_similarity_updates_existing(self, tmp_db, uid):
         m1 = _mem(kind="preference", topic="editor", content="User prefers neovim.")
         m1.embedding = [1.0, 0.0, 0.0]
-        save_memory(m1, db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
 
         m2 = _mem(kind="preference", topic="editor", content="User prefers VS Code.")
         m2.embedding = [0.98, 0.1, 0.0]  # cosine similarity ≈ 0.995 → above threshold
-        save_memory(m2, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
 
-        mems = list_memories(db_path=tmp_db)
+        mems = list_memories(uid, db_path=tmp_db)
         assert len(mems) == 1
         assert "VS Code" in mems[0].content
 
-    def test_low_cosine_similarity_inserts_new(self, tmp_db):
+    def test_low_cosine_similarity_inserts_new(self, tmp_db, uid):
         m1 = _mem(kind="hardware", topic="hardware", content="User has 32GB RAM.")
         m1.embedding = [1.0, 0.0, 0.0]
-        save_memory(m1, db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
 
         m2 = _mem(kind="hardware", topic="hardware", content="User has an Nvidia RTX 3090.")
         m2.embedding = [0.0, 1.0, 0.0]  # orthogonal → below threshold
-        save_memory(m2, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
 
-        assert len(list_memories(db_path=tmp_db)) == 2
+        assert len(list_memories(uid, db_path=tmp_db)) == 2
 
-    def test_dedup_preserves_original_created_at(self, tmp_db):
+    def test_dedup_preserves_original_created_at(self, tmp_db, uid):
         m1 = _mem(kind="preference", topic="editor", content="User prefers neovim.",
                   created_at="2024-01-01T00:00:00")
         m1.embedding = [1.0, 0.0]
-        save_memory(m1, db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
 
         m2 = _mem(kind="preference", topic="editor", content="User prefers VS Code.")
         m2.embedding = [0.97, 0.1]
-        save_memory(m2, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
 
-        mems = list_memories(db_path=tmp_db)
+        mems = list_memories(uid, db_path=tmp_db)
         assert mems[0].created_at == "2024-01-01T00:00:00"
 
-    def test_different_topic_always_inserts_new(self, tmp_db):
+    def test_different_topic_always_inserts_new(self, tmp_db, uid):
         m1 = _mem(kind="preference", topic="editor", content="User prefers neovim.")
         m1.embedding = [1.0, 0.0]
-        save_memory(m1, db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
 
         m2 = _mem(kind="preference", topic="terminal", content="User prefers alacritty.")
         m2.embedding = [1.0, 0.0]  # same embedding but different topic
-        save_memory(m2, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
 
-        assert len(list_memories(db_path=tmp_db)) == 2
+        assert len(list_memories(uid, db_path=tmp_db)) == 2
 
-    def test_keyword_dedup_identical_content(self, tmp_db):
+    def test_keyword_dedup_identical_content(self, tmp_db, uid):
         # No embeddings — Jaccard similarity of identical content = 1.0 → update.
         m1 = _mem(kind="preference", topic="editor", content="User prefers neovim for coding.")
-        save_memory(m1, db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
 
         m2 = _mem(kind="preference", topic="editor", content="User prefers neovim for coding.")
-        save_memory(m2, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
 
-        assert len(list_memories(db_path=tmp_db)) == 1
+        assert len(list_memories(uid, db_path=tmp_db)) == 1
 
-    def test_keyword_dedup_similar_preference(self, tmp_db):
+    def test_keyword_dedup_similar_preference(self, tmp_db, uid):
         # "User prefers neovim" vs "User prefers VS Code" share enough tokens
         # (user, prefers) for Jaccard ≥ 0.50 → update.
         m1 = _mem(kind="preference", topic="editor", content="User prefers neovim.")
-        save_memory(m1, db_path=tmp_db)
+        save_memory(m1, uid, db_path=tmp_db)
 
         m2 = _mem(kind="preference", topic="editor", content="User prefers VS Code.")
-        save_memory(m2, db_path=tmp_db)
+        save_memory(m2, uid, db_path=tmp_db)
 
-        mems = list_memories(db_path=tmp_db)
+        mems = list_memories(uid, db_path=tmp_db)
         assert len(mems) == 1
         assert "VS Code" in mems[0].content
 
@@ -455,46 +470,46 @@ class TestDeduplication:
 # ── v2: cosine retrieval ───────────────────────────────────────────────────────
 
 class TestRetrieverV2:
-    def test_cosine_search_returns_relevant(self, tmp_db):
+    def test_cosine_search_returns_relevant(self, tmp_db, uid):
         m = _mem(kind="preference", topic="editor", content="User prefers neovim.")
         m.embedding = [1.0, 0.0, 0.0]
         with patch("memory.store.generate_embedding", return_value=None):
-            save_memory(m, db_path=tmp_db)
+            save_memory(m, uid, db_path=tmp_db)
 
         with patch("memory.retriever.generate_embedding", return_value=[0.99, 0.1, 0.0]):
-            results = get_relevant_memories("which editor", db_path=tmp_db)
+            results = get_relevant_memories("which editor", uid, db_path=tmp_db)
 
         assert len(results) == 1
         assert results[0].topic == "editor"
 
-    def test_cosine_search_filters_irrelevant(self, tmp_db):
+    def test_cosine_search_filters_irrelevant(self, tmp_db, uid):
         m = _mem(kind="preference", topic="editor", content="User prefers neovim.")
         m.embedding = [1.0, 0.0, 0.0]
         with patch("memory.store.generate_embedding", return_value=None):
-            save_memory(m, db_path=tmp_db)
+            save_memory(m, uid, db_path=tmp_db)
 
         # Query embedding is orthogonal to memory embedding → score = 0 < threshold.
         with patch("memory.retriever.generate_embedding", return_value=[0.0, 0.0, 1.0]):
-            results = get_relevant_memories("something unrelated", db_path=tmp_db)
+            results = get_relevant_memories("something unrelated", uid, db_path=tmp_db)
 
         assert results == []
 
-    def test_falls_back_to_keyword_when_ollama_unavailable(self, tmp_db):
+    def test_falls_back_to_keyword_when_ollama_unavailable(self, tmp_db, uid):
         with patch("memory.store.generate_embedding", return_value=None):
-            save_memory(_mem(topic="fedora", content="User prefers Fedora."), db_path=tmp_db)
+            save_memory(_mem(topic="fedora", content="User prefers Fedora."), uid, db_path=tmp_db)
 
         with patch("memory.retriever.generate_embedding", return_value=None):
-            results = get_relevant_memories("fedora linux", db_path=tmp_db)
+            results = get_relevant_memories("fedora linux", uid, db_path=tmp_db)
 
         assert any("Fedora" in m.content for m in results)
 
-    def test_legacy_memories_included_via_keyword_fallback(self, tmp_db):
+    def test_legacy_memories_included_via_keyword_fallback(self, tmp_db, uid):
         # A memory with no embedding (legacy v1 row) is served via keyword
         # search even when a query embedding is available.
         with patch("memory.store.generate_embedding", return_value=None):
-            save_memory(_mem(topic="fedora", content="User prefers Fedora."), db_path=tmp_db)
+            save_memory(_mem(topic="fedora", content="User prefers Fedora."), uid, db_path=tmp_db)
 
         with patch("memory.retriever.generate_embedding", return_value=[0.5, 0.5]):
-            results = get_relevant_memories("fedora linux", db_path=tmp_db)
+            results = get_relevant_memories("fedora linux", uid, db_path=tmp_db)
 
         assert any("Fedora" in m.content for m in results)

--- a/web.py
+++ b/web.py
@@ -330,9 +330,9 @@ def remove_conversation(
 
 @app.post("/chat")
 def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_user)):
-    memories = load_memories()
+    memories = load_memories(user.id)
 
-    reply = handle_manual_memory_command(request.message)
+    reply = handle_manual_memory_command(request.message, user.id)
     if reply is not None:
         return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
 
@@ -340,13 +340,13 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
 
     if msg_lower.startswith("forget that ") or msg_lower.startswith("oublie que "):
         query = request.message.split(" ", 2)[2].strip()
-        count = delete_memories_matching(query)
+        count = delete_memories_matching(query, user.id)
         reply = f"Done. Removed {count} memory(ies) matching '{query}'." if count else "No matching memories found."
         return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
 
     if msg_lower.startswith("forget everything about ") or msg_lower.startswith("oublie tout sur "):
         query = request.message.split(" ", 3)[-1].strip()
-        count = delete_memories_matching(query)
+        count = delete_memories_matching(query, user.id)
         reply = f"Done. Removed {count} memory(ies) about '{query}'." if count else "No matching memories found."
         return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
 
@@ -355,7 +355,7 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         "what do you know about me?", "que sais-tu de moi ?", "que sais-tu de moi?",
         "montre mes souvenirs", "montre-moi mes souvenirs",
     ):
-        mems = list_natural_memories()
+        mems = list_natural_memories(user.id)
         if not mems:
             return {"response": "I don't have any natural memories stored yet.", "model": "system", "conversation_id": request.conversation_id}
         lines = ["Here's what I remember about you:\n"]
@@ -380,7 +380,7 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         forced_model = get_setting("nova_model_name", NOVA_MODEL_DEFAULT_NAME)
     else:
         forced_model = MODE_MAP.get(request.mode)
-    response, model_used = chat(history, request.message, memories, forced_model=forced_model, force_search=request.search, image=request.image)
+    response, model_used = chat(history, request.message, memories, user.id, forced_model=forced_model, force_search=request.search, image=request.image)
 
     save_message(conversation_id, "user", request.message)
     save_message(conversation_id, "assistant", response, model_used)
@@ -398,25 +398,38 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
 # ── MEMORY ENDPOINTS ──
 
 @app.get("/memories")
-def get_memories(_: bool = Depends(get_current_user)):
-    return list_memories()
+def get_memories(user: CurrentUser = Depends(get_current_user)):
+    return list_memories(user.id)
 
 
 @app.put("/memories/{memory_id}")
-def update_memory_endpoint(memory_id: int, request: MemoryUpdateRequest, _: bool = Depends(get_current_user)):
-    update_memory(memory_id, request.category, request.content)
+def update_memory_endpoint(
+    memory_id: int,
+    request: MemoryUpdateRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    if not update_memory(memory_id, request.category, request.content, user.id):
+        # 404 (not 403) so cross-user access cannot probe for existence.
+        raise HTTPException(status_code=404, detail="Mémoire introuvable.")
     return {"ok": True}
 
 
 @app.delete("/memories/{memory_id}")
-def delete_memory_endpoint(memory_id: int, _: bool = Depends(get_current_user)):
-    delete_memory(memory_id)
+def delete_memory_endpoint(
+    memory_id: int,
+    user: CurrentUser = Depends(get_current_user),
+):
+    if not delete_memory(memory_id, user.id):
+        raise HTTPException(status_code=404, detail="Mémoire introuvable.")
     return {"ok": True}
 
 
 @app.post("/memories")
-def add_memory(request: MemoryAddRequest, _: bool = Depends(get_current_user)):
-    save_memory(request.category, request.content)
+def add_memory(
+    request: MemoryAddRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    save_memory(request.category, request.content, user.id)
     return {"ok": True}
 
 


### PR DESCRIPTION
Closes #106.

Scopes manual memories and natural memories to the authenticated user.

Changes:
- Adds user ownership to memories and natural_memories
- Backfills existing memory rows to the migrated default admin
- Filters memory reads by current user
- Saves manual memory commands under the current user
- Scopes forget/show memory commands to the current user
- Scopes natural memory retrieval and deduplication by user
- Routes automatic memory extraction through user_id
- Preserves legacy CLI/background writes through the default admin user
- Adds tests for cross-user memory isolation and preserved single-user behavior

Not included:
- No user settings split (#107)
- No family controls (#108)
- No admin user-management UI (#109)
- No model registry or model permissions (#110–#112)
- No frontend changes
- No memory import save flow

https://claude.ai/code/session_017Y8ZYyZt4uASRzZkQzTGM1

---
_Generated by [Claude Code](https://claude.ai/code/session_017Y8ZYyZt4uASRzZkQzTGM1)_