### PR TITLE
refactor(ui): unify composer and soften sidebar / welcome polish

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -210,7 +210,7 @@
         }
 
         #sidebar-header {
-            padding: 18px 18px 12px;
+            padding: 18px 16px 10px;
             display: flex;
             align-items: center;
             justify-content: space-between;
@@ -218,9 +218,9 @@
 
         #sidebar-header span {
             color: var(--text);
-            font-size: 1rem;
+            font-size: 0.95rem;
             font-weight: 600;
-            letter-spacing: 0.18em;
+            letter-spacing: 0.20em;
             display: inline-flex;
             align-items: center;
             gap: 8px;
@@ -228,41 +228,42 @@
 
         #sidebar-header span::before {
             content: '';
-            width: 7px;
-            height: 7px;
+            width: 6px;
+            height: 6px;
             border-radius: 50%;
             background: var(--cyan);
-            box-shadow: 0 0 12px var(--cyan-glow);
+            box-shadow: 0 0 10px var(--cyan-glow);
         }
 
         #new-conv-btn {
-            padding: 7px 12px;
-            background: var(--cyan-soft);
-            border: 1px solid transparent;
+            padding: 6px 12px;
+            background: transparent;
+            border: 1px solid var(--border-soft);
             border-radius: var(--r-pill);
-            color: var(--cyan);
-            font-size: 0.78rem;
+            color: var(--text-mid);
+            font-size: 0.76rem;
             font-weight: 500;
             cursor: pointer;
-            transition: background var(--t-base), color var(--t-base), transform var(--t-fast);
+            transition: background var(--t-base), color var(--t-base), border-color var(--t-base), transform var(--t-fast);
             white-space: nowrap;
         }
 
         #new-conv-btn:hover {
-            background: var(--cyan);
-            color: #06181c;
+            background: var(--cyan-soft);
+            border-color: var(--cyan-glow);
+            color: var(--cyan);
         }
         #new-conv-btn:active { transform: scale(0.97); }
 
         #conversations-list {
             flex: 1;
             overflow-y: auto;
-            padding: 6px 10px 10px;
+            padding: 4px 8px 10px;
         }
 
         .conv-item {
-            padding: 10px 12px;
-            border-radius: var(--r-md);
+            padding: 9px 12px;
+            border-radius: 10px;
             cursor: pointer;
             display: flex;
             align-items: center;
@@ -273,11 +274,12 @@
             position: relative;
         }
 
-        .conv-item:hover { background: var(--bg3); }
+        .conv-item + .conv-item { margin-top: 1px; }
+
+        .conv-item:hover { background: rgba(255, 255, 255, 0.025); }
         .conv-item.active {
-            background: var(--bg-elev);
+            background: rgba(255, 255, 255, 0.04);
             color: var(--text);
-            box-shadow: inset 0 0 0 1px var(--border);
         }
         .conv-item.active::before {
             content: '';
@@ -285,21 +287,25 @@
             left: 4px;
             top: 50%;
             transform: translateY(-50%);
-            width: 3px;
-            height: 16px;
+            width: 2px;
+            height: 14px;
             border-radius: var(--r-pill);
             background: var(--cyan);
-            box-shadow: 0 0 10px var(--cyan-glow);
+            box-shadow: 0 0 8px var(--cyan-glow);
         }
 
         .conv-title {
             flex: 1;
-            font-size: 0.86rem;
+            font-size: 0.85rem;
             color: var(--text);
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            letter-spacing: 0.005em;
         }
+
+        .conv-item:not(.active) .conv-title { color: var(--text-mid); }
+        .conv-item:hover .conv-title { color: var(--text); }
 
         .conv-delete {
             color: var(--text-dim);
@@ -317,15 +323,15 @@
         .conv-delete:hover { color: var(--danger); background: rgba(224, 136, 129, 0.08); opacity: 1; }
 
         #conv-search-wrap {
-            padding: 4px 14px 12px;
+            padding: 2px 12px 10px;
         }
 
         #conv-search {
             width: 100%;
-            padding: 9px 12px;
-            background: var(--bg3);
-            border: 1px solid var(--border);
-            border-radius: var(--r-md);
+            padding: 8px 12px;
+            background: rgba(255, 255, 255, 0.025);
+            border: 1px solid transparent;
+            border-radius: 10px;
             color: var(--text);
             font-size: 0.82rem;
             outline: none;
@@ -335,16 +341,16 @@
         #conv-search:focus {
             border-color: var(--cyan-glow);
             box-shadow: 0 0 0 3px var(--cyan-soft);
-            background: var(--bg-elev);
+            background: rgba(255, 255, 255, 0.04);
         }
         #conv-search::placeholder { color: var(--text-dim); }
 
         .conv-group-header {
-            font-size: 0.68rem;
+            font-size: 0.66rem;
             color: var(--text-dim);
             text-transform: uppercase;
-            letter-spacing: 0.14em;
-            padding: 14px 12px 6px;
+            letter-spacing: 0.16em;
+            padding: 14px 14px 6px;
             font-weight: 500;
         }
 
@@ -355,28 +361,28 @@
         }
 
         #sidebar-footer {
-            padding: 12px 14px 14px;
+            padding: 10px 10px 14px;
             position: relative;
         }
         #sidebar-footer::before {
             content: '';
             position: absolute;
             top: 0;
-            left: 14px;
-            right: 14px;
+            left: 18px;
+            right: 18px;
             height: 1px;
-            background: linear-gradient(90deg, transparent, var(--border), transparent);
+            background: linear-gradient(90deg, transparent, var(--border-soft), transparent);
         }
 
         #current-user-card {
             display: flex;
             align-items: center;
             gap: 10px;
-            padding: 10px 12px;
-            background: var(--bg3);
-            border: 1px solid var(--border-soft);
-            border-radius: var(--r-md);
-            margin-bottom: 10px;
+            padding: 9px 12px;
+            background: rgba(255, 255, 255, 0.025);
+            border: 1px solid transparent;
+            border-radius: 10px;
+            margin: 4px 4px 6px;
             font-size: 0.8rem;
         }
 
@@ -407,17 +413,19 @@
 
         #logout-btn {
             width: 100%;
-            padding: 9px;
+            padding: 9px 12px;
             background: transparent;
-            border: 1px solid var(--border);
-            border-radius: var(--r-md);
+            border: 1px solid transparent;
+            border-radius: 10px;
             color: var(--text-dim);
             font-size: 0.82rem;
             cursor: pointer;
-            transition: border-color var(--t-base), color var(--t-base), background var(--t-base);
+            text-align: left;
+            transition: color var(--t-base), background var(--t-base);
+            margin-top: 4px;
         }
 
-        #logout-btn:hover { border-color: rgba(224, 136, 129, 0.4); color: var(--danger); background: rgba(224, 136, 129, 0.06); }
+        #logout-btn:hover { color: var(--danger); background: rgba(224, 136, 129, 0.06); }
 
         /* Delete confirmation inline state */
         .conv-item.confirming {
@@ -476,8 +484,8 @@
         }
 
         #chat-header {
-            padding: 14px 22px;
-            background: rgba(19, 21, 23, 0.6);
+            padding: 14px 24px;
+            background: rgba(19, 21, 23, 0.55);
             backdrop-filter: blur(14px);
             -webkit-backdrop-filter: blur(14px);
             display: flex;
@@ -490,9 +498,9 @@
         #chat-header::after {
             content: '';
             position: absolute;
-            left: 16px; right: 16px; bottom: 0;
+            left: 24px; right: 24px; bottom: 0;
             height: 1px;
-            background: linear-gradient(90deg, transparent, var(--border), transparent);
+            background: linear-gradient(90deg, transparent, var(--border-soft), transparent);
         }
 
         #menu-toggle {
@@ -522,10 +530,10 @@
         #model-badge {
             font-size: 0.72rem;
             color: var(--text-mid);
-            background: var(--bg3);
+            background: rgba(255, 255, 255, 0.025);
             padding: 5px 11px;
             border-radius: var(--r-pill);
-            border: 1px solid var(--border-soft);
+            border: 1px solid transparent;
             flex-shrink: 0;
             white-space: nowrap;
             font-weight: 500;
@@ -535,7 +543,7 @@
         #messages {
             flex: 1;
             overflow-y: auto;
-            padding: 28px 22px 24px;
+            padding: 28px 26px 16px;
             display: flex;
             flex-direction: column;
             gap: 18px;
@@ -612,19 +620,20 @@
             align-items: center;
             justify-content: center;
             color: var(--text-dim);
-            gap: 14px;
-            padding: 32px 20px;
+            gap: 12px;
+            padding: 40px 24px 24px;
         }
 
         #empty-state h2 {
             color: var(--text);
-            font-size: 1.6rem;
+            font-size: 1.7rem;
             font-weight: 500;
-            letter-spacing: 0.16em;
-            background: linear-gradient(180deg, #ffffff, var(--cyan) 140%);
+            letter-spacing: 0.20em;
+            background: linear-gradient(180deg, #ffffff, var(--cyan) 150%);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;
+            margin-bottom: 4px;
         }
 
         #empty-state-title {
@@ -635,7 +644,7 @@
         }
 
         #empty-state-hint {
-            font-size: 0.85rem;
+            font-size: 0.84rem;
             color: var(--text-dim);
             text-align: center;
             max-width: 380px;
@@ -646,16 +655,16 @@
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
             gap: 10px;
-            margin-top: 14px;
+            margin-top: 22px;
             width: 100%;
-            max-width: 600px;
+            max-width: 620px;
         }
 
         .suggest-chip {
-            background: var(--bg3);
+            background: rgba(255, 255, 255, 0.02);
             border: 1px solid var(--border-soft);
-            border-radius: var(--r-md);
-            padding: 12px 16px;
+            border-radius: 14px;
+            padding: 14px 16px;
             color: var(--text-mid);
             font-size: 0.88rem;
             text-align: left;
@@ -667,7 +676,7 @@
         .suggest-chip:hover {
             border-color: var(--cyan-glow);
             color: var(--text);
-            background: var(--bg-elev);
+            background: rgba(124, 197, 212, 0.05);
             transform: translateY(-1px);
             box-shadow: var(--shadow-md);
         }
@@ -681,7 +690,7 @@
         /* ── MODE SELECTOR ── */
         #mode-bar, #input-area { width: 100%; }
         #mode-bar {
-            padding: 8px 22px 4px;
+            padding: 10px 26px 2px;
             background: transparent;
             display: flex;
             align-items: center;
@@ -690,23 +699,23 @@
         }
 
         #mode-label-text {
-            font-size: 0.72rem;
+            font-size: 0.7rem;
             color: var(--text-dim);
             flex-shrink: 0;
             text-transform: uppercase;
-            letter-spacing: 0.1em;
+            letter-spacing: 0.12em;
             font-weight: 500;
         }
 
         #mode-wrapper { position: relative; }
 
         #mode-toggle-btn {
-            padding: 6px 14px;
+            padding: 5px 12px;
             border-radius: var(--r-pill);
-            border: 1px solid var(--border);
-            background: var(--bg3);
+            border: 1px solid var(--border-soft);
+            background: transparent;
             color: var(--text-mid);
-            font-size: 0.78rem;
+            font-size: 0.76rem;
             font-weight: 500;
             cursor: pointer;
             transition: border-color var(--t-base), color var(--t-base), background var(--t-base);
@@ -770,96 +779,133 @@
 
         .mode-option.active .mode-desc { color: var(--cyan-dim); }
 
-        /* ── INPUT ── */
+        /* ── COMPOSER ──
+           One unified rounded surface holding the textarea and the
+           camera / search / send controls, so the bar reads as a single
+           premium input rather than four adjacent rectangles. */
         #input-area {
-            padding: 12px 22px 18px;
-            background: transparent;
+            margin: 4px 24px 20px;
+            padding: 6px 6px 6px 14px;
+            background: linear-gradient(180deg, rgba(28, 31, 35, 0.72), rgba(22, 24, 27, 0.72));
+            border: 1px solid var(--border-soft);
+            border-radius: 22px;
             display: flex;
-            gap: 8px;
+            gap: 4px;
             align-items: flex-end;
             flex-shrink: 0;
+            box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.025);
+            backdrop-filter: blur(14px) saturate(140%);
+            -webkit-backdrop-filter: blur(14px) saturate(140%);
+            transition: border-color var(--t-base), box-shadow var(--t-base), background var(--t-base);
+        }
+
+        #input-area:focus-within {
+            border-color: var(--cyan-glow);
+            box-shadow: 0 0 0 3px var(--cyan-soft), var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+            background: linear-gradient(180deg, rgba(32, 36, 41, 0.85), rgba(25, 28, 32, 0.85));
         }
 
         #user-input {
             flex: 1;
-            padding: 14px 18px;
-            background: var(--bg3);
-            border: 1px solid var(--border);
-            border-radius: var(--r-lg);
+            padding: 9px 4px;
+            background: transparent;
+            border: none;
+            border-radius: 0;
             color: var(--text);
             font-size: 0.95rem;
             line-height: 1.5;
-            min-height: 50px;
-            max-height: 240px;
+            min-height: 40px;
+            max-height: 220px;
             outline: none;
             resize: none;
             overflow-y: auto;
-            transition: border-color var(--t-base), box-shadow var(--t-base), background var(--t-base);
             min-width: 0;
             width: 100%;
-            box-shadow: var(--shadow-sm);
+            box-shadow: none;
+            transition: none;
         }
 
         #user-input:focus {
-            border-color: var(--cyan-glow);
-            box-shadow: 0 0 0 4px var(--cyan-soft), var(--shadow-md);
-            background: var(--bg-elev);
+            background: transparent;
+            border: none;
+            box-shadow: none;
         }
         #user-input::placeholder { color: var(--text-dim); }
 
-        #send-btn {
-            padding: 0 20px;
-            background: linear-gradient(180deg, var(--cyan), var(--cyan-dim));
-            border: none;
-            border-radius: var(--r-lg);
-            color: #06181c;
-            font-weight: 600;
-            font-size: 0.92rem;
-            letter-spacing: 0.02em;
-            cursor: pointer;
-            height: 50px;
-            transition: filter var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
-            white-space: nowrap;
-            flex-shrink: 0;
-            box-shadow: var(--shadow-sm), 0 0 0 1px rgba(255,255,255,0.04) inset;
-        }
-
-        #send-btn:hover { filter: brightness(1.08); box-shadow: var(--shadow-md), var(--shadow-glow); }
-        #send-btn:active { transform: translateY(1px); }
-
         #search-btn,
         #image-btn {
-            padding: 0 14px;
-            background: var(--bg3);
-            border: 1px solid var(--border);
-            border-radius: var(--r-lg);
+            padding: 0;
+            background: transparent;
+            border: 1px solid transparent;
+            border-radius: var(--r-pill);
             color: var(--text-mid);
             font-size: 1rem;
             cursor: pointer;
-            height: 50px;
-            min-width: 50px;
-            transition: border-color var(--t-base), color var(--t-base), background var(--t-base), box-shadow var(--t-base);
+            height: 40px;
+            width: 40px;
+            min-width: 40px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition: color var(--t-base), background var(--t-base), border-color var(--t-base), transform var(--t-fast);
             flex-shrink: 0;
         }
 
         #search-btn:hover,
         #image-btn:hover {
-            border-color: var(--cyan-glow);
             color: var(--cyan);
             background: var(--cyan-soft);
+        }
+
+        #search-btn:focus-visible,
+        #image-btn:focus-visible {
+            outline: none;
+            color: var(--cyan);
+            background: var(--cyan-soft);
+            border-color: var(--cyan-glow);
         }
 
         #search-btn.active,
         #image-btn.active {
-            border-color: var(--cyan-glow);
             color: var(--cyan);
             background: var(--cyan-soft);
-            box-shadow: 0 0 0 3px var(--cyan-soft);
+            border-color: var(--cyan-glow);
+        }
+
+        #send-btn {
+            padding: 0 18px;
+            background: linear-gradient(180deg, var(--cyan), var(--cyan-dim));
+            border: none;
+            border-radius: 14px;
+            color: #06181c;
+            font-weight: 600;
+            font-size: 0.85rem;
+            letter-spacing: 0.02em;
+            cursor: pointer;
+            height: 40px;
+            margin-left: 4px;
+            transition: filter var(--t-base), box-shadow var(--t-base), transform var(--t-fast);
+            white-space: nowrap;
+            flex-shrink: 0;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+        }
+
+        #send-btn:hover {
+            filter: brightness(1.08);
+            box-shadow: 0 4px 14px rgba(124, 197, 212, 0.20), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+        }
+        #send-btn:active { transform: translateY(1px); }
+        #send-btn:disabled {
+            background: transparent;
+            color: var(--text-dim);
+            cursor: not-allowed;
+            box-shadow: none;
+            filter: none;
         }
 
         #image-preview {
             display: none;
-            padding: 10px 22px;
+            padding: 6px 24px 0;
             background: transparent;
             align-items: center;
             gap: 12px;
@@ -868,21 +914,21 @@
         #image-preview.show { display: flex; }
 
         #preview-img {
-            height: 64px;
-            width: 64px;
+            height: 56px;
+            width: 56px;
             object-fit: cover;
             border-radius: var(--r-md);
-            border: 1px solid var(--border);
+            border: 1px solid var(--border-soft);
             box-shadow: var(--shadow-sm);
         }
 
         #remove-image {
             background: transparent;
-            border: 1px solid var(--border);
+            border: 1px solid var(--border-soft);
             border-radius: var(--r-pill);
             color: var(--text-dim);
             cursor: pointer;
-            font-size: 0.9rem;
+            font-size: 0.85rem;
             padding: 4px 12px;
             transition: border-color var(--t-base), color var(--t-base), background var(--t-base);
         }
@@ -890,13 +936,6 @@
             border-color: rgba(224, 136, 129, 0.4);
             color: var(--danger);
             background: rgba(224, 136, 129, 0.06);
-        }
-        #send-btn:disabled {
-            background: var(--bg3);
-            color: var(--text-dim);
-            cursor: not-allowed;
-            box-shadow: none;
-            filter: none;
         }
 
         /* ── MOBILE ── */
@@ -1394,33 +1433,35 @@
 
         #settings-btn {
             width: 100%;
-            padding: 9px;
+            padding: 9px 12px;
             background: transparent;
-            border: 1px solid var(--border);
-            border-radius: var(--r-md);
-            color: var(--text-dim);
+            border: 1px solid transparent;
+            border-radius: 10px;
+            color: var(--text-mid);
             font-size: 0.82rem;
             cursor: pointer;
-            transition: border-color var(--t-base), color var(--t-base), background var(--t-base);
-            margin-top: 6px;
+            text-align: left;
+            transition: color var(--t-base), background var(--t-base);
+            margin-top: 2px;
         }
 
-        #settings-btn:hover { border-color: var(--cyan-glow); color: var(--cyan); background: var(--cyan-soft); }
+        #settings-btn:hover { color: var(--cyan); background: var(--cyan-soft); }
 
         #admin-btn {
             display: none;
             width: 100%;
-            padding: 9px;
+            padding: 9px 12px;
             background: transparent;
-            border: 1px solid var(--border);
-            border-radius: var(--r-md);
-            color: var(--text-dim);
+            border: 1px solid transparent;
+            border-radius: 10px;
+            color: var(--text-mid);
             font-size: 0.82rem;
             cursor: pointer;
-            transition: border-color var(--t-base), color var(--t-base), background var(--t-base);
-            margin-top: 6px;
+            text-align: left;
+            transition: color var(--t-base), background var(--t-base);
+            margin-top: 2px;
         }
-        #admin-btn:hover { border-color: var(--cyan-glow); color: var(--cyan); background: var(--cyan-soft); }
+        #admin-btn:hover { color: var(--cyan); background: var(--cyan-soft); }
 
         #lang-btn {
             padding: 5px 10px;


### PR DESCRIPTION
## Summary

CSS-only refinements to `static/index.html` to polish the existing
interface — no redesign, no behaviour changes, no new dependencies.

## Before / After notes

**Composer (bottom input bar)**
- Before: textarea, camera, search and send sat as four separate
  bordered rectangles with their own backgrounds and shadows; the
  bar felt heavy and boxy.
- After: one rounded translucent surface (radius `22px`, soft
  border, subtle blur + inner highlight) hosts the textarea and
  controls. The textarea is now borderless inside the composer and
  blends seamlessly. Camera/search are pill-shaped icon buttons that
  sit *inside* the composer with calm hover/focus washes; send is a
  smaller rounded button visually balanced with their height.
  Focus state lifts the whole composer with a single soft cyan ring
  via `:focus-within` instead of decorating the textarea alone.

**Sidebar**
- Before: conv-search and conv-items used solid `bg3`/`bg-elev`
  fills with `1px var(--border)` outlines, plus a `3 × 16` cyan
  pill on the active row. Footer buttons each had a full outline.
- After: search and rows use translucent white-on-dark fills
  (`rgba(255,255,255,0.025-0.04)`) and no border by default. Active
  conv shows a slimmer `2 × 14` cyan indicator. `Settings`,
  `Admin`, `Logout` are now borderless nav-style rows that highlight
  on hover. The right-edge separator and the section divider use
  the existing soft gradient.
- Conv-row typography is slightly lighter for inactive items, with
  a small letter-spacing bump for readability.

**Welcome / empty state**
- More breathing room above the suggestion grid (`margin-top` 14px → 22px,
  outer padding bumped). The `⬡ NOVA` wordmark gets a touch more size
  and letter-spacing. Suggestion chips use a softer rest fill and a
  gentle cyan-tinted hover wash instead of a flat `bg-elev` swap.

**Mode bar / chat header / model badge**
- Mode toggle is borderless transparent at rest with a softer
  hairline. Chat-header gradient rule is moved to `--border-soft`
  and pushed to the page margins for a cleaner edge. Model badge
  drops its always-on outline.

## Constraints respected

- HTML structure, IDs, and JS handlers are untouched (only CSS edits
  inside the existing `<style>` block).
- No backend changes, no new auth/admin/memory paths, no new
  dependencies, no Alpha-only surfaces exposed.
- `@media (prefers-reduced-motion: reduce)` block is preserved as-is.

## Test plan

- [ ] `Shift+Enter` / `Maj+Entrée` still inserts a newline; bare
      `Enter` still sends.
- [ ] Camera (📷) opens the file picker; image preview renders
      above the composer.
- [ ] Search (🔍) toggles its `.active` cyan state.
- [ ] Send button sends, swaps to "Stop" while streaming, and the
      disabled state still reads as muted.
- [ ] Settings, Admin, and Logout buttons in the sidebar footer
      open / behave exactly as before.
- [ ] Conversation list: hover, active indicator, delete-confirm
      flow still work.
- [ ] Existing pytest suite: no Python or HTML structural changes,
      so no test impact. (The sandbox here can't install
      `feedparser`'s legacy `sgmllib3k`, so a subset of tests can't
      collect — those failures predate this branch.)

https://claude.ai/code/session_01WPASnJXTbKqY1xgPkj8jtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPASnJXTbKqY1xgPkj8jtp)_