### PR TITLE
feat(security): add read-only SilentGuard feed integration

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -8,6 +8,7 @@ from core.identity import IDENTITY_CONTRACT
 from core.policies import ADMIN_POLICY, Policy
 from core.router import route
 from core.search import web_search, should_search
+from core.security_feed import get_security_context, is_security_query
 from core.weather import detect_weather_city, get_weather
 from memory.extractor import extract_memories
 from memory.policy import is_memory_allowed
@@ -47,6 +48,15 @@ Réponds dans la langue de l'utilisateur.
 Données météo:
 {weather_data}"""
 
+SECURITY_SYSTEM_PROMPT = """Tu es Nova, un assistant personnel intelligent.
+Tu reçois un résumé en lecture seule du flux SilentGuard (connexions, processus, statut de confiance).
+Analyse ces données pour répondre à la question de l'utilisateur, mets en évidence les anomalies, et n'hésite pas à demander si une action est souhaitée.
+Tu n'as AUCUN moyen d'agir : tu ne peux ni bloquer, ni tuer un processus, ni modifier le système. Ne suggère que des pistes d'analyse, pas des commandes destructrices.
+Réponds dans la langue de l'utilisateur.
+
+Données SilentGuard (read-only):
+{security_data}"""
+
 
 def _extract_and_save_natural_memories(user_message: str, user_id: int):
     """Runs the rule-based extractor on the user message and persists allowed memories under `user_id`."""
@@ -81,6 +91,8 @@ def build_messages(history: list[dict], user_input: str, memories: list[dict], e
         system_prompt = WEATHER_SYSTEM_PROMPT.format(weather_data=extra_context)
     elif context_type == "search":
         system_prompt = SEARCH_SYSTEM_PROMPT.format(search_results=extra_context)
+    elif context_type == "security":
+        system_prompt = SECURITY_SYSTEM_PROMPT.format(security_data=extra_context)
     else:
         memory_text = format_memories_for_prompt(memories)
         natural_text = format_for_prompt(natural_memories) if natural_memories else ""
@@ -148,6 +160,16 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
 
             if weather_result == "unknown_city":
                 return "Je n'ai pas accès à la météo pour cette ville.", model
+
+        # SilentGuard read-only feed — surfaces local security telemetry
+        # when the user explicitly asks about it. No system actions.
+        if is_security_query(user_input):
+            security_data = get_security_context()
+            if security_data:
+                messages = build_messages(history, user_input, memories, security_data, "security")
+                response = client.chat(model=model, messages=messages)
+                reply = response["message"]["content"]
+                return reply, model
 
         # Web search — both the explicit `force_search` flag and the
         # auto-detected `should_search` path require web_search_enabled.

--- a/core/security_feed.py
+++ b/core/security_feed.py
@@ -1,0 +1,292 @@
+"""
+Read-only bridge to SilentGuard's local memory file.
+
+SilentGuard is an external monitoring tool that records observed network
+connections (IP, process, port, trust status) to a JSON file in the user's
+home directory. Nova consumes that file as a passive data source so the
+assistant can answer questions like "show me suspicious connections" or
+"analyze unknown IPs" without ever changing system state.
+
+Boundaries enforced by this module:
+  * read-only file access — no writes, no deletions.
+  * no subprocess execution.
+  * no network scanning, no socket calls, no DNS lookups.
+  * no firewall, kill, or block actions.
+  * no root or elevated-privilege operations.
+
+If SilentGuard is not installed or the memory file is missing/corrupt,
+every public function returns an empty result rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FEED_PATH = Path.home() / ".silentguard_memory.json"
+
+TRUST_KNOWN = "Known"
+TRUST_UNKNOWN = "Unknown"
+TRUST_LOCAL = "Local"
+_VALID_TRUST = {TRUST_KNOWN, TRUST_UNKNOWN, TRUST_LOCAL}
+
+_MAX_FEED_BYTES = 5 * 1024 * 1024  # 5 MB cap — silently ignore anything larger.
+_DEFAULT_LIMIT = 50
+
+_SECURITY_KEYWORDS = (
+    "suspicious connection", "suspicious connections",
+    "connexion suspecte", "connexions suspectes",
+    "unknown ip", "unknown ips", "ip inconnue", "ips inconnues",
+    "silentguard", "security feed", "flux de sécurité",
+    "explain this process", "explique ce processus",
+    "analyze unknown", "analyse les inconnu", "analyse inconnu",
+    "recent security events", "événements de sécurité",
+)
+
+
+@dataclass(frozen=True)
+class SecurityEvent:
+    """One observation reported by SilentGuard."""
+
+    ip: str
+    process: str
+    port: Optional[int]
+    trust: str
+    timestamp: Optional[str] = None
+    raw: dict = field(default_factory=dict, repr=False, compare=False)
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.trust == TRUST_UNKNOWN
+
+    @property
+    def is_local(self) -> bool:
+        return self.trust == TRUST_LOCAL
+
+
+def _resolve_path(path: Optional[os.PathLike]) -> Path:
+    if path is not None:
+        return Path(path)
+    override = os.environ.get("NOVA_SILENTGUARD_PATH")
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_FEED_PATH
+
+
+def _coerce_port(value) -> Optional[int]:
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        return None
+    if port < 0 or port > 65535:
+        return None
+    return port
+
+
+def _coerce_trust(value) -> str:
+    if not isinstance(value, str):
+        return TRUST_UNKNOWN
+    normalized = value.strip().capitalize()
+    if normalized in _VALID_TRUST:
+        return normalized
+    return TRUST_UNKNOWN
+
+
+def _parse_event(entry) -> Optional[SecurityEvent]:
+    if not isinstance(entry, dict):
+        return None
+    ip = entry.get("ip") or entry.get("remote_ip") or entry.get("address")
+    process = entry.get("process") or entry.get("proc") or entry.get("command")
+    if not isinstance(ip, str) or not ip.strip():
+        return None
+    if not isinstance(process, str) or not process.strip():
+        process = "unknown"
+    return SecurityEvent(
+        ip=ip.strip(),
+        process=process.strip(),
+        port=_coerce_port(entry.get("port") or entry.get("remote_port")),
+        trust=_coerce_trust(entry.get("trust") or entry.get("status")),
+        timestamp=entry.get("timestamp") or entry.get("time"),
+        raw=entry,
+    )
+
+
+def _load_raw(path: Path) -> list:
+    """Load and decode the SilentGuard JSON file. Returns [] on any failure."""
+    try:
+        if not path.is_file():
+            return []
+        if path.stat().st_size > _MAX_FEED_BYTES:
+            logger.warning("SilentGuard feed too large (>%d bytes); skipping.", _MAX_FEED_BYTES)
+            return []
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.debug("SilentGuard feed unavailable: %s", e)
+        return []
+
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        # Common shapes: {"events": [...]} or {"connections": [...]}.
+        for key in ("events", "connections", "entries", "items"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def get_recent_security_events(
+    limit: int = _DEFAULT_LIMIT,
+    path: Optional[os.PathLike] = None,
+) -> list[SecurityEvent]:
+    """
+    Return up to `limit` most recent events from the SilentGuard feed.
+
+    Read-only. Returns [] if SilentGuard is not installed, the file is
+    missing, or the payload is malformed. Entries that cannot be parsed
+    are skipped silently.
+    """
+    if limit <= 0:
+        return []
+    feed_path = _resolve_path(path)
+    raw = _load_raw(feed_path)
+    events: list[SecurityEvent] = []
+    for entry in raw:
+        event = _parse_event(entry)
+        if event is not None:
+            events.append(event)
+    # SilentGuard appends; the tail is the newest slice.
+    return events[-limit:]
+
+
+def summarize_events(events: list[SecurityEvent]) -> dict:
+    """
+    Build a passive summary suitable for inclusion in a chat prompt.
+
+    Groups unknown connections by IP, surfaces the busiest processes, and
+    highlights anomalies (repeated unknown IPs, rare ports). No system
+    actions are taken or recommended.
+    """
+    if not events:
+        return {
+            "total": 0,
+            "unknown_count": 0,
+            "known_count": 0,
+            "local_count": 0,
+            "unknown_groups": [],
+            "top_processes": [],
+            "anomalies": [],
+        }
+
+    unknowns = [e for e in events if e.is_unknown]
+    knowns = [e for e in events if e.trust == TRUST_KNOWN]
+    locals_ = [e for e in events if e.is_local]
+
+    unknown_by_ip: dict[str, list[SecurityEvent]] = {}
+    for e in unknowns:
+        unknown_by_ip.setdefault(e.ip, []).append(e)
+
+    unknown_groups = [
+        {
+            "ip": ip,
+            "count": len(group),
+            "processes": sorted({e.process for e in group}),
+            "ports": sorted({e.port for e in group if e.port is not None}),
+        }
+        for ip, group in sorted(
+            unknown_by_ip.items(), key=lambda kv: len(kv[1]), reverse=True
+        )
+    ]
+
+    top_processes = [
+        {"process": p, "count": n}
+        for p, n in Counter(e.process for e in events).most_common(5)
+    ]
+
+    anomalies: list[str] = []
+    for group in unknown_groups:
+        if group["count"] >= 5:
+            anomalies.append(
+                f"IP {group['ip']} has {group['count']} unknown connections."
+            )
+    rare_ports = [g for g in unknown_groups if any(p and p > 49151 for p in g["ports"])]
+    for g in rare_ports:
+        anomalies.append(
+            f"IP {g['ip']} reached high/ephemeral ports {g['ports']}."
+        )
+
+    return {
+        "total": len(events),
+        "unknown_count": len(unknowns),
+        "known_count": len(knowns),
+        "local_count": len(locals_),
+        "unknown_groups": unknown_groups,
+        "top_processes": top_processes,
+        "anomalies": anomalies,
+    }
+
+
+def format_security_summary(summary: dict) -> str:
+    """Render a `summarize_events` result as a compact, prompt-friendly string."""
+    if not summary or summary.get("total", 0) == 0:
+        return "Aucun événement SilentGuard disponible."
+
+    lines = [
+        f"Événements: {summary['total']} "
+        f"(connus={summary['known_count']}, "
+        f"inconnus={summary['unknown_count']}, "
+        f"locaux={summary['local_count']}).",
+    ]
+    if summary["unknown_groups"]:
+        lines.append("Connexions inconnues groupées par IP:")
+        for g in summary["unknown_groups"][:10]:
+            ports = ", ".join(str(p) for p in g["ports"]) or "—"
+            procs = ", ".join(g["processes"]) or "—"
+            lines.append(
+                f"  - {g['ip']} ×{g['count']} (ports: {ports}; processus: {procs})"
+            )
+    if summary["top_processes"]:
+        top = ", ".join(
+            f"{p['process']} ({p['count']})" for p in summary["top_processes"]
+        )
+        lines.append(f"Processus les plus actifs: {top}.")
+    if summary["anomalies"]:
+        lines.append("Anomalies:")
+        for a in summary["anomalies"]:
+            lines.append(f"  - {a}")
+    lines.append(
+        "Lecture seule — Nova ne bloque, ne tue, ni ne modifie aucun processus."
+    )
+    return "\n".join(lines)
+
+
+def is_security_query(user_input: str) -> bool:
+    """Heuristic match for queries that should pull in the SilentGuard feed."""
+    if not isinstance(user_input, str):
+        return False
+    lower = user_input.lower()
+    return any(keyword in lower for keyword in _SECURITY_KEYWORDS)
+
+
+def get_security_context(
+    limit: int = _DEFAULT_LIMIT,
+    path: Optional[os.PathLike] = None,
+) -> Optional[str]:
+    """
+    Convenience wrapper used by the chat layer.
+
+    Returns the formatted summary string, or `None` when there is nothing
+    to report (no feed file or empty feed). Always read-only.
+    """
+    events = get_recent_security_events(limit=limit, path=path)
+    if not events:
+        return None
+    return format_security_summary(summarize_events(events))

--- a/tests/test_security_feed.py
+++ b/tests/test_security_feed.py
@@ -1,0 +1,236 @@
+import json
+
+import pytest
+
+from core import security_feed
+from core.security_feed import (
+    SecurityEvent,
+    TRUST_KNOWN,
+    TRUST_LOCAL,
+    TRUST_UNKNOWN,
+    format_security_summary,
+    get_recent_security_events,
+    get_security_context,
+    is_security_query,
+    summarize_events,
+)
+
+
+def _write_feed(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_missing_file_returns_empty(tmp_path):
+    missing = tmp_path / "nope.json"
+    assert get_recent_security_events(path=missing) == []
+    assert get_security_context(path=missing) is None
+
+
+def test_invalid_json_returns_empty(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert get_recent_security_events(path=path) == []
+
+
+def test_parses_list_of_events(tmp_path):
+    path = tmp_path / "feed.json"
+    _write_feed(path, [
+        {"ip": "1.2.3.4", "process": "curl", "port": 443, "trust": "Known"},
+        {"ip": "10.0.0.5", "process": "node", "port": 8080, "trust": "Local"},
+        {"ip": "5.6.7.8", "process": "rogue", "port": 9999, "trust": "Unknown"},
+    ])
+    events = get_recent_security_events(path=path)
+    assert len(events) == 3
+    assert {e.trust for e in events} == {TRUST_KNOWN, TRUST_LOCAL, TRUST_UNKNOWN}
+    assert events[0].port == 443
+    assert events[2].is_unknown
+
+
+def test_parses_dict_wrapper(tmp_path):
+    path = tmp_path / "feed.json"
+    _write_feed(path, {"events": [
+        {"ip": "1.1.1.1", "process": "ping", "port": 0, "trust": "Known"},
+    ]})
+    events = get_recent_security_events(path=path)
+    assert len(events) == 1
+    assert events[0].ip == "1.1.1.1"
+
+
+def test_alternative_field_names(tmp_path):
+    path = tmp_path / "feed.json"
+    _write_feed(path, [
+        {"remote_ip": "9.9.9.9", "command": "ssh", "remote_port": 22, "status": "known"},
+    ])
+    events = get_recent_security_events(path=path)
+    assert len(events) == 1
+    assert events[0].ip == "9.9.9.9"
+    assert events[0].process == "ssh"
+    assert events[0].port == 22
+    assert events[0].trust == TRUST_KNOWN
+
+
+def test_invalid_entries_are_skipped(tmp_path):
+    path = tmp_path / "feed.json"
+    _write_feed(path, [
+        "not a dict",
+        {"process": "no-ip"},
+        {"ip": "  ", "process": "blank"},
+        {"ip": "8.8.8.8", "process": "dig"},
+    ])
+    events = get_recent_security_events(path=path)
+    assert len(events) == 1
+    assert events[0].ip == "8.8.8.8"
+
+
+def test_unknown_trust_defaults(tmp_path):
+    path = tmp_path / "feed.json"
+    _write_feed(path, [{"ip": "1.2.3.4", "process": "x", "trust": "weird-value"}])
+    events = get_recent_security_events(path=path)
+    assert events[0].trust == TRUST_UNKNOWN
+
+
+def test_limit_returns_tail(tmp_path):
+    path = tmp_path / "feed.json"
+    payload = [
+        {"ip": f"10.0.0.{i}", "process": "p", "trust": "Known"} for i in range(20)
+    ]
+    _write_feed(path, payload)
+    events = get_recent_security_events(limit=5, path=path)
+    assert len(events) == 5
+    assert [e.ip for e in events] == [f"10.0.0.{i}" for i in range(15, 20)]
+
+
+def test_oversized_file_is_ignored(tmp_path, monkeypatch):
+    path = tmp_path / "feed.json"
+    _write_feed(path, [{"ip": "1.2.3.4", "process": "x", "trust": "Known"}])
+    monkeypatch.setattr(security_feed, "_MAX_FEED_BYTES", 1)
+    assert get_recent_security_events(path=path) == []
+
+
+def test_summarize_empty():
+    summary = summarize_events([])
+    assert summary["total"] == 0
+    assert summary["unknown_groups"] == []
+    assert summary["anomalies"] == []
+
+
+def test_summarize_groups_unknowns():
+    events = [
+        SecurityEvent(ip="6.6.6.6", process="rogue", port=4444, trust=TRUST_UNKNOWN),
+        SecurityEvent(ip="6.6.6.6", process="rogue", port=4445, trust=TRUST_UNKNOWN),
+        SecurityEvent(ip="1.1.1.1", process="curl", port=443, trust=TRUST_KNOWN),
+    ]
+    summary = summarize_events(events)
+    assert summary["total"] == 3
+    assert summary["unknown_count"] == 2
+    assert summary["known_count"] == 1
+    assert summary["unknown_groups"][0]["ip"] == "6.6.6.6"
+    assert summary["unknown_groups"][0]["count"] == 2
+    assert summary["unknown_groups"][0]["ports"] == [4444, 4445]
+
+
+def test_summarize_flags_repeated_unknown_anomaly():
+    events = [
+        SecurityEvent(ip="6.6.6.6", process="rogue", port=80, trust=TRUST_UNKNOWN)
+        for _ in range(5)
+    ]
+    summary = summarize_events(events)
+    assert any("6.6.6.6" in a and "5" in a for a in summary["anomalies"])
+
+
+def test_summarize_flags_high_port_anomaly():
+    events = [
+        SecurityEvent(ip="7.7.7.7", process="rogue", port=60001, trust=TRUST_UNKNOWN),
+    ]
+    summary = summarize_events(events)
+    assert any("60001" in a for a in summary["anomalies"])
+
+
+def test_format_summary_includes_readonly_disclaimer():
+    events = [
+        SecurityEvent(ip="6.6.6.6", process="rogue", port=4444, trust=TRUST_UNKNOWN),
+    ]
+    rendered = format_security_summary(summarize_events(events))
+    assert "Lecture seule" in rendered
+    assert "6.6.6.6" in rendered
+
+
+def test_format_summary_empty_message():
+    assert "Aucun" in format_security_summary(summarize_events([]))
+
+
+@pytest.mark.parametrize("query", [
+    "Show me suspicious connections",
+    "Analyze unknown IPs",
+    "Explain this process",
+    "connexions suspectes ?",
+    "que dit silentguard",
+])
+def test_is_security_query_matches(query):
+    assert is_security_query(query)
+
+
+@pytest.mark.parametrize("query", [
+    "what's the weather",
+    "tell me a joke",
+    "qui est le premier ministre",
+    "",
+])
+def test_is_security_query_negatives(query):
+    assert not is_security_query(query)
+
+
+def test_is_security_query_handles_non_string():
+    assert not is_security_query(None)
+    assert not is_security_query(42)
+
+
+def test_get_security_context_uses_env_override(tmp_path, monkeypatch):
+    path = tmp_path / "feed.json"
+    _write_feed(path, [
+        {"ip": "5.5.5.5", "process": "x", "port": 22, "trust": "Unknown"},
+    ])
+    monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+    rendered = get_security_context()
+    assert rendered is not None
+    assert "5.5.5.5" in rendered
+
+
+def test_get_security_context_returns_none_when_empty(tmp_path):
+    path = tmp_path / "empty.json"
+    _write_feed(path, [])
+    assert get_security_context(path=path) is None
+
+
+def test_no_system_action_surfaces_in_module():
+    """The module must not import or call anything that could mutate the system."""
+    import ast
+
+    with open(security_feed.__file__, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+
+    forbidden_imports = {"subprocess", "socket", "shutil", "ctypes", "signal"}
+    forbidden_calls = {"system", "kill", "popen", "remove", "unlink", "rmdir"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root not in forbidden_imports, (
+                    f"security_feed must not import {alias.name!r}"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".")[0]
+            assert root not in forbidden_imports, (
+                f"security_feed must not import from {node.module!r}"
+            )
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                assert func.attr not in forbidden_calls, (
+                    f"security_feed must not call {func.attr!r}"
+                )
+            elif isinstance(func, ast.Name):
+                assert func.id not in forbidden_calls, (
+                    f"security_feed must not call {func.id!r}"
+                )


### PR DESCRIPTION
## Summary

- Adds `core/security_feed.py`, a read-only bridge to SilentGuard's local JSON memory file (`~/.silentguard_memory.json`, override via `NOVA_SILENTGUARD_PATH`).
- Exposes `get_recent_security_events()`, `summarize_events()`, `format_security_summary()`, `is_security_query()`, and `get_security_context()` so Nova can answer prompts such as "show me suspicious connections", "analyze unknown IPs", or "explain this process".
- Wires the feed into `core/chat.py` via a new `security` context type with a dedicated system prompt that forbids destructive suggestions.
- Adds 28 tests in `tests/test_security_feed.py`, including an AST-based guard that fails the build if `subprocess`, `socket`, `os.system`, `kill`, etc. are ever introduced into the module.

## Boundaries (explicitly enforced)

- Read-only file access — no writes, no deletes.
- No subprocess execution, no socket calls, no DNS/network scanning.
- No firewall, kill, or block actions.
- No root / elevated-privilege paths.
- Graceful empty result when the feed is missing or malformed; a 5 MB cap on the file size.

## Integration shape

- `is_security_query(user_input)` matches a small EN/FR keyword set (suspicious connections, unknown IPs, silentguard, explain this process, …).
- When matched, `get_security_context()` loads the feed, groups unknowns by IP, ranks busy processes, and flags simple anomalies (≥5 unknown hits per IP, high/ephemeral ports). The result is injected into the chat prompt; if the feed is absent the request falls through to the normal flow.

## Test plan

- [x] `python -m pytest tests/test_security_feed.py` (28 passed)
- [x] `python -m pytest tests/test_weather.py tests/test_security_feed.py` (57 passed)
- [x] `python -m flake8 core/security_feed.py core/chat.py tests/test_security_feed.py` (clean)
- [x] AST defensive test confirms no system-action imports or calls in `core/security_feed.py`
- [x] End-to-end debug print of `get_recent_security_events → summarize_events → format_security_summary` against a synthetic feed

## Out of scope

- Automatic blocking, process killing, firewall modification, real-time hooks — all explicitly **not** implemented per the integration brief.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAuPVfB16JFJ3vSwTNxxpa)_