### PR TITLE
feat(integrations): add SilentGuard and NexaNote opt-in switches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,17 @@ NOVA_ALPHA_ALLOWED_USERS=githubusername1,githubusername2
 # Set to "true" to enable background RSS feed learning every hour.
 # Disabled by default to prevent low-value entries from polluting the memory DB.
 NOVA_AUTO_WEB_LEARNING=false
+
+# ── Optional integrations ─────────────────────────────────────────────
+# SilentGuard and NexaNote are disabled per-user by default and must be
+# turned on from Settings → Integrations. The variables below only set
+# the *transport* — they never enable an integration on their own.
+#
+# SilentGuard reads ~/.silentguard_memory.json; override the path with:
+# NOVA_SILENTGUARD_PATH=/custom/path/to/feed.json
+#
+# NexaNote is reached over HTTP; leave NEXANOTE_API_URL empty to keep
+# the integration unavailable for everyone.
+NEXANOTE_API_URL=
+NEXANOTE_API_TOKEN=
+NEXANOTE_TIMEOUT_SECONDS=3.0

--- a/config.py
+++ b/config.py
@@ -16,6 +16,15 @@ NOVA_AUTO_WEB_LEARNING = os.getenv("NOVA_AUTO_WEB_LEARNING", "false").lower() ==
 GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "")
 GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET", "")
 GITHUB_OAUTH_REDIRECT_URI = os.getenv("GITHUB_OAUTH_REDIRECT_URI", "")
+
+# ── Optional integrations (passive bridges) ─────────────────────────
+# SilentGuard is read from a JSON file on disk; the path is overridable
+# via NOVA_SILENTGUARD_PATH (used by core.security_feed). NexaNote is
+# reached over HTTP. All integration switches are per-user and default
+# to disabled; nothing is contacted until the user opts in.
+NEXANOTE_API_URL = os.getenv("NEXANOTE_API_URL", "").strip().rstrip("/")
+NEXANOTE_API_TOKEN = os.getenv("NEXANOTE_API_TOKEN", "").strip()
+NEXANOTE_TIMEOUT_SECONDS = float(os.getenv("NEXANOTE_TIMEOUT_SECONDS", "3.0"))
 NOVA_ALPHA_ALLOWED_USERS: frozenset[str] = frozenset(
     u.strip().lower()
     for u in os.getenv("NOVA_ALPHA_ALLOWED_USERS", "").split(",")
@@ -39,4 +48,7 @@ ALLOWED_SETTINGS = {
     "ram_budget": {"type": int, "min": 256, "max": 16384},
     "nova_model_enabled": {"type": str, "allowed": ["true", "false"]},
     "nova_model_name": {"type": str, "max_len": 100},
+    "silentguard_enabled": {"type": str, "allowed": ["true", "false"]},
+    "nexanote_enabled": {"type": str, "allowed": ["true", "false"]},
+    "nexanote_write_enabled": {"type": str, "allowed": ["true", "false"]},
 }

--- a/core/chat.py
+++ b/core/chat.py
@@ -8,7 +8,8 @@ from core.identity import IDENTITY_CONTRACT
 from core.policies import ADMIN_POLICY, Policy
 from core.router import route
 from core.search import web_search, should_search
-from core.security_feed import get_security_context, is_security_query
+from core.security_feed import is_security_query
+from core.integrations import silentguard as silentguard_integration
 from core.weather import detect_weather_city, get_weather
 from memory.extractor import extract_memories
 from memory.policy import is_memory_allowed
@@ -162,9 +163,10 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 return "Je n'ai pas accès à la météo pour cette ville.", model
 
         # SilentGuard read-only feed — surfaces local security telemetry
-        # when the user explicitly asks about it. No system actions.
+        # when the user explicitly asks about it AND the user has turned
+        # the SilentGuard integration on in Settings. No system actions.
         if is_security_query(user_input):
-            security_data = get_security_context()
+            security_data = silentguard_integration.recent_events_summary(user_id)
             if security_data:
                 messages = build_messages(history, user_input, memories, security_data, "security")
                 response = client.chat(model=model, messages=messages)

--- a/core/integrations/__init__.py
+++ b/core/integrations/__init__.py
@@ -1,0 +1,12 @@
+"""
+Optional integrations Nova can talk to without absorbing their codebases.
+
+Each module in this package is a passive bridge to an external tool:
+  * silentguard — read-only file-based feed of network observations.
+  * nexanote   — HTTP API for notes (read by default; writes opt-in).
+
+Every integration is gated behind a per-user setting and is safe to
+import even when the underlying tool is missing or unreachable. Public
+helpers must never raise on the happy "tool absent" path; they return
+empty results or a `{"state": "..."}` status dict instead.
+"""

--- a/core/integrations/nexanote.py
+++ b/core/integrations/nexanote.py
@@ -1,0 +1,257 @@
+"""
+Gated bridge to NexaNote's HTTP API.
+
+NexaNote is an external note service (separate FastAPI backend). Nova
+talks to it over HTTP only — no shared database, no shared process. The
+integration is per-user opt-in and read-only by default; writes require
+a second ``nexanote_write_enabled`` switch.
+
+Boundaries (enforced):
+  * HTTP only — never touches NexaNote's database directly.
+  * read-only by default; write helpers refuse silently when the
+    write switch is off.
+  * never raises on network or HTTP errors — returns ``None``/``[]``
+    and logs at debug level so a missing or unreachable NexaNote does
+    not break Nova.
+  * no system-level actions, no subprocess execution.
+
+Configuration (env vars, see ``config.py``):
+  * ``NEXANOTE_API_URL``    — base URL, e.g. ``https://nexanote.local``.
+                              Empty string means "not deployed";
+                              status reports ``not_found`` for everyone.
+  * ``NEXANOTE_API_TOKEN``  — optional bearer token.
+  * ``NEXANOTE_TIMEOUT_SECONDS`` — per-request timeout (default 3.0s).
+
+The expected REST shape (best-effort; failures are absorbed):
+  * ``GET  /health``           → 2xx when reachable.
+  * ``GET  /notes?limit=N``    → list of ``{id, title, content, ...}``.
+  * ``GET  /notes/{id}``       → one note.
+  * ``POST /notes``            → create from ``{title, content}``.
+  * ``PUT  /notes/{id}``       → update.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from config import (
+    NEXANOTE_API_TOKEN,
+    NEXANOTE_API_URL,
+    NEXANOTE_TIMEOUT_SECONDS,
+)
+from core.settings import get_user_setting
+
+logger = logging.getLogger(__name__)
+
+NAME = "nexanote"
+
+STATE_DISABLED = "disabled"
+STATE_CONNECTED = "connected"
+STATE_NOT_FOUND = "not_found"
+STATE_UNREACHABLE = "unreachable"
+
+
+@dataclass(frozen=True)
+class IntegrationStatus:
+    """Snapshot of an integration's availability for one user."""
+
+    name: str
+    enabled: bool
+    state: str
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "enabled": self.enabled,
+            "state": self.state,
+            "detail": self.detail,
+        }
+
+
+# ── Switch helpers ──────────────────────────────────────────────────
+
+def is_enabled(user_id: int) -> bool:
+    """True only when the user has explicitly turned the integration on."""
+    return get_user_setting(user_id, "nexanote_enabled", "false") == "true"
+
+
+def is_write_enabled(user_id: int) -> bool:
+    """
+    True only when the user has explicitly opted into writes *and* has
+    the integration enabled. Read-only by default.
+    """
+    if not is_enabled(user_id):
+        return False
+    return get_user_setting(user_id, "nexanote_write_enabled", "false") == "true"
+
+
+def _is_configured() -> bool:
+    return bool(NEXANOTE_API_URL)
+
+
+def _headers() -> dict:
+    headers = {"Accept": "application/json"}
+    if NEXANOTE_API_TOKEN:
+        headers["Authorization"] = f"Bearer {NEXANOTE_API_TOKEN}"
+    return headers
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(
+        base_url=NEXANOTE_API_URL,
+        timeout=NEXANOTE_TIMEOUT_SECONDS,
+        headers=_headers(),
+    )
+
+
+# ── Status ──────────────────────────────────────────────────────────
+
+def status(user_id: int) -> IntegrationStatus:
+    """
+    Report whether the integration is on and reachable. Never raises.
+
+    Off  → ``disabled``.
+    On + no URL configured → ``not_found``.
+    On + URL configured + ``GET /health`` succeeds → ``connected``.
+    On + URL configured + any network/HTTP failure → ``unreachable``.
+    """
+    enabled = is_enabled(user_id)
+    if not enabled:
+        return IntegrationStatus(
+            name=NAME, enabled=False, state=STATE_DISABLED,
+            detail="Turned off in Settings.",
+        )
+    if not _is_configured():
+        return IntegrationStatus(
+            name=NAME, enabled=True, state=STATE_NOT_FOUND,
+            detail="NEXANOTE_API_URL is not set on this Nova host.",
+        )
+    try:
+        with _client() as client:
+            resp = client.get("/health")
+        if 200 <= resp.status_code < 300:
+            return IntegrationStatus(
+                name=NAME, enabled=True, state=STATE_CONNECTED,
+                detail=NEXANOTE_API_URL,
+            )
+        return IntegrationStatus(
+            name=NAME, enabled=True, state=STATE_UNREACHABLE,
+            detail=f"NexaNote returned HTTP {resp.status_code}.",
+        )
+    except (httpx.HTTPError, OSError) as e:
+        logger.debug("NexaNote health check failed: %s", e)
+        return IntegrationStatus(
+            name=NAME, enabled=True, state=STATE_UNREACHABLE,
+            detail="NexaNote is not reachable.",
+        )
+
+
+# ── Read API ────────────────────────────────────────────────────────
+
+def list_notes(user_id: int, limit: int = 50) -> list[dict]:
+    """
+    Return up to ``limit`` notes from NexaNote.
+
+    Empty list when the integration is off, NexaNote is not reachable,
+    or the response cannot be decoded. Read-only.
+    """
+    if not is_enabled(user_id) or not _is_configured() or limit <= 0:
+        return []
+    try:
+        with _client() as client:
+            resp = client.get("/notes", params={"limit": limit})
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as e:
+        logger.debug("NexaNote list_notes failed: %s", e)
+        return []
+    if isinstance(data, list):
+        return [n for n in data if isinstance(n, dict)]
+    if isinstance(data, dict):
+        for key in ("notes", "items", "results"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return [n for n in value if isinstance(n, dict)]
+    return []
+
+
+def read_note(user_id: int, note_id) -> Optional[dict]:
+    """
+    Fetch a single note. ``None`` when disabled, missing, or on any
+    transport error. Read-only.
+    """
+    if not is_enabled(user_id) or not _is_configured() or note_id is None:
+        return None
+    try:
+        with _client() as client:
+            resp = client.get(f"/notes/{note_id}")
+        if not (200 <= resp.status_code < 300):
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as e:
+        logger.debug("NexaNote read_note failed: %s", e)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# ── Write API (gated behind nexanote_write_enabled) ─────────────────
+
+def create_note(user_id: int, title: str, content: str) -> Optional[dict]:
+    """
+    Create a note. Refuses silently — returns ``None`` — when:
+      * the integration is off, or
+      * the user has not opted into writes (default), or
+      * NexaNote is not configured / not reachable.
+    """
+    if not is_write_enabled(user_id) or not _is_configured():
+        return None
+    if not isinstance(title, str) or not title.strip():
+        return None
+    if not isinstance(content, str):
+        return None
+    try:
+        with _client() as client:
+            resp = client.post(
+                "/notes",
+                json={"title": title.strip(), "content": content},
+            )
+        if not (200 <= resp.status_code < 300):
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as e:
+        logger.debug("NexaNote create_note failed: %s", e)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def update_note(user_id: int, note_id, title: Optional[str] = None,
+                content: Optional[str] = None) -> Optional[dict]:
+    """
+    Update a note. Same gating as ``create_note``; returns ``None`` when
+    the integration is off, writes are off, or the call fails.
+    """
+    if not is_write_enabled(user_id) or not _is_configured() or note_id is None:
+        return None
+    payload: dict = {}
+    if isinstance(title, str) and title.strip():
+        payload["title"] = title.strip()
+    if isinstance(content, str):
+        payload["content"] = content
+    if not payload:
+        return None
+    try:
+        with _client() as client:
+            resp = client.put(f"/notes/{note_id}", json=payload)
+        if not (200 <= resp.status_code < 300):
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as e:
+        logger.debug("NexaNote update_note failed: %s", e)
+        return None
+    return data if isinstance(data, dict) else None

--- a/core/integrations/silentguard.py
+++ b/core/integrations/silentguard.py
@@ -1,0 +1,131 @@
+"""
+Gated bridge to SilentGuard's local memory file.
+
+SilentGuard is an external network-monitoring tool. It writes observed
+connections to ``~/.silentguard_memory.json`` (path overridable via the
+``NOVA_SILENTGUARD_PATH`` env var). This module exposes a per-user
+opt-in switch on top of the existing read-only parser in
+``core.security_feed``.
+
+Boundaries (enforced):
+  * read-only file access — no writes, no deletions.
+  * no subprocess, no socket, no DNS lookup, no firewall action.
+  * no root or elevated-privilege call.
+  * if the user has not enabled the integration, every public function
+    short-circuits to "disabled" without touching the disk.
+
+If SilentGuard is enabled but the file is missing or malformed, the
+status reports ``"not_found"`` and the read helpers return empty
+results — they never raise.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from core import security_feed
+from core.settings import get_user_setting
+
+logger = logging.getLogger(__name__)
+
+NAME = "silentguard"
+
+STATE_DISABLED = "disabled"
+STATE_CONNECTED = "connected"
+STATE_NOT_FOUND = "not_found"
+
+
+@dataclass(frozen=True)
+class IntegrationStatus:
+    """Snapshot of an integration's availability for one user."""
+
+    name: str
+    enabled: bool
+    state: str
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "enabled": self.enabled,
+            "state": self.state,
+            "detail": self.detail,
+        }
+
+
+def _resolved_path() -> Path:
+    """Resolve the SilentGuard feed path the same way ``security_feed`` does."""
+    override = os.environ.get("NOVA_SILENTGUARD_PATH")
+    if override:
+        return Path(override).expanduser()
+    return security_feed.DEFAULT_FEED_PATH
+
+
+def is_enabled(user_id: int) -> bool:
+    """True only when the user has explicitly turned the integration on."""
+    return get_user_setting(user_id, "silentguard_enabled", "false") == "true"
+
+
+def status(user_id: int) -> IntegrationStatus:
+    """
+    Report whether the integration is on, and whether the feed file is
+    present. Never raises: a missing or unreadable file maps to
+    ``not_found``, not an exception.
+    """
+    enabled = is_enabled(user_id)
+    if not enabled:
+        return IntegrationStatus(
+            name=NAME, enabled=False, state=STATE_DISABLED,
+            detail="Turned off in Settings.",
+        )
+    path = _resolved_path()
+    try:
+        if not path.is_file():
+            return IntegrationStatus(
+                name=NAME, enabled=True, state=STATE_NOT_FOUND,
+                detail=f"No file at {path}",
+            )
+    except OSError as e:
+        logger.debug("SilentGuard path probe failed: %s", e)
+        return IntegrationStatus(
+            name=NAME, enabled=True, state=STATE_NOT_FOUND,
+            detail="Feed path is not accessible.",
+        )
+    return IntegrationStatus(
+        name=NAME, enabled=True, state=STATE_CONNECTED,
+        detail=str(path),
+    )
+
+
+def recent_events(user_id: int, limit: int = 50) -> list[security_feed.SecurityEvent]:
+    """
+    Return up to ``limit`` recent events from the SilentGuard feed.
+
+    Empty list when the integration is off, the file is missing, or the
+    payload cannot be parsed. Read-only.
+    """
+    if not is_enabled(user_id):
+        return []
+    return security_feed.get_recent_security_events(limit=limit)
+
+
+def recent_events_summary(user_id: int, limit: int = 50) -> Optional[str]:
+    """
+    Convenience wrapper used by the chat layer.
+
+    Returns a formatted summary string suitable for prompt injection, or
+    ``None`` when the integration is off / there is nothing to report.
+    Always read-only.
+    """
+    if not is_enabled(user_id):
+        return None
+    events = security_feed.get_recent_security_events(limit=limit)
+    if not events:
+        return None
+    return security_feed.format_security_summary(
+        security_feed.summarize_events(events)
+    )

--- a/core/settings.py
+++ b/core/settings.py
@@ -27,6 +27,11 @@ from typing import Optional
 USER_SETTING_KEYS: frozenset[str] = frozenset({
     "nova_model_enabled",
     "nova_model_name",
+    # Optional integration switches. Stored per-user so each account
+    # opts in independently; integrations stay dark until flipped on.
+    "silentguard_enabled",
+    "nexanote_enabled",
+    "nexanote_write_enabled",
 })
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -953,6 +953,51 @@
             white-space: nowrap;
         }
 
+        .integration-status {
+            font-size: 0.68rem;
+            border-radius: 4px;
+            padding: 1px 6px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            white-space: nowrap;
+            border: 1px solid var(--border);
+            color: var(--text-dim);
+        }
+        .integration-status.connected {
+            color: #4caf50;
+            border-color: #2e7d32;
+        }
+        .integration-status.disabled {
+            color: var(--text-dim);
+            border-color: var(--border);
+        }
+        .integration-status.not_found,
+        .integration-status.unreachable {
+            color: #f0a000;
+            border-color: #b07a00;
+        }
+        .integration-toggle-btn {
+            font-family: monospace;
+            font-size: 0.75rem;
+            padding: 4px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            border: 1px solid var(--border);
+            background: var(--bg);
+            color: var(--text-dim);
+            min-width: 52px;
+        }
+        .integration-toggle-btn.on {
+            color: var(--cyan);
+            border-color: var(--cyan);
+        }
+        .integration-detail {
+            font-size: 0.7rem;
+            color: var(--text-dim);
+            margin-top: 4px;
+            word-break: break-all;
+        }
+
         .pers-select, .pers-textarea {
             background: var(--bg);
             border: 1px solid var(--border);
@@ -1661,6 +1706,7 @@
                 <button class="settings-nav-btn" data-pane="personalization" onclick="switchSettingsPane('personalization')" id="settings-nav-personalization">Personalization</button>
                 <button class="settings-nav-btn" data-pane="memory" onclick="switchSettingsPane('memory')" id="settings-nav-memory">Memory</button>
                 <button class="settings-nav-btn" data-pane="models" onclick="switchSettingsPane('models')" id="settings-nav-models">Models</button>
+                <button class="settings-nav-btn" data-pane="integrations" onclick="switchSettingsPane('integrations')" id="settings-nav-integrations">Integrations</button>
                 <button class="settings-nav-btn" data-pane="admin" onclick="switchSettingsPane('admin')" id="settings-nav-admin" style="display:none;">Admin</button>
                 <div class="settings-nav-divider"></div>
                 <button class="settings-nav-btn" data-pane="account" onclick="switchSettingsPane('account')" id="settings-nav-account">Account</button>
@@ -1828,6 +1874,53 @@
                     </div>
                 </section>
 
+                <!-- INTEGRATIONS -->
+                <section class="settings-pane" id="settings-pane-integrations">
+                    <div class="settings-section-title" id="settings-integrations-title">Integrations</div>
+                    <div class="settings-row-hint" id="settings-integrations-note">
+                        Optional bridges to external tools. Each switch is per-user and stays off until you turn it on. Nova never modifies the external tools.
+                    </div>
+
+                    <!-- SilentGuard -->
+                    <div class="settings-row">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-int-sg-title">SilentGuard</span>
+                                <span class="settings-row-hint" id="settings-int-sg-hint">Read-only feed of network observations from ~/.silentguard_memory.json.</span>
+                            </div>
+                            <div style="display:flex;gap:8px;align-items:center;">
+                                <span id="int-sg-status" class="integration-status disabled">checking…</span>
+                                <button id="int-sg-toggle" class="integration-toggle-btn" onclick="toggleIntegration('silentguard')">OFF</button>
+                            </div>
+                        </div>
+                        <div id="int-sg-detail" class="integration-detail"></div>
+                    </div>
+
+                    <!-- NexaNote -->
+                    <div class="settings-row">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-int-nn-title">NexaNote</span>
+                                <span class="settings-row-hint" id="settings-int-nn-hint">Notes via the NexaNote HTTP API. Read-only by default.</span>
+                            </div>
+                            <div style="display:flex;gap:8px;align-items:center;">
+                                <span id="int-nn-status" class="integration-status disabled">checking…</span>
+                                <button id="int-nn-toggle" class="integration-toggle-btn" onclick="toggleIntegration('nexanote')">OFF</button>
+                            </div>
+                        </div>
+                        <div id="int-nn-detail" class="integration-detail"></div>
+                        <div id="int-nn-write-row" style="display:none;margin-top:8px;padding-top:8px;border-top:1px dashed var(--border);">
+                            <div class="settings-row-head">
+                                <div class="settings-row-label">
+                                    <span class="settings-row-title" id="settings-int-nn-write-title">Allow writes</span>
+                                    <span class="settings-row-hint" id="settings-int-nn-write-hint">Lets Nova create or update notes via NexaNote. Off by default.</span>
+                                </div>
+                                <button id="int-nn-write-toggle" class="integration-toggle-btn" onclick="toggleIntegrationWrite('nexanote')">OFF</button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
                 <!-- ADMIN (admin-only) -->
                 <section class="settings-pane" id="settings-pane-admin">
                     <div class="settings-section-title" id="settings-admin-title">Admin</div>
@@ -1925,14 +2018,27 @@
             nav_personalization: "Personnalisation",
             nav_memory: "Mémoire",
             nav_models: "Modèles",
+            nav_integrations: "Intégrations",
             nav_admin: "Admin",
             nav_account: "Compte",
             section_general: "Général",
             section_personalization: "Personnalisation",
             section_memory: "Mémoire",
             section_models: "Modèles",
+            section_integrations: "Intégrations",
             section_admin: "Admin",
             section_account: "Compte",
+            integrations_note: "Ponts optionnels vers des outils externes. Chaque interrupteur est par utilisateur et reste désactivé jusqu'à ce que tu l'actives. Nova ne modifie jamais les outils externes.",
+            int_sg_title: "SilentGuard",
+            int_sg_hint: "Flux en lecture seule des observations réseau depuis ~/.silentguard_memory.json.",
+            int_nn_title: "NexaNote",
+            int_nn_hint: "Notes via l'API HTTP de NexaNote. Lecture seule par défaut.",
+            int_nn_write_title: "Autoriser l'écriture",
+            int_nn_write_hint: "Permet à Nova de créer ou modifier des notes via NexaNote. Désactivé par défaut.",
+            int_state_connected: "Connecté",
+            int_state_disabled: "Désactivé",
+            int_state_not_found: "Introuvable",
+            int_state_unreachable: "Injoignable",
             ram_title: "Budget RAM",
             ram_hint: "Contrôle la taille de l'historique et des mémoires",
             update_title: "Mise à jour automatique des modèles",
@@ -2012,14 +2118,27 @@
             nav_personalization: "Personalization",
             nav_memory: "Memory",
             nav_models: "Models",
+            nav_integrations: "Integrations",
             nav_admin: "Admin",
             nav_account: "Account",
             section_general: "General",
             section_personalization: "Personalization",
             section_memory: "Memory",
             section_models: "Models",
+            section_integrations: "Integrations",
             section_admin: "Admin",
             section_account: "Account",
+            integrations_note: "Optional bridges to external tools. Each switch is per-user and stays off until you turn it on. Nova never modifies the external tools.",
+            int_sg_title: "SilentGuard",
+            int_sg_hint: "Read-only feed of network observations from ~/.silentguard_memory.json.",
+            int_nn_title: "NexaNote",
+            int_nn_hint: "Notes via the NexaNote HTTP API. Read-only by default.",
+            int_nn_write_title: "Allow writes",
+            int_nn_write_hint: "Lets Nova create or update notes via NexaNote. Off by default.",
+            int_state_connected: "Connected",
+            int_state_disabled: "Disabled",
+            int_state_not_found: "Not found",
+            int_state_unreachable: "Unreachable",
             ram_title: "RAM Budget",
             ram_hint: "Controls conversation history size and memory limits",
             update_title: "Auto-update models",
@@ -2133,6 +2252,7 @@
         _setText("settings-nav-personalization", t("nav_personalization"));
         _setText("settings-nav-memory", t("nav_memory"));
         _setText("settings-nav-models", t("nav_models"));
+        _setText("settings-nav-integrations", t("nav_integrations"));
         _setText("settings-nav-admin", t("nav_admin"));
         _setText("settings-nav-account", t("nav_account"));
 
@@ -2140,8 +2260,17 @@
         _setText("settings-personalization-title", t("section_personalization"));
         _setText("settings-memory-title", t("section_memory"));
         _setText("settings-models-title", t("section_models"));
+        _setText("settings-integrations-title", t("section_integrations"));
         _setText("settings-admin-title", t("section_admin"));
         _setText("settings-account-title", t("section_account"));
+
+        _setText("settings-integrations-note", t("integrations_note"));
+        _setText("settings-int-sg-title", t("int_sg_title"));
+        _setText("settings-int-sg-hint", t("int_sg_hint"));
+        _setText("settings-int-nn-title", t("int_nn_title"));
+        _setText("settings-int-nn-hint", t("int_nn_hint"));
+        _setText("settings-int-nn-write-title", t("int_nn_write_title"));
+        _setText("settings-int-nn-write-hint", t("int_nn_write_hint"));
 
         _setText("settings-ram-title", t("ram_title"));
         _setText("settings-ram-hint", t("ram_hint"));
@@ -2935,6 +3064,108 @@
         switchSettingsPane(settingsCurrentPane || "general");
         await loadSystemSettings();
         await loadMemories();
+        loadIntegrationsStatus();
+    }
+
+    // ── INTEGRATIONS ──
+    let integrationSwitches = {
+        silentguard_enabled: false,
+        nexanote_enabled: false,
+        nexanote_write_enabled: false,
+    };
+
+    function _setIntegrationToggle(btnId, on) {
+        const btn = document.getElementById(btnId);
+        if (!btn) return;
+        btn.textContent = on ? "ON" : "OFF";
+        btn.classList.toggle("on", !!on);
+    }
+
+    function _setIntegrationStatus(elId, state, label) {
+        const el = document.getElementById(elId);
+        if (!el) return;
+        el.classList.remove("connected", "disabled", "not_found", "unreachable");
+        const safe = ["connected", "disabled", "not_found", "unreachable"].includes(state)
+            ? state : "disabled";
+        el.classList.add(safe);
+        el.textContent = label || safe;
+    }
+
+    function _statusLabel(state) {
+        const map = {
+            connected: t("int_state_connected"),
+            disabled: t("int_state_disabled"),
+            not_found: t("int_state_not_found"),
+            unreachable: t("int_state_unreachable"),
+        };
+        return map[state] || state;
+    }
+
+    async function loadIntegrationsStatus() {
+        // Pull both: persisted switches (from /settings) and live status
+        // (from /integrations/status). The two endpoints are independent
+        // so a missing external tool never breaks the toggles.
+        try {
+            const [settingsRes, statusRes] = await Promise.all([
+                fetch("/settings", { headers: { "Authorization": `Bearer ${token}` } }),
+                fetch("/integrations/status", { headers: { "Authorization": `Bearer ${token}` } }),
+            ]);
+            if (settingsRes.ok) {
+                const s = await settingsRes.json();
+                integrationSwitches.silentguard_enabled = !!s.silentguard_enabled;
+                integrationSwitches.nexanote_enabled = !!s.nexanote_enabled;
+                integrationSwitches.nexanote_write_enabled = !!s.nexanote_write_enabled;
+            }
+            _setIntegrationToggle("int-sg-toggle", integrationSwitches.silentguard_enabled);
+            _setIntegrationToggle("int-nn-toggle", integrationSwitches.nexanote_enabled);
+            _setIntegrationToggle("int-nn-write-toggle", integrationSwitches.nexanote_write_enabled);
+            document.getElementById("int-nn-write-row").style.display =
+                integrationSwitches.nexanote_enabled ? "" : "none";
+
+            if (statusRes.ok) {
+                const data = await statusRes.json();
+                const sg = data.silentguard || {};
+                _setIntegrationStatus("int-sg-status", sg.state, _statusLabel(sg.state));
+                document.getElementById("int-sg-detail").textContent = sg.detail || "";
+                const nn = data.nexanote || {};
+                _setIntegrationStatus("int-nn-status", nn.state, _statusLabel(nn.state));
+                document.getElementById("int-nn-detail").textContent = nn.detail || "";
+            }
+        } catch (e) {
+            // Never let a missing endpoint break the settings page.
+            _setIntegrationStatus("int-sg-status", "disabled", _statusLabel("disabled"));
+            _setIntegrationStatus("int-nn-status", "disabled", _statusLabel("disabled"));
+        }
+    }
+
+    async function toggleIntegration(name) {
+        const key = `${name}_enabled`;
+        const newVal = !integrationSwitches[key];
+        await fetch("/settings", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`,
+            },
+            body: JSON.stringify({ [key]: newVal }),
+        });
+        integrationSwitches[key] = newVal;
+        await loadIntegrationsStatus();
+    }
+
+    async function toggleIntegrationWrite(name) {
+        const key = `${name}_write_enabled`;
+        const newVal = !integrationSwitches[key];
+        await fetch("/settings", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`,
+            },
+            body: JSON.stringify({ [key]: newVal }),
+        });
+        integrationSwitches[key] = newVal;
+        _setIntegrationToggle(`int-${name === "nexanote" ? "nn" : name}-write-toggle`, newVal);
     }
 
     function closeSettings() {
@@ -2958,6 +3189,9 @@
         document.querySelectorAll(".settings-pane").forEach(p => {
             p.classList.toggle("active", p.id === "settings-pane-" + pane);
         });
+        if (pane === "integrations") {
+            loadIntegrationsStatus();
+        }
     }
 
     function applySettingsAdminVisibility() {

--- a/tests/test_integrations_nexanote.py
+++ b/tests/test_integrations_nexanote.py
@@ -1,0 +1,293 @@
+"""
+Tests for the NexaNote integration switch.
+
+NexaNote is reached over HTTP, so the tests stub ``httpx.Client`` rather
+than spinning up a real server. They cover:
+  * the read-only-by-default contract (writes refused without the
+    second switch),
+  * the per-user gating (off → no HTTP call at all),
+  * the never-crash guarantees on transport / decode errors,
+  * the structured status states.
+"""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+from typing import Any
+
+import httpx
+import pytest
+
+from core import memory as core_memory, settings as core_settings, users
+from core.integrations import nexanote as nn
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+@pytest.fixture
+def user_id(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, "alice", "pw")
+
+
+def _enable_read(user_id):
+    core_settings.save_user_setting(user_id, "nexanote_enabled", "true")
+
+
+def _enable_write(user_id):
+    core_settings.save_user_setting(user_id, "nexanote_enabled", "true")
+    core_settings.save_user_setting(user_id, "nexanote_write_enabled", "true")
+
+
+# ── Fake httpx client ───────────────────────────────────────────────
+# The integration always opens a client via ``httpx.Client(...)``; we
+# stub that constructor so no real network call ever fires. ``calls``
+# captures every (method, path, kwargs) so tests can also assert that
+# disabled toggles result in zero outgoing requests.
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any = None,
+                 raise_decode: bool = False):
+        self.status_code = status_code
+        self._payload = payload
+        self._raise_decode = raise_decode
+
+    def json(self):
+        if self._raise_decode:
+            raise ValueError("decode error")
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, scripted: dict, calls: list, raise_on: set | None = None):
+        self._scripted = scripted
+        self._calls = calls
+        self._raise_on = raise_on or set()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def _record(self, method: str, path: str, **kwargs):
+        self._calls.append((method, path, kwargs))
+        if path in self._raise_on:
+            raise httpx.ConnectError("boom")
+        return self._scripted.get((method, path), _FakeResponse(404))
+
+    def get(self, path: str, **kwargs):
+        return self._record("GET", path, **kwargs)
+
+    def post(self, path: str, **kwargs):
+        return self._record("POST", path, **kwargs)
+
+    def put(self, path: str, **kwargs):
+        return self._record("PUT", path, **kwargs)
+
+
+@pytest.fixture
+def http_stub(monkeypatch):
+    """
+    Returns ``(install, calls)``. Calling ``install(scripted, raise_on=...)``
+    swaps in a fake httpx.Client; ``calls`` collects every outgoing
+    request the integration tries to make.
+    """
+    calls: list = []
+    state: dict = {"scripted": {}, "raise_on": set()}
+
+    def factory(*args, **kwargs):
+        return _FakeClient(state["scripted"], calls, state["raise_on"])
+
+    monkeypatch.setattr(nn.httpx, "Client", factory)
+    monkeypatch.setattr(nn, "NEXANOTE_API_URL", "http://nexanote.test")
+
+    def install(scripted: dict, raise_on: set | None = None):
+        state["scripted"] = scripted
+        state["raise_on"] = raise_on or set()
+
+    return install, calls
+
+
+# ── Default state ───────────────────────────────────────────────────
+
+class TestDisabledByDefault:
+    def test_is_enabled_false(self, user_id):
+        assert nn.is_enabled(user_id) is False
+
+    def test_is_write_enabled_false(self, user_id):
+        assert nn.is_write_enabled(user_id) is False
+
+    def test_status_disabled(self, user_id):
+        s = nn.status(user_id)
+        assert s.enabled is False
+        assert s.state == nn.STATE_DISABLED
+
+    def test_no_http_when_disabled(self, user_id, http_stub):
+        install, calls = http_stub
+        install({})
+        assert nn.list_notes(user_id) == []
+        assert nn.read_note(user_id, 1) is None
+        assert nn.create_note(user_id, "t", "c") is None
+        assert nn.update_note(user_id, 1, title="t") is None
+        # Disabled → must never reach out over the wire.
+        assert calls == []
+
+
+# ── Status ──────────────────────────────────────────────────────────
+
+class TestStatus:
+    def test_not_found_when_url_unset(self, user_id, monkeypatch):
+        _enable_read(user_id)
+        monkeypatch.setattr(nn, "NEXANOTE_API_URL", "")
+        s = nn.status(user_id)
+        assert s.state == nn.STATE_NOT_FOUND
+
+    def test_connected_on_2xx_health(self, user_id, http_stub):
+        install, _ = http_stub
+        install({("GET", "/health"): _FakeResponse(200, {"ok": True})})
+        _enable_read(user_id)
+        s = nn.status(user_id)
+        assert s.state == nn.STATE_CONNECTED
+
+    def test_unreachable_on_5xx(self, user_id, http_stub):
+        install, _ = http_stub
+        install({("GET", "/health"): _FakeResponse(503)})
+        _enable_read(user_id)
+        s = nn.status(user_id)
+        assert s.state == nn.STATE_UNREACHABLE
+
+    def test_unreachable_on_network_error(self, user_id, http_stub):
+        install, _ = http_stub
+        install({}, raise_on={"/health"})
+        _enable_read(user_id)
+        s = nn.status(user_id)
+        assert s.state == nn.STATE_UNREACHABLE
+
+
+# ── Read API ────────────────────────────────────────────────────────
+
+class TestReadApi:
+    def test_list_notes_returns_list(self, user_id, http_stub):
+        install, calls = http_stub
+        notes = [{"id": 1, "title": "a"}, {"id": 2, "title": "b"}]
+        install({("GET", "/notes"): _FakeResponse(200, notes)})
+        _enable_read(user_id)
+        result = nn.list_notes(user_id, limit=10)
+        assert result == notes
+        # The integration must pass the limit as a query param.
+        assert calls[-1][2].get("params") == {"limit": 10}
+
+    def test_list_notes_unwraps_dict_payload(self, user_id, http_stub):
+        install, _ = http_stub
+        install({("GET", "/notes"): _FakeResponse(200, {"notes": [{"id": 1}]})})
+        _enable_read(user_id)
+        assert nn.list_notes(user_id) == [{"id": 1}]
+
+    def test_list_notes_empty_on_decode_error(self, user_id, http_stub):
+        install, _ = http_stub
+        install({("GET", "/notes"): _FakeResponse(200, raise_decode=True)})
+        _enable_read(user_id)
+        assert nn.list_notes(user_id) == []
+
+    def test_list_notes_empty_on_network_error(self, user_id, http_stub):
+        install, _ = http_stub
+        install({}, raise_on={"/notes"})
+        _enable_read(user_id)
+        assert nn.list_notes(user_id) == []
+
+    def test_read_note_fetches_one(self, user_id, http_stub):
+        install, _ = http_stub
+        install({("GET", "/notes/42"): _FakeResponse(200, {"id": 42, "title": "x"})})
+        _enable_read(user_id)
+        assert nn.read_note(user_id, 42) == {"id": 42, "title": "x"}
+
+    def test_read_note_none_on_404(self, user_id, http_stub):
+        install, _ = http_stub
+        install({("GET", "/notes/99"): _FakeResponse(404)})
+        _enable_read(user_id)
+        assert nn.read_note(user_id, 99) is None
+
+
+# ── Read-only-by-default contract ──────────────────────────────────
+
+class TestWriteGating:
+    def test_create_refused_when_only_read_enabled(self, user_id, http_stub):
+        install, calls = http_stub
+        install({("POST", "/notes"): _FakeResponse(201, {"id": 1})})
+        _enable_read(user_id)  # writes NOT enabled
+        assert nn.create_note(user_id, "t", "c") is None
+        # Read-only mode must not even attempt the POST.
+        assert all(method != "POST" for method, *_ in calls)
+
+    def test_create_succeeds_when_write_enabled(self, user_id, http_stub):
+        install, calls = http_stub
+        install({("POST", "/notes"): _FakeResponse(201, {"id": 7})})
+        _enable_write(user_id)
+        assert nn.create_note(user_id, "t", "c") == {"id": 7}
+        assert calls[-1][0] == "POST"
+        assert calls[-1][2].get("json") == {"title": "t", "content": "c"}
+
+    def test_update_refused_when_only_read_enabled(self, user_id, http_stub):
+        install, calls = http_stub
+        install({("PUT", "/notes/1"): _FakeResponse(200, {"id": 1})})
+        _enable_read(user_id)
+        assert nn.update_note(user_id, 1, title="new") is None
+        assert all(method != "PUT" for method, *_ in calls)
+
+    def test_update_succeeds_when_write_enabled(self, user_id, http_stub):
+        install, calls = http_stub
+        install({("PUT", "/notes/1"): _FakeResponse(200, {"id": 1})})
+        _enable_write(user_id)
+        assert nn.update_note(user_id, 1, content="new") == {"id": 1}
+        assert calls[-1][2].get("json") == {"content": "new"}
+
+    def test_create_swallows_network_error(self, user_id, http_stub):
+        install, _ = http_stub
+        install({}, raise_on={"/notes"})
+        _enable_write(user_id)
+        # Must not raise — integration absorbs failure.
+        assert nn.create_note(user_id, "t", "c") is None
+
+    def test_create_rejects_blank_title(self, user_id, http_stub):
+        install, calls = http_stub
+        install({("POST", "/notes"): _FakeResponse(201, {"id": 1})})
+        _enable_write(user_id)
+        assert nn.create_note(user_id, "   ", "c") is None
+        # Validation runs before any HTTP call.
+        assert calls == []
+
+
+# ── Read-only / safety guarantees ───────────────────────────────────
+
+class TestNoSystemActions:
+    def test_no_subprocess_or_socket_imports(self):
+        with open(nn.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+
+        forbidden = {"subprocess", "socket", "shutil", "ctypes", "signal", "os"}
+        # ``os`` is excluded by the integration on purpose — config reads
+        # happen in config.py, not here.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    assert root not in forbidden, (
+                        f"nexanote integration must not import {alias.name!r}"
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                root = (node.module or "").split(".")[0]
+                assert root not in forbidden, (
+                    f"nexanote integration must not import from {node.module!r}"
+                )

--- a/tests/test_integrations_silentguard.py
+++ b/tests/test_integrations_silentguard.py
@@ -1,0 +1,189 @@
+"""
+Tests for the SilentGuard integration switch.
+
+The integration is a thin wrapper over ``core.security_feed`` whose only
+job is to gate the existing parser behind a per-user setting and report
+a structured status. These tests cover the gating, the status states,
+and the read-only / never-crash guarantees demanded by the integration
+contract.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sqlite3
+
+import pytest
+
+from core import memory as core_memory, settings as core_settings, users
+from core.integrations import silentguard as sg
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+@pytest.fixture
+def user_id(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, "alice", "pw")
+
+
+def _enable(user_id):
+    core_settings.save_user_setting(user_id, "silentguard_enabled", "true")
+
+
+def _write_feed(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ── Default state ───────────────────────────────────────────────────
+
+class TestDisabledByDefault:
+    def test_is_enabled_false_for_new_user(self, user_id):
+        assert sg.is_enabled(user_id) is False
+
+    def test_status_disabled_by_default(self, user_id):
+        s = sg.status(user_id)
+        assert s.enabled is False
+        assert s.state == sg.STATE_DISABLED
+
+    def test_recent_events_empty_when_disabled(self, user_id, tmp_path, monkeypatch):
+        path = tmp_path / "feed.json"
+        _write_feed(path, [
+            {"ip": "1.2.3.4", "process": "x", "trust": "Unknown"},
+        ])
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        assert sg.recent_events(user_id) == []
+
+    def test_summary_none_when_disabled(self, user_id, tmp_path, monkeypatch):
+        path = tmp_path / "feed.json"
+        _write_feed(path, [
+            {"ip": "5.6.7.8", "process": "x", "trust": "Unknown"},
+        ])
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        assert sg.recent_events_summary(user_id) is None
+
+
+# ── Enabled state ───────────────────────────────────────────────────
+
+class TestEnabledStatus:
+    def test_status_not_found_when_file_missing(self, user_id, tmp_path, monkeypatch):
+        missing = tmp_path / "nope.json"
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(missing))
+        _enable(user_id)
+        s = sg.status(user_id)
+        assert s.enabled is True
+        assert s.state == sg.STATE_NOT_FOUND
+        assert str(missing) in s.detail
+
+    def test_status_connected_when_file_present(self, user_id, tmp_path, monkeypatch):
+        path = tmp_path / "feed.json"
+        _write_feed(path, [])
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        _enable(user_id)
+        s = sg.status(user_id)
+        assert s.enabled is True
+        assert s.state == sg.STATE_CONNECTED
+        assert s.detail == str(path)
+
+    def test_status_as_dict_shape(self, user_id):
+        s = sg.status(user_id).as_dict()
+        assert set(s.keys()) == {"name", "enabled", "state", "detail"}
+        assert s["name"] == "silentguard"
+
+
+class TestEnabledReads:
+    def test_recent_events_returns_parsed_entries(
+        self, user_id, tmp_path, monkeypatch,
+    ):
+        path = tmp_path / "feed.json"
+        _write_feed(path, [
+            {"ip": "1.2.3.4", "process": "curl", "port": 443, "trust": "Known"},
+            {"ip": "5.6.7.8", "process": "rogue", "port": 9999, "trust": "Unknown"},
+        ])
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        _enable(user_id)
+        events = sg.recent_events(user_id)
+        assert len(events) == 2
+        assert {e.ip for e in events} == {"1.2.3.4", "5.6.7.8"}
+
+    def test_summary_includes_unknowns(self, user_id, tmp_path, monkeypatch):
+        path = tmp_path / "feed.json"
+        _write_feed(path, [
+            {"ip": "9.9.9.9", "process": "rogue", "port": 4444, "trust": "Unknown"},
+        ])
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        _enable(user_id)
+        summary = sg.recent_events_summary(user_id)
+        assert summary is not None
+        assert "9.9.9.9" in summary
+
+    def test_recent_events_empty_when_file_missing(
+        self, user_id, tmp_path, monkeypatch,
+    ):
+        missing = tmp_path / "nope.json"
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(missing))
+        _enable(user_id)
+        # Enabled but no file → safe empty result, no exception.
+        assert sg.recent_events(user_id) == []
+        assert sg.recent_events_summary(user_id) is None
+
+    def test_recent_events_empty_on_invalid_json(
+        self, user_id, tmp_path, monkeypatch,
+    ):
+        path = tmp_path / "bad.json"
+        path.write_text("{not json", encoding="utf-8")
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        _enable(user_id)
+        assert sg.recent_events(user_id) == []
+
+
+# ── Read-only / safety guarantees ───────────────────────────────────
+
+class TestReadOnlyGuarantees:
+    def test_no_subprocess_or_socket_imports(self):
+        """The integration module must not import system-mutating modules."""
+        with open(sg.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+
+        forbidden = {"subprocess", "socket", "shutil", "ctypes", "signal"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    assert root not in forbidden, (
+                        f"silentguard integration must not import {alias.name!r}"
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                root = (node.module or "").split(".")[0]
+                assert root not in forbidden, (
+                    f"silentguard integration must not import from {node.module!r}"
+                )
+
+    def test_feed_file_is_not_mutated(
+        self, user_id, tmp_path, monkeypatch,
+    ):
+        path = tmp_path / "feed.json"
+        original = [
+            {"ip": "1.2.3.4", "process": "curl", "port": 443, "trust": "Known"},
+        ]
+        _write_feed(path, original)
+        original_bytes = path.read_bytes()
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(path))
+        _enable(user_id)
+
+        sg.recent_events(user_id)
+        sg.recent_events_summary(user_id)
+        sg.status(user_id)
+
+        assert path.read_bytes() == original_bytes

--- a/web.py
+++ b/web.py
@@ -47,6 +47,8 @@ from core.model_registry import (
 )
 from core import model_pulls as _model_pulls
 from core import model_access as _model_access
+from core.integrations import silentguard as _silentguard_integration
+from core.integrations import nexanote as _nexanote_integration
 import sqlite3 as _sqlite3
 from core import users as _users_mod
 from memory.store import (
@@ -273,6 +275,9 @@ class SettingsUpdateRequest(BaseModel):
     ram_budget: int | None = None
     nova_model_enabled: bool | None = None
     nova_model_name: str | None = None
+    silentguard_enabled: bool | None = None
+    nexanote_enabled: bool | None = None
+    nexanote_write_enabled: bool | None = None
 
     @field_validator("ram_budget")
     @classmethod
@@ -531,6 +536,15 @@ def get_settings(user: CurrentUser = Depends(get_current_user)):
         "nova_model_name": get_user_setting(
             user.id, "nova_model_name", NOVA_MODEL_DEFAULT_NAME
         ),
+        "silentguard_enabled": (
+            get_user_setting(user.id, "silentguard_enabled", "false") == "true"
+        ),
+        "nexanote_enabled": (
+            get_user_setting(user.id, "nexanote_enabled", "false") == "true"
+        ),
+        "nexanote_write_enabled": (
+            get_user_setting(user.id, "nexanote_write_enabled", "false") == "true"
+        ),
     }
 
 
@@ -567,7 +581,43 @@ def update_settings(
         )
     if data.nova_model_name is not None:
         save_user_setting(user.id, "nova_model_name", data.nova_model_name)
+    if data.silentguard_enabled is not None:
+        save_user_setting(
+            user.id,
+            "silentguard_enabled",
+            "true" if data.silentguard_enabled else "false",
+        )
+    if data.nexanote_enabled is not None:
+        save_user_setting(
+            user.id,
+            "nexanote_enabled",
+            "true" if data.nexanote_enabled else "false",
+        )
+    if data.nexanote_write_enabled is not None:
+        save_user_setting(
+            user.id,
+            "nexanote_write_enabled",
+            "true" if data.nexanote_write_enabled else "false",
+        )
     return {"ok": True}
+
+
+# ── INTEGRATIONS ────────────────────────────────────────────────────
+# Optional, per-user, opt-in bridges to external tools. Status is
+# computed against the caller's own switches; one user enabling
+# SilentGuard never affects another. The endpoint is read-only —
+# mutations go through /settings.
+
+@app.get("/integrations/status")
+def integrations_status(user: CurrentUser = Depends(get_current_user)):
+    """Per-integration availability snapshot for the caller."""
+    return {
+        "silentguard": _silentguard_integration.status(user.id).as_dict(),
+        "nexanote": {
+            **_nexanote_integration.status(user.id).as_dict(),
+            "write_enabled": _nexanote_integration.is_write_enabled(user.id),
+        },
+    }
 
 
 # ── ADMIN: USER MANAGEMENT ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add per-user opt-in bridges so Nova can read from SilentGuard and NexaNote without merging their codebases. Both integrations stay dark by default and never crash if the underlying tool is missing or unreachable.

> **Branch note:** the task description called for `feature/integration-switches`, but my session is constrained to push to `claude/setup-project-docs-uDyGn`, so the work landed here. The diff is otherwise exactly what the task asked for.

## Settings

Three new per-user settings (stored in `user_settings`, isolated per account):

- `silentguard_enabled` — default `false`
- `nexanote_enabled` — default `false`
- `nexanote_write_enabled` — default `false` (only consulted when `nexanote_enabled=true`)

Wired through `config.ALLOWED_SETTINGS`, `core.settings.USER_SETTING_KEYS`, the `/settings` GET payload, and the `SettingsUpdateRequest` model.

## New modules

### `core/integrations/silentguard.py`

A thin gated wrapper over the existing `core/security_feed.py` parser. Public surface:

- `is_enabled(user_id)` — checks the per-user switch
- `status(user_id)` → `IntegrationStatus(name, enabled, state, detail)` where `state ∈ {disabled, connected, not_found}`
- `recent_events(user_id, limit=50)` — empty list when off / missing / unparseable
- `recent_events_summary(user_id, limit=50)` — formatted prompt-ready string or `None`

Read-only file access only. `core/chat.py` now consults the integration (instead of going straight through `security_feed.get_security_context`) so the SilentGuard prompt branch only fires for users who opted in.

### `core/integrations/nexanote.py`

HTTP-only client. Configuration: `NEXANOTE_API_URL`, `NEXANOTE_API_TOKEN`, `NEXANOTE_TIMEOUT_SECONDS`. Public surface:

- `is_enabled(user_id)`, `is_write_enabled(user_id)`
- `status(user_id)` → states `{disabled, connected, not_found, unreachable}` via a `GET /health` probe
- Read: `list_notes(user_id, limit)`, `read_note(user_id, id)`
- Write (gated): `create_note(user_id, title, content)`, `update_note(user_id, id, …)`

Every transport / decode failure is swallowed and logged at debug; the helpers return `[]` / `None`. When the integration is off, **no HTTP call is made at all** (asserted in tests).

## API + UI

- New endpoint: `GET /integrations/status` returns the caller's per-integration snapshot.
- New "Integrations" pane in the Settings panel, with toggle buttons, a live status pill (Connected / Not found / Unreachable / Disabled), and a separate write toggle for NexaNote that only appears when NexaNote is on. EN/FR labels added.

## Integration flow

1. User flips a toggle in Settings → Integrations → `POST /settings { silentguard_enabled: true }`.
2. UI reloads `/integrations/status`, which calls `core.integrations.<name>.status(user.id)` and renders the pill.
3. On chat: `core.chat.chat()` calls `silentguard_integration.recent_events_summary(user_id)`. If the switch is off, the call returns `None` and the SilentGuard branch is skipped — exactly as if the feature didn't exist.
4. NexaNote stays read-only until `nexanote_write_enabled` is also flipped on; even then, write helpers refuse and return `None` for invalid input or transport failures.

## Safety guarantees (asserted by tests)

- No system-level actions added.
- No subprocess / socket / shutil / ctypes / signal imports in either integration.
- SilentGuard is read-only — feed file bytes are unchanged after read+summary+status calls.
- NexaNote does no I/O while disabled.
- Read-only by default for NexaNote: `create_note` / `update_note` refuse without the second switch.
- No external repos are merged; both modules are passive bridges.

## Test plan

- [x] `tests/test_integrations_silentguard.py` — 13 tests (gating, status states, missing-file safety, AST-level no-mutation check, byte-level non-mutation check)
- [x] `tests/test_integrations_nexanote.py` — 21 tests (default-disabled, status state machine, read/write gating, never-crash on transport / decode errors, AST-level safety check)
- [x] Re-ran existing `tests/test_security_feed.py` (28 tests) and the data-layer half of `tests/test_settings_scoping.py` (16 tests) — all green.
- [x] `flake8` clean on the new files.
- [ ] Pre-existing environmental failure: tests that import `web.py` (and therefore `feedparser`/`sgmllib3k`) couldn't run in this sandbox — same failure occurs on the unmodified branch and is unrelated to this PR.
- [ ] Manual UI verification on a running server (status pills, toggle round-trip, write-toggle visibility).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPTzeLDU9yGyRZGSC8tbei)_