### PR TITLE
feat: add local Ollama model registry foundation (#110)

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -7,6 +7,10 @@ from memory.store import initialize_memory_database as _init_natural_memory
 from core import users as _users
 from core.settings import migrate_user_settings as _migrate_user_settings
 from core.policies import migrate_family_controls as _migrate_family_controls
+from core.model_registry import (
+    migrate as _migrate_model_registry,
+    seed_from_config as _seed_model_registry,
+)
 
 DB_PATH = "nova.db"
 
@@ -93,6 +97,8 @@ def initialize_db():
     _migrate_memories_ownership(DB_PATH)
     _migrate_user_settings(DB_PATH)
     _migrate_family_controls(DB_PATH)
+    _migrate_model_registry(DB_PATH)
+    _seed_model_registry(DB_PATH)
     _init_natural_memory(DB_PATH)
 
 

--- a/core/model_registry.py
+++ b/core/model_registry.py
@@ -1,0 +1,233 @@
+"""
+Local Ollama model registry (issue #110).
+
+This is the foundational layer that lets admins eventually view and manage
+the set of local models Nova knows about. The scope of #110 is intentionally
+narrow — read-only registry storage + a one-time seed from config.MODELS:
+
+  * Create the `model_registry` table if missing.
+  * Seed one row per (purpose, model_name) pair from `config.MODELS`.
+  * Provide a helper to reconcile rows with `client.list()` so the
+    `installed` flag reflects what Ollama actually has on disk.
+  * Provide a list helper that the admin endpoint reads from.
+
+Out of scope here:
+  * Pulling / downloading models — that is #111.
+  * Per-user / per-role model access controls — that is #112.
+  * Frontend model-management UI.
+  * Mutating model routing — `core.router.MODEL_MAP` and `web.MODE_MAP`
+    keep their current behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+import httpx
+import ollama
+
+from core.ollama_client import client
+
+logger = logging.getLogger(__name__)
+
+
+_MODEL_REGISTRY_SQL = """
+CREATE TABLE IF NOT EXISTS model_registry (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    model_name   TEXT    NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL,
+    purpose      TEXT    NOT NULL,
+    enabled      INTEGER NOT NULL DEFAULT 1,
+    installed    INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+)
+"""
+
+_MODEL_REGISTRY_PURPOSE_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_model_registry_purpose "
+    "ON model_registry(purpose)"
+)
+
+
+# Friendly labels for the four purposes Nova currently uses. Anything not
+# listed falls back to the title-cased purpose string.
+_PURPOSE_DISPLAY_NAMES = {
+    "router": "Router",
+    "default": "Default",
+    "code": "Code",
+    "advanced": "Advanced",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _purpose_display(purpose: str) -> str:
+    return _PURPOSE_DISPLAY_NAMES.get(purpose, purpose.title())
+
+
+def _open(db_path: Optional[str] = None) -> sqlite3.Connection:
+    if db_path is None:
+        from core.memory import DB_PATH
+        db_path = DB_PATH
+    return sqlite3.connect(db_path)
+
+
+# ── Migration + seed ────────────────────────────────────────────────────────
+
+
+def migrate(db_path: str) -> None:
+    """Create the `model_registry` table and its index. Idempotent."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_MODEL_REGISTRY_SQL)
+        conn.execute(_MODEL_REGISTRY_PURPOSE_INDEX_SQL)
+
+
+def seed_from_config(
+    db_path: str,
+    models: Optional[dict] = None,
+) -> int:
+    """
+    Insert one row per (purpose, model_name) pair in `models`.
+
+    Idempotent — collisions on `model_name` are ignored, so a model that is
+    already registered keeps its admin-edited flags. Returns the number of
+    rows actually inserted.
+
+    `models` defaults to the live `config.MODELS` dict; tests pass an
+    explicit mapping so they do not depend on environment.
+    """
+    if models is None:
+        from config import MODELS
+        models = MODELS
+
+    inserted = 0
+    now = _now_iso()
+    with sqlite3.connect(db_path) as conn:
+        for purpose, model_name in models.items():
+            if not model_name:
+                continue
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO model_registry "
+                "(model_name, display_name, purpose, enabled, installed, "
+                "created_at, updated_at) VALUES (?, ?, ?, 1, 0, ?, ?)",
+                (model_name, _purpose_display(purpose), purpose, now, now),
+            )
+            inserted += cur.rowcount
+    return inserted
+
+
+# ── Reads ───────────────────────────────────────────────────────────────────
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict:
+    return {
+        "id": int(row["id"]),
+        "model_name": row["model_name"],
+        "display_name": row["display_name"],
+        "purpose": row["purpose"],
+        "enabled": bool(row["enabled"]),
+        "installed": bool(row["installed"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def list_registered(db_path: Optional[str] = None) -> list[dict]:
+    """
+    Return every row in `model_registry`, ordered by id.
+
+    Caller is responsible for gating who sees the result — raw `model_name`
+    is admin-only per the architecture doc.
+    """
+    with _open(db_path) as conn:
+        prev = conn.row_factory
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT id, model_name, display_name, purpose, enabled, "
+                "installed, created_at, updated_at "
+                "FROM model_registry ORDER BY id ASC"
+            ).fetchall()
+        finally:
+            conn.row_factory = prev
+    return [_row_to_dict(r) for r in rows]
+
+
+# ── Reconcile with Ollama ───────────────────────────────────────────────────
+
+
+def _list_installed_model_names() -> Optional[set[str]]:
+    """
+    Best-effort read of `client.list()`.
+
+    Returns the set of installed model names, or None if Ollama is
+    unreachable. This is a *read-only* call — no pulls, no downloads.
+    """
+    try:
+        payload = client.list()
+    except (ConnectionError, OSError, ollama.ResponseError, httpx.HTTPError) as e:
+        logger.debug("Ollama list unavailable, skipping reconcile: %s", e)
+        return None
+
+    names: set[str] = set()
+    for entry in payload.get("models", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("model")
+        if name:
+            names.add(name)
+    return names
+
+
+def reconcile_installed(db_path: Optional[str] = None) -> Optional[dict[str, bool]]:
+    """
+    Update each row's `installed` flag based on what Ollama currently has
+    locally. Returns a `{model_name: installed}` snapshot, or None if
+    Ollama could not be reached (existing flags are left untouched).
+
+    This function never triggers a pull — issue #111 owns that behaviour.
+    """
+    installed_names = _list_installed_model_names()
+    if installed_names is None:
+        return None
+
+    snapshot: dict[str, bool] = {}
+    now = _now_iso()
+    with _open(db_path) as conn:
+        rows = conn.execute(
+            "SELECT model_name, installed FROM model_registry"
+        ).fetchall()
+        for model_name, current_installed in rows:
+            is_installed = _matches_installed(model_name, installed_names)
+            snapshot[model_name] = is_installed
+            if bool(current_installed) != is_installed:
+                conn.execute(
+                    "UPDATE model_registry SET installed = ?, updated_at = ? "
+                    "WHERE model_name = ?",
+                    (1 if is_installed else 0, now, model_name),
+                )
+    return snapshot
+
+
+def _matches_installed(model_name: str, installed_names: Iterable[str]) -> bool:
+    """
+    Return True if `model_name` matches one of the names Ollama reports.
+
+    Ollama's list often returns `name:tag` pairs, and the registry may
+    store either the full tag or just the base name. We accept exact match
+    on either side, mirroring `core.updater.get_local_model_digest`.
+    """
+    for installed in installed_names:
+        if installed == model_name:
+            return True
+        if installed.startswith(model_name + ":"):
+            return True
+        if model_name.startswith(installed + ":"):
+            return True
+    return False

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,465 @@
+"""
+Tests for the local Ollama model registry (issue #110).
+
+Covers:
+  * `model_registry` table is created by initialize_db().
+  * Configured models from `config.MODELS` are seeded once.
+  * Seeding is idempotent — second call inserts no rows.
+  * Admin can read the registry through `GET /admin/models`.
+  * Non-admin and restricted users get 403 — raw model names stay
+    behind the admin gate.
+  * `reconcile_installed` updates the `installed` flag from
+    `client.list()` and never triggers a pull.
+  * If Ollama is unreachable, reconcile leaves persisted flags intact.
+  * Existing chat routing keeps working when registry rows are
+    disabled or unknown — the registry is read-only this issue.
+  * No Ollama pull subprocess is launched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import httpx
+import ollama
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, model_registry, users
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    # `initialize_db` seeds a default admin ("nova") and the four entries
+    # from config.MODELS. Tests in this file want a deterministic users
+    # table; the model_registry is left as seeded and asserted against.
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(
+    db_path,
+    username,
+    password="pw",
+    role=users.ROLE_USER,
+    is_restricted=False,
+):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+def _table_exists(path: str, name: str) -> bool:
+    with sqlite3.connect(path) as conn:
+        return conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone() is not None
+
+
+def _registry_rows(path: str) -> list[dict]:
+    with sqlite3.connect(path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT * FROM model_registry ORDER BY id ASC"
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ── Migration & seeding (unit) ──────────────────────────────────────────────
+
+
+class TestMigrationAndSeed:
+    def test_initialize_db_creates_model_registry_table(self, db_path):
+        assert _table_exists(db_path, "model_registry")
+
+    def test_seed_inserts_one_row_per_configured_model(self, db_path):
+        from config import MODELS
+        rows = _registry_rows(db_path)
+        # Every value from config.MODELS should land in the registry.
+        seeded_names = {r["model_name"] for r in rows}
+        assert seeded_names == set(MODELS.values())
+
+    def test_seed_records_purpose_and_display_name(self, db_path):
+        rows = _registry_rows(db_path)
+        by_purpose = {r["purpose"]: r for r in rows}
+        # The four canonical purposes are present.
+        assert {"router", "default", "code", "advanced"}.issubset(by_purpose)
+        assert by_purpose["router"]["display_name"] == "Router"
+        assert by_purpose["default"]["display_name"] == "Default"
+        assert by_purpose["code"]["display_name"] == "Code"
+        assert by_purpose["advanced"]["display_name"] == "Advanced"
+
+    def test_seed_defaults_enabled_true_installed_false(self, db_path):
+        rows = _registry_rows(db_path)
+        assert rows  # sanity
+        for r in rows:
+            assert r["enabled"] == 1
+            assert r["installed"] == 0
+
+    def test_seed_is_idempotent(self, db_path):
+        before = _registry_rows(db_path)
+        # Re-running the seed must not add or duplicate rows.
+        inserted = model_registry.seed_from_config(db_path)
+        after = _registry_rows(db_path)
+        assert inserted == 0
+        assert before == after
+
+    def test_seed_does_not_overwrite_existing_rows(self, db_path):
+        # Simulate an admin having toggled `enabled` off — re-seeding should
+        # not flip it back to the default.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE model_registry SET enabled = 0 WHERE purpose = 'router'"
+            )
+        model_registry.seed_from_config(db_path)
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT enabled FROM model_registry WHERE purpose = 'router'"
+            ).fetchone()
+        assert row[0] == 0
+
+    def test_seed_with_explicit_models_dict(self, tmp_path):
+        path = str(tmp_path / "fresh.db")
+        model_registry.migrate(path)
+        inserted = model_registry.seed_from_config(
+            path, models={"router": "tiny:1b", "default": "med:7b"}
+        )
+        assert inserted == 2
+        names = {r["model_name"] for r in _registry_rows(path)}
+        assert names == {"tiny:1b", "med:7b"}
+
+    def test_migrate_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "fresh.db")
+        model_registry.migrate(path)
+        model_registry.migrate(path)
+        assert _table_exists(path, "model_registry")
+
+    def test_unique_model_name(self, tmp_path):
+        path = str(tmp_path / "fresh.db")
+        model_registry.migrate(path)
+        # Seeding the same model_name twice still results in a single row.
+        model_registry.seed_from_config(path, models={"a": "same"})
+        model_registry.seed_from_config(path, models={"b": "same"})
+        rows = _registry_rows(path)
+        assert len(rows) == 1
+
+
+# ── list_registered (unit) ──────────────────────────────────────────────────
+
+
+class TestListRegistered:
+    def test_returns_dicts_in_id_order(self, db_path):
+        rows = model_registry.list_registered(db_path)
+        assert rows == sorted(rows, key=lambda r: r["id"])
+        for r in rows:
+            assert set(r) == {
+                "id", "model_name", "display_name", "purpose",
+                "enabled", "installed", "created_at", "updated_at",
+            }
+
+    def test_returns_python_bools(self, db_path):
+        rows = model_registry.list_registered(db_path)
+        for r in rows:
+            assert isinstance(r["enabled"], bool)
+            assert isinstance(r["installed"], bool)
+
+
+# ── reconcile_installed (unit) ──────────────────────────────────────────────
+
+
+class TestReconcileInstalled:
+    def test_updates_installed_flag_from_client_list(self, db_path):
+        from config import MODELS
+        installed = MODELS["default"]
+        with patch(
+            "core.model_registry.client.list",
+            return_value={"models": [{"name": installed}]},
+        ) as m:
+            snapshot = model_registry.reconcile_installed(db_path)
+
+        assert snapshot is not None
+        assert snapshot[installed] is True
+        # Every other registered model is reported as not installed.
+        for name, value in snapshot.items():
+            if name != installed:
+                assert value is False
+
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT installed FROM model_registry WHERE model_name = ?",
+                (installed,),
+            ).fetchone()
+        assert row[0] == 1
+        m.assert_called_once_with()
+
+    def test_returns_none_when_ollama_unreachable(self, db_path):
+        # Existing flag must remain unchanged when reconcile fails.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE model_registry SET installed = 1 "
+                "WHERE purpose = 'default'"
+            )
+        with patch(
+            "core.model_registry.client.list",
+            side_effect=ConnectionError("ollama down"),
+        ):
+            snapshot = model_registry.reconcile_installed(db_path)
+        assert snapshot is None
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT installed FROM model_registry WHERE purpose = 'default'"
+            ).fetchone()
+        assert row[0] == 1
+
+    def test_handles_ollama_response_error(self, db_path):
+        with patch(
+            "core.model_registry.client.list",
+            side_effect=ollama.ResponseError("nope"),
+        ):
+            assert model_registry.reconcile_installed(db_path) is None
+
+    def test_handles_http_error(self, db_path):
+        with patch(
+            "core.model_registry.client.list",
+            side_effect=httpx.ConnectError("refused"),
+        ):
+            assert model_registry.reconcile_installed(db_path) is None
+
+    def test_matches_tagged_and_base_names(self, db_path):
+        # Ollama often reports `name:tag`; matching both directions keeps
+        # the registry in sync regardless of how the model was registered.
+        with patch(
+            "core.model_registry.client.list",
+            return_value={
+                "models": [
+                    {"name": "gemma4:latest"},
+                    {"name": "deepseek-coder-v2"},
+                ]
+            },
+        ):
+            snapshot = model_registry.reconcile_installed(db_path)
+        assert snapshot is not None
+        assert snapshot.get("gemma4") is True
+        assert snapshot.get("deepseek-coder-v2") is True
+
+    def test_does_not_call_subprocess_or_pull(self, db_path):
+        # A pull would shell out to `ollama pull …`; reconcile must never
+        # do that. Patch subprocess.run + the registry's `client.list`,
+        # then assert the run mock was never touched.
+        with patch("subprocess.run") as run_mock, patch(
+            "core.model_registry.client.list",
+            return_value={"models": []},
+        ):
+            model_registry.reconcile_installed(db_path)
+        run_mock.assert_not_called()
+
+
+# ── Admin endpoint ──────────────────────────────────────────────────────────
+
+
+class TestAdminListModelsEndpoint:
+    def test_admin_can_list_models(self, db_path, web_client, admin_token):
+        with patch(
+            "core.model_registry.client.list",
+            return_value={"models": []},
+        ):
+            resp = web_client.get("/admin/models", headers=_h(admin_token))
+        assert resp.status_code == 200
+        body = resp.json()
+        from config import MODELS
+        seeded_names = {row["model_name"] for row in body}
+        assert seeded_names == set(MODELS.values())
+        for r in body:
+            assert {"model_name", "display_name", "purpose", "enabled",
+                    "installed"}.issubset(r)
+
+    def test_endpoint_reflects_reconciled_install_status(
+        self, db_path, web_client, admin_token
+    ):
+        from config import MODELS
+        with patch(
+            "core.model_registry.client.list",
+            return_value={"models": [{"name": MODELS["default"]}]},
+        ):
+            resp = web_client.get("/admin/models", headers=_h(admin_token))
+        assert resp.status_code == 200
+        by_purpose = {r["purpose"]: r for r in resp.json()}
+        assert by_purpose["default"]["installed"] is True
+        assert by_purpose["router"]["installed"] is False
+
+    def test_endpoint_does_not_pull_models(
+        self, db_path, web_client, admin_token
+    ):
+        with patch("subprocess.run") as run_mock, patch(
+            "core.model_registry.client.list",
+            return_value={"models": []},
+        ):
+            resp = web_client.get("/admin/models", headers=_h(admin_token))
+        assert resp.status_code == 200
+        run_mock.assert_not_called()
+
+    def test_non_admin_user_forbidden(self, db_path, web_client, admin_token):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        with patch(
+            "core.model_registry.client.list",
+            return_value={"models": []},
+        ):
+            resp = web_client.get("/admin/models", headers=_h(token))
+        assert resp.status_code == 403
+
+    def test_restricted_user_forbidden(self, db_path, web_client, admin_token):
+        _make_user(db_path, "kid", is_restricted=True)
+        token = _login(web_client, "kid")
+        with patch(
+            "core.model_registry.client.list",
+            return_value={"models": []},
+        ):
+            resp = web_client.get("/admin/models", headers=_h(token))
+        assert resp.status_code == 403
+
+    def test_unauthenticated_blocked(self, web_client):
+        resp = web_client.get("/admin/models")
+        assert resp.status_code in (401, 403)
+
+    def test_raw_model_name_not_leaked_to_non_admin(
+        self, db_path, web_client, admin_token
+    ):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        from config import MODELS
+        with patch(
+            "core.model_registry.client.list",
+            return_value={"models": []},
+        ):
+            resp = web_client.get("/admin/models", headers=_h(token))
+        assert resp.status_code == 403
+        # Defence in depth: even the 403 body must not echo a raw name.
+        body_text = resp.text
+        for raw in MODELS.values():
+            assert raw not in body_text
+
+
+# ── Chat routing is unaffected ──────────────────────────────────────────────
+
+
+class TestChatRoutingPreserved:
+    def test_router_module_still_uses_config_models(self):
+        # The registry must not have rewired routing — `core.router.MODEL_MAP`
+        # is still keyed off `config.MODELS`. (#112 owns per-user access.)
+        from core import router
+        from config import MODELS
+        assert router.MODEL_MAP["simple"] == MODELS["default"]
+        assert router.MODEL_MAP["normal"] == MODELS["default"]
+        assert router.MODEL_MAP["code"] == MODELS["code"]
+        assert router.MODEL_MAP["advanced"] == MODELS["advanced"]
+        assert router.FALLBACK_MODEL == MODELS["default"]
+
+    def test_disabling_registry_row_does_not_break_chat(self, db_path):
+        # The registry is informational only this issue. A row marked
+        # `enabled = 0` must not cause the chat layer to refuse to route.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE model_registry SET enabled = 0")
+        from core.router import route, FALLBACK_MODEL
+        with patch(
+            "core.router.client.chat",
+            side_effect=ollama.ResponseError("router down"),
+        ):
+            chosen = route("hello")
+        assert chosen == FALLBACK_MODEL
+
+    def test_unknown_registry_entry_does_not_break_chat(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO model_registry "
+                "(model_name, display_name, purpose, enabled, installed, "
+                "created_at, updated_at) "
+                "VALUES ('phantom:1b', 'Phantom', 'experimental', 1, 0, "
+                "datetime('now'), datetime('now'))"
+            )
+        from core.router import route, FALLBACK_MODEL
+        with patch(
+            "core.router.client.chat",
+            side_effect=ollama.ResponseError("router down"),
+        ):
+            chosen = route("hello")
+        assert chosen == FALLBACK_MODEL
+
+
+# ── Hard guarantee: no pulls happen anywhere in this PR ─────────────────────
+
+
+class TestNoPullsTriggered:
+    def test_initialize_db_does_not_call_subprocess(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        with patch("subprocess.run") as run_mock:
+            core_memory.initialize_db()
+        run_mock.assert_not_called()
+
+    def test_initialize_db_does_not_call_ollama_client_list(
+        self, tmp_path, monkeypatch
+    ):
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        with patch("core.model_registry.client.list") as list_mock:
+            core_memory.initialize_db()
+        # Seeding alone must not even hit Ollama — only the reconcile
+        # helper does, and it is invoked from the admin endpoint.
+        list_mock.assert_not_called()
+
+    def test_subprocess_is_not_imported_by_model_registry(self):
+        # Catch a regression where someone wires `subprocess.run("ollama pull")`
+        # into the registry. The module should not need subprocess at all.
+        import core.model_registry as mr
+        assert not hasattr(mr, "subprocess")
+        # Sanity: the symbol does exist in the global subprocess module
+        # (the import above succeeded).
+        assert subprocess.run is not None

--- a/web.py
+++ b/web.py
@@ -41,6 +41,10 @@ from core.policies import (
     get_policy,
     set_family_controls,
 )
+from core.model_registry import (
+    list_registered as list_registered_models,
+    reconcile_installed as reconcile_installed_models,
+)
 import sqlite3 as _sqlite3
 from core import users as _users_mod
 from memory.store import (
@@ -797,6 +801,22 @@ def admin_set_family_controls(
         "ok": True,
         "family_controls": get_family_controls_dict(user_id),
     }
+
+
+# ── ADMIN: MODEL REGISTRY ───────────────────────────────────────────
+# Read-only view of the local-Ollama model registry seeded at startup
+# from config.MODELS. Raw model names are admin-only; non-admin /
+# restricted callers are blocked by `require_admin`. Pulling models
+# (#111) and per-user model access (#112) are intentionally not wired
+# in this endpoint.
+
+@app.get("/admin/models")
+def admin_list_models(_: CurrentUser = Depends(require_admin)):
+    # Best-effort install-flag refresh; if Ollama is down the persisted
+    # flags are returned as-is. This call is read-only — `client.list()` —
+    # and never triggers a pull.
+    reconcile_installed_models()
+    return list_registered_models()
 
 
 @app.get("/channel")


### PR DESCRIPTION
Closes #110.

Adds a local model registry foundation for Nova's future model-management work.

Changes:
- Adds model_registry table and migration
- Seeds the registry from existing configured Nova models
- Adds read-only helpers for listing registered models
- Adds read-only reconciliation with installed Ollama models
- Adds admin-only GET /admin/models endpoint
- Adds tests for migration, seeding, admin access, non-admin blocking, and no-pull behavior

Not included:
- No Ollama pull/download flow (#111)
- No per-user/per-role model access (#112)
- No model assignment UI
- No model deletion
- No frontend changes
- No changes to chat routing