### PR TITLE
Add admin user-management UI and endpoints (#109)

### DIFF
--- a/core/policies.py
+++ b/core/policies.py
@@ -221,6 +221,35 @@ def get_policy(user, db_path: Optional[str] = None) -> Policy:
     return _policy_from_row(row)
 
 
+def get_family_controls_dict(
+    user_id: int, db_path: Optional[str] = None
+) -> Optional[dict]:
+    """
+    Return the family_controls row for `user_id` as a plain dict, or None
+    if no row exists. Caller-friendly view used by the admin endpoints.
+    """
+    try:
+        with _open(db_path) as conn:
+            row = _read_family_controls(conn, user_id)
+    except sqlite3.DatabaseError:
+        return None
+    if row is None:
+        return None
+    return {
+        "allowed_modes": sorted(_csv_to_modes(row["allowed_modes"])),
+        "web_search_enabled": bool(row["web_search_enabled"]),
+        "weather_enabled": bool(row["weather_enabled"]),
+        "memory_save_enabled": bool(row["memory_save_enabled"]),
+        "memory_import_enabled": bool(row["memory_import_enabled"]),
+        "max_prompt_chars": int(row["max_prompt_chars"]),
+        "daily_message_limit": (
+            int(row["daily_message_limit"])
+            if row["daily_message_limit"] is not None
+            else None
+        ),
+    }
+
+
 def set_family_controls(
     user_id: int,
     *,

--- a/core/users.py
+++ b/core/users.py
@@ -140,6 +140,142 @@ def create_user(
     return cur.lastrowid
 
 
+def list_users(conn: sqlite3.Connection) -> list[dict]:
+    """
+    Return all users as plain dicts, ordered by id.
+
+    The password_hash column is intentionally omitted — admin-facing
+    callers must never see it.
+    """
+    prev_factory = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT id, username, role, is_restricted, token_version, "
+            "created_at, disabled_at FROM users ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.row_factory = prev_factory
+    return [
+        {
+            "id": int(r["id"]),
+            "username": r["username"],
+            "role": r["role"],
+            "is_restricted": bool(r["is_restricted"]),
+            "token_version": int(r["token_version"]),
+            "created_at": r["created_at"],
+            "disabled_at": r["disabled_at"],
+        }
+        for r in rows
+    ]
+
+
+def get_user_by_id(
+    conn: sqlite3.Connection, user_id: int
+) -> Optional[sqlite3.Row]:
+    prev_factory = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+    finally:
+        conn.row_factory = prev_factory
+
+
+def count_active_admins(conn: sqlite3.Connection) -> int:
+    """Return the count of admin rows whose `disabled_at` is NULL."""
+    return conn.execute(
+        "SELECT COUNT(*) FROM users "
+        "WHERE role = ? AND disabled_at IS NULL",
+        (ROLE_ADMIN,),
+    ).fetchone()[0]
+
+
+def set_disabled(
+    conn: sqlite3.Connection, user_id: int, disabled: bool
+) -> bool:
+    """
+    Disable or re-enable `user_id`. Bumps token_version when disabling so
+    any previously-issued JWT for that user immediately stops working.
+
+    Returns True if a row was updated, False if the user does not exist.
+    """
+    row = get_user_by_id(conn, user_id)
+    if row is None:
+        return False
+    if disabled:
+        if row["disabled_at"] is not None:
+            return True
+        conn.execute(
+            "UPDATE users SET disabled_at = ?, "
+            "token_version = token_version + 1 WHERE id = ?",
+            (_now_iso(), user_id),
+        )
+    else:
+        if row["disabled_at"] is None:
+            return True
+        conn.execute(
+            "UPDATE users SET disabled_at = NULL WHERE id = ?",
+            (user_id,),
+        )
+    return True
+
+
+def set_role(
+    conn: sqlite3.Connection,
+    user_id: int,
+    role: str,
+    is_restricted: bool,
+) -> bool:
+    """
+    Update role + is_restricted on `user_id`. Bumps token_version when the
+    role or restriction flag actually changes, so old JWTs cannot keep
+    using stale privileges.
+
+    Returns True if the row exists, False otherwise.
+    """
+    if role not in (ROLE_ADMIN, ROLE_USER):
+        raise ValueError(f"invalid role: {role!r}")
+    if role == ROLE_ADMIN and is_restricted:
+        raise ValueError("admin cannot be restricted")
+    row = get_user_by_id(conn, user_id)
+    if row is None:
+        return False
+    same = (
+        row["role"] == role
+        and bool(row["is_restricted"]) == bool(is_restricted)
+    )
+    if same:
+        return True
+    conn.execute(
+        "UPDATE users SET role = ?, is_restricted = ?, "
+        "token_version = token_version + 1 WHERE id = ?",
+        (role, 1 if is_restricted else 0, user_id),
+    )
+    return True
+
+
+def reset_password(
+    conn: sqlite3.Connection, user_id: int, new_password: str
+) -> bool:
+    """
+    Replace the stored bcrypt hash for `user_id` and bump token_version so
+    every existing token for this user becomes invalid immediately.
+    """
+    if not new_password:
+        raise ValueError("password must be non-empty")
+    row = get_user_by_id(conn, user_id)
+    if row is None:
+        return False
+    conn.execute(
+        "UPDATE users SET password_hash = ?, "
+        "token_version = token_version + 1 WHERE id = ?",
+        (_hash_password(new_password), user_id),
+    )
+    return True
+
+
 def get_legacy_admin_id(db_path: str) -> Optional[int]:
     """
     Return the user_id of the first user in the table — the seeded admin.

--- a/static/index.html
+++ b/static/index.html
@@ -816,6 +816,194 @@
         }
 
         #settings-btn:hover { border-color: var(--cyan); color: var(--cyan); }
+        #admin-btn:hover { border-color: var(--cyan); color: var(--cyan); }
+
+        /* ── ADMIN PANEL ── */
+        #admin-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.6);
+            z-index: 30;
+            align-items: center;
+            justify-content: center;
+        }
+        #admin-overlay.open { display: flex; }
+        #admin-panel {
+            background: var(--bg2);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            width: 95%;
+            max-width: 760px;
+            max-height: 85dvh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+        #admin-header {
+            padding: 16px 20px;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        #admin-header h2 {
+            color: var(--cyan);
+            font-size: 1rem;
+            letter-spacing: 2px;
+        }
+        #admin-close {
+            background: transparent;
+            border: none;
+            color: var(--text-dim);
+            font-size: 1.2rem;
+            cursor: pointer;
+        }
+        #admin-close:hover { color: var(--danger); }
+        #admin-body {
+            flex: 1;
+            overflow-y: auto;
+            padding: 16px 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .admin-section-title {
+            font-size: 0.75rem;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .admin-user-row {
+            background: var(--bg3);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .admin-user-head {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .admin-user-name {
+            font-size: 0.9rem;
+            color: var(--text);
+            font-weight: bold;
+            flex: 1;
+            min-width: 100px;
+        }
+        .admin-tag {
+            font-size: 0.7rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            border: 1px solid var(--border);
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .admin-tag.role-admin { color: var(--cyan); border-color: var(--cyan); }
+        .admin-tag.role-restricted { color: #ce93d8; border-color: #ce93d8; }
+        .admin-tag.disabled { color: var(--danger); border-color: var(--danger); }
+        .admin-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            align-items: center;
+        }
+        .admin-btn {
+            padding: 4px 10px;
+            border-radius: 5px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: var(--text-dim);
+            font-family: monospace;
+            font-size: 0.75rem;
+            cursor: pointer;
+            transition: all 0.15s;
+        }
+        .admin-btn:hover { border-color: var(--cyan); color: var(--cyan); }
+        .admin-btn.danger:hover { border-color: var(--danger); color: var(--danger); }
+        .admin-select {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 5px;
+            color: var(--text);
+            font-family: monospace;
+            font-size: 0.75rem;
+            padding: 4px 6px;
+            cursor: pointer;
+        }
+        .admin-fc {
+            display: none;
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 10px;
+            font-size: 0.78rem;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 8px;
+        }
+        .admin-fc label {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            color: var(--text-dim);
+        }
+        .admin-fc input[type="number"], .admin-fc input[type="text"] {
+            width: 80px;
+            background: var(--bg3);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            color: var(--text);
+            font-family: monospace;
+            font-size: 0.78rem;
+            padding: 3px 6px;
+            outline: none;
+        }
+        #admin-create-form {
+            background: var(--bg3);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        #admin-create-form .row {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        #admin-create-form input, #admin-create-form select {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            font-family: monospace;
+            font-size: 0.85rem;
+            padding: 6px 10px;
+            outline: none;
+            flex: 1;
+            min-width: 120px;
+        }
+        #admin-create-btn {
+            padding: 7px 14px;
+            background: var(--cyan);
+            border: none;
+            border-radius: 6px;
+            color: #000;
+            font-family: monospace;
+            font-size: 0.85rem;
+            font-weight: bold;
+            cursor: pointer;
+        }
+        #admin-create-btn:hover { background: var(--cyan-dim); }
+        #admin-error { color: var(--danger); font-size: 0.8rem; min-height: 16px; }
 
         /* ── SCROLLBAR ── */
         ::-webkit-scrollbar { width: 4px; }
@@ -951,6 +1139,7 @@
             <div id="conversations-list"></div>
             <div id="sidebar-footer">
                 <button id="settings-btn" onclick="openSettings()">⚙ Settings</button>
+                <button id="admin-btn" onclick="openAdmin()" style="display:none;width:100%;padding:8px;background:transparent;border:1px solid var(--border);border-radius:5px;color:var(--text-dim);font-family:monospace;font-size:0.8rem;cursor:pointer;transition:all 0.2s;margin-top:6px;">⚑ Admin</button>
                 <button id="logout-btn" onclick="logout()">Déconnexion</button>
             </div>
         </div>
@@ -1038,6 +1227,36 @@
             </div>
         </div>
 
+    </div>
+</div>
+
+<!-- ADMIN PANEL -->
+<div id="admin-overlay" onclick="handleAdminOverlayClick(event)">
+    <div id="admin-panel">
+        <div id="admin-header">
+            <h2>⚑ ADMIN — USERS</h2>
+            <button id="admin-close" onclick="closeAdmin()">✕</button>
+        </div>
+        <div id="admin-body">
+            <div class="admin-section-title">Create user</div>
+            <div id="admin-create-form">
+                <div class="row">
+                    <input id="admin-new-username" type="text" placeholder="username" autocomplete="off" />
+                    <input id="admin-new-password" type="password" placeholder="password" autocomplete="new-password" />
+                </div>
+                <div class="row">
+                    <select id="admin-new-role">
+                        <option value="user">user</option>
+                        <option value="admin">admin</option>
+                        <option value="restricted">restricted (child)</option>
+                    </select>
+                    <button id="admin-create-btn" onclick="adminCreateUser()">+ Create user</button>
+                </div>
+                <div id="admin-error"></div>
+            </div>
+            <div class="admin-section-title">Users</div>
+            <div id="admin-users-list"></div>
+        </div>
     </div>
 </div>
 
@@ -1400,10 +1619,29 @@
     });
 
     // ── INIT ──
+    let currentUser = null;
+
+    async function loadCurrentUser() {
+        try {
+            const res = await fetch("/me", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.ok) {
+                currentUser = await res.json();
+                const adminBtn = document.getElementById("admin-btn");
+                if (adminBtn) {
+                    adminBtn.style.display = currentUser.role === "admin" ? "block" : "none";
+                }
+            }
+        } catch (e) {}
+    }
+
     function initApp() {
         document.getElementById("login-screen").style.display = "none";
         document.getElementById("app").style.display = "flex";
         setMode(currentMode);
+        loadCurrentUser();
         loadConversations();
         loadChannelInfo();
     }
@@ -1899,6 +2137,236 @@
     document.getElementById("new-mem-content")?.addEventListener("keydown", e => {
         if (e.key === "Enter") addMemory();
     });
+
+    // ── ADMIN ──
+    async function openAdmin() {
+        if (!currentUser || currentUser.role !== "admin") return;
+        document.getElementById("admin-overlay").classList.add("open");
+        closeSidebar();
+        await loadAdminUsers();
+    }
+
+    function closeAdmin() {
+        document.getElementById("admin-overlay").classList.remove("open");
+        document.getElementById("admin-error").textContent = "";
+    }
+
+    function handleAdminOverlayClick(e) {
+        if (e.target === document.getElementById("admin-overlay")) closeAdmin();
+    }
+
+    async function loadAdminUsers() {
+        const res = await fetch("/admin/users", {
+            headers: { "Authorization": `Bearer ${token}` }
+        });
+        if (res.status === 401) { logout(); return; }
+        if (res.status === 403) {
+            document.getElementById("admin-users-list").innerHTML =
+                '<div style="color:var(--danger);font-size:0.85rem;">Access denied.</div>';
+            return;
+        }
+        const users = await res.json();
+        renderAdminUsers(users);
+    }
+
+    function roleLabel(u) {
+        if (u.role === "admin") return "admin";
+        if (u.is_restricted) return "restricted";
+        return "user";
+    }
+
+    function renderAdminUsers(users) {
+        const list = document.getElementById("admin-users-list");
+        list.innerHTML = "";
+        for (const u of users) {
+            const row = document.createElement("div");
+            row.className = "admin-user-row";
+
+            const head = document.createElement("div");
+            head.className = "admin-user-head";
+
+            const name = document.createElement("span");
+            name.className = "admin-user-name";
+            name.textContent = u.username;
+            head.appendChild(name);
+
+            const roleTag = document.createElement("span");
+            const r = roleLabel(u);
+            roleTag.className = "admin-tag role-" + r;
+            roleTag.textContent = r;
+            head.appendChild(roleTag);
+
+            if (u.disabled) {
+                const dt = document.createElement("span");
+                dt.className = "admin-tag disabled";
+                dt.textContent = "disabled";
+                head.appendChild(dt);
+            }
+
+            row.appendChild(head);
+
+            const actions = document.createElement("div");
+            actions.className = "admin-actions";
+
+            // Role select
+            const sel = document.createElement("select");
+            sel.className = "admin-select";
+            ["user", "admin", "restricted"].forEach(opt => {
+                const o = document.createElement("option");
+                o.value = opt;
+                o.textContent = opt;
+                if (opt === r) o.selected = true;
+                sel.appendChild(o);
+            });
+            sel.onchange = () => adminChangeRole(u.id, sel.value);
+            actions.appendChild(sel);
+
+            // Disable / enable
+            const dBtn = document.createElement("button");
+            dBtn.className = "admin-btn" + (u.disabled ? "" : " danger");
+            dBtn.textContent = u.disabled ? "enable" : "disable";
+            dBtn.onclick = () => adminSetDisabled(u.id, !u.disabled);
+            actions.appendChild(dBtn);
+
+            // Reset password
+            const pBtn = document.createElement("button");
+            pBtn.className = "admin-btn";
+            pBtn.textContent = "reset password";
+            pBtn.onclick = () => adminResetPassword(u.id, u.username);
+            actions.appendChild(pBtn);
+
+            // Family controls toggle (restricted only)
+            if (u.is_restricted) {
+                const fcBtn = document.createElement("button");
+                fcBtn.className = "admin-btn";
+                fcBtn.textContent = "limits";
+                fcBtn.onclick = () => {
+                    const block = row.querySelector(".admin-fc");
+                    block.style.display = block.style.display === "none" ? "grid" : "none";
+                };
+                actions.appendChild(fcBtn);
+            }
+
+            row.appendChild(actions);
+
+            // Family-controls block
+            if (u.is_restricted) {
+                const fc = u.family_controls || {};
+                const block = document.createElement("div");
+                block.className = "admin-fc";
+                block.style.display = "none";
+                block.innerHTML = `
+                    <label>web search <input type="checkbox" data-k="web_search_enabled" ${fc.web_search_enabled ? "checked" : ""}></label>
+                    <label>weather <input type="checkbox" data-k="weather_enabled" ${fc.weather_enabled !== false ? "checked" : ""}></label>
+                    <label>memory save <input type="checkbox" data-k="memory_save_enabled" ${fc.memory_save_enabled ? "checked" : ""}></label>
+                    <label>memory import <input type="checkbox" data-k="memory_import_enabled" ${fc.memory_import_enabled ? "checked" : ""}></label>
+                    <label>max prompt chars <input type="number" min="0" data-k="max_prompt_chars" value="${fc.max_prompt_chars ?? 2000}"></label>
+                    <label>daily limit <input type="number" min="0" data-k="daily_message_limit" value="${fc.daily_message_limit ?? 200}"></label>
+                    <label style="grid-column:1/-1;">modes <input type="text" data-k="allowed_modes" value="${(fc.allowed_modes || ["chat"]).join(",")}" placeholder="chat,code"></label>
+                    <button class="admin-btn" style="grid-column:1/-1;" onclick="adminSaveFamilyControls(${u.id}, this)">save limits</button>
+                `;
+                row.appendChild(block);
+            }
+
+            list.appendChild(row);
+        }
+    }
+
+    async function adminCreateUser() {
+        const username = document.getElementById("admin-new-username").value.trim();
+        const password = document.getElementById("admin-new-password").value;
+        const roleSel = document.getElementById("admin-new-role").value;
+        const errEl = document.getElementById("admin-error");
+        errEl.textContent = "";
+
+        if (!username || !password) {
+            errEl.textContent = "Username and password required.";
+            return;
+        }
+        const role = roleSel === "admin" ? "admin" : "user";
+        const is_restricted = roleSel === "restricted";
+
+        const res = await fetch("/admin/users", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify({ username, password, role, is_restricted })
+        });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            errEl.textContent = data.detail || "Creation failed.";
+            return;
+        }
+        document.getElementById("admin-new-username").value = "";
+        document.getElementById("admin-new-password").value = "";
+        await loadAdminUsers();
+    }
+
+    async function adminChangeRole(id, choice) {
+        const role = choice === "admin" ? "admin" : "user";
+        const is_restricted = choice === "restricted";
+        const res = await fetch(`/admin/users/${id}/role`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify({ role, is_restricted })
+        });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            alert(data.detail || "Role change failed.");
+        }
+        await loadAdminUsers();
+    }
+
+    async function adminSetDisabled(id, disabled) {
+        const res = await fetch(`/admin/users/${id}/disable`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify({ disabled })
+        });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            alert(data.detail || "Update failed.");
+        }
+        await loadAdminUsers();
+    }
+
+    async function adminResetPassword(id, name) {
+        const password = prompt(`New password for ${name}:`);
+        if (!password) return;
+        const res = await fetch(`/admin/users/${id}/password`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify({ password })
+        });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            alert(data.detail || "Reset failed.");
+        } else {
+            alert("Password reset.");
+        }
+    }
+
+    async function adminSaveFamilyControls(id, btn) {
+        const block = btn.closest(".admin-fc");
+        const payload = {};
+        block.querySelectorAll("[data-k]").forEach(el => {
+            const k = el.dataset.k;
+            if (el.type === "checkbox") payload[k] = el.checked;
+            else if (el.type === "number") payload[k] = parseInt(el.value, 10) || 0;
+            else payload[k] = el.value.split(",").map(s => s.trim()).filter(Boolean);
+        });
+        const res = await fetch(`/admin/users/${id}/family-controls`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+            body: JSON.stringify(payload)
+        });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            alert(data.detail || "Save failed.");
+        } else {
+            btn.textContent = "saved!";
+            setTimeout(() => { btn.textContent = "save limits"; }, 1500);
+        }
+    }
 
     // ── UTILS ──
     function escapeHtml(str) {

--- a/tests/test_admin_users.py
+++ b/tests/test_admin_users.py
@@ -1,0 +1,595 @@
+"""
+Tests for the admin user-management endpoints (issue #109).
+
+Covers:
+  * Admin can list / create / disable / enable users.
+  * Admin can change role and reset password.
+  * Disabling or password reset bumps token_version, invalidating old JWTs.
+  * Disabled users cannot log in.
+  * Non-admin (user, restricted) callers receive 403 on every admin route.
+  * Admin cannot disable or demote the last active admin.
+  * Admin endpoints never expose password_hash.
+  * Family controls can be edited only on restricted users.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, policies, users
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    # `initialize_db` runs the users migration which seeds a default admin
+    # ("nova"). Tests in this file create their own admin / user fixtures and
+    # need a deterministic users table to assert on.
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(
+    db_path,
+    username,
+    password="pw",
+    role=users.ROLE_USER,
+    is_restricted=False,
+):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+# ── Core helpers (unit) ─────────────────────────────────────────────────────
+
+class TestUserHelpers:
+    def test_list_users_excludes_password_hash(self, db_path):
+        _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+        _make_user(db_path, "bob")
+        with sqlite3.connect(db_path) as conn:
+            rows = users.list_users(conn)
+        assert len(rows) == 2
+        for r in rows:
+            assert "password_hash" not in r
+
+    def test_set_disabled_bumps_token_version(self, db_path):
+        uid = _make_user(db_path, "bob")
+        with sqlite3.connect(db_path) as conn:
+            tv0 = users.get_user_by_id(conn, uid)["token_version"]
+            users.set_disabled(conn, uid, True)
+            row = users.get_user_by_id(conn, uid)
+        assert row["disabled_at"] is not None
+        assert row["token_version"] == tv0 + 1
+
+    def test_set_disabled_re_enable_clears_disabled_at(self, db_path):
+        uid = _make_user(db_path, "bob")
+        with sqlite3.connect(db_path) as conn:
+            users.set_disabled(conn, uid, True)
+            users.set_disabled(conn, uid, False)
+            row = users.get_user_by_id(conn, uid)
+        assert row["disabled_at"] is None
+
+    def test_set_role_bumps_token_version_on_change(self, db_path):
+        uid = _make_user(db_path, "bob")
+        with sqlite3.connect(db_path) as conn:
+            tv0 = users.get_user_by_id(conn, uid)["token_version"]
+            users.set_role(conn, uid, users.ROLE_ADMIN, False)
+            row = users.get_user_by_id(conn, uid)
+        assert row["role"] == "admin"
+        assert row["token_version"] == tv0 + 1
+
+    def test_set_role_no_change_keeps_token_version(self, db_path):
+        uid = _make_user(db_path, "bob")
+        with sqlite3.connect(db_path) as conn:
+            tv0 = users.get_user_by_id(conn, uid)["token_version"]
+            users.set_role(conn, uid, users.ROLE_USER, False)
+            tv1 = users.get_user_by_id(conn, uid)["token_version"]
+        assert tv1 == tv0
+
+    def test_set_role_rejects_admin_restricted(self, db_path):
+        uid = _make_user(db_path, "bob")
+        with sqlite3.connect(db_path) as conn, pytest.raises(ValueError):
+            users.set_role(conn, uid, users.ROLE_ADMIN, True)
+
+    def test_reset_password_bumps_token_and_changes_hash(self, db_path):
+        uid = _make_user(db_path, "bob", password="old")
+        with sqlite3.connect(db_path) as conn:
+            old_hash = users.get_user_by_id(conn, uid)["password_hash"]
+            tv0 = users.get_user_by_id(conn, uid)["token_version"]
+            users.reset_password(conn, uid, "new")
+            row = users.get_user_by_id(conn, uid)
+        assert row["password_hash"] != old_hash
+        assert row["token_version"] == tv0 + 1
+
+    def test_count_active_admins(self, db_path):
+        _make_user(db_path, "a1", role=users.ROLE_ADMIN)
+        _make_user(db_path, "a2", role=users.ROLE_ADMIN)
+        _make_user(db_path, "u1")
+        with sqlite3.connect(db_path) as conn:
+            assert users.count_active_admins(conn) == 2
+            uid = users.get_user_by_username(conn, "a2")["id"]
+            users.set_disabled(conn, uid, True)
+            assert users.count_active_admins(conn) == 1
+
+
+# ── Endpoint: list users ────────────────────────────────────────────────────
+
+class TestListUsers:
+    def test_admin_can_list_users(self, db_path, web_client, admin_token):
+        _make_user(db_path, "bob")
+        _make_user(db_path, "kid", is_restricted=True)
+        resp = web_client.get("/admin/users", headers=_h(admin_token))
+        assert resp.status_code == 200
+        body = resp.json()
+        names = [u["username"] for u in body]
+        assert names == ["alice", "bob", "kid"]
+
+    def test_list_does_not_expose_password_hash(
+        self, db_path, web_client, admin_token
+    ):
+        _make_user(db_path, "bob")
+        resp = web_client.get("/admin/users", headers=_h(admin_token))
+        for u in resp.json():
+            assert "password_hash" not in u
+
+    def test_list_includes_family_controls_for_restricted(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        policies.set_family_controls(
+            uid, max_prompt_chars=500, daily_message_limit=20, db_path=db_path,
+        )
+        resp = web_client.get("/admin/users", headers=_h(admin_token))
+        kid = next(u for u in resp.json() if u["username"] == "kid")
+        assert kid["family_controls"]["max_prompt_chars"] == 500
+        assert kid["family_controls"]["daily_message_limit"] == 20
+
+    def test_non_admin_user_forbidden(self, db_path, web_client, admin_token):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        resp = web_client.get("/admin/users", headers=_h(token))
+        assert resp.status_code == 403
+
+    def test_restricted_user_forbidden(self, db_path, web_client, admin_token):
+        _make_user(db_path, "kid", is_restricted=True)
+        token = _login(web_client, "kid")
+        resp = web_client.get("/admin/users", headers=_h(token))
+        assert resp.status_code == 403
+
+    def test_unauthenticated_blocked(self, web_client):
+        resp = web_client.get("/admin/users")
+        # FastAPI's HTTPBearer auto-rejects calls without credentials.
+        assert resp.status_code in (401, 403)
+
+
+# ── Endpoint: create user ───────────────────────────────────────────────────
+
+class TestCreateUser:
+    def test_admin_can_create_normal_user(
+        self, db_path, web_client, admin_token
+    ):
+        resp = web_client.post(
+            "/admin/users",
+            headers=_h(admin_token),
+            json={"username": "bob", "password": "pw"},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["username"] == "bob"
+        assert data["role"] == "user"
+        assert data["is_restricted"] is False
+        assert "password_hash" not in data
+        assert _login(web_client, "bob") is not None
+
+    def test_admin_can_create_restricted_user(
+        self, db_path, web_client, admin_token
+    ):
+        resp = web_client.post(
+            "/admin/users",
+            headers=_h(admin_token),
+            json={
+                "username": "kid",
+                "password": "pw",
+                "role": "user",
+                "is_restricted": True,
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["is_restricted"] is True
+
+    def test_admin_can_create_admin_user(
+        self, db_path, web_client, admin_token
+    ):
+        resp = web_client.post(
+            "/admin/users",
+            headers=_h(admin_token),
+            json={"username": "carol", "password": "pw", "role": "admin"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["role"] == "admin"
+
+    def test_admin_restricted_combo_rejected(
+        self, db_path, web_client, admin_token
+    ):
+        resp = web_client.post(
+            "/admin/users",
+            headers=_h(admin_token),
+            json={
+                "username": "x",
+                "password": "pw",
+                "role": "admin",
+                "is_restricted": True,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_duplicate_username_returns_409(
+        self, db_path, web_client, admin_token
+    ):
+        web_client.post(
+            "/admin/users",
+            headers=_h(admin_token),
+            json={"username": "bob", "password": "pw"},
+        )
+        resp = web_client.post(
+            "/admin/users",
+            headers=_h(admin_token),
+            json={"username": "bob", "password": "pw"},
+        )
+        assert resp.status_code == 409
+
+    def test_non_admin_cannot_create(self, db_path, web_client, admin_token):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        resp = web_client.post(
+            "/admin/users",
+            headers=_h(token),
+            json={"username": "eve", "password": "pw"},
+        )
+        assert resp.status_code == 403
+
+
+# ── Endpoint: disable / enable ──────────────────────────────────────────────
+
+class TestDisableEnable:
+    def test_disable_user_blocks_login(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        resp = web_client.post(
+            f"/admin/users/{uid}/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        assert resp.status_code == 200
+        login = web_client.post(
+            "/login", json={"username": "bob", "password": "pw"}
+        )
+        assert login.status_code == 401
+
+    def test_disable_invalidates_existing_token(
+        self, db_path, web_client, admin_token
+    ):
+        _make_user(db_path, "bob")
+        bob_token = _login(web_client, "bob")
+        # Token is valid pre-disable
+        assert web_client.get("/me", headers=_h(bob_token)).status_code == 200
+        with sqlite3.connect(db_path) as conn:
+            uid = users.get_user_by_username(conn, "bob")["id"]
+        web_client.post(
+            f"/admin/users/{uid}/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        assert web_client.get("/me", headers=_h(bob_token)).status_code == 401
+
+    def test_re_enable_allows_login_again(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        web_client.post(
+            f"/admin/users/{uid}/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        web_client.post(
+            f"/admin/users/{uid}/disable",
+            headers=_h(admin_token),
+            json={"disabled": False},
+        )
+        login = web_client.post(
+            "/login", json={"username": "bob", "password": "pw"}
+        )
+        assert login.status_code == 200
+
+    def test_cannot_disable_only_active_admin(
+        self, db_path, web_client, admin_token
+    ):
+        with sqlite3.connect(db_path) as conn:
+            alice_id = users.get_user_by_username(conn, "alice")["id"]
+        # alice is the sole admin
+        resp = web_client.post(
+            f"/admin/users/{alice_id}/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        assert resp.status_code == 400
+
+    def test_cannot_self_disable(self, db_path, web_client, admin_token):
+        with sqlite3.connect(db_path) as conn:
+            alice_id = users.get_user_by_username(conn, "alice")["id"]
+        # Add a second admin so the "last admin" guard does not trip first.
+        _make_user(db_path, "alice2", role=users.ROLE_ADMIN)
+        resp = web_client.post(
+            f"/admin/users/{alice_id}/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        assert resp.status_code == 400
+
+    def test_can_disable_admin_when_other_active_admin_exists(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "carol", role=users.ROLE_ADMIN)
+        resp = web_client.post(
+            f"/admin/users/{uid}/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        assert resp.status_code == 200
+
+    def test_disable_unknown_user_returns_404(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/users/9999/disable",
+            headers=_h(admin_token),
+            json={"disabled": True},
+        )
+        assert resp.status_code == 404
+
+    def test_non_admin_cannot_disable(
+        self, db_path, web_client, admin_token
+    ):
+        bob_id = _make_user(db_path, "bob")
+        _make_user(db_path, "mallory")
+        token = _login(web_client, "mallory")
+        resp = web_client.post(
+            f"/admin/users/{bob_id}/disable",
+            headers=_h(token),
+            json={"disabled": True},
+        )
+        assert resp.status_code == 403
+
+
+# ── Endpoint: change role ───────────────────────────────────────────────────
+
+class TestSetRole:
+    def test_admin_can_promote_to_admin(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        resp = web_client.post(
+            f"/admin/users/{uid}/role",
+            headers=_h(admin_token),
+            json={"role": "admin"},
+        )
+        assert resp.status_code == 200
+        with sqlite3.connect(db_path) as conn:
+            row = users.get_user_by_id(conn, uid)
+        assert row["role"] == "admin"
+
+    def test_admin_can_set_restricted(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        resp = web_client.post(
+            f"/admin/users/{uid}/role",
+            headers=_h(admin_token),
+            json={"role": "user", "is_restricted": True},
+        )
+        assert resp.status_code == 200
+
+    def test_role_change_invalidates_existing_token(
+        self, db_path, web_client, admin_token
+    ):
+        _make_user(db_path, "bob")
+        bob_token = _login(web_client, "bob")
+        assert web_client.get("/me", headers=_h(bob_token)).status_code == 200
+        with sqlite3.connect(db_path) as conn:
+            uid = users.get_user_by_username(conn, "bob")["id"]
+        web_client.post(
+            f"/admin/users/{uid}/role",
+            headers=_h(admin_token),
+            json={"role": "user", "is_restricted": True},
+        )
+        assert web_client.get("/me", headers=_h(bob_token)).status_code == 401
+
+    def test_cannot_demote_only_admin(
+        self, db_path, web_client, admin_token
+    ):
+        with sqlite3.connect(db_path) as conn:
+            alice_id = users.get_user_by_username(conn, "alice")["id"]
+        resp = web_client.post(
+            f"/admin/users/{alice_id}/role",
+            headers=_h(admin_token),
+            json={"role": "user"},
+        )
+        assert resp.status_code == 400
+
+    def test_admin_restricted_combo_rejected(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        resp = web_client.post(
+            f"/admin/users/{uid}/role",
+            headers=_h(admin_token),
+            json={"role": "admin", "is_restricted": True},
+        )
+        assert resp.status_code == 400
+
+    def test_non_admin_cannot_change_role(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        _make_user(db_path, "mallory")
+        token = _login(web_client, "mallory")
+        resp = web_client.post(
+            f"/admin/users/{uid}/role",
+            headers=_h(token),
+            json={"role": "admin"},
+        )
+        assert resp.status_code == 403
+
+
+# ── Endpoint: reset password ────────────────────────────────────────────────
+
+class TestResetPassword:
+    def test_admin_can_reset_password(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob", password="old")
+        resp = web_client.post(
+            f"/admin/users/{uid}/password",
+            headers=_h(admin_token),
+            json={"password": "newpw"},
+        )
+        assert resp.status_code == 200
+        # Old password rejected.
+        assert web_client.post(
+            "/login", json={"username": "bob", "password": "old"}
+        ).status_code == 401
+        # New password works.
+        assert web_client.post(
+            "/login", json={"username": "bob", "password": "newpw"}
+        ).status_code == 200
+
+    def test_password_reset_invalidates_existing_token(
+        self, db_path, web_client, admin_token
+    ):
+        _make_user(db_path, "bob", password="pw")
+        old_token = _login(web_client, "bob")
+        with sqlite3.connect(db_path) as conn:
+            uid = users.get_user_by_username(conn, "bob")["id"]
+        web_client.post(
+            f"/admin/users/{uid}/password",
+            headers=_h(admin_token),
+            json={"password": "another"},
+        )
+        assert web_client.get("/me", headers=_h(old_token)).status_code == 401
+
+    def test_non_admin_cannot_reset_password(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        _make_user(db_path, "mallory")
+        token = _login(web_client, "mallory")
+        resp = web_client.post(
+            f"/admin/users/{uid}/password",
+            headers=_h(token),
+            json={"password": "newpw"},
+        )
+        assert resp.status_code == 403
+
+
+# ── Endpoint: family controls ───────────────────────────────────────────────
+
+class TestFamilyControlsEndpoint:
+    def test_admin_can_set_family_controls_on_restricted(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        resp = web_client.put(
+            f"/admin/users/{uid}/family-controls",
+            headers=_h(admin_token),
+            json={
+                "allowed_modes": ["chat", "code"],
+                "daily_message_limit": 50,
+                "max_prompt_chars": 800,
+                "web_search_enabled": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["family_controls"]["daily_message_limit"] == 50
+        assert sorted(body["family_controls"]["allowed_modes"]) == ["chat", "code"]
+
+    def test_cannot_set_family_controls_on_non_restricted(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "bob")
+        resp = web_client.put(
+            f"/admin/users/{uid}/family-controls",
+            headers=_h(admin_token),
+            json={"daily_message_limit": 5},
+        )
+        assert resp.status_code == 400
+
+    def test_non_admin_cannot_set_family_controls(
+        self, db_path, web_client, admin_token
+    ):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        _make_user(db_path, "mallory")
+        token = _login(web_client, "mallory")
+        resp = web_client.put(
+            f"/admin/users/{uid}/family-controls",
+            headers=_h(token),
+            json={"daily_message_limit": 5},
+        )
+        assert resp.status_code == 403
+
+
+# ── /me endpoint ────────────────────────────────────────────────────────────
+
+class TestWhoami:
+    def test_me_returns_role(self, db_path, web_client, admin_token):
+        resp = web_client.get("/me", headers=_h(admin_token))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["username"] == "alice"
+        assert body["role"] == "admin"
+        assert body["is_restricted"] is False

--- a/web.py
+++ b/web.py
@@ -33,11 +33,16 @@ from core.settings import (
     get_user_setting, save_user_setting,
 )
 from core.policies import (
+    KNOWN_MODES,
     PolicyDenial,
     check_chat_request,
     enforce_daily_limit,
+    get_family_controls_dict,
     get_policy,
+    set_family_controls,
 )
+import sqlite3 as _sqlite3
+from core import users as _users_mod
 from memory.store import (
     list_memories as list_natural_memories,
     delete_memories_matching,
@@ -533,6 +538,265 @@ def update_settings(
     if data.nova_model_name is not None:
         save_user_setting(user.id, "nova_model_name", data.nova_model_name)
     return {"ok": True}
+
+
+# ── ADMIN: USER MANAGEMENT ──────────────────────────────────────────
+
+class AdminCreateUserRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    username: str = Field(min_length=1, max_length=64)
+    password: str = Field(min_length=1, max_length=256)
+    role: str = "user"
+    is_restricted: bool = False
+
+    @field_validator("role")
+    @classmethod
+    def _role(cls, v):
+        if v not in ("admin", "user"):
+            raise ValueError("role must be 'admin' or 'user'")
+        return v
+
+    @field_validator("username")
+    @classmethod
+    def _username(cls, v):
+        v = v.strip()
+        if not v:
+            raise ValueError("username must be non-empty")
+        return v
+
+
+class AdminSetRoleRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    role: str
+    is_restricted: bool = False
+
+    @field_validator("role")
+    @classmethod
+    def _role(cls, v):
+        if v not in ("admin", "user"):
+            raise ValueError("role must be 'admin' or 'user'")
+        return v
+
+
+class AdminDisableRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    disabled: bool
+
+
+class AdminResetPasswordRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    password: str = Field(min_length=1, max_length=256)
+
+
+class AdminFamilyControlsRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    allowed_modes: list[str] | None = None
+    web_search_enabled: bool | None = None
+    weather_enabled: bool | None = None
+    memory_save_enabled: bool | None = None
+    memory_import_enabled: bool | None = None
+    max_prompt_chars: int | None = Field(default=None, ge=0, le=100_000)
+    daily_message_limit: int | None = Field(default=None, ge=0, le=1_000_000)
+
+    @field_validator("allowed_modes")
+    @classmethod
+    def _modes(cls, v):
+        if v is None:
+            return v
+        cleaned = [m for m in v if m in KNOWN_MODES]
+        if not cleaned:
+            raise ValueError("allowed_modes must contain at least one known mode")
+        return cleaned
+
+
+def require_admin(user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin only.")
+    return user
+
+
+def _admin_db():
+    from core.memory import DB_PATH
+    return _sqlite3.connect(DB_PATH)
+
+
+def _user_to_dict(row: dict) -> dict:
+    out = dict(row)
+    out["disabled"] = row.get("disabled_at") is not None
+    out.pop("token_version", None)
+    return out
+
+
+@app.get("/me")
+def whoami(user: CurrentUser = Depends(get_current_user)):
+    return {
+        "id": user.id,
+        "username": user.username,
+        "role": user.role,
+        "is_restricted": user.is_restricted,
+    }
+
+
+@app.get("/admin/users")
+def admin_list_users(_: CurrentUser = Depends(require_admin)):
+    with _admin_db() as conn:
+        users = _users_mod.list_users(conn)
+    out = []
+    for u in users:
+        entry = _user_to_dict(u)
+        if u["is_restricted"]:
+            entry["family_controls"] = get_family_controls_dict(u["id"])
+        else:
+            entry["family_controls"] = None
+        out.append(entry)
+    return out
+
+
+@app.post("/admin/users", status_code=201)
+def admin_create_user(
+    req: AdminCreateUserRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    if req.role == "admin" and req.is_restricted:
+        raise HTTPException(
+            status_code=400, detail="Admin cannot be restricted."
+        )
+    try:
+        with _admin_db() as conn:
+            try:
+                uid = _users_mod.create_user(
+                    conn,
+                    req.username,
+                    req.password,
+                    role=req.role,
+                    is_restricted=req.is_restricted,
+                )
+            except _sqlite3.IntegrityError:
+                raise HTTPException(
+                    status_code=409, detail="Username already exists."
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            row = _users_mod.get_user_by_id(conn, uid)
+    finally:
+        pass
+    return _user_to_dict({
+        "id": int(row["id"]),
+        "username": row["username"],
+        "role": row["role"],
+        "is_restricted": bool(row["is_restricted"]),
+        "created_at": row["created_at"],
+        "disabled_at": row["disabled_at"],
+    })
+
+
+@app.post("/admin/users/{user_id}/disable")
+def admin_set_disabled(
+    user_id: int,
+    req: AdminDisableRequest,
+    actor: CurrentUser = Depends(require_admin),
+):
+    with _admin_db() as conn:
+        target = _users_mod.get_user_by_id(conn, user_id)
+        if target is None:
+            raise HTTPException(status_code=404, detail="User not found.")
+
+        if req.disabled:
+            # Block disabling the last active admin or self-lockout.
+            if target["role"] == "admin" and target["disabled_at"] is None:
+                active = _users_mod.count_active_admins(conn)
+                if active <= 1:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Cannot disable the only active admin.",
+                    )
+            if int(target["id"]) == int(actor.id):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Admin cannot disable their own account.",
+                )
+
+        _users_mod.set_disabled(conn, user_id, req.disabled)
+    return {"ok": True}
+
+
+@app.post("/admin/users/{user_id}/role")
+def admin_set_role(
+    user_id: int,
+    req: AdminSetRoleRequest,
+    actor: CurrentUser = Depends(require_admin),
+):
+    if req.role == "admin" and req.is_restricted:
+        raise HTTPException(
+            status_code=400, detail="Admin cannot be restricted."
+        )
+    with _admin_db() as conn:
+        target = _users_mod.get_user_by_id(conn, user_id)
+        if target is None:
+            raise HTTPException(status_code=404, detail="User not found.")
+        # Demoting the last admin would lock out admin access entirely.
+        if (
+            target["role"] == "admin"
+            and req.role != "admin"
+            and target["disabled_at"] is None
+        ):
+            active = _users_mod.count_active_admins(conn)
+            if active <= 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot demote the only active admin.",
+                )
+        try:
+            _users_mod.set_role(
+                conn, user_id, req.role, req.is_restricted
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True}
+
+
+@app.post("/admin/users/{user_id}/password")
+def admin_reset_password(
+    user_id: int,
+    req: AdminResetPasswordRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    with _admin_db() as conn:
+        ok = _users_mod.reset_password(conn, user_id, req.password)
+    if not ok:
+        raise HTTPException(status_code=404, detail="User not found.")
+    return {"ok": True}
+
+
+@app.put("/admin/users/{user_id}/family-controls")
+def admin_set_family_controls(
+    user_id: int,
+    req: AdminFamilyControlsRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    with _admin_db() as conn:
+        target = _users_mod.get_user_by_id(conn, user_id)
+        if target is None:
+            raise HTTPException(status_code=404, detail="User not found.")
+        if not bool(target["is_restricted"]):
+            raise HTTPException(
+                status_code=400,
+                detail="Family controls only apply to restricted users.",
+            )
+    set_family_controls(
+        user_id,
+        allowed_modes=req.allowed_modes,
+        web_search_enabled=req.web_search_enabled,
+        weather_enabled=req.weather_enabled,
+        memory_save_enabled=req.memory_save_enabled,
+        memory_import_enabled=req.memory_import_enabled,
+        max_prompt_chars=req.max_prompt_chars,
+        daily_message_limit=req.daily_message_limit,
+    )
+    return {
+        "ok": True,
+        "family_controls": get_family_controls_dict(user_id),
+    }
 
 
 @app.get("/channel")


### PR DESCRIPTION
Closes #109.

Adds a minimal admin-only user management surface for local Nova users.

Changes:
- Adds admin-only user management endpoints
- Adds /me for current user/role discovery
- Adds helpers for listing users, disabling/enabling users, changing roles, and resetting passwords
- Adds admin UI for creating users and managing roles/status/passwords
- Adds restricted-user family-control editing
- Guards against disabling or demoting the last active admin
- Invalidates existing tokens by bumping token_version on disable, role change, and password reset
- Adds tests for admin permissions, user creation, disabling, role changes, password reset, and data safety

Security/privacy:
- Admin endpoints do not return password_hash
- Non-admin and restricted users receive 403
- Admin UI does not expose private conversations or memories
- No surveillance dashboard is added

Not included:
- No model registry (#110)
- No Ollama pull flow (#111)
- No per-user/per-role model access (#112)
- No admin access to private conversations or memories

---
_Generated by [Claude Code](https://claude.ai/code/session_013MkT47sMaXBPxGBJG4xfxL)_