### PR TITLE
feat(time-context): add day-of-week to the prompt block

### DIFF
--- a/core/time_context.py
+++ b/core/time_context.py
@@ -3,6 +3,13 @@ import pathlib
 import zoneinfo
 from datetime import datetime, timedelta
 
+# Locale-independent day names so the prompt is deterministic regardless of
+# the host's LC_TIME setting.
+_DAY_NAMES = (
+    "Monday", "Tuesday", "Wednesday", "Thursday",
+    "Friday", "Saturday", "Sunday",
+)
+
 
 def _get_timezone_name() -> str:
     tz_name = os.environ.get("NOVA_TIMEZONE", "").strip()
@@ -78,6 +85,7 @@ def get_time_context() -> dict:
     return {
         "current_date": dt.date().isoformat(),
         "current_time": dt.strftime("%H:%M"),
+        "day_of_week":  _DAY_NAMES[dt.weekday()],
         "timezone":     _get_timezone_name(),
     }
 
@@ -87,6 +95,7 @@ def format_time_context() -> str:
     return (
         f"[Time context]\n"
         f"current_date: {ctx['current_date']}\n"
+        f"day_of_week: {ctx['day_of_week']}\n"
         f"current_time: {ctx['current_time']}\n"
         f"timezone: {ctx['timezone']}"
     )

--- a/tests/test_time_context.py
+++ b/tests/test_time_context.py
@@ -75,6 +75,7 @@ def test_get_time_context_keys():
     ctx = get_time_context()
     assert "current_date" in ctx
     assert "current_time" in ctx
+    assert "day_of_week" in ctx
     assert "timezone" in ctx
 
 
@@ -95,7 +96,38 @@ def test_format_time_context_contains_fields():
     text = format_time_context()
     assert "current_date" in text
     assert "current_time" in text
+    assert "day_of_week" in text
     assert "timezone" in text
+
+
+def test_get_time_context_day_of_week_matches_now():
+    ctx = get_time_context()
+    expected = (
+        "Monday", "Tuesday", "Wednesday", "Thursday",
+        "Friday", "Saturday", "Sunday",
+    )[now().weekday()]
+    assert ctx["day_of_week"] == expected
+
+
+def test_get_time_context_day_of_week_is_english_name():
+    # Locale-independent: must be one of the seven canonical English names,
+    # regardless of the host's LC_TIME.
+    ctx = get_time_context()
+    assert ctx["day_of_week"] in {
+        "Monday", "Tuesday", "Wednesday", "Thursday",
+        "Friday", "Saturday", "Sunday",
+    }
+
+
+def test_format_time_context_day_of_week_is_english_name():
+    text = format_time_context()
+    assert any(
+        f"day_of_week: {name}" in text
+        for name in (
+            "Monday", "Tuesday", "Wednesday", "Thursday",
+            "Friday", "Saturday", "Sunday",
+        )
+    )
 
 
 # ── Relative date resolution ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the first concrete future issue listed under §10 Phase 1 of `docs/cognitive-copilot-roadmap.md`:

> **Add day-of-week to the time-context system prompt block.**

§4.2 motivates this as "cheap, useful for 'is this a workday?' reasoning." Phase 1 is the smallest, highest-ratio improvement called out in the roadmap, and this is its smallest sub-issue.

## What changed

- `core/time_context.py`
  - `get_time_context()` now exposes a `day_of_week` field.
  - `format_time_context()` emits a `day_of_week: …` line in the system-prompt block, alongside the existing `current_date`, `current_time`, `timezone` lines.
  - Day names are a fixed English tuple indexed by `datetime.weekday()`, so the output stays deterministic regardless of the host's `LC_TIME`. The roadmap's §6.5 ("auditable in code, not vibes") and the explainability principle in §2.4 both argue for this over `strftime("%A")`.
- `tests/test_time_context.py`
  - Added assertions to existing key/field tests for `day_of_week`.
  - Added two new tests: that the value matches `now().weekday()`, and that it is one of the seven canonical English names regardless of locale.

## Architectural reasoning

The roadmap is design guidance, not permission to ship phases wholesale. I picked the single smallest item it explicitly enumerates as a future issue (§10) so the change is genuinely foundational and reviewable in isolation:

- **No schema, no migration.** Stays inside §3's "no code in this PR" guard for semantic memory work.
- **No new tool surface and no new settings.** Doesn't open any of the read-only or confirmed-write surfaces from §5/§8 — git, GitHub, filesystem are untouched.
- **No new autonomy.** The change is a deterministic value injected into the existing system prompt block. No background work, no inference, no scoring (§2.5, §8.1, §8.2).
- **Local-first preserved.** Pure local computation; no environment variables added, no network paths touched.
- **Explainable.** The added line is plain text in the prompt block; users who can already see the time-context block in settings (planned in §10) will see the day name there too.
- **Maintainability.** A locale-independent constant tuple replaces an implicit dependency on host locale — making the prompt's textual contents reproducible across environments, which matters for any future test that asserts on prompt content.

Deliberately **not** included to keep this PR focused (each is its own future issue per §10):

- Per-user timezone override.
- Weekday/numeric-offset extensions to `resolve_relative_date()`.
- A "what time does Nova think it is?" settings panel.
- The §4.2 model-level guardrail about "use the time context, not your training data" — that's a system-prompt wording change with its own review surface.

## Test plan

- [x] `pytest tests/test_time_context.py` — 27 passed.
- [x] Smoke check: `format_time_context()` output now includes a `day_of_week: Wednesday` line in the expected position.
- [ ] Reviewer to confirm the new line slots cleanly into the system prompt as rendered by `core/chat.py:124` (no behavior change there; it consumes the block as one string).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XCiBYDUwczCpDV3U4Nm1Ef)_