### PR TITLE
infra: Docker / Compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,41 @@
+# VCS
+.git
+.gitignore
+.gitattributes
+
+# Python
 .venv/
-nova.db
+venv/
 __pycache__/
 *.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+
+# Local secrets and runtime data — MUST NOT be baked into the image
 .env
+.env.*
+!.env.example
+*.db
+*.db.*
+*.backup
+*.save
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# CI / docs that aren't needed at runtime
+.github/
+tests/
+docs/
+
+# Docker meta
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,75 @@
+name: Docker image
+
+# Build the Nova container image. On pushes to main, also publish to GHCR
+# as ghcr.io/thezupzup/nova:latest (plus a short commit SHA tag).
+#
+# Pull requests build the image but do NOT publish — keeps the workflow safe
+# to run on contributor forks without leaking credentials.
+#
+# This workflow does not deploy anywhere. Updating a server is a manual
+# `docker compose pull && docker compose up -d` step on that server.
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "docker/**"
+      - "docker-compose.yml"
+      - "requirements.txt"
+      - "**/*.py"
+      - "static/**"
+      - ".github/workflows/docker-image.yml"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "docker/**"
+      - "docker-compose.yml"
+      - ".github/workflows/docker-image.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # `packages: write` is only used on push-to-main below.
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        # Only authenticate when we'll actually push, i.e. on main of this repo.
+        # The built-in GITHUB_TOKEN is scoped to this repository's packages.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/thezupzup/nova
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+
+      - name: Build (and push on main)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,51 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1.7
+
+# Nova — self-hosted local AI assistant
+# Build: docker build -t nova .
+# Run:   docker run -p 8080:8080 --env-file .env -v nova-data:/data nova
+#
+# This image bundles only the application code and Python dependencies.
+# It contains NO secrets, NO database, and NO Ollama models.
+#   - Credentials are passed at runtime via environment variables.
+#   - The SQLite database is stored on a host-managed volume (/data).
+#   - Ollama runs externally and is reached over the network via OLLAMA_HOST.
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install runtime OS deps. tini gives us proper PID-1 signal handling so
+# `docker stop` reaches uvicorn cleanly.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/*
 
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+# Application source. The .dockerignore prevents nova.db, .env, .venv,
+# __pycache__, tests, and other local artefacts from entering the image.
 COPY . .
+
+# Drop privileges. The /data volume is chowned by the entrypoint at runtime
+# so a host bind-mount with arbitrary ownership still works.
+RUN useradd --system --create-home --uid 1000 nova \
+    && mkdir -p /data \
+    && chown -R nova:nova /app /data
+
+COPY --chown=nova:nova docker/entrypoint.sh /usr/local/bin/nova-entrypoint
+RUN chmod +x /usr/local/bin/nova-entrypoint
+
+USER nova
 
 EXPOSE 8080
 
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/sbin/tini", "--", "/usr/local/bin/nova-entrypoint"]
 CMD ["uvicorn", "web:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -183,7 +183,11 @@ pytest tests/test_router.py -v
 
 The test suite covers model routing, memory storage and parsing, manual memory commands, rate limiting, the identity contract, and weather integration.
 
-A `Dockerfile` is included in the repository for containerised setups. It is not the primary supported deployment method at this stage.
+## Docker deployment
+
+A `Dockerfile` and `docker-compose.yml` are included for self-hosted container deployments. The compose stack persists `nova.db` in a Docker volume, keeps Ollama external (reachable via `OLLAMA_HOST`), and supports clean updates via `docker compose pull`.
+
+See [docs/docker.md](docs/docker.md) for the full guide: first run, updates, where data is stored, how to point Nova at an Ollama on the host or another machine, and backup notes.
 
 ## Contributing
 
@@ -211,7 +215,6 @@ The following are areas of active interest, not commitments:
 - Hardening the natural language memory pipeline for production use
 - Multi-user support (currently single-user via one set of credentials) — see the design plan in [docs/multi-user-architecture.md](docs/multi-user-architecture.md)
 - Improved model fallback and error reporting in the web UI
-- Docker Compose setup for simpler deployment
 - Broader test coverage
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+# Nova — Docker Compose deployment
+#
+# Usage:
+#   1. Copy .env.example to .env and set NOVA_USERNAME / NOVA_PASSWORD /
+#      NOVA_SECRET_KEY before the first start.
+#   2. Make sure Ollama is running and reachable via OLLAMA_HOST below.
+#   3. docker compose up -d
+#
+# Updates:
+#   docker compose pull && docker compose up -d
+#
+# Data location:
+#   The named volume `nova-data` holds nova.db. List with `docker volume ls`,
+#   inspect with `docker volume inspect nova-data`. See docs/docker.md for
+#   backup guidance.
+#
+# This is a LOCAL / SELF-HOSTED deployment. There is no cloud component.
+
+services:
+  nova:
+    # Use the prebuilt image from GHCR for `docker compose pull`-based updates,
+    # or comment `image:` and uncomment `build:` to build from this checkout.
+    image: ghcr.io/thezupzup/nova:latest
+    # build: .
+    container_name: nova
+    restart: unless-stopped
+    ports:
+      # Host:Container — change the host side if 8080 is already in use.
+      - "8080:8080"
+    environment:
+      # ── Credentials (REQUIRED) ─────────────────────────────────────
+      # Set these in .env. Defaults in .env.example are intentionally weak
+      # and must be overridden before the first start.
+      NOVA_USERNAME: ${NOVA_USERNAME:?set NOVA_USERNAME in .env}
+      NOVA_PASSWORD: ${NOVA_PASSWORD:?set NOVA_PASSWORD in .env}
+      NOVA_SECRET_KEY: ${NOVA_SECRET_KEY:?set NOVA_SECRET_KEY in .env}
+
+      # ── Ollama endpoint ────────────────────────────────────────────
+      # Default points at the host machine. On Linux, host.docker.internal
+      # only resolves thanks to the extra_hosts entry below. If Ollama runs
+      # on a different machine, set OLLAMA_HOST=http://<lan-ip>:11434.
+      OLLAMA_HOST: ${OLLAMA_HOST:-http://host.docker.internal:11434}
+
+      # ── Release channel (optional) ─────────────────────────────────
+      NOVA_CHANNEL: ${NOVA_CHANNEL:-stable}
+
+      # ── Other optional toggles, forwarded only if set in .env ──────
+      NOVA_BRANCH: ${NOVA_BRANCH:-main}
+      NOVA_ADMIN_UI: ${NOVA_ADMIN_UI:-false}
+      NOVA_AUTO_WEB_LEARNING: ${NOVA_AUTO_WEB_LEARNING:-false}
+    volumes:
+      # Persistent storage for nova.db. Survives `docker compose down` and
+      # `docker compose pull`. Removed only by `docker volume rm nova-data`
+      # or `docker compose down -v` (destructive).
+      - nova-data:/data
+    extra_hosts:
+      # Lets the container reach an Ollama running on the Docker host on
+      # Linux, matching the Mac/Windows behaviour. Harmless on other OSes.
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  nova-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Nova container entrypoint.
+#
+# Nova's code uses a relative DB_PATH ("nova.db" in the working directory).
+# To persist the database across container rebuilds without modifying app
+# code, we mount a Docker volume at /data and symlink /app/nova.db to it.
+# The first time the app writes to nova.db, the file is created inside the
+# volume and survives container replacement.
+set -eu
+
+DATA_DIR="${NOVA_DATA_DIR:-/data}"
+mkdir -p "$DATA_DIR"
+
+# If a legacy nova.db was baked into the image (it shouldn't be, but be safe)
+# and the volume is empty, migrate it once. Otherwise the volume copy wins.
+if [ -f /app/nova.db ] && [ ! -L /app/nova.db ] && [ ! -e "$DATA_DIR/nova.db" ]; then
+    mv /app/nova.db "$DATA_DIR/nova.db"
+fi
+
+# Always replace /app/nova.db with a symlink into the volume so the running
+# app reads/writes through to persistent storage.
+rm -f /app/nova.db
+ln -s "$DATA_DIR/nova.db" /app/nova.db
+
+exec "$@"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,181 @@
+# Running Nova with Docker
+
+Nova ships with a `Dockerfile` and `docker-compose.yml` for self-hosted deployments. This is a **local / self-hosted** setup: there is no cloud component, no remote sync, and no auto-deploy. You run Nova on a machine you control, talking to an Ollama you control.
+
+> **Warning.** The container exposes Nova's web UI on the network. Do not publish port 8080 to the public internet without a reverse proxy and TLS in front of it. Defaults in `.env.example` are intentionally weak; change them before the first start.
+
+## What ends up where
+
+| Component | Location |
+|---|---|
+| Application code | Inside the image at `/app` |
+| SQLite database (`nova.db`) | Docker volume `nova-data`, mounted at `/data` |
+| Credentials | `.env` on the host, passed in via `docker compose` |
+| Ollama models | **Outside the container.** Nova calls Ollama over the network. |
+
+The image contains no secrets and no database. Pulling a new version cannot overwrite your data.
+
+## Prerequisites
+
+- Docker Engine 24+ and the `docker compose` plugin
+- An Ollama instance reachable from the container (see [Connecting to Ollama](#connecting-to-ollama))
+- The Ollama models referenced in `config.py` already pulled on that Ollama instance
+
+## First run
+
+```bash
+git clone https://github.com/TheZupZup/Nova.git
+cd Nova
+
+cp .env.example .env
+# Edit .env and set:
+#   NOVA_USERNAME       — your login
+#   NOVA_PASSWORD       — your password (change before first start)
+#   NOVA_SECRET_KEY     — a long random string used to sign JWTs
+#   OLLAMA_HOST         — see "Connecting to Ollama" below
+# Optionally set NOVA_CHANNEL=stable|beta|alpha.
+
+docker compose up -d
+```
+
+Nova is now reachable at `http://<host>:8080`. Log in with the credentials you set in `.env`.
+
+To follow logs:
+
+```bash
+docker compose logs -f nova
+```
+
+## Updating
+
+The image is published to GHCR as `ghcr.io/thezupzup/nova:latest`. To update:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+This replaces the container but leaves the `nova-data` volume — and therefore `nova.db` — untouched.
+
+If you'd rather build from your local checkout, edit `docker-compose.yml`: comment the `image:` line and uncomment `build: .`, then:
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+## Where data is stored
+
+`nova.db` lives in the named Docker volume `nova-data`, mounted inside the container at `/data`. The application's relative `nova.db` path is symlinked into that volume by the entrypoint, so app code sees it at the usual location without any code change.
+
+To find the path on disk:
+
+```bash
+docker volume inspect nova-data --format '{{ .Mountpoint }}'
+```
+
+On a default Linux Docker install this is typically `/var/lib/docker/volumes/nova-data/_data`.
+
+### Backing up `nova.db`
+
+Stop the container before copying the file to avoid catching it mid-write:
+
+```bash
+docker compose stop nova
+docker run --rm -v nova-data:/data -v "$PWD":/backup alpine \
+    cp /data/nova.db /backup/nova.db.$(date +%Y%m%d-%H%M%S)
+docker compose start nova
+```
+
+Restore by copying a backup back into the volume the same way before starting the container.
+
+> **Backup note.** `nova.db` is a single SQLite file. Copy it while the app is stopped, or use SQLite's `.backup` command against a live DB. Don't copy it under load — you may capture an inconsistent snapshot.
+
+## Connecting to Ollama
+
+Nova does **not** bundle Ollama. The container reaches Ollama over the network via `OLLAMA_HOST`. Three common setups:
+
+### 1. Ollama on the same host as Docker (Linux)
+
+Use the `host.docker.internal` alias wired up by the `extra_hosts` entry in `docker-compose.yml`:
+
+```env
+OLLAMA_HOST=http://host.docker.internal:11434
+```
+
+Make sure Ollama is listening on an interface the container can reach. By default `ollama serve` binds to `127.0.0.1`, which is **not** reachable from inside the container. Bind to all interfaces:
+
+```bash
+OLLAMA_HOST=0.0.0.0 ollama serve
+```
+
+(or set `Environment=OLLAMA_HOST=0.0.0.0` in your Ollama systemd unit).
+
+### 2. Ollama on the same host (Docker Desktop, macOS / Windows)
+
+`host.docker.internal` resolves natively. The same `OLLAMA_HOST=http://host.docker.internal:11434` works without extra setup.
+
+### 3. Ollama on a different machine
+
+Point `OLLAMA_HOST` at that machine's LAN IP:
+
+```env
+OLLAMA_HOST=http://192.168.1.50:11434
+```
+
+The other machine must be running Ollama with `OLLAMA_HOST=0.0.0.0` so the port is reachable across the network.
+
+## Changing the password before first start
+
+Always set `NOVA_PASSWORD` in `.env` before the first `docker compose up`. The very first start creates the admin record from these environment variables.
+
+If you've already started the container with the default password and want to rotate it before exposing Nova:
+
+```bash
+docker compose down
+# Edit .env, set the new NOVA_PASSWORD
+docker volume rm nova-data    # destructive: wipes nova.db, including conversations
+docker compose up -d
+```
+
+If you don't want to wipe the database, change the password from inside Nova's settings UI after logging in instead.
+
+## Environment variables forwarded to the container
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `NOVA_USERNAME` | yes | Admin login |
+| `NOVA_PASSWORD` | yes | Admin password (change before first start) |
+| `NOVA_SECRET_KEY` | yes | JWT signing secret — long random string |
+| `OLLAMA_HOST` | yes | URL of your Ollama instance |
+| `NOVA_CHANNEL` | no | `stable` (default), `beta`, or `alpha` |
+| `NOVA_BRANCH` | no | Display-only branch label |
+| `NOVA_ADMIN_UI` | no | `true` to expose admin-only UI controls |
+| `NOVA_AUTO_WEB_LEARNING` | no | `true` to enable background RSS learning |
+
+The `alpha` channel additionally requires `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `NOVA_ALPHA_ALLOWED_USERS`. See `.env.example` for details — add them under `environment:` in `docker-compose.yml` if you use that channel.
+
+## What this deployment does NOT do
+
+- No bundled Ollama. Models are not downloaded by the image.
+- No automatic updates. You run `docker compose pull` when you want to update.
+- No remote deploy hook. Nothing in this repo will push to your server for you.
+- No telemetry, cloud sync, or third-party calls beyond Nova's existing optional integrations.
+
+## Troubleshooting
+
+**`Cannot connect to Ollama`**
+Check `OLLAMA_HOST` from inside the container:
+```bash
+docker compose exec nova python -c "import os, httpx; print(httpx.get(os.environ['OLLAMA_HOST']+'/api/tags').text)"
+```
+If this fails, Ollama is either not running, not bound to a reachable interface, or blocked by a firewall.
+
+**`docker compose pull` says credentials are missing**
+The compose file requires `NOVA_USERNAME`, `NOVA_PASSWORD`, and `NOVA_SECRET_KEY` to be set. They live in `.env` next to `docker-compose.yml`. They are not needed for `docker compose pull` itself, but `docker compose up` validates them.
+
+**Want to start over from a clean state**
+```bash
+docker compose down -v   # removes the nova-data volume — DESTRUCTIVE
+docker compose up -d
+```


### PR DESCRIPTION
## Summary

Adds a self-contained Docker deployment path so Nova can be run on another PC or server without a Python toolchain. Local data persists across image updates and Ollama stays external.

This PR is **deployment-only**. No app, auth, memory, model, or family-control logic was touched.

## Files

- **`Dockerfile`** — `python:3.11-slim`, non-root user, `tini` for clean PID-1 signals, entrypoint that symlinks `/app/nova.db` into the `/data` volume so the app's relative `DB_PATH` keeps working without code changes.
- **`docker/entrypoint.sh`** — prepares `/data`, sets up the symlink, then `exec`s the CMD.
- **`docker-compose.yml`** — single `nova` service, named volume `nova-data`, `restart: unless-stopped`, env passthrough for `NOVA_USERNAME` / `NOVA_PASSWORD` / `NOVA_SECRET_KEY` / `OLLAMA_HOST` / `NOVA_CHANNEL`, `host.docker.internal:host-gateway` so Linux hosts can reach Ollama on the host. Uses `image: ghcr.io/thezupzup/nova:latest` for `compose pull`-based updates; a commented `build: .` stays available for local builds.
- **`.dockerignore`** — excludes `.env`, `*.db`, `*.backup`, `.venv`, `tests/`, `docs/`, `.git/`, etc. Secrets and local data cannot be baked into the image.
- **`docs/docker.md`** — first run, update flow (`docker compose pull && docker compose up -d`), where `nova.db` lives, three `OLLAMA_HOST` setups (same Linux host / Docker Desktop / LAN machine), password rotation before first start, backup guidance for `nova.db`, and a self-hosted-only warning.
- **`README.md`** — short link to `docs/docker.md`; removed the now-done roadmap entry.
- **`.github/workflows/docker-image.yml`** — builds on PRs (no push), builds + pushes to `ghcr.io/thezupzup/nova:latest` only on push to `main`. Uses the built-in `GITHUB_TOKEN`; no extra secrets, no deploy step, no machine targeting.

## Design notes

- **Data persistence without app changes.** `core/memory.py` and `memory/store.py` use a hard-coded relative `DB_PATH = "nova.db"`. Rather than touch that, the entrypoint replaces `/app/nova.db` with a symlink into `/data/nova.db`. The named Docker volume `nova-data` survives `docker compose down` and `docker compose pull`.
- **No bundled Ollama / no models.** Nova reaches Ollama over the network via `OLLAMA_HOST`. The image stays small and the user controls model pulls on the Ollama side.
- **No secrets in the image.** Credentials come from the host `.env`. `.dockerignore` blocks `.env` and `nova.db` from any `COPY .` step.

## Test plan

- [ ] `docker compose config` validates with a populated `.env` (verified locally — sandbox has no Docker daemon, so a full `docker build` could not be run here; the workflow will exercise it on the first push).
- [ ] First run: `cp .env.example .env`, set creds, `docker compose up -d`, log in at `http://localhost:8080`.
- [ ] Restart preserves data: `docker compose down && docker compose up -d` keeps conversations and memories.
- [ ] Update flow: `docker compose pull && docker compose up -d` replaces the container, volume untouched.
- [ ] OLLAMA_HOST: container reaches host Ollama via `http://host.docker.internal:11434` on Linux (with `OLLAMA_HOST=0.0.0.0 ollama serve` on the host).
- [ ] CI workflow builds the image on PR; push to `main` publishes `ghcr.io/thezupzup/nova:latest`.

## Confirmation

No application behavior changes. No changes to `core/auth.py`, `core/memory.py`, `core/users.py`, `core/policies.py`, `core/model_*`, `web.py`, `main.py`, or any test. `git diff origin/main...HEAD --name-only` covers only Docker, docs, and CI files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XynG3etjAH57cacNBVXaiS)_