### PR TITLE
feat(ui): deterministic "continue where we left off" banner

### DIFF
--- a/core/session_continuity.py
+++ b/core/session_continuity.py
@@ -1,0 +1,280 @@
+"""
+Session continuity — a small, deterministic helper that builds a calm
+"continue where we left off" summary from the user's recent conversations.
+
+Design notes
+------------
+This module is intentionally tiny and local-first. It does **not**:
+
+- call any LLM or external service,
+- store hidden summaries,
+- infer mood, intent, or anything emotional,
+- run on a background loop.
+
+It only reads conversation rows the user already owns and produces a
+short, human-readable summary the UI can display once and dismiss. If
+the local signals are too weak to be useful, it returns
+``has_continuity=False`` and the UI shows nothing — silence is the
+correct fallback.
+
+The output is fully derived from data the user can already inspect in
+the sidebar. There is no information here that the user could not
+reconstruct themselves; the module just saves them a glance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timedelta
+from typing import Iterable, Optional
+
+from core.memory import load_conversations
+
+
+# How far back we look for "recent" activity. Past this horizon the
+# summary is too stale to be reassuring; we'd rather show nothing than
+# remind the user of something they finished weeks ago.
+RECENT_WINDOW_DAYS = 14
+
+# How many distinct titles we surface. Three is enough to feel grounded
+# without becoming a wall of text.
+MAX_TITLES = 3
+
+# How many topic tokens we extract. Same reasoning: terse beats noisy.
+MAX_TOPICS = 3
+
+# Minimum number of distinct, non-trivial conversations needed before we
+# show anything. With only one recent conversation the user is already
+# looking at it; the banner would just be repeating the obvious.
+MIN_CONVERSATIONS = 1
+
+# Generic "Nouvelle conversation" / "New conversation" titles carry no
+# information. They are filtered out before we look at content. The
+# match is intentionally case-insensitive and language-aware.
+_PLACEHOLDER_TITLE_RE = re.compile(
+    r"^\s*(nouvelle conversation|new conversation|untitled|sans titre)\s*$",
+    re.IGNORECASE,
+)
+
+# Pull `#123`-style issue/PR references straight out of titles. The
+# leading boundary keeps `pr#1` out — we want a real anchor.
+_PR_REF_RE = re.compile(r"(?<![A-Za-z0-9])#(\d{1,5})(?![A-Za-z0-9])")
+
+# Tokens we consider "interesting" for the topic list. We only keep
+# words that look like project / capability names, which on this
+# project tend to be CamelCase, ALL-CAPS, or names with internal
+# punctuation (e.g. `nova-voice`, `Piper`). Plain English filler is
+# dropped to keep the summary honest.
+_TOPIC_TOKEN_RE = re.compile(
+    r"\b("
+    r"[A-Z][A-Za-z0-9]+(?:[-_/][A-Za-z0-9]+)+"  # Nova-voice, Foo/Bar
+    r"|[A-Z]{2,}[A-Za-z0-9]*"  # ROCm, UI, API
+    r"|[A-Z][a-z]+[A-Z][A-Za-z0-9]*"  # CamelCase
+    r")\b"
+)
+
+# Words we never want to surface as a topic, even if they slip past
+# the token regex. Keep short and conservative; the goal is to avoid
+# obvious noise, not to exhaustively curate vocabulary.
+_TOPIC_STOPLIST = frozenset(
+    {
+        "I",
+        "Im",
+        "Ive",
+        "OK",
+        "TODO",
+        "FIXME",
+        "PR",
+        "PRs",
+        "Issue",
+        "Issues",
+    }
+)
+
+
+def _parse_iso(value: str | None) -> Optional[datetime]:
+    """Parse an ISO timestamp; return None if it's missing or malformed.
+
+    The store writes timestamps via ``datetime.now().isoformat()``, but
+    we still tolerate junk so a corrupt row never blocks the rest of
+    the summary.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_meaningful_title(title: str | None) -> bool:
+    if not title:
+        return False
+    stripped = title.strip()
+    if len(stripped) < 3:
+        return False
+    if _PLACEHOLDER_TITLE_RE.match(stripped):
+        return False
+    return True
+
+
+def _relative_label(when: datetime, now: datetime) -> str:
+    """Render ``when`` as a calm relative phrase like 'yesterday'.
+
+    The output is deliberately coarse: hour-level precision would
+    sound clinical, and Nova should sound like a colleague, not a log
+    file.
+    """
+    delta = now - when
+    if delta < timedelta(0):
+        # Clock skew: treat future timestamps as "just now" rather than
+        # surfacing a confusing negative duration.
+        return "just now"
+    if delta < timedelta(hours=1):
+        return "just now"
+    if delta < timedelta(hours=12) and when.date() == now.date():
+        return "earlier today"
+    if when.date() == now.date():
+        return "today"
+    if when.date() == (now - timedelta(days=1)).date():
+        return "yesterday"
+    days = delta.days
+    if days < 7:
+        return f"{days} days ago"
+    if days < 14:
+        return "last week"
+    weeks = days // 7
+    return f"{weeks} weeks ago"
+
+
+def _extract_topics(titles: Iterable[str]) -> list[str]:
+    """Pull a small, ordered list of topic tokens from recent titles.
+
+    Order is preserved by first appearance so the most recent
+    conversation's topics surface first. Duplicates (case-insensitive)
+    are dropped.
+    """
+    seen: dict[str, str] = {}
+    for title in titles:
+        # PR / issue references first — they're the most concrete signal.
+        for match in _PR_REF_RE.finditer(title):
+            label = f"PR #{match.group(1)}"
+            key = label.lower()
+            if key not in seen:
+                seen[key] = label
+            if len(seen) >= MAX_TOPICS:
+                return list(seen.values())
+        for match in _TOPIC_TOKEN_RE.finditer(title):
+            token = match.group(1)
+            if token in _TOPIC_STOPLIST:
+                continue
+            key = token.lower()
+            if key in seen:
+                continue
+            seen[key] = token
+            if len(seen) >= MAX_TOPICS:
+                return list(seen.values())
+    return list(seen.values())
+
+
+def _compose_summary(
+    titles: list[str],
+    topics: list[str],
+    last_label: str,
+) -> str:
+    """Build the one-line, plain-English banner string.
+
+    The phrasing is intentionally hedged ("focused on", "you were
+    working on") because we are summarising titles, not reading minds.
+    """
+    if topics:
+        if len(topics) == 1:
+            joined = topics[0]
+        elif len(topics) == 2:
+            joined = f"{topics[0]} and {topics[1]}"
+        else:
+            joined = ", ".join(topics[:-1]) + f", and {topics[-1]}"
+        return f"Last session ({last_label}) focused on {joined}."
+    # No structured topics — fall back to the most recent title verbatim.
+    # Quoting it makes clear we're echoing, not paraphrasing.
+    return f'Last session ({last_label}): "{titles[0]}".'
+
+
+def _fingerprint(titles: list[str], last_active_iso: str) -> str:
+    """A short stable hash of the summary inputs.
+
+    The UI uses this to remember which summary the user has already
+    dismissed. If new activity changes the fingerprint, the banner is
+    eligible to reappear; otherwise it stays hidden.
+    """
+    payload = "|".join([last_active_iso, *titles])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def build_session_continuity(
+    user_id: int,
+    *,
+    now: Optional[datetime] = None,
+    exclude_conversation_id: int | None = None,
+) -> dict:
+    """Return a small structured summary for the user's recent activity.
+
+    The returned dict always contains ``has_continuity``. When the
+    signal is too thin (no recent conversations, only placeholders,
+    only the conversation the user is already looking at), the rest of
+    the fields are omitted and the UI shows nothing.
+
+    Parameters
+    ----------
+    user_id:
+        Owner of the conversations being summarised. Memory scoping
+        is enforced by ``load_conversations`` upstream.
+    now:
+        Optional override for the current time (used by tests so the
+        relative-label logic is deterministic).
+    exclude_conversation_id:
+        If set, the conversation with this id is excluded from the
+        summary. Useful when the user already has that conversation
+        open — repeating its title back at them is noise.
+    """
+    now = now or datetime.now()
+    cutoff = now - timedelta(days=RECENT_WINDOW_DAYS)
+
+    rows = load_conversations(user_id) or []
+
+    recent: list[tuple[datetime, str]] = []
+    for row in rows:
+        if exclude_conversation_id is not None and row.get("id") == exclude_conversation_id:
+            continue
+        title = row.get("title")
+        if not _is_meaningful_title(title):
+            continue
+        updated = _parse_iso(row.get("updated"))
+        if updated is None or updated < cutoff:
+            continue
+        recent.append((updated, title.strip()))
+
+    if len(recent) < MIN_CONVERSATIONS:
+        return {"has_continuity": False}
+
+    # ``load_conversations`` already returns rows updated-DESC, but we
+    # re-sort defensively so callers can pass a list in any order.
+    recent.sort(key=lambda pair: pair[0], reverse=True)
+
+    titles = [title for _, title in recent[:MAX_TITLES]]
+    last_active_dt, _ = recent[0]
+    last_active_iso = last_active_dt.isoformat()
+    last_label = _relative_label(last_active_dt, now)
+    topics = _extract_topics(titles)
+    summary = _compose_summary(titles, topics, last_label)
+
+    return {
+        "has_continuity": True,
+        "summary": summary,
+        "last_active": last_active_iso,
+        "last_active_label": last_label,
+        "recent_titles": titles,
+        "topics": topics,
+        "fingerprint": _fingerprint(titles, last_active_iso),
+    }

--- a/static/index.html
+++ b/static/index.html
@@ -687,6 +687,59 @@
             box-shadow: 0 0 0 3px var(--cyan-soft);
         }
 
+        /* ── SESSION CONTINUITY ── */
+        /* A calm, low-contrast informational card. Lives above the
+           empty-state suggestion chips, dismissable, never modal. */
+        #continuity-card {
+            width: 100%;
+            max-width: 620px;
+            margin: 18px auto 0;
+            padding: 12px 14px;
+            background: rgba(124, 197, 212, 0.04);
+            border: 1px solid var(--border-soft);
+            border-radius: var(--r-md);
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            color: var(--text-mid);
+            font-size: 0.84rem;
+            line-height: 1.5;
+            opacity: 0;
+            transform: translateY(-4px);
+            transition: opacity var(--t-slow), transform var(--t-slow);
+        }
+        #continuity-card.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        #continuity-card .continuity-icon {
+            flex-shrink: 0;
+            color: var(--cyan-dim);
+            font-size: 0.78rem;
+            line-height: 1.5;
+            letter-spacing: 0.06em;
+        }
+        #continuity-card .continuity-text {
+            flex: 1;
+            color: var(--text-mid);
+        }
+        #continuity-card .continuity-dismiss {
+            flex-shrink: 0;
+            background: transparent;
+            border: none;
+            color: var(--text-dim);
+            font-size: 0.95rem;
+            line-height: 1;
+            cursor: pointer;
+            padding: 2px 6px;
+            border-radius: var(--r-sm);
+            transition: color var(--t-base), background var(--t-base);
+        }
+        #continuity-card .continuity-dismiss:hover {
+            color: var(--text);
+            background: rgba(255, 255, 255, 0.04);
+        }
+
         /* ── MODE SELECTOR ── */
         #mode-bar, #input-area { width: 100%; }
         #mode-bar {
@@ -2149,6 +2202,7 @@
                     <h2>⬡ NOVA</h2>
                     <span id="empty-state-title">Commence une nouvelle conversation</span>
                     <span id="empty-state-hint">Choisis une suggestion ou écris ta question</span>
+                    <div id="continuity-slot"></div>
                     <div id="suggestion-chips"></div>
                 </div>
             </div>
@@ -3322,6 +3376,10 @@
         if (currentConvId === null && allConversations.length > 0) {
             const sorted = [...allConversations].sort((a, b) => b.id - a.id);
             openConversation(sorted[0].id, sorted[0].title);
+        } else if (currentConvId === null) {
+            // No conversation auto-opened — surface the continuity hint
+            // on the empty-state landing pad.
+            renderSessionContinuity();
         }
     }
 
@@ -3420,10 +3478,86 @@
                 <h2>⬡ NOVA</h2>
                 <span id="empty-state-title">${t("empty_state")}</span>
                 <span id="empty-state-hint">${t("empty_state_hint")}</span>
+                <div id="continuity-slot"></div>
                 <div id="suggestion-chips"></div>
             </div>
         `;
         renderSuggestionChips();
+        renderSessionContinuity();
+    }
+
+    // ── SESSION CONTINUITY ──
+    // The dismissed-fingerprint is stored in localStorage so a calm
+    // "you were working on X" hint stops repeating once the user has
+    // acknowledged it. A new fingerprint (different recent titles)
+    // makes the banner eligible to reappear, which is the whole point.
+    const CONTINUITY_DISMISS_KEY = "nova_continuity_dismissed";
+
+    function readDismissedFingerprint() {
+        try { return localStorage.getItem(CONTINUITY_DISMISS_KEY) || ""; }
+        catch { return ""; }
+    }
+
+    function writeDismissedFingerprint(value) {
+        try { localStorage.setItem(CONTINUITY_DISMISS_KEY, value || ""); }
+        catch {}
+    }
+
+    async function renderSessionContinuity() {
+        const slot = document.getElementById("continuity-slot");
+        if (!slot) return;
+        slot.innerHTML = "";
+        // Only show on the empty / pre-conversation surface. Once the
+        // user is in a thread, the banner would be in the way.
+        if (currentConvId !== null) return;
+
+        let data = null;
+        try {
+            const res = await fetch("/session-continuity", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (!res.ok) return;
+            data = await res.json();
+        } catch { return; }
+
+        if (!data || !data.has_continuity) return;
+        if (!data.summary) return;
+        if (data.fingerprint && data.fingerprint === readDismissedFingerprint()) {
+            return;
+        }
+
+        const card = document.createElement("div");
+        card.id = "continuity-card";
+        card.setAttribute("role", "status");
+        card.setAttribute("aria-live", "polite");
+
+        const icon = document.createElement("span");
+        icon.className = "continuity-icon";
+        icon.textContent = "↻";
+        card.appendChild(icon);
+
+        const text = document.createElement("span");
+        text.className = "continuity-text";
+        text.textContent = data.summary;
+        card.appendChild(text);
+
+        const dismiss = document.createElement("button");
+        dismiss.type = "button";
+        dismiss.className = "continuity-dismiss";
+        dismiss.setAttribute("aria-label", "Dismiss");
+        dismiss.textContent = "✕";
+        dismiss.addEventListener("click", () => {
+            writeDismissedFingerprint(data.fingerprint || "");
+            card.classList.remove("visible");
+            // Wait for the fade-out before removing the node from the
+            // layout so the surrounding chips don't snap upward.
+            setTimeout(() => { card.remove(); }, 320);
+        });
+        card.appendChild(dismiss);
+
+        slot.appendChild(card);
+        // Trigger the fade-in on the next frame so the transition runs.
+        requestAnimationFrame(() => card.classList.add("visible"));
     }
 
     function newConversation() {

--- a/tests/test_session_continuity.py
+++ b/tests/test_session_continuity.py
@@ -1,0 +1,172 @@
+"""
+Tests for ``core.session_continuity``.
+
+The summariser is intentionally deterministic and local, so the tests
+pin its behaviour rather than its phrasing in detail. The shape of
+the output, the topic extraction, the recency window, and the
+"silence beats hallucination" rule each get their own case.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from core import memory as core_memory, users, session_continuity
+from memory import store as natural_store
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(username: str = "alice") -> int:
+    with sqlite3.connect(core_memory.DB_PATH) as conn:
+        return users.create_user(conn, username, "pw", role=users.ROLE_USER)
+
+
+def _set_updated(conv_id: int, when: datetime) -> None:
+    """Force a conversation's ``updated`` timestamp to ``when``.
+
+    ``create_conversation`` always stamps ``now()``; tests need to
+    place rows at controlled points in the past.
+    """
+    with sqlite3.connect(core_memory.DB_PATH) as conn:
+        conn.execute(
+            "UPDATE conversations SET updated = ? WHERE id = ?",
+            (when.isoformat(), conv_id),
+        )
+
+
+class TestEmptyAndStale:
+    def test_no_conversations_returns_no_continuity(self, db_path):
+        uid = _make_user()
+        result = session_continuity.build_session_continuity(uid)
+        assert result == {"has_continuity": False}
+
+    def test_only_placeholder_titles_returns_no_continuity(self, db_path):
+        uid = _make_user()
+        cid = core_memory.create_conversation("Nouvelle conversation", uid)
+        _set_updated(cid, datetime.now())
+        result = session_continuity.build_session_continuity(uid)
+        assert result == {"has_continuity": False}
+
+    def test_only_stale_conversations_returns_no_continuity(self, db_path):
+        """Conversations older than the window must be ignored.
+
+        Showing "you were doing X two months ago" is the wrong shape
+        for a continue-where-we-left-off card; silence is correct.
+        """
+        uid = _make_user()
+        cid = core_memory.create_conversation("Nova voice tuning", uid)
+        _set_updated(cid, datetime.now() - timedelta(days=60))
+        result = session_continuity.build_session_continuity(uid)
+        assert result == {"has_continuity": False}
+
+
+class TestBasicSummary:
+    def test_recent_conversation_produces_summary(self, db_path):
+        uid = _make_user()
+        cid = core_memory.create_conversation("Nova-voice improvements", uid)
+        now = datetime.now()
+        _set_updated(cid, now - timedelta(hours=2))
+        result = session_continuity.build_session_continuity(uid, now=now)
+        assert result["has_continuity"] is True
+        assert "Nova-voice" in result["summary"]
+        assert result["recent_titles"] == ["Nova-voice improvements"]
+        assert "Nova-voice" in result["topics"]
+        assert isinstance(result["fingerprint"], str) and len(result["fingerprint"]) >= 6
+
+    def test_pr_reference_surfaces_as_topic(self, db_path):
+        uid = _make_user()
+        cid = core_memory.create_conversation("Reviewing PR #154 piper integration", uid)
+        now = datetime.now()
+        _set_updated(cid, now - timedelta(hours=3))
+        result = session_continuity.build_session_continuity(uid, now=now)
+        assert result["has_continuity"] is True
+        assert "PR #154" in result["topics"]
+        assert "PR #154" in result["summary"]
+
+    def test_summary_uses_relative_label(self, db_path):
+        uid = _make_user()
+        cid = core_memory.create_conversation("UI refinements", uid)
+        now = datetime(2026, 5, 7, 10, 0, 0)
+        _set_updated(cid, now - timedelta(days=1))
+        result = session_continuity.build_session_continuity(uid, now=now)
+        assert result["last_active_label"] == "yesterday"
+        assert "yesterday" in result["summary"]
+
+
+class TestExclusionAndOrdering:
+    def test_excluded_conversation_is_skipped(self, db_path):
+        """Don't quote the conversation the user is already looking at."""
+        uid = _make_user()
+        a = core_memory.create_conversation("UI refinements", uid)
+        b = core_memory.create_conversation("Piper integration", uid)
+        now = datetime.now()
+        _set_updated(a, now - timedelta(hours=10))
+        _set_updated(b, now - timedelta(hours=2))
+        result = session_continuity.build_session_continuity(
+            uid, now=now, exclude_conversation_id=b
+        )
+        assert result["recent_titles"] == ["UI refinements"]
+
+    def test_titles_sorted_most_recent_first(self, db_path):
+        uid = _make_user()
+        old = core_memory.create_conversation("Older topic Foo", uid)
+        mid = core_memory.create_conversation("Mid topic Bar", uid)
+        new = core_memory.create_conversation("Newest topic Baz", uid)
+        now = datetime.now()
+        _set_updated(old, now - timedelta(days=5))
+        _set_updated(mid, now - timedelta(days=2))
+        _set_updated(new, now - timedelta(hours=1))
+        result = session_continuity.build_session_continuity(uid, now=now)
+        assert result["recent_titles"][0] == "Newest topic Baz"
+        # MAX_TITLES is 3 — all three should be present, newest first.
+        assert result["recent_titles"][:3] == [
+            "Newest topic Baz",
+            "Mid topic Bar",
+            "Older topic Foo",
+        ]
+
+
+class TestUserScoping:
+    def test_other_users_conversations_are_invisible(self, db_path):
+        """Continuity respects per-user scoping; no cross-user leakage."""
+        alice = _make_user("alice")
+        bob = _make_user("bob")
+        cid = core_memory.create_conversation("Bob's secret project", bob)
+        _set_updated(cid, datetime.now() - timedelta(hours=1))
+        result = session_continuity.build_session_continuity(alice)
+        assert result == {"has_continuity": False}
+
+
+class TestDeterminism:
+    def test_fingerprint_stable_for_same_inputs(self, db_path):
+        uid = _make_user()
+        cid = core_memory.create_conversation("Stable Fingerprint check", uid)
+        now = datetime(2026, 5, 7, 10, 0, 0)
+        _set_updated(cid, now - timedelta(hours=2))
+        a = session_continuity.build_session_continuity(uid, now=now)
+        b = session_continuity.build_session_continuity(uid, now=now)
+        assert a["fingerprint"] == b["fingerprint"]
+
+    def test_fingerprint_changes_when_titles_change(self, db_path):
+        uid = _make_user()
+        cid = core_memory.create_conversation("First topic Alpha", uid)
+        now = datetime(2026, 5, 7, 10, 0, 0)
+        _set_updated(cid, now - timedelta(hours=2))
+        before = session_continuity.build_session_continuity(uid, now=now)
+
+        cid2 = core_memory.create_conversation("Second topic Beta", uid)
+        _set_updated(cid2, now - timedelta(hours=1))
+        after = session_continuity.build_session_continuity(uid, now=now)
+
+        assert before["fingerprint"] != after["fingerprint"]

--- a/web.py
+++ b/web.py
@@ -20,6 +20,7 @@ from core.learner import learn_from_feeds
 from core.updater import check_and_update_models
 from core.chat import chat
 from core.memory_command import handle_manual_memory_command
+from core.session_continuity import build_session_continuity
 from core.memory import (
     initialize_db, load_memories, save_memory,
     create_conversation, load_conversations,
@@ -373,6 +374,21 @@ def login(request: LoginRequest, _: None = Depends(check_login_rate_limit)):
 @app.get("/conversations")
 def get_conversations(user: CurrentUser = Depends(get_current_user)):
     return load_conversations(user.id)
+
+
+@app.get("/session-continuity")
+def get_session_continuity(
+    exclude: int | None = None,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Return a small, deterministic summary of recent local activity.
+
+    See ``core/session_continuity.py`` for the design notes. The
+    endpoint never invents content: if there is nothing meaningful in
+    the user's recent conversations, ``has_continuity`` is False and
+    the UI shows nothing.
+    """
+    return build_session_continuity(user.id, exclude_conversation_id=exclude)
 
 
 @app.post("/conversations")


### PR DESCRIPTION
## Summary

A small, calm "continue where we left off" foundation for Nova, in keeping
with the cognitive-copilot roadmap's local-first / non-autonomous posture.
When the user has recent activity, the empty-state landing pad shows a
single dismissable card like:

> ↻  Last session (yesterday) focused on PR #154 and Piper integration.

If recent signal is too thin (no recent conversations, only placeholder
titles, only the conversation already open), the banner stays hidden —
silence beats hallucination.

## What this is

- A new `core/session_continuity.py` helper that reads `load_conversations`
  for the current user and produces a deterministic summary:
  - 14-day recency window (`RECENT_WINDOW_DAYS`)
  - up to 3 recent titles, most recent first
  - up to 3 topic tokens extracted by regex (`#NNN` PR/issue refs,
    CamelCase / hyphenated names, all-caps acronyms)
  - a coarse relative label (`yesterday` / `3 days ago` / `last week`)
  - a short stable `fingerprint` so the UI can suppress already-dismissed
    summaries until something changes
- A new `GET /session-continuity` endpoint (auth-scoped to the current
  user, with an optional `?exclude=<id>` so the active conversation isn't
  quoted back at the user).
- A new dismissable `#continuity-card` rendered into the empty state,
  matching Nova's existing soft typography / depth tokens (cyan-dim
  accent, fade-in transition, no modal popups).
- 11 tests in `tests/test_session_continuity.py` covering: empty/stale
  cases, summary shape, PR-ref topic extraction, relative labels,
  exclusion, ordering, per-user scoping, and fingerprint determinism.

## What this is **not**

- No LLM call, no embeddings pipeline, no autonomous planning, no mood
  inference, no engagement scoring.
- No hidden summary the user can't inspect — every input is a row already
  visible in the sidebar.
- No memory schema changes; existing conversations / memory behaviour is
  untouched.
- No cross-user visibility: continuity is filtered by `user_id` at the
  data layer (`load_conversations`).
- No new auth, admin, alpha-channel, or external service.

## Behaviour

- Shown only on the empty state (`currentConvId === null`), so an in-thread
  user is never interrupted.
- The dismiss button writes the fingerprint to `localStorage`; the card
  reappears only when recent titles change, not for every reload.
- If the user has only one freshly-created placeholder ("New conversation"),
  the helper returns `has_continuity: false` and nothing renders.

## Test plan

- [x] `pytest tests/test_session_continuity.py` — 11/11 passing
- [ ] Manual: open Nova fresh with several recent conversations → banner
      appears on empty state with the most recent topic
- [ ] Manual: dismiss → reload → banner stays hidden until activity
      changes
- [ ] Manual: open an existing conversation directly → banner does **not**
      render mid-thread
- [ ] Manual: mobile viewport — card flows under the suggestion chips
      without overflow

https://claude.ai/code/session_01JzvRTduwFMmjke5MpetUdh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzvRTduwFMmjke5MpetUdh)_