### PR TITLE
feat: add clock and calendar awareness to Nova

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,9 @@ NOVA_AUTO_WEB_LEARNING=false
 NEXANOTE_API_URL=
 NEXANOTE_API_TOKEN=
 NEXANOTE_TIMEOUT_SECONDS=3.0
+
+# ── Time / calendar context ───────────────────────────────────────────
+# Override the timezone Nova uses when resolving "today", "yesterday", etc.
+# Must be a valid IANA timezone name (e.g. America/Montreal, Europe/Paris).
+# Falls back to the system timezone (/etc/timezone) when not set.
+NOVA_TIMEZONE=

--- a/core/chat.py
+++ b/core/chat.py
@@ -10,6 +10,7 @@ from core.router import route
 from core.search import web_search, should_search
 from core.security_feed import is_security_query
 from core.integrations import silentguard as silentguard_integration
+from core.time_context import format_time_context
 from core.weather import detect_weather_city, get_weather
 from memory.extractor import extract_memories
 from memory.policy import is_memory_allowed
@@ -100,7 +101,7 @@ def build_messages(history: list[dict], user_input: str, memories: list[dict], e
         combined = "\n\n".join(filter(None, [memory_text, natural_text]))
         system_prompt = NOVA_SYSTEM_PROMPT.format(memories=combined)
 
-    messages = [{"role": "system", "content": IDENTITY_CONTRACT + "\n\n" + system_prompt}]
+    messages = [{"role": "system", "content": IDENTITY_CONTRACT + "\n\n" + system_prompt + "\n\n" + format_time_context()}]
     messages += history[-CHAT_HISTORY_LIMIT:]
     messages.append({"role": "user", "content": user_input})
     return messages

--- a/core/time_context.py
+++ b/core/time_context.py
@@ -1,0 +1,92 @@
+import os
+import pathlib
+import zoneinfo
+from datetime import datetime, timedelta
+
+
+def _get_timezone_name() -> str:
+    tz_name = os.environ.get("NOVA_TIMEZONE", "").strip()
+    if tz_name:
+        try:
+            zoneinfo.ZoneInfo(tz_name)
+            return tz_name
+        except (zoneinfo.ZoneInfoNotFoundError, KeyError):
+            pass
+    try:
+        name = pathlib.Path("/etc/timezone").read_text().strip()
+        if name:
+            return name
+    except OSError:
+        pass
+    return "UTC"
+
+
+def _get_tz() -> zoneinfo.ZoneInfo:
+    try:
+        return zoneinfo.ZoneInfo(_get_timezone_name())
+    except (zoneinfo.ZoneInfoNotFoundError, KeyError):
+        return zoneinfo.ZoneInfo("UTC")
+
+
+def now() -> datetime:
+    return datetime.now(_get_tz())
+
+
+def today_iso() -> str:
+    return now().date().isoformat()
+
+
+def get_timezone_name() -> str:
+    return _get_timezone_name()
+
+
+def resolve_relative_date(expression: str) -> str | None:
+    """Return the ISO date string for a simple relative date expression, or None if unrecognised."""
+    expr = expression.lower().strip()
+    today = now().date()
+    mapping = {
+        "today":                        timedelta(0),
+        "aujourd'hui":                  timedelta(0),
+        "yesterday":                    timedelta(days=-1),
+        "hier":                         timedelta(days=-1),
+        "tomorrow":                     timedelta(days=1),
+        "demain":                       timedelta(days=1),
+    }
+    if expr in mapping:
+        return (today + mapping[expr]).isoformat()
+
+    # Week expressions — always anchored to the Monday of the week
+    week_offsets = {
+        "this week":            0,
+        "cette semaine":        0,
+        "last week":            -7,
+        "la semaine dernière":  -7,
+        "semaine dernière":     -7,
+        "next week":            7,
+        "la semaine prochaine": 7,
+        "semaine prochaine":    7,
+    }
+    if expr in week_offsets:
+        monday = today - timedelta(days=today.weekday()) + timedelta(days=week_offsets[expr])
+        return monday.isoformat()
+
+    return None
+
+
+def get_time_context() -> dict:
+    dt = now()
+    return {
+        "current_date": dt.date().isoformat(),
+        "current_time": dt.strftime("%H:%M"),
+        "timezone":     _get_timezone_name(),
+    }
+
+
+def format_time_context() -> str:
+    ctx = get_time_context()
+    return (
+        f"[Time context]\n"
+        f"current_date: {ctx['current_date']}\n"
+        f"current_time: {ctx['current_time']}\n"
+        f"timezone: {ctx['timezone']}"
+    )

--- a/core/time_context.py
+++ b/core/time_context.py
@@ -57,14 +57,14 @@ def resolve_relative_date(expression: str) -> str | None:
 
     # Week expressions — always anchored to the Monday of the week
     week_offsets = {
-        "this week":            0,
-        "cette semaine":        0,
-        "last week":            -7,
-        "la semaine dernière":  -7,
-        "semaine dernière":     -7,
-        "next week":            7,
+        "this week": 0,
+        "cette semaine": 0,
+        "last week": -7,
+        "la semaine dernière": -7,
+        "semaine dernière": -7,
+        "next week": 7,
         "la semaine prochaine": 7,
-        "semaine prochaine":    7,
+        "semaine prochaine": 7,
     }
     if expr in week_offsets:
         monday = today - timedelta(days=today.weekday()) + timedelta(days=week_offsets[expr])

--- a/tests/test_time_context.py
+++ b/tests/test_time_context.py
@@ -1,0 +1,178 @@
+import os
+import zoneinfo
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from core.time_context import (
+    format_time_context,
+    get_time_context,
+    get_timezone_name,
+    now,
+    resolve_relative_date,
+    today_iso,
+)
+
+
+# ── Timezone handling ────────────────────────────────────────────────────────
+
+
+def test_nova_timezone_env_is_respected():
+    with patch.dict(os.environ, {"NOVA_TIMEZONE": "America/Montreal"}):
+        name = get_timezone_name()
+    assert name == "America/Montreal"
+
+
+def test_nova_timezone_invalid_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOVA_TIMEZONE", "Not/AReal_Zone")
+    # Should not raise; falls back gracefully (system tz or UTC)
+    name = get_timezone_name()
+    assert name != "Not/AReal_Zone"
+
+
+def test_nova_timezone_empty_uses_system_or_utc(monkeypatch):
+    monkeypatch.delenv("NOVA_TIMEZONE", raising=False)
+    name = get_timezone_name()
+    assert isinstance(name, str)
+    assert len(name) > 0
+
+
+def test_now_returns_timezone_aware_datetime():
+    with patch.dict(os.environ, {"NOVA_TIMEZONE": "UTC"}):
+        dt = now()
+    assert dt.tzinfo is not None
+
+
+def test_now_uses_configured_timezone():
+    with patch.dict(os.environ, {"NOVA_TIMEZONE": "America/Montreal"}):
+        dt = now()
+    assert dt.tzinfo is not None
+    assert dt.tzname() in ("EST", "EDT")  # Montreal observes both
+
+
+# ── Current date retrieval ───────────────────────────────────────────────────
+
+
+def test_today_iso_format():
+    with patch.dict(os.environ, {"NOVA_TIMEZONE": "UTC"}):
+        iso = today_iso()
+    parts = iso.split("-")
+    assert len(parts) == 3
+    assert len(parts[0]) == 4  # year
+    assert len(parts[1]) == 2  # month
+    assert len(parts[2]) == 2  # day
+
+
+def test_today_iso_matches_now():
+    with patch.dict(os.environ, {"NOVA_TIMEZONE": "UTC"}):
+        iso = today_iso()
+        dt = now()
+    assert iso == dt.date().isoformat()
+
+
+def test_get_time_context_keys():
+    ctx = get_time_context()
+    assert "current_date" in ctx
+    assert "current_time" in ctx
+    assert "timezone" in ctx
+
+
+def test_get_time_context_date_is_iso():
+    ctx = get_time_context()
+    d = date.fromisoformat(ctx["current_date"])  # raises if invalid
+    assert isinstance(d, date)
+
+
+def test_get_time_context_time_format():
+    ctx = get_time_context()
+    parts = ctx["current_time"].split(":")
+    assert len(parts) == 2
+    assert parts[0].isdigit() and parts[1].isdigit()
+
+
+def test_format_time_context_contains_fields():
+    text = format_time_context()
+    assert "current_date" in text
+    assert "current_time" in text
+    assert "timezone" in text
+
+
+# ── Relative date resolution ─────────────────────────────────────────────────
+
+
+def _today_in_tz(tz_name: str = "UTC") -> date:
+    import datetime as _dt
+    return _dt.datetime.now(zoneinfo.ZoneInfo(tz_name)).date()
+
+
+@pytest.fixture(autouse=True)
+def force_utc(monkeypatch):
+    monkeypatch.setenv("NOVA_TIMEZONE", "UTC")
+
+
+def test_resolve_today():
+    assert resolve_relative_date("today") == _today_in_tz().isoformat()
+
+
+def test_resolve_today_fr():
+    assert resolve_relative_date("aujourd'hui") == _today_in_tz().isoformat()
+
+
+def test_resolve_yesterday():
+    expected = (_today_in_tz() - timedelta(days=1)).isoformat()
+    assert resolve_relative_date("yesterday") == expected
+
+
+def test_resolve_hier():
+    expected = (_today_in_tz() - timedelta(days=1)).isoformat()
+    assert resolve_relative_date("hier") == expected
+
+
+def test_resolve_tomorrow():
+    expected = (_today_in_tz() + timedelta(days=1)).isoformat()
+    assert resolve_relative_date("tomorrow") == expected
+
+
+def test_resolve_demain():
+    expected = (_today_in_tz() + timedelta(days=1)).isoformat()
+    assert resolve_relative_date("demain") == expected
+
+
+def test_resolve_this_week_is_monday():
+    result = resolve_relative_date("this week")
+    d = date.fromisoformat(result)
+    assert d.weekday() == 0  # Monday
+
+
+def test_resolve_cette_semaine_is_monday():
+    result = resolve_relative_date("cette semaine")
+    d = date.fromisoformat(result)
+    assert d.weekday() == 0
+
+
+def test_resolve_last_week_is_monday_before_this_week():
+    this_monday = date.fromisoformat(resolve_relative_date("this week"))
+    last_monday = date.fromisoformat(resolve_relative_date("last week"))
+    assert this_monday - last_monday == timedelta(days=7)
+
+
+def test_resolve_next_week_is_monday_after_this_week():
+    this_monday = date.fromisoformat(resolve_relative_date("this week"))
+    next_monday = date.fromisoformat(resolve_relative_date("next week"))
+    assert next_monday - this_monday == timedelta(days=7)
+
+
+def test_resolve_unknown_returns_none():
+    assert resolve_relative_date("last year") is None
+    assert resolve_relative_date("in three days") is None
+    assert resolve_relative_date("") is None
+
+
+def test_resolve_case_insensitive():
+    assert resolve_relative_date("TODAY") == resolve_relative_date("today")
+    assert resolve_relative_date("YESTERDAY") == resolve_relative_date("yesterday")
+
+
+def test_resolve_strips_whitespace():
+    assert resolve_relative_date("  tomorrow  ") == resolve_relative_date("tomorrow")


### PR DESCRIPTION
## Summary

- Adds `core/time_context.py` — a stdlib-only module that resolves the current datetime using `NOVA_TIMEZONE` env var (falls back to `/etc/timezone`, then UTC)
- Injects a `[Time context]` block (`current_date`, `current_time`, `timezone`) into every system prompt via a single-line change in `build_messages`
- Adds 24 unit tests covering timezone resolution, ISO date retrieval, and all relative date expressions (today/yesterday/tomorrow/this week/last week/next week) in English and French

## What changed

| File | Change |
|---|---|
| `core/time_context.py` | New — time provider, `resolve_relative_date()`, `format_time_context()` |
| `core/chat.py` | +1 import, +1 string concatenation in `build_messages` |
| `.env.example` | Documents `NOVA_TIMEZONE=` |
| `tests/test_time_context.py` | New — 24 unit tests, all passing |

## What was NOT touched

- `core/auth.py` — untouched
- `core/memory.py` / `memory/` — untouched
- `core/model_access.py` / `core/model_registry.py` / `core/model_pulls.py` — untouched
- `core/users.py` / `core/policies.py` — untouched
- `core/router.py` — untouched
- `static/index.html` — untouched

## Test plan

- [ ] `python -m pytest tests/test_time_context.py -v` → 24 passed
- [ ] Set `NOVA_TIMEZONE=America/Montreal` and verify Nova reports the correct local date/time
- [ ] Ask Nova "what is today's date?" and "what was yesterday?" and confirm correct ISO dates
- [ ] Leave `NOVA_TIMEZONE` unset and verify fallback to system timezone

https://claude.ai/code/session_01FbKa6wP6QNHM1jwCcocdiY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbKa6wP6QNHM1jwCcocdiY)_