### PR TITLE
feat: role-based family controls (#108)

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -5,6 +5,7 @@ from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
 from core.ollama_client import client
 from core.memory import format_memories_for_prompt, parse_and_save
 from core.identity import IDENTITY_CONTRACT
+from core.policies import ADMIN_POLICY, Policy
 from core.router import route
 from core.search import web_search, should_search
 from core.weather import detect_weather_city, get_weather
@@ -101,14 +102,20 @@ def build_image_messages(user_input: str, image: str) -> list[dict]:
     }]
 
 
-def chat(history: list[dict], user_input: str, memories: list[dict], user_id: int, forced_model: str = None, force_search: bool = False, image: str = None) -> tuple[str, str]:
+def chat(history: list[dict], user_input: str, memories: list[dict], user_id: int, forced_model: str = None, force_search: bool = False, image: str = None, policy: Policy | None = None) -> tuple[str, str]:  # noqa: E501
     """
     Envoie un message à Nova et retourne sa réponse et le modèle utilisé.
 
     Toutes les opérations mémoire (récupération, extraction, sauvegarde)
     sont scopées à `user_id` — un utilisateur ne voit jamais les souvenirs
     d'un autre.
+
+    `policy` gates the dual-use side effects (weather lookup, web search,
+    memory extraction). It defaults to the admin policy so non-HTTP
+    callers (CLI, learner) keep their pre-#108 behaviour.
     """
+    if policy is None:
+        policy = ADMIN_POLICY
     try:
         # Image → vision model, no routing
         if image:
@@ -116,31 +123,35 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             messages = build_image_messages(user_input, image)
             response = client.chat(model=MODELS["default"], messages=messages)
             reply = response["message"]["content"]
-            extract_and_save_memory(user_input or "image", reply, user_id)
+            if policy.memory_save_enabled:
+                extract_and_save_memory(user_input or "image", reply, user_id)
             return reply, MODELS["default"]
 
         model = forced_model if forced_model else route(user_input)
 
         natural_mems = get_relevant_memories(user_input, user_id)
 
-        # Météo en temps réel
-        weather_result = detect_weather_city(user_input)
-        if isinstance(weather_result, tuple):
-            lat, lon, city = weather_result
-            weather_data = get_weather(lat, lon, city)
-            messages = build_messages(history, user_input, memories, weather_data, "weather")
-            response = client.chat(model=model, messages=messages)
-            reply = response["message"]["content"]
-            return reply, model
+        # Weather is gated; restricted users with weather disabled fall
+        # straight through to the regular chat branch.
+        if policy.weather_enabled:
+            weather_result = detect_weather_city(user_input)
+            if isinstance(weather_result, tuple):
+                lat, lon, city = weather_result
+                weather_data = get_weather(lat, lon, city)
+                messages = build_messages(history, user_input, memories, weather_data, "weather")
+                response = client.chat(model=model, messages=messages)
+                reply = response["message"]["content"]
+                return reply, model
 
-        if weather_result in ("no_city", "multiple"):
-            return "Quelle ville ?", model
+            if weather_result in ("no_city", "multiple"):
+                return "Quelle ville ?", model
 
-        if weather_result == "unknown_city":
-            return "Je n'ai pas accès à la météo pour cette ville.", model
+            if weather_result == "unknown_city":
+                return "Je n'ai pas accès à la météo pour cette ville.", model
 
-        # Web search
-        if force_search or should_search(user_input):
+        # Web search — both the explicit `force_search` flag and the
+        # auto-detected `should_search` path require web_search_enabled.
+        if policy.web_search_enabled and (force_search or should_search(user_input)):
             search_results = web_search(user_input)
             messages = build_messages(history, user_input, memories, search_results, "search")
             response = client.chat(model=model, messages=messages)
@@ -161,15 +172,16 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             "je ne suis pas sûr", "je ne suis pas certain",
         ]
 
-        if any(t in reply.lower() for t in uncertainty_triggers):
+        if policy.web_search_enabled and any(t in reply.lower() for t in uncertainty_triggers):
             search_results = web_search(user_input)
             if search_results and "Aucun résultat" not in search_results:
                 messages = build_messages(history, user_input, memories, search_results, "search")
                 response = client.chat(model=model, messages=messages)
                 reply = response["message"]["content"]
 
-        extract_and_save_memory(user_input, reply, user_id)
-        _extract_and_save_natural_memories(user_input, user_id)
+        if policy.memory_save_enabled:
+            extract_and_save_memory(user_input, reply, user_id)
+            _extract_and_save_natural_memories(user_input, user_id)
         return reply, model
 
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:

--- a/core/memory.py
+++ b/core/memory.py
@@ -6,6 +6,7 @@ from typing import Optional
 from memory.store import initialize_memory_database as _init_natural_memory
 from core import users as _users
 from core.settings import migrate_user_settings as _migrate_user_settings
+from core.policies import migrate_family_controls as _migrate_family_controls
 
 DB_PATH = "nova.db"
 
@@ -91,6 +92,7 @@ def initialize_db():
     _migrate_conversation_ownership(DB_PATH)
     _migrate_memories_ownership(DB_PATH)
     _migrate_user_settings(DB_PATH)
+    _migrate_family_controls(DB_PATH)
     _init_natural_memory(DB_PATH)
 
 

--- a/core/policies.py
+++ b/core/policies.py
@@ -1,0 +1,426 @@
+"""
+Role-based family controls (issue #108).
+
+This is the server-side enforcement layer for admin / user / restricted
+accounts. Every protected feature reads a `Policy` resolved from the
+caller's identity, and the web layer surfaces 403 / 429 responses when a
+request fails the policy check. The frontend never decides; it only
+mirrors what the backend allows.
+
+Resolution rules:
+  * `admin`                 → full access (`ADMIN_POLICY`).
+  * `user`, not restricted  → permissive defaults (`DEFAULT_USER_POLICY`).
+  * `user`, `is_restricted` → defaults from `DEFAULT_RESTRICTED_POLICY`,
+                              overridden field-by-field by the row in
+                              `family_controls` if one exists.
+
+Storage:
+  * `family_controls(user_id PK, …)` — one row per restricted user.
+    Absent rows fall back to `DEFAULT_RESTRICTED_POLICY`.
+  * `user_daily_usage(user_id, usage_date PK)` — counter table for the
+    daily message limit. `record_message` is the single writer.
+
+Out of scope for this issue (#108):
+  * Admin endpoints to manage `family_controls` rows (#109).
+  * Model registry / per-user model allowlist (#110–#112).
+  * Surveillance dashboards / shared family memory.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from core.users import ROLE_ADMIN, ROLE_USER  # noqa: F401
+
+KNOWN_MODES: frozenset[str] = frozenset({"auto", "chat", "code", "deep"})
+
+# A `max_prompt_chars` of 0 means "no cap"; anything else is the strict
+# upper bound on the user-supplied message length.
+NO_PROMPT_CAP = 0
+NO_DAILY_LIMIT: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class Policy:
+    """Resolved feature/limit set for one request."""
+
+    role: str
+    is_restricted: bool
+    allowed_modes: frozenset[str]
+    web_search_enabled: bool
+    weather_enabled: bool
+    memory_save_enabled: bool
+    memory_import_enabled: bool
+    max_prompt_chars: int = NO_PROMPT_CAP
+    daily_message_limit: Optional[int] = NO_DAILY_LIMIT
+
+    @property
+    def is_admin(self) -> bool:
+        return self.role == ROLE_ADMIN
+
+    def mode_allowed(self, mode: str) -> bool:
+        return mode in self.allowed_modes
+
+    def prompt_too_long(self, text: str) -> bool:
+        return self.max_prompt_chars > 0 and len(text) > self.max_prompt_chars
+
+
+ADMIN_POLICY = Policy(
+    role=ROLE_ADMIN,
+    is_restricted=False,
+    allowed_modes=KNOWN_MODES,
+    web_search_enabled=True,
+    weather_enabled=True,
+    memory_save_enabled=True,
+    memory_import_enabled=True,
+    max_prompt_chars=NO_PROMPT_CAP,
+    daily_message_limit=NO_DAILY_LIMIT,
+)
+
+DEFAULT_USER_POLICY = Policy(
+    role=ROLE_USER,
+    is_restricted=False,
+    allowed_modes=KNOWN_MODES,
+    web_search_enabled=True,
+    weather_enabled=True,
+    memory_save_enabled=True,
+    memory_import_enabled=True,
+    max_prompt_chars=NO_PROMPT_CAP,
+    daily_message_limit=NO_DAILY_LIMIT,
+)
+
+DEFAULT_RESTRICTED_POLICY = Policy(
+    role=ROLE_USER,
+    is_restricted=True,
+    allowed_modes=frozenset({"chat"}),
+    web_search_enabled=False,
+    weather_enabled=True,
+    memory_save_enabled=False,
+    memory_import_enabled=False,
+    max_prompt_chars=2000,
+    daily_message_limit=200,
+)
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+_FAMILY_CONTROLS_SQL = """
+CREATE TABLE IF NOT EXISTS family_controls (
+    user_id               INTEGER PRIMARY KEY
+                                  REFERENCES users(id) ON DELETE CASCADE,
+    daily_message_limit   INTEGER,
+    allowed_modes         TEXT    NOT NULL DEFAULT 'chat',
+    web_search_enabled    INTEGER NOT NULL DEFAULT 0,
+    weather_enabled       INTEGER NOT NULL DEFAULT 1,
+    memory_save_enabled   INTEGER NOT NULL DEFAULT 0,
+    memory_import_enabled INTEGER NOT NULL DEFAULT 0,
+    max_prompt_chars      INTEGER NOT NULL DEFAULT 2000
+)
+"""
+
+_USER_DAILY_USAGE_SQL = """
+CREATE TABLE IF NOT EXISTS user_daily_usage (
+    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    usage_date    TEXT    NOT NULL,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, usage_date)
+)
+"""
+
+
+def _open(db_path: Optional[str] = None) -> sqlite3.Connection:
+    if db_path is None:
+        from core.memory import DB_PATH
+        db_path = DB_PATH
+    return sqlite3.connect(db_path)
+
+
+def migrate_family_controls(db_path: str) -> None:
+    """Create the `family_controls` and `user_daily_usage` tables. Idempotent."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_FAMILY_CONTROLS_SQL)
+        conn.execute(_USER_DAILY_USAGE_SQL)
+
+
+# ── CSV helpers for `allowed_modes` ─────────────────────────────────────────
+
+def _modes_to_csv(modes) -> str:
+    cleaned = sorted({m for m in modes if m in KNOWN_MODES})
+    if not cleaned:
+        cleaned = ["chat"]
+    return ",".join(cleaned)
+
+
+def _csv_to_modes(value: str) -> frozenset[str]:
+    parts = {p.strip() for p in (value or "").split(",") if p.strip()}
+    return frozenset(parts & KNOWN_MODES) or frozenset({"chat"})
+
+
+# ── Policy resolution ───────────────────────────────────────────────────────
+
+def _read_family_controls(
+    conn: sqlite3.Connection, user_id: int
+) -> Optional[sqlite3.Row]:
+    prev = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM family_controls WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+    finally:
+        conn.row_factory = prev
+
+
+def _policy_from_row(row: sqlite3.Row) -> Policy:
+    return Policy(
+        role=ROLE_USER,
+        is_restricted=True,
+        allowed_modes=_csv_to_modes(row["allowed_modes"]),
+        web_search_enabled=bool(row["web_search_enabled"]),
+        weather_enabled=bool(row["weather_enabled"]),
+        memory_save_enabled=bool(row["memory_save_enabled"]),
+        memory_import_enabled=bool(row["memory_import_enabled"]),
+        max_prompt_chars=int(row["max_prompt_chars"]),
+        daily_message_limit=(
+            int(row["daily_message_limit"])
+            if row["daily_message_limit"] is not None
+            else NO_DAILY_LIMIT
+        ),
+    )
+
+
+def get_policy(user, db_path: Optional[str] = None) -> Policy:
+    """
+    Resolve the policy for `user`.
+
+    Accepts any object exposing `role` and `is_restricted`. Admins and
+    non-restricted users are resolved without touching the database; only
+    a restricted user's row in `family_controls` triggers a read.
+    """
+    if user is None:
+        # No identity → behave as the most permissive user (CLI / learner
+        # paths run as the legacy admin and pass `None` rather than a
+        # CurrentUser). Family controls do not apply here.
+        return ADMIN_POLICY
+    if getattr(user, "role", None) == ROLE_ADMIN:
+        return ADMIN_POLICY
+    if not getattr(user, "is_restricted", False):
+        return DEFAULT_USER_POLICY
+    user_id = int(getattr(user, "id"))
+    try:
+        with _open(db_path) as conn:
+            row = _read_family_controls(conn, user_id)
+    except sqlite3.DatabaseError:
+        row = None
+    if row is None:
+        return DEFAULT_RESTRICTED_POLICY
+    return _policy_from_row(row)
+
+
+def set_family_controls(
+    user_id: int,
+    *,
+    allowed_modes=None,
+    web_search_enabled: Optional[bool] = None,
+    weather_enabled: Optional[bool] = None,
+    memory_save_enabled: Optional[bool] = None,
+    memory_import_enabled: Optional[bool] = None,
+    max_prompt_chars: Optional[int] = None,
+    daily_message_limit: Optional[int] = None,
+    db_path: Optional[str] = None,
+) -> None:
+    """
+    Upsert the `family_controls` row for `user_id`.
+
+    Fields left as `None` fall back to the schema defaults on insert and
+    are left untouched on update. The admin endpoints that drive this
+    helper land in #109; #108 provides the storage path so enforcement
+    has something to read.
+    """
+    with _open(db_path) as conn:
+        existing = _read_family_controls(conn, user_id)
+        if existing is None:
+            conn.execute(
+                "INSERT INTO family_controls ("
+                "user_id, daily_message_limit, allowed_modes, "
+                "web_search_enabled, weather_enabled, "
+                "memory_save_enabled, memory_import_enabled, "
+                "max_prompt_chars) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    user_id,
+                    daily_message_limit,
+                    _modes_to_csv(
+                        allowed_modes
+                        if allowed_modes is not None
+                        else DEFAULT_RESTRICTED_POLICY.allowed_modes
+                    ),
+                    int(
+                        web_search_enabled
+                        if web_search_enabled is not None
+                        else DEFAULT_RESTRICTED_POLICY.web_search_enabled
+                    ),
+                    int(
+                        weather_enabled
+                        if weather_enabled is not None
+                        else DEFAULT_RESTRICTED_POLICY.weather_enabled
+                    ),
+                    int(
+                        memory_save_enabled
+                        if memory_save_enabled is not None
+                        else DEFAULT_RESTRICTED_POLICY.memory_save_enabled
+                    ),
+                    int(
+                        memory_import_enabled
+                        if memory_import_enabled is not None
+                        else DEFAULT_RESTRICTED_POLICY.memory_import_enabled
+                    ),
+                    int(
+                        max_prompt_chars
+                        if max_prompt_chars is not None
+                        else DEFAULT_RESTRICTED_POLICY.max_prompt_chars
+                    ),
+                ),
+            )
+            return
+
+        updates: list[tuple[str, object]] = []
+        if allowed_modes is not None:
+            updates.append(("allowed_modes", _modes_to_csv(allowed_modes)))
+        if web_search_enabled is not None:
+            updates.append(("web_search_enabled", int(web_search_enabled)))
+        if weather_enabled is not None:
+            updates.append(("weather_enabled", int(weather_enabled)))
+        if memory_save_enabled is not None:
+            updates.append(("memory_save_enabled", int(memory_save_enabled)))
+        if memory_import_enabled is not None:
+            updates.append(("memory_import_enabled", int(memory_import_enabled)))
+        if max_prompt_chars is not None:
+            updates.append(("max_prompt_chars", int(max_prompt_chars)))
+        if daily_message_limit is not None:
+            updates.append(("daily_message_limit", int(daily_message_limit)))
+        if not updates:
+            return
+        cols = ", ".join(f"{k} = ?" for k, _ in updates)
+        params = [v for _, v in updates] + [user_id]
+        conn.execute(
+            f"UPDATE family_controls SET {cols} WHERE user_id = ?", params
+        )
+
+
+# ── Daily message accounting ────────────────────────────────────────────────
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _seconds_until_midnight_utc() -> int:
+    now = datetime.now(timezone.utc)
+    end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return max(1, int((end - now).total_seconds()) + 1)
+
+
+def today_usage(user_id: int, db_path: Optional[str] = None) -> int:
+    with _open(db_path) as conn:
+        row = conn.execute(
+            "SELECT message_count FROM user_daily_usage "
+            "WHERE user_id = ? AND usage_date = ?",
+            (user_id, _today_utc()),
+        ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def record_message(user_id: int, db_path: Optional[str] = None) -> int:
+    """Increment today's counter for `user_id` and return the new total."""
+    today = _today_utc()
+    with _open(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_daily_usage (user_id, usage_date, message_count) "
+            "VALUES (?, ?, 1) "
+            "ON CONFLICT(user_id, usage_date) DO UPDATE SET "
+            "message_count = message_count + 1",
+            (user_id, today),
+        )
+        row = conn.execute(
+            "SELECT message_count FROM user_daily_usage "
+            "WHERE user_id = ? AND usage_date = ?",
+            (user_id, today),
+        ).fetchone()
+    return int(row[0]) if row else 0
+
+
+# ── Enforcement helpers ─────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class PolicyDenial:
+    """Describes why a request was refused. Mapped to HTTP at the web edge."""
+
+    status_code: int
+    detail: str
+    headers: dict = field(default_factory=dict)
+
+
+def check_chat_request(
+    policy: Policy,
+    *,
+    mode: str,
+    message: str,
+    requested_search: bool,
+) -> Optional[PolicyDenial]:
+    """
+    Validate a /chat payload against `policy`.
+
+    Returns `None` when the request is allowed. Returns a `PolicyDenial`
+    describing the first violation found. Daily-limit accounting is
+    handled separately by `enforce_daily_limit` so that the counter is
+    only touched once enforcement has otherwise succeeded.
+    """
+    if not policy.mode_allowed(mode):
+        return PolicyDenial(
+            status_code=403,
+            detail=f"Mode '{mode}' is not allowed for this account.",
+        )
+    if requested_search and not policy.web_search_enabled:
+        return PolicyDenial(
+            status_code=403,
+            detail="Web search is disabled for this account.",
+        )
+    if policy.prompt_too_long(message):
+        return PolicyDenial(
+            status_code=403,
+            detail=(
+                f"Message exceeds the {policy.max_prompt_chars}-character "
+                "limit for this account."
+            ),
+        )
+    return None
+
+
+def enforce_daily_limit(
+    policy: Policy, user_id: int, db_path: Optional[str] = None
+) -> Optional[PolicyDenial]:
+    """
+    Check today's usage against `policy.daily_message_limit` and, if the
+    request is allowed, record one message.
+
+    Returns a 429 `PolicyDenial` with a `Retry-After` header (in seconds
+    until UTC midnight) when the limit has already been reached.
+    """
+    if policy.daily_message_limit is None:
+        return None
+    used = today_usage(user_id, db_path=db_path)
+    if used >= policy.daily_message_limit:
+        retry = _seconds_until_midnight_utc()
+        return PolicyDenial(
+            status_code=429,
+            detail=(
+                "Daily message limit reached "
+                f"({policy.daily_message_limit}/day)."
+            ),
+            headers={"Retry-After": str(retry)},
+        )
+    record_message(user_id, db_path=db_path)
+    return None

--- a/tests/test_family_controls.py
+++ b/tests/test_family_controls.py
@@ -1,0 +1,423 @@
+"""
+Tests for role-based family controls (issue #108).
+
+Covers:
+  * Schema: `family_controls` and `user_daily_usage` tables exist after
+    migration and the migration is idempotent.
+  * Policy resolution: admins / normal users / restricted users with and
+    without an explicit family_controls row.
+  * `set_family_controls` upsert behaviour.
+  * Daily-usage accounting.
+  * `/chat` enforcement: allowed modes, web search, prompt length, daily
+    message limit, manual memory commands, even when the request is
+    crafted to bypass any frontend.
+  * `/memories` POST gated by memory_save_enabled.
+  * Existing single-user/default-admin behaviour is preserved.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, policies, users
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(
+    db_path,
+    username,
+    password="pw",
+    role=users.ROLE_USER,
+    is_restricted=False,
+):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+class TestSchema:
+    def test_family_controls_table_exists(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='family_controls'"
+            ).fetchone()
+        assert row is not None
+
+    def test_user_daily_usage_table_exists(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='user_daily_usage'"
+            ).fetchone()
+        assert row is not None
+
+    def test_migration_is_idempotent(self, db_path):
+        core_memory.initialize_db()
+        core_memory.initialize_db()
+        with sqlite3.connect(db_path) as conn:
+            tables = [r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name IN "
+                "('family_controls', 'user_daily_usage')"
+            ).fetchall()]
+        assert sorted(tables) == ["family_controls", "user_daily_usage"]
+
+
+# ── Policy resolution ───────────────────────────────────────────────────────
+
+class _Identity:
+    """Minimal duck-typed CurrentUser for direct policy tests."""
+
+    def __init__(self, id, role, is_restricted=False):
+        self.id = id
+        self.role = role
+        self.is_restricted = is_restricted
+
+
+class TestPolicyResolution:
+    def test_admin_gets_full_policy(self, db_path):
+        admin = _Identity(1, users.ROLE_ADMIN)
+        p = policies.get_policy(admin, db_path=db_path)
+        assert p is policies.ADMIN_POLICY
+        assert p.is_admin
+        assert p.web_search_enabled
+        assert p.weather_enabled
+        assert p.memory_save_enabled
+        assert p.daily_message_limit is None
+        assert p.max_prompt_chars == 0
+
+    def test_normal_user_gets_permissive_defaults(self, db_path):
+        u = _Identity(2, users.ROLE_USER)
+        p = policies.get_policy(u, db_path=db_path)
+        assert p is policies.DEFAULT_USER_POLICY
+        assert p.web_search_enabled
+        assert p.memory_save_enabled
+        assert p.daily_message_limit is None
+
+    def test_restricted_user_with_no_row_uses_defaults(self, db_path):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        p = policies.get_policy(u, db_path=db_path)
+        assert p.is_restricted
+        assert not p.web_search_enabled
+        assert p.weather_enabled
+        assert not p.memory_save_enabled
+        assert "chat" in p.allowed_modes
+        assert "code" not in p.allowed_modes
+        assert p.max_prompt_chars == 2000
+        assert p.daily_message_limit == 200
+
+    def test_restricted_user_with_row_overrides_defaults(self, db_path):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        policies.set_family_controls(
+            uid,
+            allowed_modes=("chat", "code"),
+            web_search_enabled=True,
+            memory_save_enabled=True,
+            max_prompt_chars=500,
+            daily_message_limit=10,
+            db_path=db_path,
+        )
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        p = policies.get_policy(u, db_path=db_path)
+        assert p.allowed_modes == frozenset({"chat", "code"})
+        assert p.web_search_enabled
+        assert p.memory_save_enabled
+        assert p.max_prompt_chars == 500
+        assert p.daily_message_limit == 10
+
+    def test_set_family_controls_update_preserves_unspecified_fields(self, db_path):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        policies.set_family_controls(
+            uid, web_search_enabled=True, max_prompt_chars=1000, db_path=db_path,
+        )
+        # Update only one field; the other must stick.
+        policies.set_family_controls(
+            uid, max_prompt_chars=750, db_path=db_path,
+        )
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        p = policies.get_policy(u, db_path=db_path)
+        assert p.web_search_enabled is True
+        assert p.max_prompt_chars == 750
+
+
+# ── Daily usage ─────────────────────────────────────────────────────────────
+
+class TestDailyUsage:
+    def test_record_message_increments(self, db_path):
+        uid = _make_user(db_path, "alice")
+        assert policies.today_usage(uid, db_path=db_path) == 0
+        assert policies.record_message(uid, db_path=db_path) == 1
+        assert policies.record_message(uid, db_path=db_path) == 2
+        assert policies.today_usage(uid, db_path=db_path) == 2
+
+    def test_enforce_daily_limit_blocks_after_limit(self, db_path):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        policies.set_family_controls(
+            uid, daily_message_limit=2, db_path=db_path,
+        )
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        policy = policies.get_policy(u, db_path=db_path)
+
+        assert policies.enforce_daily_limit(policy, uid, db_path=db_path) is None
+        assert policies.enforce_daily_limit(policy, uid, db_path=db_path) is None
+        denial = policies.enforce_daily_limit(policy, uid, db_path=db_path)
+        assert denial is not None
+        assert denial.status_code == 429
+        assert "Retry-After" in denial.headers
+
+    def test_no_limit_for_admin(self, db_path):
+        # Admin policy has daily_message_limit=None, so enforcement is a no-op.
+        admin = _Identity(1, users.ROLE_ADMIN)
+        p = policies.get_policy(admin, db_path=db_path)
+        for _ in range(10):
+            assert policies.enforce_daily_limit(p, 1, db_path=db_path) is None
+
+
+# ── /chat enforcement (HTTP) ────────────────────────────────────────────────
+
+def _restricted_user(db_path, username, **overrides):
+    uid = _make_user(db_path, username, is_restricted=True)
+    if overrides:
+        policies.set_family_controls(uid, db_path=db_path, **overrides)
+    return uid
+
+
+class TestChatPolicyEnforcement:
+    def test_admin_can_use_all_features(self, db_path, web_client):
+        _make_user(db_path, "boss", role=users.ROLE_ADMIN)
+        token = _login(web_client, "boss")
+        with patch("web.chat", return_value=("ok", "stub")) as m:
+            resp = web_client.post(
+                "/chat",
+                json={"message": "hello", "mode": "deep", "search": True},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        # Admin's policy: web_search+weather+memory_save all on.
+        passed_policy = m.call_args.kwargs["policy"]
+        assert passed_policy.is_admin
+        assert passed_policy.web_search_enabled
+        assert passed_policy.memory_save_enabled
+
+    def test_normal_user_keeps_default_features(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        with patch("web.chat", return_value=("ok", "stub")) as m:
+            resp = web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "code", "search": True},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        passed_policy = m.call_args.kwargs["policy"]
+        assert not passed_policy.is_admin
+        assert passed_policy.web_search_enabled
+        assert passed_policy.memory_save_enabled
+
+    def test_restricted_user_cannot_use_disallowed_mode(self, db_path, web_client):
+        _restricted_user(db_path, "kid")  # default allowed_modes = {"chat"}
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "hi", "mode": "code"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+        assert "Mode" in resp.json()["detail"]
+
+    def test_restricted_user_cannot_force_web_search(self, db_path, web_client):
+        _restricted_user(db_path, "kid")  # default web_search_enabled = False
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "hi", "mode": "chat", "search": True},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+        assert "search" in resp.json()["detail"].lower()
+
+    def test_restricted_user_can_chat_when_within_policy(self, db_path, web_client):
+        _restricted_user(db_path, "kid")
+        token = _login(web_client, "kid")
+        with patch("web.chat", return_value=("ok", "stub")) as m:
+            resp = web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "chat", "search": False},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        passed_policy = m.call_args.kwargs["policy"]
+        assert passed_policy.is_restricted
+        assert not passed_policy.web_search_enabled
+        assert not passed_policy.memory_save_enabled
+
+    def test_prompt_length_limit_is_enforced(self, db_path, web_client):
+        _restricted_user(db_path, "kid", max_prompt_chars=20)
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "x" * 50, "mode": "chat"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+        assert "20" in resp.json()["detail"]
+
+    def test_daily_message_limit_is_enforced(self, db_path, web_client):
+        _restricted_user(db_path, "kid", daily_message_limit=2)
+        token = _login(web_client, "kid")
+        with patch("web.chat", return_value=("ok", "stub")):
+            r1 = web_client.post(
+                "/chat", json={"message": "a", "mode": "chat"}, headers=_h(token),
+            )
+            r2 = web_client.post(
+                "/chat", json={"message": "b", "mode": "chat"}, headers=_h(token),
+            )
+            r3 = web_client.post(
+                "/chat", json={"message": "c", "mode": "chat"}, headers=_h(token),
+            )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r3.status_code == 429
+        assert r3.headers.get("retry-after") is not None
+
+    def test_manual_memory_command_blocked_when_memory_save_disabled(
+        self, db_path, web_client,
+    ):
+        _restricted_user(db_path, "kid")  # default memory_save_enabled = False
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "Souviens-toi: nothing", "mode": "chat"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+        assert "memory" in resp.json()["detail"].lower()
+
+    def test_manual_memory_command_allowed_when_memory_save_enabled(
+        self, db_path, web_client,
+    ):
+        _restricted_user(db_path, "kid", memory_save_enabled=True)
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "Souviens-toi: ma couleur préférée", "mode": "chat"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 200
+        assert "Souvenir" in resp.json()["response"]
+
+    def test_backend_rejects_forbidden_request_even_when_crafted(
+        self, db_path, web_client,
+    ):
+        """A manually crafted JSON request bypassing a hypothetical UI is still refused."""
+        _restricted_user(db_path, "kid")
+        token = _login(web_client, "kid")
+        # Frontend would not allow these — the backend must refuse anyway.
+        attempts = [
+            {"message": "x", "mode": "deep"},
+            {"message": "x", "mode": "chat", "search": True},
+        ]
+        for body in attempts:
+            resp = web_client.post("/chat", json=body, headers=_h(token))
+            assert resp.status_code == 403, body
+
+
+class TestMemoryEndpointPolicy:
+    def test_memory_post_blocked_when_memory_save_disabled(
+        self, db_path, web_client,
+    ):
+        _restricted_user(db_path, "kid")
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/memories",
+            json={"category": "x", "content": "y"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+
+    def test_memory_post_allowed_for_normal_user(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/memories",
+            json={"category": "x", "content": "y"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 200
+
+
+# ── Default admin / single-user behaviour preserved ─────────────────────────
+
+class TestSingleUserBehaviorPreserved:
+    def test_default_admin_has_unrestricted_policy(self, db_path):
+        admin_id = users.get_legacy_admin_id(db_path)
+        assert admin_id is not None
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT role, is_restricted FROM users WHERE id = ?",
+                (admin_id,),
+            ).fetchone()
+        assert row[0] == "admin"
+        assert row[1] == 0
+        admin = _Identity(admin_id, "admin")
+        p = policies.get_policy(admin, db_path=db_path)
+        assert p is policies.ADMIN_POLICY
+
+    def test_default_admin_chat_unrestricted(self, db_path, web_client):
+        # Logging in as the seeded admin still yields full feature access.
+        token = _login(web_client, "nova", "nova")
+        with patch("web.chat", return_value=("ok", "stub")) as m:
+            resp = web_client.post(
+                "/chat",
+                json={"message": "y", "mode": "deep", "search": True},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        assert m.call_args.kwargs["policy"].is_admin

--- a/web.py
+++ b/web.py
@@ -32,6 +32,12 @@ from core.memory import (
 from core.settings import (
     get_user_setting, save_user_setting,
 )
+from core.policies import (
+    PolicyDenial,
+    check_chat_request,
+    enforce_daily_limit,
+    get_policy,
+)
 from memory.store import (
     list_memories as list_natural_memories,
     delete_memories_matching,
@@ -287,6 +293,14 @@ def get_current_user(
     return user
 
 
+def _raise_policy_denial(denial: PolicyDenial) -> None:
+    raise HTTPException(
+        status_code=denial.status_code,
+        detail=denial.detail,
+        headers=denial.headers or None,
+    )
+
+
 @app.post("/login")
 def login(request: LoginRequest, _: None = Depends(check_login_rate_limit)):
     user = authenticate(request.username, request.password)
@@ -333,13 +347,37 @@ def remove_conversation(
 
 @app.post("/chat")
 def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_user)):
+    policy = get_policy(user)
+
+    denial = check_chat_request(
+        policy,
+        mode=request.mode,
+        message=request.message,
+        requested_search=request.search,
+    )
+    if denial is not None:
+        _raise_policy_denial(denial)
+
+    denial = enforce_daily_limit(policy, user.id)
+    if denial is not None:
+        _raise_policy_denial(denial)
+
     memories = load_memories(user.id)
+
+    msg_lower = request.message.lower().strip()
+    is_manual_memory_command = any(
+        msg_lower.startswith(p)
+        for p in ("retiens ça:", "souviens-toi de ça:", "souviens-toi:")
+    )
+    if is_manual_memory_command and not policy.memory_save_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="Memory saving is disabled for this account.",
+        )
 
     reply = handle_manual_memory_command(request.message, user.id)
     if reply is not None:
         return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
-
-    msg_lower = request.message.lower().strip()
 
     if msg_lower.startswith("forget that ") or msg_lower.startswith("oublie que "):
         query = request.message.split(" ", 2)[2].strip()
@@ -385,7 +423,7 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         )
     else:
         forced_model = MODE_MAP.get(request.mode)
-    response, model_used = chat(history, request.message, memories, user.id, forced_model=forced_model, force_search=request.search, image=request.image)
+    response, model_used = chat(history, request.message, memories, user.id, forced_model=forced_model, force_search=request.search, image=request.image, policy=policy)
 
     save_message(conversation_id, "user", request.message)
     save_message(conversation_id, "assistant", response, model_used)
@@ -434,6 +472,12 @@ def add_memory(
     request: MemoryAddRequest,
     user: CurrentUser = Depends(get_current_user),
 ):
+    policy = get_policy(user)
+    if not policy.memory_save_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="Memory saving is disabled for this account.",
+        )
     save_memory(request.category, request.content, user.id)
     return {"ok": True}
 


### PR DESCRIPTION
Closes #108.

Adds backend role-based family controls for Nova.

Changes:
- Adds a centralized policy layer for admin/user/restricted users
- Adds family_controls and user_daily_usage storage
- Enforces allowed modes, web search, weather, memory saving, prompt length, and daily message limits server-side
- Applies policy checks to /chat and manual memory save paths
- Preserves default-admin behavior
- Adds tests for policy resolution, daily usage, and backend enforcement

Not included:
- No admin user-management UI (#109)
- No model registry or model permissions (#110–#112)
- No Ollama pull flow
- No frontend admin UI
- No surveillance dashboard
- No admin access to private conversations or memories

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtiEnU5zosBEDGw1BE8Aiz)_