### PR TITLE
feat: per-user / per-role model and mode access controls (#112)

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -12,6 +12,7 @@ from core.model_registry import (
     seed_from_config as _seed_model_registry,
 )
 from core.model_pulls import migrate as _migrate_model_pulls
+from core.model_access import migrate as _migrate_model_access
 
 DB_PATH = "nova.db"
 
@@ -101,6 +102,7 @@ def initialize_db():
     _migrate_model_registry(DB_PATH)
     _seed_model_registry(DB_PATH)
     _migrate_model_pulls(DB_PATH)
+    _migrate_model_access(DB_PATH)
     _init_natural_memory(DB_PATH)
 
 

--- a/core/model_access.py
+++ b/core/model_access.py
@@ -1,0 +1,473 @@
+"""
+Per-user / per-role model and mode access controls (issue #112).
+
+This is the backend access-control foundation that lets admins eventually
+decide which modes (chat / code / deep / auto) and which raw models a
+given user or role may use. The scope of #112 is intentionally narrow:
+
+  * Storage for per-role and per-user overrides.
+  * A helper that computes the *effective* allowed modes/models for a
+    user, layered on top of `core.policies.get_policy(user)`.
+  * Enforcement helpers used by `/chat`.
+  * A friendly-label view used by `/me` so non-admin clients never see
+    raw model names.
+
+Resolution rules:
+  * Admins always pass through with full access (all known modes and
+    every enabled registry model).
+  * Non-admin users start from `policies.get_policy(user).allowed_modes`
+    and `model_registry` (enabled rows). Any per-role and per-user
+    override only INTERSECTS — overrides cannot grant access that the
+    base policy already refuses. This keeps the family-controls
+    invariants intact even when an admin assigns a per-user override.
+
+Privacy:
+  * Raw `model_name` is admin-only. The helpers in this module return
+    raw names only to the enforcement layer (where they are compared
+    against the resolved Ollama model). Non-admin views use friendly
+    mode labels.
+
+Out of scope here (other issues):
+  * Admin endpoints / UI for assigning role or per-user access — #127.
+  * Admin model-management UI — #124.
+  * Ollama pull flow — #111.
+  * Model deletion or marketplace.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from core.policies import KNOWN_MODES, get_policy
+from core.users import ROLE_ADMIN, ROLE_USER  # noqa: F401
+
+
+# ── Friendly mode labels (non-admin /me) ────────────────────────────────────
+
+# Stable, user-facing labels. Keys must be a subset of `KNOWN_MODES`.
+MODE_LABELS: dict[str, str] = {
+    "auto": "Auto",
+    "chat": "Chat",
+    "code": "Code",
+    "deep": "Deep",
+}
+
+# Stable presentation order for /me.
+_MODE_ORDER: tuple[str, ...] = ("chat", "auto", "code", "deep")
+
+
+def mode_label(mode: str) -> str:
+    """Return the friendly label for `mode`, or the mode itself if unknown."""
+    return MODE_LABELS.get(mode, mode)
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+_ROLE_MODEL_ACCESS_SQL = """
+CREATE TABLE IF NOT EXISTS role_model_access (
+    role           TEXT    NOT NULL,
+    is_restricted  INTEGER NOT NULL,
+    allowed_modes  TEXT,
+    allowed_models TEXT,
+    PRIMARY KEY (role, is_restricted)
+)
+"""
+
+_USER_MODEL_ACCESS_SQL = """
+CREATE TABLE IF NOT EXISTS user_model_access (
+    user_id        INTEGER PRIMARY KEY
+                          REFERENCES users(id) ON DELETE CASCADE,
+    allowed_modes  TEXT,
+    allowed_models TEXT
+)
+"""
+
+
+def migrate(db_path: str) -> None:
+    """Create the role_model_access and user_model_access tables. Idempotent."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_ROLE_MODEL_ACCESS_SQL)
+        conn.execute(_USER_MODEL_ACCESS_SQL)
+
+
+def _open(db_path: Optional[str] = None) -> sqlite3.Connection:
+    if db_path is None:
+        from core.memory import DB_PATH
+        db_path = DB_PATH
+    return sqlite3.connect(db_path)
+
+
+# ── CSV helpers ─────────────────────────────────────────────────────────────
+#
+# `None` (NULL in storage) means "inherit from the previous resolution
+# layer" — built-in defaults for role rows, the role row for user rows.
+# An empty string ("") means "explicitly deny everything".
+
+def _modes_to_csv(modes: Optional[Iterable[str]]) -> Optional[str]:
+    if modes is None:
+        return None
+    cleaned = sorted({m for m in modes if m in KNOWN_MODES})
+    return ",".join(cleaned)
+
+
+def _csv_to_modes(value: Optional[str]) -> Optional[frozenset[str]]:
+    if value is None:
+        return None
+    parts = {p.strip() for p in value.split(",") if p.strip()}
+    return frozenset(parts & KNOWN_MODES)
+
+
+def _models_to_csv(models: Optional[Iterable[str]]) -> Optional[str]:
+    if models is None:
+        return None
+    cleaned = sorted({m.strip() for m in models if m and m.strip()})
+    return ",".join(cleaned)
+
+
+def _csv_to_models(value: Optional[str]) -> Optional[frozenset[str]]:
+    if value is None:
+        return None
+    parts = {p.strip() for p in value.split(",") if p.strip()}
+    return frozenset(parts)
+
+
+# ── Reads ───────────────────────────────────────────────────────────────────
+
+def _read_role_row(
+    conn: sqlite3.Connection, role: str, is_restricted: bool
+) -> Optional[sqlite3.Row]:
+    prev = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT allowed_modes, allowed_models FROM role_model_access "
+            "WHERE role = ? AND is_restricted = ?",
+            (role, 1 if is_restricted else 0),
+        ).fetchone()
+    finally:
+        conn.row_factory = prev
+
+
+def _read_user_row(
+    conn: sqlite3.Connection, user_id: int
+) -> Optional[sqlite3.Row]:
+    prev = conn.row_factory
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT allowed_modes, allowed_models FROM user_model_access "
+            "WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+    finally:
+        conn.row_factory = prev
+
+
+def _list_enabled_models(conn: sqlite3.Connection) -> frozenset[str]:
+    """
+    Return the set of registry model_names where `enabled = 1`.
+
+    Disabled registry rows are excluded from non-admin allowed_models so
+    a model the admin has turned off cannot be reached by a normal user.
+    """
+    try:
+        rows = conn.execute(
+            "SELECT model_name FROM model_registry WHERE enabled = 1"
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        return frozenset()
+    return frozenset(r[0] for r in rows)
+
+
+# ── Effective access ────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class EffectiveAccess:
+    """Resolved per-user view of allowed modes and models."""
+
+    is_admin: bool
+    allowed_modes: frozenset[str] = field(default_factory=frozenset)
+    allowed_models: frozenset[str] = field(default_factory=frozenset)
+
+    def mode_allowed(self, mode: str) -> bool:
+        if self.is_admin:
+            # Admin keeps full access regardless of stored rows.
+            return mode in KNOWN_MODES
+        return mode in self.allowed_modes
+
+    def model_allowed(self, model: str) -> bool:
+        if not model:
+            return False
+        if self.is_admin:
+            return True
+        return model in self.allowed_models
+
+
+def get_effective_access(
+    user, db_path: Optional[str] = None
+) -> EffectiveAccess:
+    """
+    Resolve the effective allowed modes and models for `user`.
+
+    Admins return an `EffectiveAccess(is_admin=True, …)` and bypass every
+    override layer. Non-admins start from the base policy and intersect
+    each layer (role row, then user row) — no override can grant access
+    the base policy already refuses.
+    """
+    policy = get_policy(user, db_path=db_path)
+    if policy.is_admin:
+        with _open(db_path) as conn:
+            enabled_models = _list_enabled_models(conn)
+        return EffectiveAccess(
+            is_admin=True,
+            allowed_modes=KNOWN_MODES,
+            allowed_models=enabled_models,
+        )
+
+    role = getattr(user, "role", ROLE_USER)
+    is_restricted = bool(getattr(user, "is_restricted", False))
+    user_id = int(getattr(user, "id"))
+
+    # Base modes from policy (covers family controls for restricted users
+    # and KNOWN_MODES for normal users).
+    modes: set[str] = set(policy.allowed_modes)
+
+    with _open(db_path) as conn:
+        enabled_models = _list_enabled_models(conn)
+
+        # `models` starts as None so we can distinguish "no constraint
+        # applied yet" (= all enabled registry models) from "empty set"
+        # (= explicitly deny everything). We intersect with the enabled
+        # registry once at the end.
+        models: Optional[set[str]] = None
+
+        role_row = _read_role_row(conn, role, is_restricted)
+        if role_row is not None:
+            r_modes = _csv_to_modes(role_row["allowed_modes"])
+            if r_modes is not None:
+                modes &= set(r_modes)
+            r_models = _csv_to_models(role_row["allowed_models"])
+            if r_models is not None:
+                models = set(r_models)
+
+        user_row = _read_user_row(conn, user_id)
+        if user_row is not None:
+            u_modes = _csv_to_modes(user_row["allowed_modes"])
+            if u_modes is not None:
+                modes &= set(u_modes)
+            u_models = _csv_to_models(user_row["allowed_models"])
+            if u_models is not None:
+                models = (
+                    set(u_models)
+                    if models is None
+                    else (models & set(u_models))
+                )
+
+    if models is None:
+        # No explicit model restriction → all enabled registry models.
+        effective_models = set(enabled_models)
+    else:
+        # Always intersect with what the registry actually has enabled, so
+        # a disabled model can never be reached by a non-admin caller.
+        effective_models = models & enabled_models
+
+    return EffectiveAccess(
+        is_admin=False,
+        allowed_modes=frozenset(modes),
+        allowed_models=frozenset(effective_models),
+    )
+
+
+# ── Friendly /me view ───────────────────────────────────────────────────────
+
+def available_modes_for(user, db_path: Optional[str] = None) -> list[dict]:
+    """
+    Return the modes `user` may request, as friendly entries.
+
+    Each entry is `{"mode": str, "label": str}`. Raw model names are
+    intentionally not included — admin clients should read the registry
+    via `/admin/models` instead. The returned list preserves a stable,
+    user-facing order so the UI does not have to sort it.
+    """
+    access = get_effective_access(user, db_path=db_path)
+    seen: set[str] = set()
+    out: list[dict] = []
+    for mode in _MODE_ORDER:
+        if mode in access.allowed_modes and mode not in seen:
+            out.append({"mode": mode, "label": mode_label(mode)})
+            seen.add(mode)
+    # Anything else known (future modes added to KNOWN_MODES) — keep
+    # sorted for deterministic output.
+    for mode in sorted(access.allowed_modes):
+        if mode not in seen:
+            out.append({"mode": mode, "label": mode_label(mode)})
+            seen.add(mode)
+    return out
+
+
+# ── Enforcement helpers ─────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class AccessDenial:
+    """Why a request was refused. The web layer maps to HTTPException."""
+
+    status_code: int
+    detail: str
+
+
+def check_mode_access(
+    user, mode: str, db_path: Optional[str] = None
+) -> Optional[AccessDenial]:
+    """
+    Validate that `user` can request `mode`. Returns None when allowed.
+
+    The denial detail is generic and never echoes raw model information.
+    """
+    access = get_effective_access(user, db_path=db_path)
+    if access.mode_allowed(mode):
+        return None
+    return AccessDenial(
+        status_code=403,
+        detail=f"Mode '{mode}' is not allowed for this account.",
+    )
+
+
+def check_model_access(
+    user, model: str, db_path: Optional[str] = None
+) -> Optional[AccessDenial]:
+    """
+    Validate that `user` can target the raw model `model`. Returns None
+    when allowed. The denial detail does not echo the model name back —
+    raw names stay admin-only even in error paths.
+    """
+    access = get_effective_access(user, db_path=db_path)
+    if access.model_allowed(model):
+        return None
+    return AccessDenial(
+        status_code=403,
+        detail="The requested model is not allowed for this account.",
+    )
+
+
+# ── Setters (admin-managed; used by tests and future admin endpoints) ───────
+
+def set_role_access(
+    role: str,
+    is_restricted: bool,
+    *,
+    allowed_modes: Optional[Iterable[str]] = None,
+    allowed_models: Optional[Iterable[str]] = None,
+    db_path: Optional[str] = None,
+) -> None:
+    """
+    Upsert the role override row for `(role, is_restricted)`.
+
+    Pass `None` to leave a column NULL (= inherit from the built-in
+    defaults). Pass an explicit iterable (including `[]` / `frozenset()`)
+    to deny everything for that column.
+    """
+    modes_csv = _modes_to_csv(allowed_modes)
+    models_csv = _models_to_csv(allowed_models)
+    with _open(db_path) as conn:
+        existing = _read_role_row(conn, role, is_restricted)
+        if existing is None:
+            conn.execute(
+                "INSERT INTO role_model_access "
+                "(role, is_restricted, allowed_modes, allowed_models) "
+                "VALUES (?, ?, ?, ?)",
+                (role, 1 if is_restricted else 0, modes_csv, models_csv),
+            )
+            return
+        conn.execute(
+            "UPDATE role_model_access SET allowed_modes = ?, "
+            "allowed_models = ? WHERE role = ? AND is_restricted = ?",
+            (modes_csv, models_csv, role, 1 if is_restricted else 0),
+        )
+
+
+def clear_role_access(
+    role: str, is_restricted: bool, db_path: Optional[str] = None
+) -> None:
+    """Remove the role override row, restoring built-in defaults."""
+    with _open(db_path) as conn:
+        conn.execute(
+            "DELETE FROM role_model_access "
+            "WHERE role = ? AND is_restricted = ?",
+            (role, 1 if is_restricted else 0),
+        )
+
+
+def get_role_access(
+    role: str, is_restricted: bool, db_path: Optional[str] = None
+) -> Optional[dict]:
+    """Return the role override row as a dict (or None if absent)."""
+    with _open(db_path) as conn:
+        row = _read_role_row(conn, role, is_restricted)
+    if row is None:
+        return None
+    modes = _csv_to_modes(row["allowed_modes"])
+    models = _csv_to_models(row["allowed_models"])
+    return {
+        "role": role,
+        "is_restricted": bool(is_restricted),
+        "allowed_modes": sorted(modes) if modes is not None else None,
+        "allowed_models": sorted(models) if models is not None else None,
+    }
+
+
+def set_user_access(
+    user_id: int,
+    *,
+    allowed_modes: Optional[Iterable[str]] = None,
+    allowed_models: Optional[Iterable[str]] = None,
+    db_path: Optional[str] = None,
+) -> None:
+    """
+    Upsert the per-user override row for `user_id`.
+
+    `None` columns inherit from the role row (or built-in defaults).
+    """
+    modes_csv = _modes_to_csv(allowed_modes)
+    models_csv = _models_to_csv(allowed_models)
+    with _open(db_path) as conn:
+        existing = _read_user_row(conn, user_id)
+        if existing is None:
+            conn.execute(
+                "INSERT INTO user_model_access "
+                "(user_id, allowed_modes, allowed_models) "
+                "VALUES (?, ?, ?)",
+                (user_id, modes_csv, models_csv),
+            )
+            return
+        conn.execute(
+            "UPDATE user_model_access SET allowed_modes = ?, "
+            "allowed_models = ? WHERE user_id = ?",
+            (modes_csv, models_csv, user_id),
+        )
+
+
+def clear_user_access(user_id: int, db_path: Optional[str] = None) -> None:
+    """Remove the per-user override row, falling back to role defaults."""
+    with _open(db_path) as conn:
+        conn.execute(
+            "DELETE FROM user_model_access WHERE user_id = ?", (user_id,)
+        )
+
+
+def get_user_access(
+    user_id: int, db_path: Optional[str] = None
+) -> Optional[dict]:
+    """Return the per-user override row as a dict (or None if absent)."""
+    with _open(db_path) as conn:
+        row = _read_user_row(conn, user_id)
+    if row is None:
+        return None
+    modes = _csv_to_modes(row["allowed_modes"])
+    models = _csv_to_models(row["allowed_models"])
+    return {
+        "user_id": user_id,
+        "allowed_modes": sorted(modes) if modes is not None else None,
+        "allowed_models": sorted(models) if models is not None else None,
+    }

--- a/core/model_access.py
+++ b/core/model_access.py
@@ -41,7 +41,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, Optional
 
 from core.policies import KNOWN_MODES, get_policy
-from core.users import ROLE_ADMIN, ROLE_USER  # noqa: F401
+from core.users import ROLE_USER
 
 
 # ── Friendly mode labels (non-admin /me) ────────────────────────────────────

--- a/tests/test_model_access.py
+++ b/tests/test_model_access.py
@@ -1,0 +1,688 @@
+"""
+Tests for per-user / per-role model and mode access controls (issue #112).
+
+Covers:
+  * Schema: `role_model_access` and `user_model_access` tables exist
+    after migration and the migration is idempotent.
+  * Effective access resolution for admin / normal / restricted users
+    with and without role/user overrides.
+  * Per-role overrides can deny a mode.
+  * Per-user overrides can further restrict mode/model access.
+  * Overrides cannot grant access the base policy refuses (intersect
+    semantics — the family-controls invariants stay intact).
+  * Disabled registry models are filtered out of non-admin access.
+  * /chat returns 403 for disallowed modes / models, even when crafted
+    to bypass any frontend.
+  * /me exposes available modes with friendly labels and never raw
+    model names for non-admin callers.
+  * No Ollama pull is triggered by anything in this module.
+  * Existing default-admin behaviour is preserved.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core import (
+    memory as core_memory,
+    model_access,
+    users,
+)
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(
+    db_path,
+    username,
+    password="pw",
+    role=users.ROLE_USER,
+    is_restricted=False,
+):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class _Identity:
+    """Minimal duck-typed CurrentUser for direct module tests."""
+
+    def __init__(self, id, role, is_restricted=False):
+        self.id = id
+        self.role = role
+        self.is_restricted = is_restricted
+
+
+def _set_model_enabled(db_path, model_name, enabled):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE model_registry SET enabled = ? WHERE model_name = ?",
+            (1 if enabled else 0, model_name),
+        )
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+
+class TestSchema:
+    def test_role_model_access_table_exists(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='role_model_access'"
+            ).fetchone()
+        assert row is not None
+
+    def test_user_model_access_table_exists(self, db_path):
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='user_model_access'"
+            ).fetchone()
+        assert row is not None
+
+    def test_migration_is_idempotent(self, db_path):
+        core_memory.initialize_db()
+        core_memory.initialize_db()
+        with sqlite3.connect(db_path) as conn:
+            tables = sorted(
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name IN "
+                    "('role_model_access', 'user_model_access')"
+                ).fetchall()
+            )
+        assert tables == ["role_model_access", "user_model_access"]
+
+
+# ── Effective access resolution ─────────────────────────────────────────────
+
+
+class TestEffectiveAccess:
+    def test_admin_has_full_access(self, db_path):
+        admin = _Identity(1, users.ROLE_ADMIN)
+        access = model_access.get_effective_access(admin, db_path=db_path)
+        assert access.is_admin
+        # Admin sees all modes.
+        for m in ("auto", "chat", "code", "deep"):
+            assert access.mode_allowed(m)
+        # Admin sees all enabled registry models. The seed inserts the
+        # four config.MODELS purposes (router/default/code/advanced).
+        assert access.allowed_models  # non-empty
+        from config import MODELS
+        for raw in MODELS.values():
+            assert access.model_allowed(raw)
+
+    def test_admin_can_use_disabled_models(self, db_path):
+        # Admin must keep access to a disabled registry row — disabling
+        # is admin-facing and does not lock the admin out.
+        from config import MODELS
+        target = MODELS["code"]
+        _set_model_enabled(db_path, target, False)
+        admin = _Identity(1, users.ROLE_ADMIN)
+        access = model_access.get_effective_access(admin, db_path=db_path)
+        assert access.model_allowed(target)
+
+    def test_normal_user_default_is_all_modes(self, db_path):
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert not access.is_admin
+        assert access.allowed_modes == frozenset({"auto", "chat", "code", "deep"})
+
+    def test_normal_user_default_has_all_enabled_models(self, db_path):
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        from config import MODELS
+        for raw in MODELS.values():
+            assert access.model_allowed(raw)
+
+    def test_normal_user_does_not_see_disabled_models(self, db_path):
+        from config import MODELS
+        target = MODELS["code"]
+        _set_model_enabled(db_path, target, False)
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert not access.model_allowed(target)
+
+    def test_restricted_user_default_is_chat_only(self, db_path):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.allowed_modes == frozenset({"chat"})
+        assert not access.mode_allowed("code")
+        assert not access.mode_allowed("deep")
+        assert not access.mode_allowed("auto")
+
+
+class TestRoleOverrides:
+    def test_role_override_can_deny_a_mode(self, db_path):
+        # Take "deep" away from non-restricted users at the role level.
+        model_access.set_role_access(
+            users.ROLE_USER,
+            False,
+            allowed_modes={"chat", "code", "auto"},
+            db_path=db_path,
+        )
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.mode_allowed("chat")
+        assert access.mode_allowed("code")
+        assert not access.mode_allowed("deep")
+
+    def test_role_override_can_allow_only_a_subset(self, db_path):
+        model_access.set_role_access(
+            users.ROLE_USER,
+            False,
+            allowed_modes={"chat"},
+            db_path=db_path,
+        )
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.allowed_modes == frozenset({"chat"})
+
+    def test_role_override_restricts_models(self, db_path):
+        from config import MODELS
+        keep = MODELS["default"]
+        model_access.set_role_access(
+            users.ROLE_USER,
+            False,
+            allowed_models={keep},
+            db_path=db_path,
+        )
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.model_allowed(keep)
+        assert not access.model_allowed(MODELS["code"])
+
+    def test_role_override_can_target_restricted_role(self, db_path):
+        # Even restricted users obey role overrides on top of family
+        # controls. Default is just {"chat"}; an override that adds
+        # "code" cannot grant it because the base policy refuses it.
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        model_access.set_role_access(
+            users.ROLE_USER,
+            True,
+            allowed_modes={"chat", "code"},
+            db_path=db_path,
+        )
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        # `code` is intersected away by the base policy; `chat` survives.
+        assert access.allowed_modes == frozenset({"chat"})
+
+    def test_clear_role_override_restores_defaults(self, db_path):
+        model_access.set_role_access(
+            users.ROLE_USER, False, allowed_modes={"chat"}, db_path=db_path
+        )
+        model_access.clear_role_access(
+            users.ROLE_USER, False, db_path=db_path
+        )
+        u = _Identity(2, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.allowed_modes == frozenset(
+            {"auto", "chat", "code", "deep"}
+        )
+
+    def test_get_role_access_round_trips(self, db_path):
+        model_access.set_role_access(
+            users.ROLE_USER,
+            False,
+            allowed_modes={"chat", "code"},
+            allowed_models={"gemma4"},
+            db_path=db_path,
+        )
+        got = model_access.get_role_access(
+            users.ROLE_USER, False, db_path=db_path
+        )
+        assert got is not None
+        assert got["allowed_modes"] == ["chat", "code"]
+        assert got["allowed_models"] == ["gemma4"]
+
+    def test_admin_role_override_does_not_lock_admin_out(self, db_path):
+        # Even if an admin row gets created, admins keep full access.
+        model_access.set_role_access(
+            users.ROLE_ADMIN,
+            False,
+            allowed_modes={"chat"},
+            db_path=db_path,
+        )
+        admin = _Identity(1, users.ROLE_ADMIN)
+        access = model_access.get_effective_access(admin, db_path=db_path)
+        assert access.is_admin
+        assert access.mode_allowed("deep")
+
+
+class TestUserOverrides:
+    def test_user_override_can_deny_a_mode(self, db_path):
+        uid = _make_user(db_path, "alice")
+        model_access.set_user_access(
+            uid, allowed_modes={"chat", "auto"}, db_path=db_path
+        )
+        u = _Identity(uid, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.mode_allowed("chat")
+        assert not access.mode_allowed("code")
+        assert not access.mode_allowed("deep")
+
+    def test_user_override_intersects_with_role_override(self, db_path):
+        uid = _make_user(db_path, "alice")
+        model_access.set_role_access(
+            users.ROLE_USER, False,
+            allowed_modes={"chat", "code"},
+            db_path=db_path,
+        )
+        # User override re-allows "deep" at the user level — but the
+        # role row already removed it, and overrides only intersect.
+        model_access.set_user_access(
+            uid, allowed_modes={"chat", "code", "deep"}, db_path=db_path
+        )
+        u = _Identity(uid, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.allowed_modes == frozenset({"chat", "code"})
+
+    def test_user_override_cannot_grant_beyond_policy(self, db_path):
+        # A restricted user cannot escape their family-controls modes
+        # via a per-user override row.
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        model_access.set_user_access(
+            uid,
+            allowed_modes={"chat", "code", "deep"},
+            db_path=db_path,
+        )
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.allowed_modes == frozenset({"chat"})
+
+    def test_user_override_restricts_models(self, db_path):
+        from config import MODELS
+        uid = _make_user(db_path, "alice")
+        model_access.set_user_access(
+            uid, allowed_models={MODELS["default"]}, db_path=db_path
+        )
+        u = _Identity(uid, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.model_allowed(MODELS["default"])
+        assert not access.model_allowed(MODELS["code"])
+
+    def test_clear_user_override(self, db_path):
+        uid = _make_user(db_path, "alice")
+        model_access.set_user_access(
+            uid, allowed_modes={"chat"}, db_path=db_path
+        )
+        model_access.clear_user_access(uid, db_path=db_path)
+        u = _Identity(uid, users.ROLE_USER)
+        access = model_access.get_effective_access(u, db_path=db_path)
+        assert access.allowed_modes == frozenset(
+            {"auto", "chat", "code", "deep"}
+        )
+
+    def test_admin_user_override_is_ignored(self, db_path):
+        # A persisted user-row for an admin must not strip admin power.
+        admin_id = users.get_legacy_admin_id(db_path)
+        model_access.set_user_access(
+            admin_id, allowed_modes={"chat"}, db_path=db_path
+        )
+        admin = _Identity(admin_id, users.ROLE_ADMIN)
+        access = model_access.get_effective_access(admin, db_path=db_path)
+        assert access.is_admin
+        assert access.mode_allowed("deep")
+
+
+# ── Friendly mode view (/me) ────────────────────────────────────────────────
+
+
+class TestAvailableModesFor:
+    def test_admin_gets_full_label_list(self, db_path):
+        admin = _Identity(1, users.ROLE_ADMIN)
+        modes = model_access.available_modes_for(admin, db_path=db_path)
+        as_set = {entry["mode"] for entry in modes}
+        assert as_set == {"auto", "chat", "code", "deep"}
+        # Friendly labels are present and stable.
+        labels = {entry["mode"]: entry["label"] for entry in modes}
+        assert labels["chat"] == "Chat"
+        assert labels["deep"] == "Deep"
+
+    def test_restricted_user_only_sees_chat(self, db_path):
+        uid = _make_user(db_path, "kid", is_restricted=True)
+        u = _Identity(uid, users.ROLE_USER, is_restricted=True)
+        modes = model_access.available_modes_for(u, db_path=db_path)
+        as_list = [entry["mode"] for entry in modes]
+        assert as_list == ["chat"]
+
+    def test_normal_user_with_role_override(self, db_path):
+        model_access.set_role_access(
+            users.ROLE_USER, False,
+            allowed_modes={"chat", "code"},
+            db_path=db_path,
+        )
+        u = _Identity(2, users.ROLE_USER)
+        modes = model_access.available_modes_for(u, db_path=db_path)
+        as_list = [entry["mode"] for entry in modes]
+        # Order is the stable user-facing one (chat, auto, code, deep).
+        assert as_list == ["chat", "code"]
+
+    def test_entries_never_carry_raw_model_names(self, db_path):
+        u = _Identity(2, users.ROLE_USER)
+        modes = model_access.available_modes_for(u, db_path=db_path)
+        assert all(set(entry.keys()) == {"mode", "label"} for entry in modes)
+
+
+# ── /chat enforcement (HTTP) ────────────────────────────────────────────────
+
+
+class TestChatEnforcement:
+    def test_admin_can_use_all_modes(self, db_path, web_client):
+        _make_user(db_path, "boss", role=users.ROLE_ADMIN)
+        token = _login(web_client, "boss")
+        with patch("web.chat", return_value=("ok", "stub")):
+            for mode in ("chat", "code", "deep", "auto"):
+                resp = web_client.post(
+                    "/chat",
+                    json={"message": "hi", "mode": mode},
+                    headers=_h(token),
+                )
+                assert resp.status_code == 200, (mode, resp.text)
+
+    def test_normal_user_can_use_default_modes(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        with patch("web.chat", return_value=("ok", "stub")):
+            for mode in ("chat", "code", "deep", "auto"):
+                resp = web_client.post(
+                    "/chat",
+                    json={"message": "hi", "mode": mode},
+                    headers=_h(token),
+                )
+                assert resp.status_code == 200, (mode, resp.text)
+
+    def test_restricted_user_cannot_use_disallowed_mode(
+        self, db_path, web_client,
+    ):
+        _make_user(db_path, "kid", is_restricted=True)
+        token = _login(web_client, "kid")
+        for body in (
+            {"message": "x", "mode": "code"},
+            {"message": "x", "mode": "deep"},
+        ):
+            resp = web_client.post("/chat", json=body, headers=_h(token))
+            assert resp.status_code == 403, body
+            # Detail does NOT contain raw model names (privacy).
+            for raw in ("gemma4", "deepseek-coder-v2", "qwen2.5"):
+                assert raw not in resp.json()["detail"]
+
+    def test_role_override_enforced_in_chat(self, db_path, web_client):
+        # Role-level: take "deep" away from normal users.
+        _make_user(db_path, "alice")
+        model_access.set_role_access(
+            users.ROLE_USER, False,
+            allowed_modes={"chat", "code", "auto"},
+            db_path=db_path,
+        )
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "x", "mode": "deep"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+
+    def test_user_override_enforced_in_chat(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        model_access.set_user_access(
+            uid, allowed_modes={"chat"}, db_path=db_path,
+        )
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "x", "mode": "code"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+
+    def test_crafted_request_for_disallowed_mode_is_refused(
+        self, db_path, web_client,
+    ):
+        # Mirrors the family-controls "crafted request" coverage so a
+        # non-UI client cannot bypass the model-access layer either.
+        _make_user(db_path, "alice")
+        model_access.set_user_access(
+            _make_user(db_path, "child"),
+            allowed_modes={"chat"},
+            db_path=db_path,
+        )
+        token = _login(web_client, "child")
+        for body in (
+            {"message": "x", "mode": "deep"},
+            {"message": "x", "mode": "code"},
+        ):
+            resp = web_client.post("/chat", json=body, headers=_h(token))
+            assert resp.status_code == 403
+
+    def test_disallowed_model_via_nova_assistant_is_refused(
+        self, db_path, web_client,
+    ):
+        # A user who has the nova-assistant override turned on can pick
+        # any model_name in their settings. /chat must still refuse a
+        # raw model that is not in their allowed_models set.
+        from core.settings import save_user_setting
+        from config import MODELS
+        uid = _make_user(db_path, "alice")
+        save_user_setting(uid, "nova_model_enabled", "true")
+        save_user_setting(uid, "nova_model_name", MODELS["code"])
+        # Pin alice to gemma4 only — code model becomes off-limits.
+        model_access.set_user_access(
+            uid, allowed_models={MODELS["default"]}, db_path=db_path,
+        )
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "x", "mode": "chat"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+        # Privacy: the denial does NOT echo the raw model name back.
+        assert MODELS["code"] not in resp.json()["detail"]
+
+    def test_allowed_mode_passes_through(self, db_path, web_client):
+        # Sanity: the new check does not break the happy path.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        with patch("web.chat", return_value=("ok", "stub")) as m:
+            resp = web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "code"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        assert m.called
+
+    def test_disabled_registry_model_blocks_non_admin(
+        self, db_path, web_client,
+    ):
+        from core.settings import save_user_setting
+        from config import MODELS
+        uid = _make_user(db_path, "alice")
+        # User wants the code model via nova-assistant override.
+        save_user_setting(uid, "nova_model_enabled", "true")
+        save_user_setting(uid, "nova_model_name", MODELS["code"])
+        # Admin disables that model in the registry.
+        _set_model_enabled(db_path, MODELS["code"], False)
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/chat",
+            json={"message": "x", "mode": "chat"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+
+
+# ── /me view (HTTP) ─────────────────────────────────────────────────────────
+
+
+class TestMeEndpoint:
+    def test_me_returns_available_modes_for_admin(self, db_path, web_client):
+        _make_user(db_path, "boss", role=users.ROLE_ADMIN)
+        token = _login(web_client, "boss")
+        resp = web_client.get("/me", headers=_h(token))
+        assert resp.status_code == 200
+        body = resp.json()
+        modes = {m["mode"] for m in body["available_modes"]}
+        assert modes == {"auto", "chat", "code", "deep"}
+
+    def test_me_returns_restricted_modes_for_child_user(
+        self, db_path, web_client,
+    ):
+        _make_user(db_path, "kid", is_restricted=True)
+        token = _login(web_client, "kid")
+        resp = web_client.get("/me", headers=_h(token))
+        body = resp.json()
+        modes = [m["mode"] for m in body["available_modes"]]
+        assert modes == ["chat"]
+
+    def test_me_does_not_expose_raw_model_names(self, db_path, web_client):
+        from config import MODELS
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.get("/me", headers=_h(token))
+        body = resp.json()
+        # No raw model name appears anywhere in the payload.
+        text = repr(body)
+        for raw in MODELS.values():
+            assert raw not in text
+        # Also: only friendly fields are exposed on each entry.
+        for entry in body["available_modes"]:
+            assert set(entry.keys()) == {"mode", "label"}
+
+    def test_me_reflects_role_override(self, db_path, web_client):
+        model_access.set_role_access(
+            users.ROLE_USER, False,
+            allowed_modes={"chat"},
+            db_path=db_path,
+        )
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.get("/me", headers=_h(token))
+        modes = [m["mode"] for m in resp.json()["available_modes"]]
+        assert modes == ["chat"]
+
+    def test_me_reflects_user_override(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        model_access.set_user_access(
+            uid, allowed_modes={"chat", "code"}, db_path=db_path,
+        )
+        token = _login(web_client, "alice")
+        resp = web_client.get("/me", headers=_h(token))
+        modes = [m["mode"] for m in resp.json()["available_modes"]]
+        # Stable, user-facing order: chat then code.
+        assert modes == ["chat", "code"]
+
+
+# ── Existing routing & no-side-effects ──────────────────────────────────────
+
+
+class TestExistingRoutingPreserved:
+    def test_existing_chat_routing_still_works(self, db_path, web_client):
+        # Allowed mode + default user → chat() is invoked with the
+        # MODE_MAP-resolved model.
+        from config import MODELS
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        with patch("web.chat", return_value=("ok", "stub")) as m:
+            resp = web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        assert m.call_args.kwargs["forced_model"] == MODELS["default"]
+
+    def test_default_admin_still_unrestricted(self, db_path, web_client):
+        token = _login(web_client, "nova", "nova")
+        with patch("web.chat", return_value=("ok", "stub")):
+            for mode in ("chat", "code", "deep"):
+                resp = web_client.post(
+                    "/chat",
+                    json={"message": "hi", "mode": mode},
+                    headers=_h(token),
+                )
+                assert resp.status_code == 200
+
+    def test_no_ollama_pull_subprocess(self, db_path, web_client):
+        # The whole module is read/enforce only — no pull side-effects.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        with patch("subprocess.run") as run, patch(
+            "subprocess.Popen"
+        ) as popen, patch("web.chat", return_value=("ok", "stub")):
+            web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+            web_client.get("/me", headers=_h(token))
+            model_access.get_effective_access(
+                _Identity(1, users.ROLE_ADMIN), db_path=db_path,
+            )
+        assert not run.called
+        assert not popen.called
+
+    def test_no_model_pull_module_used(self, db_path, web_client):
+        # And nothing routes through `_model_pulls.request_pull`.
+        from core import model_pulls
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        with patch.object(model_pulls, "request_pull") as rp, patch(
+            "web.chat", return_value=("ok", "stub")
+        ):
+            web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+            web_client.get("/me", headers=_h(token))
+        assert not rp.called

--- a/tests/test_model_access.py
+++ b/tests/test_model_access.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import contextlib
 import sqlite3
-import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_model_download_warnings.py
+++ b/tests/test_model_download_warnings.py
@@ -590,17 +590,14 @@ class TestExistingBehaviourUnchanged:
             assert forbidden not in public
 
     def test_no_new_tables_introduced(self, db_path):
-        # #126 must stay on the warning side — no schema changes.
+        # #126 must stay on the warning side — no schema changes of its
+        # own. (Per-user model access tables `user_model_access` /
+        # `role_model_access` are introduced by #112, not #126.)
         with sqlite3.connect(db_path) as conn:
             tables = {
                 row[0] for row in conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table'"
                 ).fetchall()
             }
-        for forbidden in (
-            "model_warnings",
-            "model_size_limits",
-            "user_model_access",  # #112
-            "model_access",       # #112
-        ):
+        for forbidden in ("model_warnings", "model_size_limits"):
             assert forbidden not in tables

--- a/tests/test_model_pulls.py
+++ b/tests/test_model_pulls.py
@@ -740,26 +740,9 @@ class TestChatRoutingPreserved:
 
 
 class TestNoPerUserModelAccess:
-    def test_no_model_access_table_introduced(self, db_path):
-        # #112 will introduce some form of user_model_access / allowlist
-        # table. #111 must not. Fail loudly if a future commit slips one
-        # in under this PR's scope.
-        with sqlite3.connect(db_path) as conn:
-            tables = {
-                row[0]
-                for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'"
-                ).fetchall()
-            }
-        for forbidden in (
-            "user_model_access",
-            "model_access",
-            "user_models",
-            "user_allowed_models",
-        ):
-            assert forbidden not in tables, (
-                f"#111 should not introduce table {forbidden!r}; that is #112"
-            )
+    # The per-user / per-role access tables (`user_model_access`,
+    # `role_model_access`) are owned by #112. #111 must not consult them
+    # for pull authorisation — admin gating is the only check here.
 
     def test_admin_pull_endpoint_does_not_consult_per_user_acl(
         self, db_path, web_client, admin_token

--- a/web.py
+++ b/web.py
@@ -46,6 +46,7 @@ from core.model_registry import (
     reconcile_installed as reconcile_installed_models,
 )
 from core import model_pulls as _model_pulls
+from core import model_access as _model_access
 import sqlite3 as _sqlite3
 from core import users as _users_mod
 from memory.store import (
@@ -368,6 +369,17 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
     if denial is not None:
         _raise_policy_denial(denial)
 
+    # Per-user / per-role mode access (#112). Layered on top of the base
+    # policy so a crafted request for a mode the admin has scoped away
+    # from this account is refused even if the family-controls row would
+    # otherwise allow it.
+    access_denial = _model_access.check_mode_access(user, request.mode)
+    if access_denial is not None:
+        raise HTTPException(
+            status_code=access_denial.status_code,
+            detail=access_denial.detail,
+        )
+
     denial = enforce_daily_limit(policy, user.id)
     if denial is not None:
         _raise_policy_denial(denial)
@@ -433,6 +445,19 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         )
     else:
         forced_model = MODE_MAP.get(request.mode)
+
+    # Per-user / per-role model access (#112). Only validated when a
+    # concrete forced_model is resolved (mode=auto leaves it None and
+    # delegates to the router, which already picks from configured
+    # models). The mode check above is the primary control for auto.
+    if forced_model is not None:
+        model_denial = _model_access.check_model_access(user, forced_model)
+        if model_denial is not None:
+            raise HTTPException(
+                status_code=model_denial.status_code,
+                detail=model_denial.detail,
+            )
+
     response, model_used = chat(history, request.message, memories, user.id, forced_model=forced_model, force_search=request.search, image=request.image, policy=policy)
 
     save_message(conversation_id, "user", request.message)
@@ -634,11 +659,15 @@ def _user_to_dict(row: dict) -> dict:
 
 @app.get("/me")
 def whoami(user: CurrentUser = Depends(get_current_user)):
+    # `available_modes` is the friendly-label view for the client. Raw
+    # model names stay admin-only — they are reachable through
+    # /admin/models, not /me.
     return {
         "id": user.id,
         "username": user.username,
         "role": user.role,
         "is_restricted": user.is_restricted,
+        "available_modes": _model_access.available_modes_for(user),
     }
 
 


### PR DESCRIPTION
Closes #112.

Adds backend model and mode access controls for users and roles.

Changes:
- Adds role_model_access and user_model_access tables
- Adds effective model/mode access resolution
- Adds backend enforcement for allowed modes and resolved models in /chat
- Adds available_modes to /me using friendly labels
- Keeps raw model names out of normal user-facing access output
- Adds helpers for future admin assignment UI work
- Adds tests for admin/user/restricted access, mode enforcement, model enforcement, and override behavior

Not included:
- No admin model management UI (#124)
- No model assignment UI (#127)
- No Ollama pull changes (#111)
- No frontend changes
- No model deletion
- No marketplace
- No automatic model switching

https://claude.ai/code/session_0128FybN1exYY9QS2RjZN7i9

---
_Generated by [Claude Code](https://claude.ai/code/session_0128FybN1exYY9QS2RjZN7i9)_