### PR TITLE
docs(security): add hardened systemd unit example and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ sudo systemctl enable nova
 sudo systemctl start nova
 ```
 
+For an optional hardened unit file with systemd sandbox restrictions
+(`NoNewPrivileges`, `ProtectSystem=strict`, capability drop, etc.), see
+[deploy/systemd/README.md](deploy/systemd/README.md). It is a drop-in
+replacement for the minimal unit above and does not change Nova's behavior.
+
 ## Configuration
 
 All configuration is read from `.env` at startup. Key variables:

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,121 @@
+# Hardened systemd unit for Nova
+
+This directory contains an optional, hardened example unit file for running
+Nova as a systemd service. It is a drop-in replacement for the minimal unit
+shown in the top-level [README](../../README.md#running-as-a-systemd-service)
+and adds sandbox restrictions that reduce the blast radius if Nova, one of
+its tools, or a future plugin behaves unsafely.
+
+The application itself is unchanged. None of the directives below alter
+Nova's behavior — they only restrict what the process is allowed to do at
+the kernel level.
+
+## What this is, and what it is not
+
+This unit is **defense in depth**, not a perfect security boundary. It
+makes a number of common host-level attacks harder, but it does not:
+
+- replace authentication or authorization inside Nova
+- audit or filter what the model says or what tools do at the application
+  layer
+- contain a determined attacker who already has code execution as the
+  `nova` user with full filesystem access to the checkout
+- substitute for keeping Nova, Python, Ollama and the host kernel patched
+
+If you need stronger isolation, run Nova in a container or VM and apply
+this hardening to the container/VM host as well.
+
+## Files
+
+- `nova.service` — the hardened example unit. Ships with `USERNAME` and
+  `/path/to/Nova` placeholders so it cannot accidentally be used unedited.
+
+## What stays the same
+
+- Nova still needs **read/write access to `nova.db`** in its working
+  directory. `ReadWritePaths=` is set to the Nova checkout for exactly that
+  reason. Backups (`nova.db.backup`, see `core/memory.py`) are written to
+  the same directory.
+- Nova still talks to Ollama over HTTP through **`OLLAMA_HOST`** (default
+  `http://localhost:11434`). `RestrictAddressFamilies=AF_INET AF_INET6
+  AF_UNIX` keeps that path open. If you point `OLLAMA_HOST` at a remote
+  host, no further unit changes are needed — the network call uses
+  `AF_INET`/`AF_INET6` like any other outbound HTTP request.
+- Optional outbound calls (DuckDuckGo web search, Open-Meteo weather,
+  RSS learner) continue to work for the same reason.
+- The web UI still listens on `0.0.0.0:8080` by default. Adjust the
+  `ExecStart=` line if you bind elsewhere.
+
+## What each hardening directive does
+
+| Directive | Effect |
+|---|---|
+| `NoNewPrivileges=true` | The process and its children can never gain new privileges, even via setuid binaries. |
+| `PrivateTmp=true` | `/tmp` and `/var/tmp` are private to the unit and wiped on stop. |
+| `ProtectSystem=strict` | The whole filesystem is mounted read-only for the unit, except paths listed in `ReadWritePaths=`. |
+| `ProtectHome=read-only` | `/home`, `/root` and `/run/user` are mounted read-only. Nova does not need to write there. |
+| `ReadWritePaths=/path/to/Nova` | Restores write access to the Nova checkout so `nova.db` and its backups continue to work. Add extra entries if the database lives elsewhere. |
+| `CapabilityBoundingSet=` (empty) | Drops every Linux capability for the unit. Nova is a userspace HTTP app and needs none. |
+| `AmbientCapabilities=` (empty) | Belt-and-suspenders companion to the line above; ensures no capability is granted to the started process. |
+| `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX` | Only IPv4, IPv6 and Unix domain sockets are usable. Blocks raw sockets, netlink, packet sockets, etc. |
+| `LockPersonality=true` | The personality(2) syscall is locked, preventing runtime switches to legacy execution domains. |
+| `MemoryDenyWriteExecute=true` | Refuses memory mappings that are both writable and executable — a common class of in-memory code injection. |
+| `SystemCallArchitectures=native` | Rejects syscalls from non-native ABIs (e.g. i386/x32 on x86_64). |
+| `RestrictSUIDSGID=true` | The unit cannot create files with the SUID/SGID bits or acquire them on exec. |
+| `ProtectKernelTunables=true` | `/proc/sys`, `/sys`, `/proc/sysrq-trigger` and similar kernel tunables become read-only or invisible. |
+| `ProtectKernelModules=true` | The unit cannot load or unload kernel modules. |
+| `ProtectControlGroups=true` | The cgroup hierarchy becomes read-only, so the unit cannot rewrite or escape its own resource limits. |
+
+For the authoritative reference, see
+[`systemd.exec(5)`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html).
+
+## Installing the hardened unit
+
+1. Edit `deploy/systemd/nova.service` and replace the placeholders:
+   - `USERNAME` → the local Linux account that owns the Nova checkout.
+   - `/path/to/Nova` → the absolute path of the checkout (the directory
+     that contains `web.py` and where `nova.db` lives).
+
+2. Install, reload, and start:
+
+   ```bash
+   sudo cp deploy/systemd/nova.service /etc/systemd/system/nova.service
+   sudo systemctl daemon-reload
+   sudo systemctl restart nova
+   systemctl status nova
+   ```
+
+   On first install, also run `sudo systemctl enable nova` so the unit
+   starts on boot.
+
+3. Tail logs if anything looks off:
+
+   ```bash
+   journalctl -u nova -f
+   ```
+
+## Testing the hardening
+
+systemd ships an analyzer that scores the sandbox profile of a unit:
+
+```bash
+systemd-analyze security nova.service
+```
+
+It prints a per-directive table and an overall exposure score (lower is
+better). Use it to confirm the directives above are picked up, and to spot
+anything you may want to tighten further on your specific host. A non-zero
+score is normal — it does not mean the unit is misconfigured.
+
+## Troubleshooting
+
+- **`Read-only file system` on startup.** `nova.db` is being written
+  somewhere outside the path listed in `ReadWritePaths=`. Either move the
+  database into the checkout or add its directory to `ReadWritePaths=`.
+- **Cannot reach Ollama.** Confirm `OLLAMA_HOST` is set correctly and that
+  the Ollama service is up (`systemctl status ollama`). Network access
+  itself is not blocked by this unit.
+- **Service fails immediately with no useful log.** Temporarily comment out
+  the `MemoryDenyWriteExecute=` and `SystemCallArchitectures=` lines and
+  restart; some Python extensions built with JIT or non-native wheels can
+  trip those. Re-enable one at a time once you've identified the culprit.

--- a/deploy/systemd/nova.service
+++ b/deploy/systemd/nova.service
@@ -1,0 +1,95 @@
+# Nova — hardened systemd unit (example)
+#
+# This is an OPTIONAL hardened unit file. The minimal unit shown in the project
+# README still works. This file adds systemd sandbox restrictions that reduce
+# the blast radius of any unsafe behavior from Nova, the underlying tools, or
+# future plugins. It does not change how Nova runs or what it can do at the
+# application level.
+#
+# Before installing:
+#   1. Replace USERNAME with the local Linux account that owns the Nova checkout.
+#   2. Replace /path/to/Nova with the absolute path of your Nova checkout
+#      (the directory that contains web.py and nova.db).
+#   3. If you keep nova.db somewhere other than the checkout, add that path to
+#      ReadWritePaths= as well.
+#
+# See deploy/systemd/README.md for the full guide and a per-option explanation.
+
+[Unit]
+Description=Nova AI Assistant (hardened)
+After=network.target ollama.service
+
+[Service]
+Type=simple
+User=USERNAME
+Group=USERNAME
+WorkingDirectory=/path/to/Nova
+ExecStart=/path/to/Nova/.venv/bin/uvicorn web:app --host 0.0.0.0 --port 8080
+Restart=always
+RestartSec=5
+Environment="PATH=/path/to/Nova/.venv/bin:/usr/bin:/usr/local/bin"
+
+# ── Sandbox hardening ──────────────────────────────────────────────────────
+# These directives restrict what the Nova process can see and do on the host.
+# They do not modify Nova's application behavior; they constrain the kernel
+# surface available to it.
+
+# Refuse to gain new privileges (e.g. via setuid binaries) for the lifetime
+# of the process and any children it spawns.
+NoNewPrivileges=true
+
+# Give the unit a private /tmp and /var/tmp that disappear when it stops.
+PrivateTmp=true
+
+# Mount the entire filesystem read-only, with /usr, /boot and /efi made
+# inaccessible for write. Only paths listed in ReadWritePaths= remain writable.
+ProtectSystem=strict
+
+# /home, /root and /run/user are mounted read-only. Nova does not need to
+# write there; it only reads its own checkout.
+ProtectHome=read-only
+
+# Restore write access to the Nova checkout so nova.db, backups, and any
+# file written under WorkingDirectory continue to work. Adjust this list if
+# the database lives outside the checkout.
+ReadWritePaths=/path/to/Nova
+
+# Drop every Linux capability. Nova is a userspace HTTP app and needs none
+# of them.
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# Allow only the address families Nova actually uses: IPv4 and IPv6 for the
+# HTTP listener and outbound calls to Ollama / web tools, plus AF_UNIX for
+# local IPC primitives the Python runtime may use.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# Disallow personality(2) changes — the process cannot switch to a different
+# execution domain (e.g. legacy 32-bit emulation) at runtime.
+LockPersonality=true
+
+# Refuse memory mappings that are simultaneously writable and executable.
+# Blocks a common class of in-memory code-injection techniques.
+MemoryDenyWriteExecute=true
+
+# Reject syscalls compiled for non-native architectures. On x86_64 this
+# blocks the i386 and x32 ABIs that are otherwise exposed to the process.
+SystemCallArchitectures=native
+
+# Block creation of SUID/SGID files and prevent the process from acquiring
+# those bits at exec time.
+RestrictSUIDSGID=true
+
+# Make /proc/sys, /sys, /proc/sysrq-trigger and related kernel tunables
+# read-only or invisible.
+ProtectKernelTunables=true
+
+# Disallow loading or unloading kernel modules from this unit.
+ProtectKernelModules=true
+
+# Make the cgroup hierarchy read-only, so the unit cannot escape or rewrite
+# its own resource limits.
+ProtectControlGroups=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds an optional, hardened example systemd unit at `deploy/systemd/nova.service` as a drop-in replacement for the minimal unit in the README.
- Adds `deploy/systemd/README.md` documenting each hardening directive, what stays the same (nova.db writes, Ollama access via `OLLAMA_HOST`), install/reload commands, and how to score the unit with `systemd-analyze security`.
- Adds a short pointer from the top-level README to the new hardening guide.

## Hardening included

`NoNewPrivileges`, `PrivateTmp`, `ProtectSystem=strict`, `ProtectHome=read-only`, `ReadWritePaths` scoped to the Nova checkout, empty `CapabilityBoundingSet`/`AmbientCapabilities`, `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX`, `LockPersonality`, `MemoryDenyWriteExecute`, `SystemCallArchitectures=native`, `RestrictSUIDSGID`, `ProtectKernelTunables`, `ProtectKernelModules`, `ProtectControlGroups`.

## What is explicitly NOT changed

- No app code, auth, memory, model, family-control, or Docker/Podman changes.
- No SELinux policy, no DB schema, no new AI-agent permissions.
- The minimal unit in `README.md` still works; the hardened unit is opt-in.

## Notes for reviewers

- The unit ships with `USERNAME` and `/path/to/Nova` placeholders so it cannot accidentally be installed unedited.
- Docs explicitly call out that this is defense in depth, not a perfect security boundary, and that a container or VM is appropriate when stronger isolation is needed.
- `ReadWritePaths=` is set to the Nova checkout because `core/memory.py` uses `DB_PATH = "nova.db"` (relative to `WorkingDirectory`) and writes `nova.db.backup` next to it.

## Test plan

- [ ] Edit `deploy/systemd/nova.service` placeholders, install, and confirm `systemctl status nova` shows the service active.
- [ ] Confirm Nova continues to read/write `nova.db` (login, store a memory, restart, retrieve it).
- [ ] Confirm Nova reaches Ollama via `OLLAMA_HOST` and that web search / weather still work.
- [ ] Run `systemd-analyze security nova.service` and confirm the hardened directives are picked up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWwXG3AnEjwiXn2VKBeJPo)_