### PR TITLE
feat(time-context): resolve weekdays and numeric date offsets

### DIFF
--- a/core/time_context.py
+++ b/core/time_context.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import re
 import zoneinfo
 from datetime import datetime, timedelta
 
@@ -9,6 +10,37 @@ _DAY_NAMES = (
     "Monday", "Tuesday", "Wednesday", "Thursday",
     "Friday", "Saturday", "Sunday",
 )
+
+# Weekday lookup for relative-date parsing. Keys are lowercase EN/FR names;
+# values are the Python `weekday()` index (Monday=0).
+_WEEKDAY_INDEX = {
+    "monday": 0,    "lundi":    0,
+    "tuesday": 1,   "mardi":    1,
+    "wednesday": 2, "mercredi": 2,
+    "thursday": 3,  "jeudi":    3,
+    "friday": 4,    "vendredi": 4,
+    "saturday": 5,  "samedi":   5,
+    "sunday": 6,    "dimanche": 6,
+}
+
+_WEEKDAY_NAMES_RE = "|".join(_WEEKDAY_INDEX.keys())
+
+# "next monday" / "last friday"
+_EN_NEXT_LAST_WEEKDAY = re.compile(
+    rf"^(next|last)\s+({_WEEKDAY_NAMES_RE})$"
+)
+# "lundi prochain" / "vendredi dernier"
+_FR_WEEKDAY_NEXT_LAST = re.compile(
+    rf"^({_WEEKDAY_NAMES_RE})\s+(prochain|dernier)$"
+)
+# "in 3 days", "in 2 weeks"
+_EN_IN_N = re.compile(r"^in\s+(\d+)\s+(day|days|week|weeks)$")
+# "3 days ago", "2 weeks ago"
+_EN_N_AGO = re.compile(r"^(\d+)\s+(day|days|week|weeks)\s+ago$")
+# "dans 3 jours", "dans 2 semaines"
+_FR_DANS_N = re.compile(r"^dans\s+(\d+)\s+(jour|jours|semaine|semaines)$")
+# "il y a 3 jours", "il y a 2 semaines"
+_FR_IL_Y_A_N = re.compile(r"^il y a\s+(\d+)\s+(jour|jours|semaine|semaines)$")
 
 
 def _get_timezone_name() -> str:
@@ -48,8 +80,26 @@ def get_timezone_name() -> str:
 
 
 def resolve_relative_date(expression: str) -> str | None:
-    """Return the ISO date string for a simple relative date expression, or None if unrecognised."""
+    """Return the ISO date string for a simple relative date expression, or None if unrecognised.
+
+    Supports a small, deterministic set of EN/FR phrases:
+
+    - ``today / yesterday / tomorrow`` (and ``aujourd'hui / hier / demain``)
+    - ``this / last / next week`` (and ``cette / la semaine dernière / prochaine``),
+      always anchored to the Monday of the target week
+    - ``next <weekday>`` / ``last <weekday>`` (and ``<weekday> prochain / dernier``),
+      where "next" is the first occurrence strictly after today and "last"
+      the most recent occurrence strictly before today
+    - ``in N days / weeks`` and ``N days / weeks ago``
+      (and ``dans N jours / semaines``, ``il y a N jours / semaines``)
+
+    Anything outside this set returns ``None`` and is expected to fall through
+    to the model with the time context already attached, rather than be
+    silently guessed here.
+    """
     expr = expression.lower().strip()
+    if not expr:
+        return None
     today = now().date()
     mapping = {
         "today":                        timedelta(0),
@@ -77,6 +127,53 @@ def resolve_relative_date(expression: str) -> str | None:
         monday = today - timedelta(days=today.weekday()) + timedelta(days=week_offsets[expr])
         return monday.isoformat()
 
+    # "next monday" / "last friday" / "lundi prochain" / "vendredi dernier".
+    # "next" is the first occurrence strictly after today; "last" the most
+    # recent strictly before today (today itself never matches).
+    weekday_match = _parse_weekday_expr(expr)
+    if weekday_match is not None:
+        direction, target = weekday_match
+        if direction == "next":
+            delta = (target - today.weekday()) % 7 or 7
+            return (today + timedelta(days=delta)).isoformat()
+        back = (today.weekday() - target) % 7 or 7
+        return (today - timedelta(days=back)).isoformat()
+
+    # Numeric offsets: "in N days/weeks" and "N days/weeks ago", EN + FR
+    offset = _parse_numeric_offset(expr)
+    if offset is not None:
+        return (today + timedelta(days=offset)).isoformat()
+
+    return None
+
+
+def _parse_weekday_expr(expr: str) -> tuple[str, int] | None:
+    """Return (direction, weekday_index) for "next/last <weekday>" forms."""
+    m = _EN_NEXT_LAST_WEEKDAY.match(expr)
+    if m is not None:
+        return (m.group(1), _WEEKDAY_INDEX[m.group(2)])
+    m = _FR_WEEKDAY_NEXT_LAST.match(expr)
+    if m is not None:
+        direction = "next" if m.group(2) == "prochain" else "last"
+        return (direction, _WEEKDAY_INDEX[m.group(1)])
+    return None
+
+
+def _parse_numeric_offset(expr: str) -> int | None:
+    """Return a signed day offset for "in N days/weeks" and "N days/weeks ago"."""
+    for pattern, sign in (
+        (_EN_IN_N,    +1),
+        (_FR_DANS_N,  +1),
+        (_EN_N_AGO,   -1),
+        (_FR_IL_Y_A_N, -1),
+    ):
+        m = pattern.match(expr)
+        if m is None:
+            continue
+        n = int(m.group(1))
+        unit = m.group(2)
+        days = n * 7 if unit.startswith(("week", "semaine")) else n
+        return sign * days
     return None
 
 

--- a/tests/test_time_context.py
+++ b/tests/test_time_context.py
@@ -197,8 +197,10 @@ def test_resolve_next_week_is_monday_after_this_week():
 
 def test_resolve_unknown_returns_none():
     assert resolve_relative_date("last year") is None
+    # Number words ("three") are intentionally not parsed — only digits are.
     assert resolve_relative_date("in three days") is None
     assert resolve_relative_date("") is None
+    assert resolve_relative_date("   ") is None
 
 
 def test_resolve_case_insensitive():
@@ -208,3 +210,121 @@ def test_resolve_case_insensitive():
 
 def test_resolve_strips_whitespace():
     assert resolve_relative_date("  tomorrow  ") == resolve_relative_date("tomorrow")
+
+
+# ── Relative date — weekday names ────────────────────────────────────────────
+
+
+def test_resolve_next_weekday_is_strictly_in_the_future():
+    today = _today_in_tz()
+    today_name = ("monday", "tuesday", "wednesday", "thursday",
+                  "friday", "saturday", "sunday")[today.weekday()]
+    result = date.fromisoformat(resolve_relative_date(f"next {today_name}"))
+    # "next monday" on a Monday is the Monday seven days from now, never today.
+    assert result == today + timedelta(days=7)
+
+
+def test_resolve_last_weekday_is_strictly_in_the_past():
+    today = _today_in_tz()
+    today_name = ("monday", "tuesday", "wednesday", "thursday",
+                  "friday", "saturday", "sunday")[today.weekday()]
+    result = date.fromisoformat(resolve_relative_date(f"last {today_name}"))
+    assert result == today - timedelta(days=7)
+
+
+def test_resolve_next_weekday_lands_on_target_weekday():
+    today = _today_in_tz()
+    for idx, name in enumerate(("monday", "tuesday", "wednesday", "thursday",
+                                "friday", "saturday", "sunday")):
+        result = date.fromisoformat(resolve_relative_date(f"next {name}"))
+        assert result.weekday() == idx
+        assert result > today
+
+
+def test_resolve_last_weekday_lands_on_target_weekday():
+    today = _today_in_tz()
+    for idx, name in enumerate(("monday", "tuesday", "wednesday", "thursday",
+                                "friday", "saturday", "sunday")):
+        result = date.fromisoformat(resolve_relative_date(f"last {name}"))
+        assert result.weekday() == idx
+        assert result < today
+
+
+def test_resolve_french_weekday_prochain():
+    today = _today_in_tz()
+    result = date.fromisoformat(resolve_relative_date("mardi prochain"))
+    assert result.weekday() == 1
+    assert result > today
+
+
+def test_resolve_french_weekday_dernier():
+    today = _today_in_tz()
+    result = date.fromisoformat(resolve_relative_date("vendredi dernier"))
+    assert result.weekday() == 4
+    assert result < today
+
+
+def test_resolve_bare_weekday_returns_none():
+    # "monday" alone is ambiguous (next or last?) — leave it to the model.
+    assert resolve_relative_date("monday") is None
+    assert resolve_relative_date("lundi") is None
+
+
+# ── Relative date — numeric offsets ──────────────────────────────────────────
+
+
+def test_resolve_in_n_days():
+    today = _today_in_tz()
+    assert resolve_relative_date("in 3 days") == (today + timedelta(days=3)).isoformat()
+    assert resolve_relative_date("in 1 day") == (today + timedelta(days=1)).isoformat()
+    assert resolve_relative_date("in 0 days") == today.isoformat()
+
+
+def test_resolve_n_days_ago():
+    today = _today_in_tz()
+    assert resolve_relative_date("3 days ago") == (today - timedelta(days=3)).isoformat()
+    assert resolve_relative_date("1 day ago") == (today - timedelta(days=1)).isoformat()
+
+
+def test_resolve_in_n_weeks():
+    today = _today_in_tz()
+    assert resolve_relative_date("in 2 weeks") == (today + timedelta(days=14)).isoformat()
+    assert resolve_relative_date("in 1 week") == (today + timedelta(days=7)).isoformat()
+
+
+def test_resolve_n_weeks_ago():
+    today = _today_in_tz()
+    assert resolve_relative_date("2 weeks ago") == (today - timedelta(days=14)).isoformat()
+
+
+def test_resolve_french_dans_n_jours():
+    today = _today_in_tz()
+    assert resolve_relative_date("dans 3 jours") == (today + timedelta(days=3)).isoformat()
+    assert resolve_relative_date("dans 1 jour") == (today + timedelta(days=1)).isoformat()
+
+
+def test_resolve_french_il_y_a_n_jours():
+    today = _today_in_tz()
+    assert resolve_relative_date("il y a 5 jours") == (today - timedelta(days=5)).isoformat()
+
+
+def test_resolve_french_dans_n_semaines():
+    today = _today_in_tz()
+    assert resolve_relative_date("dans 2 semaines") == (today + timedelta(days=14)).isoformat()
+
+
+def test_resolve_french_il_y_a_n_semaines():
+    today = _today_in_tz()
+    assert resolve_relative_date("il y a 1 semaine") == (today - timedelta(days=7)).isoformat()
+
+
+def test_resolve_numeric_offset_case_insensitive():
+    assert resolve_relative_date("IN 3 DAYS") == resolve_relative_date("in 3 days")
+
+
+def test_resolve_numeric_offset_malformed_returns_none():
+    # Negative numbers, decimals, missing units — all fall through.
+    assert resolve_relative_date("in -1 days") is None
+    assert resolve_relative_date("in 1.5 days") is None
+    assert resolve_relative_date("in days") is None
+    assert resolve_relative_date("3 days") is None  # missing "ago" / "in"


### PR DESCRIPTION
## Summary

Extend `core/time_context.py::resolve_relative_date()` with a small, deterministic set of additional phrases. This is the next foundational step in §4.4 of `docs/cognitive-copilot-roadmap.md` (and listed in §10 under "Time / context (Phase 1)").

Newly recognised phrases (all return an ISO date or `None`):

- `next <weekday>` / `last <weekday>` — EN, strict (today is never matched)
- `<weekday> prochain` / `<weekday> dernier` — FR equivalent
- `in N days` / `in N weeks` and `N days ago` / `N weeks ago` — EN
- `dans N jours` / `dans N semaines` and `il y a N jours` / `il y a N semaines` — FR

Anything outside this fixed set continues to return `None` and falls through to the model with the existing time-context block attached, exactly as the roadmap mandates ("Cases the resolver does not recognise should fall through to the model with the time context attached, not be silently guessed").

## Why this is foundational

- **Deterministic, auditable.** Date math stays in code, not "what the LLM felt like."
- **Local-first / no new dependencies.** Pure stdlib regex + `datetime`.
- **No autonomy added.** Resolver returns a string or `None`; nothing is acted on.
- **No schema, no prompt, no migration.** Pure additive change inside one helper.
- **Coarse but useful.** Bare weekday names (`monday`, `lundi`) intentionally remain unresolved — they are ambiguous between past and future, so they are left to the model rather than silently guessed.

## What this PR does *not* do

- No changes to the system prompt, no new prompt blocks.
- No changes to retrieval, memory, routing, or any other module.
- No number-word parsing (`"in three days"` still returns `None`).
- No autonomous behaviour, no background work, no git/GitHub writes.

## Test plan

- [x] Existing time-context tests still pass.
- [x] New tests cover: weekday next/last (EN + FR) for all 7 days, "today is never matched", numeric day/week offsets (EN + FR), case insensitivity, malformed inputs (negative, decimal, missing unit).
- [x] `python3 -m pytest tests/test_time_context.py -v` → **44 passed**.

https://claude.ai/code/session_01Mj4afeeGDwe4VCkqk469dt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mj4afeeGDwe4VCkqk469dt)_