### PR TITLE
feat(settings): persist per-user personalization preferences

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -22,6 +22,33 @@ from __future__ import annotations
 import sqlite3
 from typing import Optional
 
+# ── Personalization ─────────────────────────────────────────────────────────
+# Tone-shaping preferences the user can flip from the settings panel. Stored
+# as plain strings in user_settings; enum values are validated server-side
+# before any write so the column never carries a value the UI can't render.
+PERSONALIZATION_ENUMS: dict[str, frozenset[str]] = {
+    "response_style": frozenset({"default", "concise", "detailed", "technical"}),
+    "warmth_level": frozenset({"low", "normal", "high"}),
+    "enthusiasm_level": frozenset({"low", "normal", "high"}),
+    "emoji_level": frozenset({"none", "low", "medium"}),
+}
+
+PERSONALIZATION_DEFAULTS: dict[str, str] = {
+    "response_style": "default",
+    "warmth_level": "normal",
+    "enthusiasm_level": "normal",
+    "emoji_level": "low",
+    "custom_instructions": "",
+}
+
+# Hard cap on the free-text instructions field. The UI sets the same limit
+# via maxlength; the server enforces it independently so a crafted client
+# can't smuggle a larger blob into the DB.
+CUSTOM_INSTRUCTIONS_MAX_LEN = 1000
+
+PERSONALIZATION_KEYS: frozenset[str] = frozenset(PERSONALIZATION_DEFAULTS)
+
+
 # Keys that belong to a user, not to the host. Anything not in this set
 # is treated as a system/global setting.
 USER_SETTING_KEYS: frozenset[str] = frozenset({
@@ -32,11 +59,58 @@ USER_SETTING_KEYS: frozenset[str] = frozenset({
     "silentguard_enabled",
     "nexanote_enabled",
     "nexanote_write_enabled",
+    # Personalization preferences. Per-user so one account's tone choices
+    # never leak onto another's chat.
+    *PERSONALIZATION_KEYS,
 })
 
 
 def is_user_setting(key: str) -> bool:
     return key in USER_SETTING_KEYS
+
+
+def validate_personalization_value(key: str, value: str) -> str:
+    """
+    Normalize and validate a personalization value before storage.
+
+    Raises ValueError on unknown keys, unknown enum values, or
+    over-length custom instructions. The returned string is what should
+    be persisted (trimmed for free-text, untouched for enums).
+    """
+    if key == "custom_instructions":
+        if not isinstance(value, str):
+            raise ValueError("custom_instructions must be a string")
+        # Trim incidental whitespace; leave internal newlines intact so the
+        # user's formatting choices survive round-tripping.
+        cleaned = value.strip()
+        if len(cleaned) > CUSTOM_INSTRUCTIONS_MAX_LEN:
+            raise ValueError(
+                f"custom_instructions too long "
+                f"(max {CUSTOM_INSTRUCTIONS_MAX_LEN} characters)"
+            )
+        return cleaned
+
+    allowed = PERSONALIZATION_ENUMS.get(key)
+    if allowed is None:
+        raise ValueError(f"unknown personalization key: {key}")
+    if value not in allowed:
+        raise ValueError(
+            f"invalid value for {key}: must be one of "
+            f"{sorted(allowed)}"
+        )
+    return value
+
+
+def get_personalization(user_id: int) -> dict[str, str]:
+    """
+    Read the full personalization payload for a user, falling back to
+    defaults for unset keys. The shape is stable so the client can render
+    every control without checking for missing fields.
+    """
+    return {
+        key: get_user_setting(user_id, key, default)
+        for key, default in PERSONALIZATION_DEFAULTS.items()
+    }
 
 
 def _db_path() -> str:

--- a/static/index.html
+++ b/static/index.html
@@ -1766,9 +1766,8 @@
                                 <span class="settings-row-title" id="pers-style-title">Response style</span>
                                 <span class="settings-row-hint" id="pers-style-hint">How detailed Nova's answers should be.</span>
                             </div>
-                            <span class="settings-coming-soon" id="pers-coming-soon-1">coming soon</span>
                         </div>
-                        <select id="pers-response-style" class="pers-select" disabled>
+                        <select id="pers-response-style" class="pers-select" onchange="savePersonalizationField('response_style', this.value)">
                             <option value="default">Default</option>
                             <option value="concise">Concise</option>
                             <option value="detailed">Detailed</option>
@@ -1782,9 +1781,8 @@
                                 <span class="settings-row-title" id="pers-warmth-title">Warmth</span>
                                 <span class="settings-row-hint" id="pers-warmth-hint">How warm or neutral Nova should sound.</span>
                             </div>
-                            <span class="settings-coming-soon" id="pers-coming-soon-2">coming soon</span>
                         </div>
-                        <select id="pers-warmth" class="pers-select" disabled>
+                        <select id="pers-warmth" class="pers-select" onchange="savePersonalizationField('warmth_level', this.value)">
                             <option value="low">Low</option>
                             <option value="normal" selected>Normal</option>
                             <option value="high">High</option>
@@ -1797,9 +1795,8 @@
                                 <span class="settings-row-title" id="pers-enth-title">Enthusiasm</span>
                                 <span class="settings-row-hint" id="pers-enth-hint">How energetic Nova's replies should feel.</span>
                             </div>
-                            <span class="settings-coming-soon" id="pers-coming-soon-3">coming soon</span>
                         </div>
-                        <select id="pers-enthusiasm" class="pers-select" disabled>
+                        <select id="pers-enthusiasm" class="pers-select" onchange="savePersonalizationField('enthusiasm_level', this.value)">
                             <option value="low">Low</option>
                             <option value="normal" selected>Normal</option>
                             <option value="high">High</option>
@@ -1812,9 +1809,8 @@
                                 <span class="settings-row-title" id="pers-emoji-title">Emoji level</span>
                                 <span class="settings-row-hint" id="pers-emoji-hint">How often Nova may use emoji.</span>
                             </div>
-                            <span class="settings-coming-soon" id="pers-coming-soon-4">coming soon</span>
                         </div>
-                        <select id="pers-emoji" class="pers-select" disabled>
+                        <select id="pers-emoji" class="pers-select" onchange="savePersonalizationField('emoji_level', this.value)">
                             <option value="none">None</option>
                             <option value="low" selected>Low</option>
                             <option value="medium">Medium</option>
@@ -1827,9 +1823,9 @@
                                 <span class="settings-row-title" id="pers-instr-title">Custom instructions</span>
                                 <span class="settings-row-hint" id="pers-instr-hint">A short note Nova should keep in mind for your messages.</span>
                             </div>
-                            <span class="settings-coming-soon" id="pers-coming-soon-5">coming soon</span>
                         </div>
-                        <textarea id="pers-custom-instructions" class="pers-textarea" maxlength="1000" disabled
+                        <textarea id="pers-custom-instructions" class="pers-textarea" maxlength="1000"
+                            onchange="savePersonalizationField('custom_instructions', this.value)"
                             placeholder="e.g. Prefer short answers. Avoid headings unless asked."></textarea>
                     </div>
                 </section>
@@ -2287,7 +2283,6 @@
         _setText("pers-emoji-hint", t("pers_emoji_hint"));
         _setText("pers-instr-title", t("pers_instr_title"));
         _setText("pers-instr-hint", t("pers_instr_hint"));
-        for (let i = 1; i <= 5; i++) _setText("pers-coming-soon-" + i, t("coming_soon"));
 
         _setText("settings-memory-note", t("memory_note"));
         const memSearch = document.getElementById("mem-search");
@@ -2973,6 +2968,53 @@
         const nameInput = document.getElementById("nova-model-name-input");
         if (nameInput && data.nova_model_name) {
             nameInput.value = data.nova_model_name;
+        }
+        applyPersonalizationUI(data);
+    }
+
+    // ── PERSONALIZATION ──
+    // Maps each /settings field to the DOM control that surfaces it. The
+    // map is the single source of truth for both the load and save paths.
+    const PERSONALIZATION_FIELDS = {
+        response_style: "pers-response-style",
+        warmth_level: "pers-warmth",
+        enthusiasm_level: "pers-enthusiasm",
+        emoji_level: "pers-emoji",
+        custom_instructions: "pers-custom-instructions",
+    };
+
+    function applyPersonalizationUI(data) {
+        for (const [key, elId] of Object.entries(PERSONALIZATION_FIELDS)) {
+            const el = document.getElementById(elId);
+            if (!el) continue;
+            const value = data[key];
+            if (value === undefined || value === null) continue;
+            el.value = value;
+        }
+    }
+
+    async function savePersonalizationField(key, rawValue) {
+        if (!(key in PERSONALIZATION_FIELDS)) return;
+        // Mirror the server-side trim so the control reflects exactly what
+        // will be stored when the user blurs the textarea.
+        const value = key === "custom_instructions"
+            ? (rawValue || "").trim()
+            : rawValue;
+        const resp = await fetch("/settings", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`,
+            },
+            body: JSON.stringify({ [key]: value }),
+        });
+        if (!resp.ok) {
+            // Re-pull on rejection so the UI snaps back to the persisted
+            // value rather than showing a phantom write.
+            await loadSystemSettings();
+        } else if (key === "custom_instructions") {
+            const el = document.getElementById(PERSONALIZATION_FIELDS[key]);
+            if (el) el.value = value;
         }
     }
 

--- a/tests/test_personalization_settings.py
+++ b/tests/test_personalization_settings.py
@@ -1,0 +1,403 @@
+"""
+Tests for per-user personalization settings.
+
+Personalization (response style, warmth, enthusiasm, emoji level, custom
+instructions) lives on top of the same per-user settings infrastructure
+introduced in #107: each preference is a row in `user_settings`, scoped
+to the caller, validated server-side, and surfaced through the existing
+GET /settings and POST /settings endpoints.
+
+Covers:
+  * data-layer round-trip and per-user isolation
+  * enum validation and custom-instructions length cap
+  * /settings GET returns sensible defaults when nothing is saved
+  * /settings POST persists the values for the calling user only
+  * non-admin callers can write personalization but still cannot mutate
+    system-scoped keys (ram_budget) through the same endpoint
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, settings as core_settings, users
+from memory import store as natural_store
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post(
+        "/login", json={"username": username, "password": password}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# Convenient shorthand used across the HTTP tests.
+ALL_FIELDS = {
+    "response_style": "concise",
+    "warmth_level": "high",
+    "enthusiasm_level": "low",
+    "emoji_level": "medium",
+    "custom_instructions": "Prefer short answers.",
+}
+
+
+# ── Module surface ──────────────────────────────────────────────────────────
+
+class TestPersonalizationConstants:
+    def test_keys_are_user_scoped(self):
+        # Each personalization key must round-trip through the per-user
+        # settings table, never the global settings table.
+        for key in core_settings.PERSONALIZATION_KEYS:
+            assert core_settings.is_user_setting(key), key
+
+    def test_enums_match_spec(self):
+        assert core_settings.PERSONALIZATION_ENUMS["response_style"] == frozenset(
+            {"default", "concise", "detailed", "technical"}
+        )
+        assert core_settings.PERSONALIZATION_ENUMS["warmth_level"] == frozenset(
+            {"low", "normal", "high"}
+        )
+        assert core_settings.PERSONALIZATION_ENUMS["enthusiasm_level"] == frozenset(
+            {"low", "normal", "high"}
+        )
+        assert core_settings.PERSONALIZATION_ENUMS["emoji_level"] == frozenset(
+            {"none", "low", "medium"}
+        )
+
+    def test_defaults_cover_every_field(self):
+        expected = {
+            "response_style", "warmth_level", "enthusiasm_level",
+            "emoji_level", "custom_instructions",
+        }
+        assert set(core_settings.PERSONALIZATION_DEFAULTS) == expected
+
+
+class TestValidatePersonalizationValue:
+    def test_accepts_allowed_enum_values(self):
+        for key, allowed in core_settings.PERSONALIZATION_ENUMS.items():
+            for v in allowed:
+                assert core_settings.validate_personalization_value(key, v) == v
+
+    def test_rejects_unknown_enum_value(self):
+        with pytest.raises(ValueError):
+            core_settings.validate_personalization_value(
+                "response_style", "verbose"
+            )
+
+    def test_rejects_unknown_key(self):
+        with pytest.raises(ValueError):
+            core_settings.validate_personalization_value("not_a_key", "default")
+
+    def test_custom_instructions_trimmed(self):
+        out = core_settings.validate_personalization_value(
+            "custom_instructions", "  hello  "
+        )
+        assert out == "hello"
+
+    def test_custom_instructions_at_limit_accepted(self):
+        s = "x" * core_settings.CUSTOM_INSTRUCTIONS_MAX_LEN
+        assert core_settings.validate_personalization_value(
+            "custom_instructions", s
+        ) == s
+
+    def test_custom_instructions_over_limit_rejected(self):
+        s = "x" * (core_settings.CUSTOM_INSTRUCTIONS_MAX_LEN + 1)
+        with pytest.raises(ValueError):
+            core_settings.validate_personalization_value(
+                "custom_instructions", s
+            )
+
+
+# ── Data-layer scoping ──────────────────────────────────────────────────────
+
+class TestPersonalizationStorage:
+    def test_get_personalization_returns_defaults_for_new_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        prefs = core_settings.get_personalization(a)
+        assert prefs == core_settings.PERSONALIZATION_DEFAULTS
+
+    def test_save_then_get_round_trip(self, db_path):
+        a = _make_user(db_path, "alice")
+        for key, value in ALL_FIELDS.items():
+            core_settings.save_user_setting(a, key, value)
+        assert core_settings.get_personalization(a) == ALL_FIELDS
+
+    def test_user_a_settings_do_not_affect_user_b(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        for key, value in ALL_FIELDS.items():
+            core_settings.save_user_setting(a, key, value)
+        # Bob has saved nothing — he should still see the defaults.
+        assert core_settings.get_personalization(b) == (
+            core_settings.PERSONALIZATION_DEFAULTS
+        )
+        # Alice's payload is unaffected by Bob existing.
+        assert core_settings.get_personalization(a) == ALL_FIELDS
+
+
+# ── HTTP endpoints ──────────────────────────────────────────────────────────
+
+class TestSettingsGet:
+    def test_defaults_returned_for_fresh_user(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        body = web_client.get("/settings", headers=_h(token)).json()
+        for key, default in core_settings.PERSONALIZATION_DEFAULTS.items():
+            assert body[key] == default
+
+    def test_returns_saved_values(self, db_path, web_client):
+        a = _make_user(db_path, "alice")
+        for key, value in ALL_FIELDS.items():
+            core_settings.save_user_setting(a, key, value)
+        token = _login(web_client, "alice")
+        body = web_client.get("/settings", headers=_h(token)).json()
+        for key, value in ALL_FIELDS.items():
+            assert body[key] == value
+
+
+class TestSettingsPost:
+    def test_user_can_save_personalization_settings(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings", json=ALL_FIELDS, headers=_h(token)
+        )
+        assert resp.status_code == 200, resp.text
+
+        body = web_client.get("/settings", headers=_h(token)).json()
+        for key, value in ALL_FIELDS.items():
+            assert body[key] == value
+
+    def test_settings_survive_reload(self, db_path, web_client):
+        """A second login pulls the same payload, simulating a page reload."""
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        web_client.post("/settings", json=ALL_FIELDS, headers=_h(token))
+
+        # Fresh login → fresh token, but the persisted prefs are the same.
+        token2 = _login(web_client, "alice")
+        body = web_client.get("/settings", headers=_h(token2)).json()
+        for key, value in ALL_FIELDS.items():
+            assert body[key] == value
+
+    def test_user_a_post_does_not_affect_user_b(self, db_path, web_client):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+        b_token = _login(web_client, "bob")
+
+        resp = web_client.post(
+            "/settings", json=ALL_FIELDS, headers=_h(a_token)
+        )
+        assert resp.status_code == 200
+
+        a_body = web_client.get("/settings", headers=_h(a_token)).json()
+        b_body = web_client.get("/settings", headers=_h(b_token)).json()
+        for key, value in ALL_FIELDS.items():
+            assert a_body[key] == value
+            assert b_body[key] == core_settings.PERSONALIZATION_DEFAULTS[key]
+
+        # The DB row exists only for Alice.
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT user_id, key FROM user_settings "
+                "WHERE key IN (?, ?, ?, ?, ?)",
+                tuple(ALL_FIELDS.keys()),
+            ).fetchall()
+        assert all(r[0] == a for r in rows)
+        assert {r[1] for r in rows} == set(ALL_FIELDS.keys())
+        assert all(r[0] != b for r in rows)
+
+    def test_partial_update_only_touches_supplied_fields(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        web_client.post("/settings", json=ALL_FIELDS, headers=_h(token))
+
+        # Only emoji_level changes; everything else is left alone.
+        resp = web_client.post(
+            "/settings", json={"emoji_level": "none"}, headers=_h(token),
+        )
+        assert resp.status_code == 200
+
+        body = web_client.get("/settings", headers=_h(token)).json()
+        assert body["emoji_level"] == "none"
+        assert body["response_style"] == ALL_FIELDS["response_style"]
+        assert body["warmth_level"] == ALL_FIELDS["warmth_level"]
+        assert body["enthusiasm_level"] == ALL_FIELDS["enthusiasm_level"]
+        assert body["custom_instructions"] == ALL_FIELDS["custom_instructions"]
+
+    @pytest.mark.parametrize("key,value", [
+        ("response_style", "verbose"),
+        ("warmth_level", "extreme"),
+        ("enthusiasm_level", ""),
+        ("emoji_level", "all"),
+    ])
+    def test_invalid_enum_value_is_rejected(self, db_path, web_client, key, value):
+        a = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings", json={key: value}, headers=_h(token)
+        )
+        assert resp.status_code == 422
+        # Nothing was written for the rejected field.
+        assert core_settings.get_user_setting(a, key, "MISSING") == "MISSING"
+
+    def test_custom_instructions_too_long_is_rejected(self, db_path, web_client):
+        a = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        too_long = "x" * (core_settings.CUSTOM_INSTRUCTIONS_MAX_LEN + 1)
+        resp = web_client.post(
+            "/settings",
+            json={"custom_instructions": too_long},
+            headers=_h(token),
+        )
+        assert resp.status_code == 422
+        assert core_settings.get_user_setting(
+            a, "custom_instructions", "MISSING"
+        ) == "MISSING"
+
+    def test_custom_instructions_at_limit_is_accepted(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        at_limit = "x" * core_settings.CUSTOM_INSTRUCTIONS_MAX_LEN
+        resp = web_client.post(
+            "/settings",
+            json={"custom_instructions": at_limit},
+            headers=_h(token),
+        )
+        assert resp.status_code == 200
+        body = web_client.get("/settings", headers=_h(token)).json()
+        assert body["custom_instructions"] == at_limit
+
+    def test_custom_instructions_is_trimmed_server_side(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        web_client.post(
+            "/settings",
+            json={"custom_instructions": "  trim me  "},
+            headers=_h(token),
+        )
+        body = web_client.get("/settings", headers=_h(token)).json()
+        assert body["custom_instructions"] == "trim me"
+
+
+class TestSettingsAuthorization:
+    def test_non_admin_cannot_change_system_settings_via_personalization_payload(
+        self, db_path, web_client,
+    ):
+        """
+        A non-admin posting personalization plus a system key must be
+        refused on the system key, and the personalization must NOT be
+        partially applied. This is the existing #107 behaviour: the
+        system-key check fires first and aborts the whole request.
+        """
+        a = _make_user(db_path, "alice", role=users.ROLE_USER)
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings",
+            json={"ram_budget": 4096, "response_style": "technical"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 403
+        # System setting unchanged.
+        assert core_settings.get_system_setting("ram_budget", "2048") == "2048"
+        # Personalization left untouched (no half-applied write).
+        assert core_settings.get_user_setting(
+            a, "response_style", "MISSING"
+        ) == "MISSING"
+
+    def test_restricted_user_can_save_personalization(self, db_path, web_client):
+        """
+        Restricted accounts retain access to harmless personalization
+        settings. The /settings endpoint never gates user-scoped writes
+        on role or restriction, so a restricted user's POST goes through.
+        """
+        a = _make_user(
+            db_path, "kid", role=users.ROLE_USER, is_restricted=True,
+        )
+        token = _login(web_client, "kid")
+        resp = web_client.post(
+            "/settings", json=ALL_FIELDS, headers=_h(token),
+        )
+        assert resp.status_code == 200
+        for key, value in ALL_FIELDS.items():
+            assert core_settings.get_user_setting(a, key) == value
+
+    def test_unknown_field_is_rejected(self, db_path, web_client):
+        """`extra="forbid"` covers the personalization endpoint too."""
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings",
+            json={"telepathy_level": "max"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 422
+
+    def test_settings_get_does_not_expose_raw_model_names(
+        self, db_path, web_client,
+    ):
+        """
+        The personalization payload must not leak the host's MODEL_MAP
+        or any raw model identifier. Only the user's own nova_model_name
+        (already #107) is allowed through, and personalization is purely
+        labels — no model strings.
+        """
+        a = _make_user(db_path, "alice")
+        for key, value in ALL_FIELDS.items():
+            core_settings.save_user_setting(a, key, value)
+        token = _login(web_client, "alice")
+        body = web_client.get("/settings", headers=_h(token)).json()
+
+        from config import MODELS
+        raw_names = {v for v in MODELS.values()}
+        for key in (
+            "response_style", "warmth_level", "enthusiasm_level",
+            "emoji_level", "custom_instructions",
+        ):
+            assert body[key] not in raw_names

--- a/web.py
+++ b/web.py
@@ -31,6 +31,10 @@ from core.memory import (
 )
 from core.settings import (
     get_user_setting, save_user_setting,
+    get_personalization,
+    validate_personalization_value,
+    CUSTOM_INSTRUCTIONS_MAX_LEN,
+    PERSONALIZATION_ENUMS,
 )
 from core.policies import (
     KNOWN_MODES,
@@ -281,6 +285,16 @@ class SettingsUpdateRequest(BaseModel):
     nexanote_enabled: bool | None = None
     nexanote_write_enabled: bool | None = None
 
+    # Personalization preferences (per-user). Enum fields are validated
+    # against PERSONALIZATION_ENUMS so the DB never carries a value the
+    # UI can't render; custom_instructions is length-capped server-side
+    # to match the textarea's maxlength.
+    response_style: str | None = None
+    warmth_level: str | None = None
+    enthusiasm_level: str | None = None
+    emoji_level: str | None = None
+    custom_instructions: str | None = None
+
     @field_validator("ram_budget")
     @classmethod
     def validate_ram_budget(cls, v):
@@ -299,6 +313,34 @@ class SettingsUpdateRequest(BaseModel):
                 raise ValueError("model name cannot be empty")
             if len(v) > ALLOWED_SETTINGS["nova_model_name"]["max_len"]:
                 raise ValueError("model name too long (max 100 characters)")
+        return v
+
+    @field_validator(
+        "response_style", "warmth_level", "enthusiasm_level", "emoji_level"
+    )
+    @classmethod
+    def validate_personalization_enum(cls, v, info):
+        if v is None:
+            return v
+        allowed = PERSONALIZATION_ENUMS[info.field_name]
+        if v not in allowed:
+            raise ValueError(
+                f"must be one of {sorted(allowed)}"
+            )
+        return v
+
+    @field_validator("custom_instructions")
+    @classmethod
+    def validate_custom_instructions(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, str):
+            raise ValueError("must be a string")
+        v = v.strip()
+        if len(v) > CUSTOM_INSTRUCTIONS_MAX_LEN:
+            raise ValueError(
+                f"must be {CUSTOM_INSTRUCTIONS_MAX_LEN} characters or fewer"
+            )
         return v
 
 
@@ -528,7 +570,7 @@ def add_memory(
 def get_settings(user: CurrentUser = Depends(get_current_user)):
     # System-scoped values are global; user-scoped values are read for the
     # caller, so two users see two different `nova_model_*` payloads.
-    return {
+    payload = {
         "ram_budget": get_setting("ram_budget", "2048"),
         "last_model_update": get_setting("last_model_update", "Never"),
         "last_updated_models": get_setting("last_updated_models", ""),
@@ -548,6 +590,11 @@ def get_settings(user: CurrentUser = Depends(get_current_user)):
             get_user_setting(user.id, "nexanote_write_enabled", "false") == "true"
         ),
     }
+    # Personalization is read for the caller and merged in flat; the
+    # client renders one control per key without checking for missing
+    # fields.
+    payload.update(get_personalization(user.id))
+    return payload
 
 
 @app.post("/models/update")
@@ -600,6 +647,23 @@ def update_settings(
             user.id,
             "nexanote_write_enabled",
             "true" if data.nexanote_write_enabled else "false",
+        )
+    # Personalization. Pydantic has already validated each field; the
+    # second pass through validate_personalization_value is the canonical
+    # check used by tests and any non-HTTP caller, and it normalises
+    # custom_instructions consistently.
+    for key in (
+        "response_style",
+        "warmth_level",
+        "enthusiasm_level",
+        "emoji_level",
+        "custom_instructions",
+    ):
+        value = getattr(data, key)
+        if value is None:
+            continue
+        save_user_setting(
+            user.id, key, validate_personalization_value(key, value)
         )
     return {"ok": True}
 


### PR DESCRIPTION
## Summary
- Wires up the previously placeholder Personalization pane: response style, warmth, enthusiasm, emoji level, and a free-text custom-instructions field are now saved per-user via the existing `/settings` endpoints.
- Storage reuses the `user_settings` table from #107; no schema migration is required.
- Server-side enum validation + 1000-char cap on custom instructions; `extra="forbid"` already on `SettingsUpdateRequest` rejects unknown fields.

## Scope
- Touched: `core/settings.py`, `web.py` (only `SettingsUpdateRequest` + `/settings` GET/POST), `static/index.html` (Personalization pane + load/save JS), `tests/test_personalization_settings.py` (new).
- **Not** touched: `core/chat.py`, `core/router.py`, `core/policies.py`, `core/memory.py`, `memory/store.py`, `core/model_*`, any admin endpoint. Preferences are stored only — they are **not** injected into the chat/system prompt yet.
- No raw model names exposed; verified by test.

## Behaviour
- Each user gets independent personalization rows.
- Restricted users can save their own personalization (existing per-user-write policy).
- Non-admin posting `ram_budget` alongside personalization is still 403'd, and personalization is **not** half-applied — the system-key check fires first.
- Settings UI loads saved values when the panel opens and posts changes on each control's `change` event.

## Test plan
- [x] `pytest tests/test_personalization_settings.py` → 29 passed
- [x] `pytest` (full suite) → 769 passed
- [ ] Smoke-test in a browser: open Settings → Personalization, change each control, reload, confirm values persist
- [ ] Confirm no admin/system setting is mutated when a non-admin saves personalization

https://claude.ai/code/session_01M93tHm269DiAYWZi4ZENUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01M93tHm269DiAYWZi4ZENUb)_