### PR TITLE
feat: admin-only Ollama model pull flow (#111)

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -11,6 +11,7 @@ from core.model_registry import (
     migrate as _migrate_model_registry,
     seed_from_config as _seed_model_registry,
 )
+from core.model_pulls import migrate as _migrate_model_pulls
 
 DB_PATH = "nova.db"
 
@@ -99,6 +100,7 @@ def initialize_db():
     _migrate_family_controls(DB_PATH)
     _migrate_model_registry(DB_PATH)
     _seed_model_registry(DB_PATH)
+    _migrate_model_pulls(DB_PATH)
     _init_natural_memory(DB_PATH)
 
 

--- a/core/model_pulls.py
+++ b/core/model_pulls.py
@@ -1,0 +1,543 @@
+"""
+Admin-only Ollama model pull (issue #111).
+
+This module owns the *pulling* side of the local model registry:
+
+  * `model_pulls` table — one row per pull attempt, tracking status,
+    progress, and timestamps.
+  * `validate_model_name` — strict allowlist that rejects whitespace,
+    shell metacharacters, path traversal, and oversized inputs *before*
+    any Ollama call.
+  * `request_pull` — admin-driven entry point. It validates the name,
+    skips the work when the model is already installed, returns the
+    in-progress job when one already exists for the same model, and
+    otherwise inserts a new row + dispatches a background worker.
+  * `_run_pull` — the worker. It uses the Ollama Python client (no
+    subprocess, no shell) to stream progress, persists snapshots, and
+    flips `model_registry.installed = 1` on success.
+
+Out of scope (see the issue body for the full list):
+  * Per-user / per-role model access control (#112).
+  * Frontend admin model-management UI (a tiny status surface only).
+  * Auto-switching the chat router to a freshly pulled model.
+  * Model deletion or removal.
+
+Concurrency model:
+  * A module-level `threading.Lock` guards the in-memory active-set,
+    which prevents two concurrent pulls of the *same* model.
+  * `_MAX_CONCURRENT_PULLS` caps the total number of in-flight pull
+    workers so a flurry of admin clicks cannot saturate the host.
+  * The DB row is the source of truth; the in-memory set is a fast
+    short-circuit for the common case.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Optional
+
+import httpx
+import ollama
+
+from core.ollama_client import client
+
+logger = logging.getLogger(__name__)
+
+
+# ── Status constants ────────────────────────────────────────────────────────
+
+STATUS_QUEUED = "queued"
+STATUS_PULLING = "pulling"
+STATUS_DONE = "done"
+STATUS_ERROR = "error"
+
+_ACTIVE_STATUSES = (STATUS_QUEUED, STATUS_PULLING)
+_TERMINAL_STATUSES = (STATUS_DONE, STATUS_ERROR)
+
+# Hard upper bound on the number of pull workers that may be running at
+# the same time. Pulls are large downloads — a single one is usually the
+# right answer, but we leave a small head-room so an admin can queue one
+# more without waiting for the first to finish.
+_MAX_CONCURRENT_PULLS = 2
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+# Ollama model names look like `[host/][namespace/]name[:tag]`. A safe
+# allowlist is more than enough — refusing anything outside this charset
+# blocks every form of shell injection up-front, regardless of how the
+# name is passed downstream.
+#
+# Components ::= [A-Za-z0-9] [A-Za-z0-9._-]{0,62}
+# Names      ::= Components ("/" Components){0,3}
+# Tag        ::= ":" Components
+_NAME_PART = r"[A-Za-z0-9][A-Za-z0-9._-]{0,62}"
+_MODEL_NAME_RE = re.compile(
+    rf"^{_NAME_PART}(?:/{_NAME_PART}){{0,3}}(?::{_NAME_PART})?$"
+)
+_MAX_MODEL_NAME_LENGTH = 200
+
+
+class InvalidModelName(ValueError):
+    """Raised when a caller-supplied model name fails the strict allowlist."""
+
+
+class PullAlreadyInProgress(Exception):
+    """Raised when a pull for the same model is already queued or running."""
+
+    def __init__(self, job: dict):
+        super().__init__(f"pull already in progress for {job['model_name']!r}")
+        self.job = job
+
+
+class ModelAlreadyInstalled(Exception):
+    """Raised when the registry already reports the model as installed."""
+
+    def __init__(self, model_name: str):
+        super().__init__(f"model {model_name!r} is already installed")
+        self.model_name = model_name
+
+
+class TooManyPullsInProgress(Exception):
+    """Raised when the global concurrent-pull cap has been reached."""
+
+    def __init__(self, in_flight: int, cap: int):
+        super().__init__(
+            f"already {in_flight} pulls in progress (cap={cap})"
+        )
+        self.in_flight = in_flight
+        self.cap = cap
+
+
+def validate_model_name(name: object) -> str:
+    """
+    Return the canonicalised model name, or raise `InvalidModelName`.
+
+    The check is intentionally strict — anything outside the allowlist
+    is rejected, including leading whitespace, shell metacharacters
+    (`;`, `|`, `&`, backticks, `$`, `(`, `)`), path-traversal segments
+    (`.`, `..`), embedded NUL bytes, and names exceeding 200 chars.
+    Validation runs *before* any Ollama call so a malicious input never
+    reaches a network or process boundary.
+    """
+    if not isinstance(name, str):
+        raise InvalidModelName("model name must be a string")
+    stripped = name.strip()
+    if stripped != name:
+        raise InvalidModelName("model name must not contain leading/trailing whitespace")
+    if not stripped:
+        raise InvalidModelName("model name must not be empty")
+    if len(stripped) > _MAX_MODEL_NAME_LENGTH:
+        raise InvalidModelName(
+            f"model name must be at most {_MAX_MODEL_NAME_LENGTH} characters"
+        )
+    if "\x00" in stripped:
+        raise InvalidModelName("model name must not contain NUL bytes")
+    # Reject path-traversal segments anywhere in the name. The regex below
+    # would also reject these, but checking explicitly gives a clearer error.
+    for segment in stripped.split("/"):
+        if segment in ("", ".", ".."):
+            raise InvalidModelName("model name must not contain path traversal")
+    if not _MODEL_NAME_RE.match(stripped):
+        raise InvalidModelName("model name contains disallowed characters")
+    return stripped
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+_MODEL_PULLS_SQL = """
+CREATE TABLE IF NOT EXISTS model_pulls (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    model_name      TEXT    NOT NULL,
+    status          TEXT    NOT NULL CHECK (status IN
+                        ('queued', 'pulling', 'done', 'error')),
+    total_bytes     INTEGER,
+    completed_bytes INTEGER,
+    error_message   TEXT,
+    started_at      TEXT,
+    finished_at     TEXT,
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+)
+"""
+
+_MODEL_PULLS_NAME_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_model_pulls_model_name "
+    "ON model_pulls(model_name)"
+)
+
+_MODEL_PULLS_STATUS_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_model_pulls_status "
+    "ON model_pulls(status)"
+)
+
+
+def migrate(db_path: str) -> None:
+    """Create the `model_pulls` table and its indexes. Idempotent."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_MODEL_PULLS_SQL)
+        conn.execute(_MODEL_PULLS_NAME_INDEX_SQL)
+        conn.execute(_MODEL_PULLS_STATUS_INDEX_SQL)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _open(db_path: Optional[str] = None) -> sqlite3.Connection:
+    if db_path is None:
+        from core.memory import DB_PATH
+        db_path = DB_PATH
+    return sqlite3.connect(db_path)
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict:
+    completed = row["completed_bytes"]
+    total = row["total_bytes"]
+    progress: Optional[float] = None
+    if total and total > 0 and completed is not None:
+        # Clamp to [0.0, 1.0] in case the upstream reports a slightly
+        # over-estimated `total` mid-stream.
+        progress = max(0.0, min(1.0, completed / total))
+    return {
+        "id": int(row["id"]),
+        "model_name": row["model_name"],
+        "status": row["status"],
+        "total_bytes": int(total) if total is not None else None,
+        "completed_bytes": int(completed) if completed is not None else None,
+        "progress": progress,
+        "error_message": row["error_message"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _fetch_one(conn: sqlite3.Connection, sql: str, params: tuple) -> Optional[dict]:
+    prev = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(sql, params).fetchone()
+    finally:
+        conn.row_factory = prev
+    return _row_to_dict(row) if row else None
+
+
+def _fetch_all(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> list[dict]:
+    prev = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(sql, params).fetchall()
+    finally:
+        conn.row_factory = prev
+    return [_row_to_dict(r) for r in rows]
+
+
+# ── In-memory active-set (thread-safe) ──────────────────────────────────────
+
+_state_lock = threading.Lock()
+_active_models: set[str] = set()
+
+
+def _try_reserve(model_name: str) -> bool:
+    """
+    Atomically reserve a slot for `model_name`. Returns True if reserved,
+    False if the model is already in flight or the global cap is reached.
+    """
+    with _state_lock:
+        if model_name in _active_models:
+            return False
+        if len(_active_models) >= _MAX_CONCURRENT_PULLS:
+            return False
+        _active_models.add(model_name)
+        return True
+
+
+def _release(model_name: str) -> None:
+    with _state_lock:
+        _active_models.discard(model_name)
+
+
+def _is_active(model_name: str) -> bool:
+    with _state_lock:
+        return model_name in _active_models
+
+
+# ── Reads ───────────────────────────────────────────────────────────────────
+
+def list_pulls(db_path: Optional[str] = None, limit: int = 100) -> list[dict]:
+    """Return pull jobs ordered most-recent first."""
+    with _open(db_path) as conn:
+        return _fetch_all(
+            conn,
+            "SELECT * FROM model_pulls ORDER BY id DESC LIMIT ?",
+            (int(limit),),
+        )
+
+
+def get_pull(pull_id: int, db_path: Optional[str] = None) -> Optional[dict]:
+    with _open(db_path) as conn:
+        return _fetch_one(
+            conn, "SELECT * FROM model_pulls WHERE id = ?", (int(pull_id),)
+        )
+
+
+def _get_active_pull_for(
+    conn: sqlite3.Connection, model_name: str
+) -> Optional[dict]:
+    return _fetch_one(
+        conn,
+        "SELECT * FROM model_pulls WHERE model_name = ? "
+        "AND status IN ('queued', 'pulling') ORDER BY id DESC LIMIT 1",
+        (model_name,),
+    )
+
+
+def _model_is_installed(conn: sqlite3.Connection, model_name: str) -> bool:
+    row = conn.execute(
+        "SELECT installed FROM model_registry WHERE model_name = ?",
+        (model_name,),
+    ).fetchone()
+    return bool(row[0]) if row else False
+
+
+# ── Public entry point: request_pull ────────────────────────────────────────
+
+def request_pull(
+    model_name: str,
+    db_path: Optional[str] = None,
+    *,
+    runner: Optional[Callable[[int, str, str], None]] = None,
+) -> dict:
+    """
+    Validate the input, decide whether work is needed, and start the
+    background worker. Returns the job row dict that the caller should
+    surface to the user.
+
+    Raises:
+        InvalidModelName       — name fails the allowlist.
+        ModelAlreadyInstalled  — registry already reports installed.
+        PullAlreadyInProgress  — same model has a queued/pulling row;
+                                 the existing job is attached.
+
+    `runner` is the function used to invoke the worker. It defaults to
+    `_dispatch_in_thread`, which runs `_run_pull` in a daemon thread.
+    Tests inject a synchronous runner so the worker executes inline.
+    """
+    canonical = validate_model_name(model_name)
+
+    if db_path is None:
+        from core.memory import DB_PATH
+        db_path = DB_PATH
+
+    with _open(db_path) as conn:
+        if _model_is_installed(conn, canonical):
+            raise ModelAlreadyInstalled(canonical)
+
+        existing = _get_active_pull_for(conn, canonical)
+        if existing is not None:
+            raise PullAlreadyInProgress(existing)
+
+        # Reserve a worker slot before inserting the row. If the cap is
+        # reached the request is rejected outright so the admin gets a
+        # clear "too many pulls" signal instead of a row that sits in
+        # `queued` indefinitely with nothing servicing it.
+        if not _try_reserve(canonical):
+            with _state_lock:
+                in_flight = len(_active_models)
+            raise TooManyPullsInProgress(in_flight, _MAX_CONCURRENT_PULLS)
+
+        now = _now_iso()
+        cur = conn.execute(
+            "INSERT INTO model_pulls "
+            "(model_name, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            (canonical, STATUS_QUEUED, now, now),
+        )
+        pull_id = int(cur.lastrowid)
+        job = _fetch_one(
+            conn, "SELECT * FROM model_pulls WHERE id = ?", (pull_id,)
+        )
+
+    dispatch = runner or _dispatch_in_thread
+    try:
+        dispatch(pull_id, canonical, db_path)
+    except Exception:
+        # If the worker could not even be scheduled, release the slot
+        # and mark the row as errored so the admin sees a failure
+        # rather than a forever-queued job.
+        _release(canonical)
+        _mark_error(db_path, pull_id, "failed to start pull worker")
+        raise
+
+    return job  # type: ignore[return-value]
+
+
+# ── Worker dispatch and execution ───────────────────────────────────────────
+
+def _dispatch_in_thread(pull_id: int, model_name: str, db_path: str) -> None:
+    """Default runner — start `_run_pull` on a daemon thread."""
+    t = threading.Thread(
+        target=_run_pull,
+        args=(pull_id, model_name, db_path),
+        name=f"ollama-pull-{pull_id}",
+        daemon=True,
+    )
+    t.start()
+
+
+def _mark_error(db_path: str, pull_id: int, message: str) -> None:
+    now = _now_iso()
+    with _open(db_path) as conn:
+        conn.execute(
+            "UPDATE model_pulls SET status = ?, error_message = ?, "
+            "finished_at = COALESCE(finished_at, ?), updated_at = ? "
+            "WHERE id = ?",
+            (STATUS_ERROR, message, now, now, pull_id),
+        )
+
+
+def _safe_error_message(exc: BaseException) -> str:
+    """
+    Map a raw exception to a short, deterministic string suitable for
+    surfacing to an admin client. Avoids echoing full tracebacks, hostnames,
+    file paths, or anything that could leak environment data.
+    """
+    cls = type(exc).__name__
+    if isinstance(exc, ollama.ResponseError):
+        return f"ollama refused the pull ({cls})"
+    if isinstance(exc, httpx.HTTPError):
+        return f"network error talking to ollama ({cls})"
+    if isinstance(exc, (ConnectionError, OSError)):
+        return f"could not reach ollama ({cls})"
+    return f"pull failed ({cls})"
+
+
+def _update_progress(
+    db_path: str,
+    pull_id: int,
+    *,
+    completed: Optional[int] = None,
+    total: Optional[int] = None,
+) -> None:
+    now = _now_iso()
+    sets = ["updated_at = ?"]
+    params: list[object] = [now]
+    if completed is not None:
+        sets.append("completed_bytes = ?")
+        params.append(int(completed))
+    if total is not None:
+        sets.append("total_bytes = ?")
+        params.append(int(total))
+    params.append(pull_id)
+    with _open(db_path) as conn:
+        conn.execute(
+            f"UPDATE model_pulls SET {', '.join(sets)} WHERE id = ?",
+            params,
+        )
+
+
+def _consume_pull_stream(stream: Iterable, db_path: str, pull_id: int) -> None:
+    """
+    Walk the generator returned by `client.pull(stream=True)` and persist
+    progress snapshots. Each event is a dict with a `status` field and,
+    for download events, `completed` / `total` byte counters.
+    """
+    last_completed: Optional[int] = None
+    last_total: Optional[int] = None
+    for event in stream:
+        if not isinstance(event, dict):
+            continue
+        completed = event.get("completed")
+        total = event.get("total")
+        # Only write to the DB when something actually changed, to avoid
+        # hammering SQLite during the per-chunk progress callbacks.
+        if (
+            completed is not None and completed != last_completed
+        ) or (
+            total is not None and total != last_total
+        ):
+            _update_progress(
+                db_path, pull_id, completed=completed, total=total
+            )
+            if completed is not None:
+                last_completed = completed
+            if total is not None:
+                last_total = total
+
+
+def _mark_started(db_path: str, pull_id: int) -> None:
+    now = _now_iso()
+    with _open(db_path) as conn:
+        conn.execute(
+            "UPDATE model_pulls SET status = ?, "
+            "started_at = COALESCE(started_at, ?), updated_at = ? "
+            "WHERE id = ?",
+            (STATUS_PULLING, now, now, pull_id),
+        )
+
+
+def _mark_done(db_path: str, pull_id: int, model_name: str) -> None:
+    now = _now_iso()
+    with _open(db_path) as conn:
+        conn.execute(
+            "UPDATE model_pulls SET status = ?, finished_at = ?, "
+            "updated_at = ? WHERE id = ?",
+            (STATUS_DONE, now, now, pull_id),
+        )
+        # Reflect the successful pull in the registry so the admin
+        # /admin/models view immediately shows installed=True without
+        # requiring a reconcile pass.
+        conn.execute(
+            "UPDATE model_registry SET installed = 1, updated_at = ? "
+            "WHERE model_name = ?",
+            (now, model_name),
+        )
+
+
+def _run_pull(pull_id: int, model_name: str, db_path: str) -> None:
+    """
+    Background worker. Calls `client.pull(model_name, stream=True)` —
+    the Ollama Python client speaks HTTP to the local daemon, no
+    subprocess, no shell. Updates the DB row as the stream progresses,
+    flips the registry on success, and persists a safe error string on
+    failure.
+    """
+    try:
+        _mark_started(db_path, pull_id)
+        try:
+            stream = client.pull(model_name, stream=True)
+        except TypeError:
+            # Older client versions may not accept the `stream` kwarg —
+            # fall back to a single-shot call so the worker still makes
+            # progress even on a stripped-down Ollama install.
+            stream = client.pull(model_name)
+            stream = [stream] if stream is not None else []
+        _consume_pull_stream(stream, db_path, pull_id)
+        _mark_done(db_path, pull_id, model_name)
+        logger.info("Ollama pull completed for %s", model_name)
+    except (
+        ollama.ResponseError,
+        httpx.HTTPError,
+        ConnectionError,
+        OSError,
+    ) as exc:
+        logger.warning(
+            "Ollama pull failed for %s: %s", model_name, type(exc).__name__
+        )
+        _mark_error(db_path, pull_id, _safe_error_message(exc))
+    except Exception as exc:  # noqa: BLE001
+        # Last-resort guard: a programmer error inside the worker must
+        # not leave a job stuck in `pulling` forever, but we also must
+        # not echo the raw exception text back to the admin.
+        logger.exception("Unexpected error during Ollama pull for %s", model_name)
+        _mark_error(db_path, pull_id, _safe_error_message(exc))
+    finally:
+        _release(model_name)

--- a/tests/test_model_pulls.py
+++ b/tests/test_model_pulls.py
@@ -37,7 +37,7 @@ import ollama
 import pytest
 from fastapi.testclient import TestClient
 
-from core import memory as core_memory, model_pulls, model_registry, users
+from core import memory as core_memory, model_pulls, users
 from memory import store as natural_store
 
 
@@ -696,7 +696,6 @@ class TestAdminEndpoints:
 class TestNonBlocking:
     def test_request_pull_returns_before_worker_finishes(self, db_path):
         _seed_registry(db_path, "slowmodel:1b")
-        gate = threading.Event()
         released = threading.Event()
 
         def slow_stream(name, **kwargs):

--- a/tests/test_model_pulls.py
+++ b/tests/test_model_pulls.py
@@ -1,0 +1,808 @@
+"""
+Tests for the admin Ollama model-pull flow (issue #111).
+
+Covers:
+  * `model_pulls` table is created by `initialize_db()` and the
+    `migrate` helper is idempotent.
+  * `validate_model_name` accepts realistic Ollama tags and rejects
+    every form of dangerous input — whitespace, shell metacharacters,
+    path traversal, NUL bytes, and oversized strings.
+  * `request_pull` validates first, then refuses already-installed
+    models, returns the existing job for an in-progress duplicate, and
+    rejects when the global concurrent-pull cap is reached.
+  * The background worker walks the Ollama stream, persists progress,
+    and on success flips `model_registry.installed = 1`.
+  * Pull failures are captured as a *safe* error string — no raw
+    exception text is leaked.
+  * The admin endpoints (POST /admin/models/pull, GET .../pulls,
+    GET .../pulls/{id}) enforce admin role; non-admin and restricted
+    callers get 403.
+  * No `subprocess` call is ever made — the implementation uses the
+    Ollama Python client only.
+  * Existing chat routing keeps working; per-user model access is
+    still not enforced (deferred to #112).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import subprocess
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import httpx
+import ollama
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, model_pulls, model_registry, users
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_active_models():
+    """Reset module-level concurrency state between tests."""
+    with model_pulls._state_lock:
+        model_pulls._active_models.clear()
+    yield
+    with model_pulls._state_lock:
+        model_pulls._active_models.clear()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(
+    db_path,
+    username,
+    password="pw",
+    role=users.ROLE_USER,
+    is_restricted=False,
+):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+def _table_exists(path: str, name: str) -> bool:
+    with sqlite3.connect(path) as conn:
+        return conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone() is not None
+
+
+def _registry_installed(path: str, model_name: str) -> bool:
+    with sqlite3.connect(path) as conn:
+        row = conn.execute(
+            "SELECT installed FROM model_registry WHERE model_name = ?",
+            (model_name,),
+        ).fetchone()
+    return bool(row[0]) if row else False
+
+
+def _seed_registry(path: str, model_name: str, *, installed: bool = False) -> None:
+    """Insert an extra row in model_registry for a model not in config.MODELS."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO model_registry "
+            "(model_name, display_name, purpose, enabled, installed, "
+            "created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?, ?)",
+            (
+                model_name,
+                model_name,
+                "extra",
+                1 if installed else 0,
+                now,
+                now,
+            ),
+        )
+
+
+def _sync_runner(pull_id, model_name, db_path):
+    """Run the worker inline so tests can assert on the final state."""
+    model_pulls._run_pull(pull_id, model_name, db_path)
+
+
+# ── Migration ───────────────────────────────────────────────────────────────
+
+
+class TestMigration:
+    def test_initialize_db_creates_model_pulls_table(self, db_path):
+        assert _table_exists(db_path, "model_pulls")
+
+    def test_migrate_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "fresh.db")
+        model_pulls.migrate(path)
+        model_pulls.migrate(path)
+        model_pulls.migrate(path)
+        assert _table_exists(path, "model_pulls")
+
+    def test_initialize_db_does_not_call_subprocess(self, tmp_path, monkeypatch):
+        # Sanity-check that wiring up the new migration didn't smuggle a
+        # subprocess.run() call into startup.
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        with patch("subprocess.run") as run_mock:
+            core_memory.initialize_db()
+        run_mock.assert_not_called()
+
+
+# ── validate_model_name ─────────────────────────────────────────────────────
+
+
+class TestValidateModelName:
+    @pytest.mark.parametrize("name", [
+        "gemma4",
+        "gemma3:1b",
+        "qwen2.5:32b",
+        "deepseek-coder-v2",
+        "llama3.2:latest",
+        "library/llama3:8b",
+        "hf.co/user/model:gguf",
+        "user_with_underscores:tag",
+        "qwen3.6:27b",  # the example from the issue
+    ])
+    def test_accepts_realistic_ollama_names(self, name):
+        assert model_pulls.validate_model_name(name) == name
+
+    @pytest.mark.parametrize("bad", [
+        "",
+        " ",
+        " gemma4 ",  # leading/trailing whitespace stripped is rejected
+        "gemma 4",
+        "gemma\t4",
+        "gemma\n4",
+        "gemma;rm -rf /",
+        "gemma|cat",
+        "gemma&background",
+        "$(whoami)",
+        "`whoami`",
+        "gemma>file",
+        "gemma<file",
+        "gemma\\backslash",
+        "gemma'quoted'",
+        "gemma\"dq\"",
+        "gemma#comment",
+        "gemma?q",
+        "gemma*",
+        "../etc/passwd",
+        "gemma/../etc",
+        "./relative",
+        "..",
+        ".",
+        "/absolute",
+        "gemma\x00null",
+        ":notag",      # tag without name
+        "name:",       # empty tag
+        "/leading-slash",
+        "trailing/",
+        "double//slash",
+        "a" * 201,     # over the max length
+    ])
+    def test_rejects_dangerous_or_malformed(self, bad):
+        with pytest.raises(model_pulls.InvalidModelName):
+            model_pulls.validate_model_name(bad)
+
+    def test_rejects_non_string(self):
+        for bad in (None, 42, 3.14, b"bytes", ["list"], {"d": 1}):
+            with pytest.raises(model_pulls.InvalidModelName):
+                model_pulls.validate_model_name(bad)
+
+
+# ── request_pull (job lifecycle) ────────────────────────────────────────────
+
+
+class TestRequestPull:
+    def test_creates_job_and_runs_worker(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+
+        events = [
+            {"status": "pulling manifest"},
+            {"status": "downloading", "completed": 50, "total": 100},
+            {"status": "downloading", "completed": 100, "total": 100},
+            {"status": "success"},
+        ]
+        with patch(
+            "core.model_pulls.client.pull",
+            return_value=iter(events),
+        ) as pull_mock:
+            job = model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+
+        assert job["model_name"] == "newmodel:1b"
+        assert job["status"] == model_pulls.STATUS_QUEUED  # snapshot at insert
+        # Worker has now finished synchronously; refetch.
+        final = model_pulls.get_pull(job["id"], db_path)
+        assert final["status"] == model_pulls.STATUS_DONE
+        assert final["completed_bytes"] == 100
+        assert final["total_bytes"] == 100
+        assert final["progress"] == 1.0
+        assert final["started_at"] is not None
+        assert final["finished_at"] is not None
+        assert final["error_message"] is None
+        # Registry flipped to installed=true.
+        assert _registry_installed(db_path, "newmodel:1b") is True
+        pull_mock.assert_called_once()
+        # No subprocess interaction.
+        with patch("subprocess.run") as run_mock:
+            pass
+        run_mock.assert_not_called()
+
+    def test_invalid_name_rejected_before_any_ollama_call(self, db_path):
+        with patch("core.model_pulls.client.pull") as pull_mock:
+            with pytest.raises(model_pulls.InvalidModelName):
+                model_pulls.request_pull(
+                    "bad; rm -rf /", db_path, runner=_sync_runner
+                )
+        pull_mock.assert_not_called()
+        # And no row was inserted.
+        assert model_pulls.list_pulls(db_path) == []
+
+    def test_already_installed_raises(self, db_path):
+        from config import MODELS
+        # The default-config model is registered but installed=False after
+        # seed; flip the flag to simulate an already-pulled model.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE model_registry SET installed = 1 WHERE model_name = ?",
+                (MODELS["default"],),
+            )
+        with patch("core.model_pulls.client.pull") as pull_mock:
+            with pytest.raises(model_pulls.ModelAlreadyInstalled):
+                model_pulls.request_pull(
+                    MODELS["default"], db_path, runner=_sync_runner
+                )
+        pull_mock.assert_not_called()
+        assert model_pulls.list_pulls(db_path) == []
+
+    def test_duplicate_in_progress_returns_existing_job(self, db_path):
+        # Insert a queued row by hand and reserve the slot, simulating an
+        # in-progress pull. A second request for the same model must
+        # surface the existing job, not start a new one.
+        _seed_registry(db_path, "newmodel:1b")
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "INSERT INTO model_pulls "
+                "(model_name, status, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?)",
+                ("newmodel:1b", model_pulls.STATUS_PULLING, now, now),
+            )
+            existing_id = cur.lastrowid
+        model_pulls._try_reserve("newmodel:1b")  # mimic active worker
+
+        with patch("core.model_pulls.client.pull") as pull_mock:
+            with pytest.raises(model_pulls.PullAlreadyInProgress) as exc_info:
+                model_pulls.request_pull(
+                    "newmodel:1b", db_path, runner=_sync_runner
+                )
+        pull_mock.assert_not_called()
+        assert exc_info.value.job["id"] == existing_id
+        # No second row was inserted.
+        rows = model_pulls.list_pulls(db_path)
+        assert len(rows) == 1
+
+    def test_global_cap_rejects_extra_pulls(self, db_path, monkeypatch):
+        monkeypatch.setattr(model_pulls, "_MAX_CONCURRENT_PULLS", 1)
+        _seed_registry(db_path, "modela:1b")
+        _seed_registry(db_path, "modelb:1b")
+        # Reserve the only slot manually.
+        assert model_pulls._try_reserve("modela:1b") is True
+
+        with patch("core.model_pulls.client.pull") as pull_mock:
+            with pytest.raises(model_pulls.TooManyPullsInProgress):
+                model_pulls.request_pull(
+                    "modelb:1b", db_path, runner=_sync_runner
+                )
+        pull_mock.assert_not_called()
+        # No row was inserted because the cap was hit before the INSERT.
+        assert model_pulls.list_pulls(db_path) == []
+
+    def test_failed_pull_marks_error_with_safe_message(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+
+        secret = "AUTH_TOKEN=hunter2 user=root host=192.168.1.1"
+        with patch(
+            "core.model_pulls.client.pull",
+            side_effect=ollama.ResponseError(secret),
+        ):
+            job = model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+
+        final = model_pulls.get_pull(job["id"], db_path)
+        assert final["status"] == model_pulls.STATUS_ERROR
+        assert final["finished_at"] is not None
+        # Safe error string — never echoes the raw exception text.
+        assert secret not in (final["error_message"] or "")
+        assert "ResponseError" in final["error_message"]
+        # Registry was NOT flipped to installed.
+        assert _registry_installed(db_path, "newmodel:1b") is False
+
+    def test_network_error_marks_error(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch(
+            "core.model_pulls.client.pull",
+            side_effect=httpx.ConnectError("connection refused at /tmp/secret"),
+        ):
+            job = model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        final = model_pulls.get_pull(job["id"], db_path)
+        assert final["status"] == model_pulls.STATUS_ERROR
+        assert "/tmp/secret" not in (final["error_message"] or "")
+
+    def test_unexpected_error_does_not_leave_job_pulling(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch(
+            "core.model_pulls.client.pull",
+            side_effect=RuntimeError("oops"),
+        ):
+            job = model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        final = model_pulls.get_pull(job["id"], db_path)
+        assert final["status"] == model_pulls.STATUS_ERROR
+
+    def test_active_set_is_released_after_run(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch(
+            "core.model_pulls.client.pull",
+            return_value=iter([{"status": "success"}]),
+        ):
+            model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        # The worker has finished; the active-set must be empty so the
+        # next pull request can proceed.
+        with model_pulls._state_lock:
+            assert "newmodel:1b" not in model_pulls._active_models
+
+    def test_active_set_released_on_failure(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch(
+            "core.model_pulls.client.pull",
+            side_effect=ollama.ResponseError("nope"),
+        ):
+            model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        with model_pulls._state_lock:
+            assert "newmodel:1b" not in model_pulls._active_models
+
+    def test_dispatcher_failure_marks_error(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+
+        def boom(pull_id, name, db):
+            raise RuntimeError("scheduler down")
+
+        with patch("core.model_pulls.client.pull"):
+            with pytest.raises(RuntimeError):
+                model_pulls.request_pull(
+                    "newmodel:1b", db_path, runner=boom
+                )
+        # The job was inserted then immediately marked error; the slot
+        # was released.
+        rows = model_pulls.list_pulls(db_path)
+        assert len(rows) == 1
+        assert rows[0]["status"] == model_pulls.STATUS_ERROR
+        with model_pulls._state_lock:
+            assert "newmodel:1b" not in model_pulls._active_models
+
+
+# ── Ollama interaction details ──────────────────────────────────────────────
+
+
+class TestOllamaInteraction:
+    def test_pull_uses_python_client_not_subprocess(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch("subprocess.run") as run_mock, patch(
+            "subprocess.Popen"
+        ) as popen_mock, patch(
+            "core.model_pulls.client.pull",
+            return_value=iter([{"status": "success"}]),
+        ):
+            model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        run_mock.assert_not_called()
+        popen_mock.assert_not_called()
+
+    def test_falls_back_to_non_streaming_pull_on_typeerror(self, db_path):
+        # Some Ollama client builds reject `stream=True`; the worker must
+        # fall back to a single-shot pull so the job still completes.
+        _seed_registry(db_path, "newmodel:1b")
+        calls = []
+
+        def fake_pull(name, **kwargs):
+            calls.append(kwargs)
+            if "stream" in kwargs:
+                raise TypeError("unexpected kwarg")
+            return {"status": "success"}
+
+        with patch("core.model_pulls.client.pull", side_effect=fake_pull):
+            job = model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        final = model_pulls.get_pull(job["id"], db_path)
+        assert final["status"] == model_pulls.STATUS_DONE
+        # First call had stream=True, second was the fallback.
+        assert calls[0].get("stream") is True
+        assert "stream" not in calls[1]
+
+
+# ── HTTP endpoints ──────────────────────────────────────────────────────────
+
+
+class TestAdminEndpoints:
+    def test_admin_can_start_pull(self, db_path, web_client, admin_token):
+        _seed_registry(db_path, "newmodel:1b")
+        # Patch dispatch so the endpoint returns immediately and we can
+        # assert on the inserted row without waiting for a thread.
+        with patch(
+            "core.model_pulls._dispatch_in_thread"
+        ) as dispatch_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(admin_token),
+                json={"model": "newmodel:1b"},
+            )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["model_name"] == "newmodel:1b"
+        assert body["status"] == model_pulls.STATUS_QUEUED
+        dispatch_mock.assert_called_once()
+
+    def test_invalid_name_returns_400(self, db_path, web_client, admin_token):
+        with patch(
+            "core.model_pulls._dispatch_in_thread"
+        ) as dispatch_mock, patch(
+            "core.model_pulls.client.pull"
+        ) as pull_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(admin_token),
+                json={"model": "bad; rm -rf /"},
+            )
+        assert resp.status_code == 400
+        dispatch_mock.assert_not_called()
+        pull_mock.assert_not_called()
+
+    def test_already_installed_returns_200_with_status(
+        self, db_path, web_client, admin_token
+    ):
+        from config import MODELS
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE model_registry SET installed = 1 WHERE model_name = ?",
+                (MODELS["default"],),
+            )
+        with patch("core.model_pulls._dispatch_in_thread") as dispatch_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(admin_token),
+                json={"model": MODELS["default"]},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {
+            "status": "already_installed",
+            "model": MODELS["default"],
+        }
+        dispatch_mock.assert_not_called()
+
+    def test_duplicate_pull_returns_existing_job(
+        self, db_path, web_client, admin_token
+    ):
+        _seed_registry(db_path, "newmodel:1b")
+        # Block the worker from finishing so the second request sees the
+        # first job as in-progress. We achieve that by pinning the slot
+        # via _try_reserve and inserting a queued row by hand.
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "INSERT INTO model_pulls "
+                "(model_name, status, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?)",
+                ("newmodel:1b", model_pulls.STATUS_PULLING, now, now),
+            )
+            first_id = cur.lastrowid
+        model_pulls._try_reserve("newmodel:1b")
+
+        with patch("core.model_pulls._dispatch_in_thread") as dispatch_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(admin_token),
+                json={"model": "newmodel:1b"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == first_id
+        dispatch_mock.assert_not_called()
+
+    def test_too_many_pulls_returns_429(
+        self, db_path, web_client, admin_token, monkeypatch
+    ):
+        monkeypatch.setattr(model_pulls, "_MAX_CONCURRENT_PULLS", 1)
+        _seed_registry(db_path, "modela:1b")
+        _seed_registry(db_path, "modelb:1b")
+        model_pulls._try_reserve("modela:1b")
+
+        with patch("core.model_pulls._dispatch_in_thread") as dispatch_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(admin_token),
+                json={"model": "modelb:1b"},
+            )
+        assert resp.status_code == 429
+        dispatch_mock.assert_not_called()
+
+    def test_non_admin_user_forbidden(self, db_path, web_client, admin_token):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        with patch("core.model_pulls._dispatch_in_thread") as dispatch_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(token),
+                json={"model": "any:tag"},
+            )
+        assert resp.status_code == 403
+        dispatch_mock.assert_not_called()
+
+    def test_restricted_user_forbidden(self, db_path, web_client, admin_token):
+        _make_user(db_path, "kid", is_restricted=True)
+        token = _login(web_client, "kid")
+        with patch("core.model_pulls._dispatch_in_thread") as dispatch_mock:
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(token),
+                json={"model": "any:tag"},
+            )
+        assert resp.status_code == 403
+        dispatch_mock.assert_not_called()
+
+    def test_unauthenticated_blocked(self, web_client):
+        resp = web_client.post(
+            "/admin/models/pull", json={"model": "x"}
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_malformed_body_rejected(self, db_path, web_client, admin_token):
+        # Extra fields are rejected so callers cannot smuggle in
+        # surprises (e.g. `{"model": "x", "as_user": 99}`).
+        resp = web_client.post(
+            "/admin/models/pull",
+            headers=_h(admin_token),
+            json={"model": "gemma4", "as_user": 99},
+        )
+        assert resp.status_code == 422
+
+    def test_admin_can_list_pulls(self, db_path, web_client, admin_token):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch(
+            "core.model_pulls.client.pull",
+            return_value=iter([{"status": "success"}]),
+        ):
+            model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        resp = web_client.get(
+            "/admin/models/pulls", headers=_h(admin_token)
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]["model_name"] == "newmodel:1b"
+        assert body[0]["status"] == model_pulls.STATUS_DONE
+
+    def test_non_admin_cannot_list_pulls(self, db_path, web_client, admin_token):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        resp = web_client.get("/admin/models/pulls", headers=_h(token))
+        assert resp.status_code == 403
+
+    def test_restricted_cannot_list_pulls(self, db_path, web_client, admin_token):
+        _make_user(db_path, "kid", is_restricted=True)
+        token = _login(web_client, "kid")
+        resp = web_client.get("/admin/models/pulls", headers=_h(token))
+        assert resp.status_code == 403
+
+    def test_admin_can_get_single_pull(self, db_path, web_client, admin_token):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch(
+            "core.model_pulls.client.pull",
+            return_value=iter([{"status": "success"}]),
+        ):
+            job = model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        resp = web_client.get(
+            f"/admin/models/pulls/{job['id']}", headers=_h(admin_token)
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == job["id"]
+
+    def test_get_unknown_pull_returns_404(self, db_path, web_client, admin_token):
+        resp = web_client.get(
+            "/admin/models/pulls/9999", headers=_h(admin_token)
+        )
+        assert resp.status_code == 404
+
+    def test_non_admin_cannot_get_single_pull(
+        self, db_path, web_client, admin_token
+    ):
+        _make_user(db_path, "bob")
+        token = _login(web_client, "bob")
+        resp = web_client.get(
+            "/admin/models/pulls/1", headers=_h(token)
+        )
+        assert resp.status_code == 403
+
+
+# ── Concurrency / non-blocking ──────────────────────────────────────────────
+
+
+class TestNonBlocking:
+    def test_request_pull_returns_before_worker_finishes(self, db_path):
+        _seed_registry(db_path, "slowmodel:1b")
+        gate = threading.Event()
+        released = threading.Event()
+
+        def slow_stream(name, **kwargs):
+            # Hold the worker until the test releases it. This proves
+            # that the request thread does not wait for completion.
+            released.wait(timeout=5)
+            return iter([{"status": "success"}])
+
+        with patch("core.model_pulls.client.pull", side_effect=slow_stream):
+            t0 = time.monotonic()
+            job = model_pulls.request_pull("slowmodel:1b", db_path)
+            elapsed = time.monotonic() - t0
+            assert elapsed < 1.0, f"request_pull blocked for {elapsed:.2f}s"
+            assert job["status"] == model_pulls.STATUS_QUEUED
+            released.set()
+            # Wait for the worker to finish so the active-set clears
+            # before this test ends.
+            for _ in range(50):
+                final = model_pulls.get_pull(job["id"], db_path)
+                if final["status"] == model_pulls.STATUS_DONE:
+                    break
+                time.sleep(0.05)
+            assert final["status"] == model_pulls.STATUS_DONE
+
+
+# ── Existing chat routing is untouched ──────────────────────────────────────
+
+
+class TestChatRoutingPreserved:
+    def test_router_still_uses_config_models(self):
+        # #111 must not change model routing — that is #112's responsibility.
+        from core import router
+        from config import MODELS
+        assert router.MODEL_MAP["simple"] == MODELS["default"]
+        assert router.MODEL_MAP["normal"] == MODELS["default"]
+        assert router.MODEL_MAP["code"] == MODELS["code"]
+        assert router.MODEL_MAP["advanced"] == MODELS["advanced"]
+        assert router.FALLBACK_MODEL == MODELS["default"]
+
+
+# ── No per-user/per-role model access (deferred to #112) ────────────────────
+
+
+class TestNoPerUserModelAccess:
+    def test_no_model_access_table_introduced(self, db_path):
+        # #112 will introduce some form of user_model_access / allowlist
+        # table. #111 must not. Fail loudly if a future commit slips one
+        # in under this PR's scope.
+        with sqlite3.connect(db_path) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        for forbidden in (
+            "user_model_access",
+            "model_access",
+            "user_models",
+            "user_allowed_models",
+        ):
+            assert forbidden not in tables, (
+                f"#111 should not introduce table {forbidden!r}; that is #112"
+            )
+
+    def test_admin_pull_endpoint_does_not_consult_per_user_acl(
+        self, db_path, web_client, admin_token
+    ):
+        # The endpoint authorises on `role == admin` only — there is no
+        # extra per-user ACL lookup that #112 will eventually wire in.
+        _seed_registry(db_path, "any:1b")
+        with patch(
+            "core.model_pulls._dispatch_in_thread"
+        ):
+            resp = web_client.post(
+                "/admin/models/pull",
+                headers=_h(admin_token),
+                json={"model": "any:1b"},
+            )
+        # Admin succeeds straight through, no hidden ACL gate.
+        assert resp.status_code == 202
+
+
+# ── Hard guarantee: subprocess never used ───────────────────────────────────
+
+
+class TestNoSubprocess:
+    def test_subprocess_module_not_imported_by_model_pulls(self):
+        import core.model_pulls as mp
+        assert not hasattr(mp, "subprocess")
+        # Sanity: module exists when imported separately.
+        assert subprocess.run is not None
+
+    def test_no_subprocess_call_during_full_pull_cycle(self, db_path):
+        _seed_registry(db_path, "newmodel:1b")
+        with patch("subprocess.run") as run_mock, patch(
+            "subprocess.Popen"
+        ) as popen_mock, patch(
+            "core.model_pulls.client.pull",
+            return_value=iter([
+                {"status": "downloading", "completed": 1, "total": 1},
+                {"status": "success"},
+            ]),
+        ):
+            model_pulls.request_pull(
+                "newmodel:1b", db_path, runner=_sync_runner
+            )
+        run_mock.assert_not_called()
+        popen_mock.assert_not_called()

--- a/web.py
+++ b/web.py
@@ -45,6 +45,7 @@ from core.model_registry import (
     list_registered as list_registered_models,
     reconcile_installed as reconcile_installed_models,
 )
+from core import model_pulls as _model_pulls
 import sqlite3 as _sqlite3
 from core import users as _users_mod
 from memory.store import (
@@ -817,6 +818,63 @@ def admin_list_models(_: CurrentUser = Depends(require_admin)):
     # and never triggers a pull.
     reconcile_installed_models()
     return list_registered_models()
+
+
+# ── ADMIN: MODEL PULL ───────────────────────────────────────────────
+# Admin-only Ollama pull flow (#111). The pull itself runs on a daemon
+# thread so /chat is never blocked. Model names are validated against a
+# strict allowlist before any Ollama call. Per-user / per-role model
+# access (#112), pull cancellation, and model deletion are intentionally
+# not part of this endpoint.
+
+class AdminPullModelRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    model: str = Field(min_length=1, max_length=200)
+
+
+@app.post("/admin/models/pull", status_code=202)
+def admin_pull_model(
+    req: AdminPullModelRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    try:
+        job = _model_pulls.request_pull(req.model)
+    except _model_pulls.InvalidModelName as exc:
+        # Surface a generic message; the regex specifics are not useful
+        # to the client and could be probed for behaviour.
+        raise HTTPException(status_code=400, detail=str(exc))
+    except _model_pulls.ModelAlreadyInstalled:
+        # 200 + a clear status so the admin UI can show "already installed"
+        # without retrying. We do not start a new job.
+        return JSONResponse(
+            status_code=200,
+            content={"status": "already_installed", "model": req.model},
+        )
+    except _model_pulls.PullAlreadyInProgress as exc:
+        # 200 with the existing job — the caller polls the same id.
+        return JSONResponse(status_code=200, content=exc.job)
+    except _model_pulls.TooManyPullsInProgress as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many pulls in progress (cap={exc.cap}).",
+        )
+    return job
+
+
+@app.get("/admin/models/pulls")
+def admin_list_pulls(_: CurrentUser = Depends(require_admin)):
+    return _model_pulls.list_pulls()
+
+
+@app.get("/admin/models/pulls/{pull_id}")
+def admin_get_pull(
+    pull_id: int,
+    _: CurrentUser = Depends(require_admin),
+):
+    job = _model_pulls.get_pull(pull_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Pull job not found.")
+    return job
 
 
 @app.get("/channel")


### PR DESCRIPTION
Closes #111.

Adds an admin-only backend flow for pulling local Ollama models.

Changes:
- Adds model pull job storage and migration
- Adds model name validation before any Ollama call
- Adds admin-only endpoints to start and inspect model pulls
- Runs pulls in background threads so the web server is not blocked
- Tracks pull status, progress, started/finished timestamps, and safe error messages
- Prevents duplicate active pulls for the same model
- Limits concurrent active pulls
- Updates model_registry installed status after successful pull
- Adds tests for validation, permissions, job status, success, failure, and no-shell behavior

Security:
- Admin-only server-side enforcement
- No shell=True
- No subprocess-based model pull
- Invalid model names are rejected before any pull
- Non-admin/restricted users receive 403

Not included:
- No per-user/per-role model access (#112)
- No model assignment UI
- No automatic model switching
- No model deletion
- No chat routing changes
- No memory import changes

---
_Generated by [Claude Code](https://claude.ai/code/session_0136LxHkxP8XEJeGtx3hC4jh)_