### PR TITLE
feat(security): read-only SilentGuard provider foundation (Phase 1)

### DIFF
--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -1,0 +1,78 @@
+"""
+Read-only security provider foundation for Nova (Phase 1).
+
+Nova is the cognitive / conversational layer. It does **not** enforce
+network policy, modify firewall rules, run privileged commands, or
+take autonomous security actions. SilentGuard (and any future
+security tool) remains the security/network engine.
+
+This package provides the smallest abstraction Nova needs to talk to
+such tools safely:
+
+  * a ``SecurityStatus`` snapshot describing whether a security
+    provider is reachable on this host.
+  * a ``SecurityProvider`` Protocol with a single ``get_status``
+    method that never raises.
+  * a ``NullSecurityProvider`` default so Nova works normally when
+    nothing is configured.
+  * a ``SilentGuardProvider`` that probes SilentGuard's local
+    presence (file-based today; ready for a future local read API).
+
+Higher layers — the existing per-user gate in
+``core.integrations.silentguard`` and the chat-side summariser in
+``core.security_feed`` — keep their current responsibilities. This
+package is a small, additive foundation, not a rewrite.
+
+See ``docs/silentguard-integration-roadmap.md`` for the broader
+design and the explicit non-goals (no blocking, no firewall
+mutations, no background polling, no autonomous behaviour).
+"""
+
+from core.security.provider import (
+    NullSecurityProvider,
+    SecurityProvider,
+    SecurityStatus,
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE,
+    now_iso,
+)
+from core.security.silentguard import SilentGuardProvider
+
+__all__ = [
+    "NullSecurityProvider",
+    "SecurityProvider",
+    "SecurityStatus",
+    "SilentGuardProvider",
+    "STATE_AVAILABLE",
+    "STATE_OFFLINE",
+    "STATE_UNAVAILABLE",
+    "default_provider",
+    "get_security_context_summary",
+    "now_iso",
+]
+
+
+def default_provider() -> SecurityProvider:
+    """Return the safe default security provider.
+
+    Currently always a ``NullSecurityProvider`` so Nova's behaviour is
+    unchanged when no provider has been wired up. Wiring a real
+    provider (e.g. ``SilentGuardProvider``) into the chat / web
+    paths is intentionally deferred to follow-up work.
+    """
+    return NullSecurityProvider()
+
+
+def get_security_context_summary(
+    provider: SecurityProvider | None = None,
+) -> dict:
+    """Return a small, prompt-friendly dict describing provider state.
+
+    The shape mirrors ``SecurityStatus.as_dict``: short scalar
+    fields only (``available``, ``service``, ``state``, ``message``,
+    ``timestamp``), no raw payloads. Falls back to the safe default
+    provider when no argument is supplied. Read-only.
+    """
+    active = provider if provider is not None else default_provider()
+    return active.get_status().as_dict()

--- a/core/security/provider.py
+++ b/core/security/provider.py
@@ -1,0 +1,112 @@
+"""
+Generic security provider foundation (Phase 1 — read-only).
+
+Nova's cognitive layer can describe security telemetry produced by an
+external monitoring tool, but Nova does not enforce or act. To keep
+that boundary explicit, the cognitive layer talks to security tools
+through a small ``SecurityProvider`` Protocol that exposes one read
+method: ``get_status``. Every implementation reports whether the
+underlying tool is reachable from this host, and never raises on the
+absent path.
+
+Boundaries enforced by this module (and by every implementation in
+this package):
+
+  * read-only — no writes, no deletions, no subprocess, no socket,
+    no DNS, no firewall action.
+  * graceful absence — a missing tool, an unreadable file, or any
+    transport error maps to a ``SecurityStatus`` with
+    ``available=False`` and an explanatory message.
+  * decoupled — providers must not import anything that requires the
+    backing tool to be installed. Importing the package on a host
+    that has never heard of SilentGuard must remain safe.
+
+This module deliberately ships only the foundation: status snapshots
+and the provider Protocol. Higher layers (the existing per-user
+``core.integrations.silentguard`` gate and the chat-side
+``core.security_feed`` summariser) keep their current
+responsibilities. See ``docs/silentguard-integration-roadmap.md`` for
+the broader design and the explicit non-goals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional, Protocol, runtime_checkable
+
+
+# Provider availability states. Kept as plain strings so the snapshot
+# round-trips through JSON without bespoke encoders.
+STATE_AVAILABLE = "available"      # tool is configured and reachable
+STATE_UNAVAILABLE = "unavailable"  # tool is not installed / not configured
+STATE_OFFLINE = "offline"          # tool is configured but not reachable
+
+
+@dataclass(frozen=True)
+class SecurityStatus:
+    """Read-only snapshot of one security provider's availability.
+
+    The shape is intentionally flat (``available`` / ``service`` /
+    ``state`` / ``message`` / ``timestamp``) so it can be surfaced as
+    JSON, logged, or threaded into a future prompt summary without a
+    schema-specific renderer.
+    """
+
+    available: bool
+    service: str
+    state: str
+    message: str = ""
+    timestamp: Optional[str] = None  # ISO-8601 UTC, when known
+
+    def as_dict(self) -> dict:
+        return {
+            "available": self.available,
+            "service": self.service,
+            "state": self.state,
+            "message": self.message,
+            "timestamp": self.timestamp,
+        }
+
+
+def now_iso() -> str:
+    """ISO-8601 UTC timestamp for status snapshots."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@runtime_checkable
+class SecurityProvider(Protocol):
+    """Read-only contract every security provider must satisfy.
+
+    Implementations expose a stable ``name`` and a ``get_status``
+    method. ``get_status`` must never raise: a missing tool, an
+    unreadable path, a network failure, or a config error all map to a
+    ``SecurityStatus`` with ``available=False`` and a short
+    explanatory message.
+    """
+
+    name: str
+
+    def get_status(self) -> SecurityStatus:
+        """Return a snapshot of provider availability. Never raises."""
+        ...
+
+
+class NullSecurityProvider:
+    """Default-safe provider that always reports unavailable.
+
+    Used when no security provider has been configured, so Nova
+    continues to work normally — the cognitive layer sees a calm
+    ``available=False`` state instead of an exception path.
+    """
+
+    name: str = "none"
+
+    def get_status(self) -> SecurityStatus:
+        return SecurityStatus(
+            available=False,
+            service=self.name,
+            state=STATE_UNAVAILABLE,
+            message="No security provider is configured.",
+            timestamp=now_iso(),
+        )

--- a/core/security/silentguard.py
+++ b/core/security/silentguard.py
@@ -1,0 +1,123 @@
+"""
+SilentGuardProvider — read-only foundation (Phase 1).
+
+This is the smallest possible adapter for SilentGuard, the external
+network-monitoring tool Nova integrates with. Phase 1 only answers
+one question: *is SilentGuard reachable on this host?* Reading
+events, listing connections, surfacing alerts, or any other slice of
+SilentGuard's state is intentionally **out of scope** for this PR
+and lives in follow-up work. See
+``docs/silentguard-integration-roadmap.md`` for the full plan and
+its non-goals.
+
+Boundaries (commitments, not aspirations):
+
+  * read-only — never writes, never spawns processes, never opens
+    sockets, never modifies firewall rules.
+  * graceful — every ``get_status`` call returns a ``SecurityStatus``,
+    even on error. A missing file, an unreadable path, or an
+    OS-level probe failure all map to ``available=False``.
+  * decoupled — does not import the per-user integration or the file
+    parser. Safe to import on hosts that have never installed
+    SilentGuard.
+
+The provider is structured so a future phase can swap the on-disk
+probe for a loopback HTTP probe (if SilentGuard ever ships a local
+read API) without touching callers above this layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from core.security.provider import (
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE,
+    SecurityStatus,
+    now_iso,
+)
+
+logger = logging.getLogger(__name__)
+
+NAME = "silentguard"
+
+# Default location SilentGuard writes to, mirroring
+# ``core.security_feed.DEFAULT_FEED_PATH``. Kept as a module-level
+# constant so the path is easy to override in tests via the
+# ``feed_path`` constructor argument or the
+# ``NOVA_SILENTGUARD_PATH`` env var.
+DEFAULT_SILENTGUARD_PATH = Path.home() / ".silentguard_memory.json"
+
+
+class SilentGuardProvider:
+    """Read-only security provider that probes SilentGuard's presence.
+
+    Phase 1 checks only that the on-disk memory file is reachable.
+    The provider returns ``available=True`` when the file exists and
+    is statable, and a calm ``available=False`` snapshot otherwise.
+    No file content is read here; parsing stays in
+    ``core.security_feed`` so this provider does not regress the
+    existing behaviour.
+    """
+
+    name: str = NAME
+
+    def __init__(self, feed_path: Optional[os.PathLike] = None) -> None:
+        self._explicit_path: Optional[Path] = (
+            Path(feed_path) if feed_path is not None else None
+        )
+
+    def _resolved_path(self) -> Path:
+        """Resolve the SilentGuard feed path, honouring the env override."""
+        if self._explicit_path is not None:
+            return self._explicit_path
+        override = os.environ.get("NOVA_SILENTGUARD_PATH")
+        if override:
+            return Path(override).expanduser()
+        return DEFAULT_SILENTGUARD_PATH
+
+    def get_status(self) -> SecurityStatus:
+        """Probe whether SilentGuard's local state is reachable.
+
+        Outcomes:
+          * file present and statable → ``available=True``,
+            ``state=available``.
+          * file simply missing       → ``available=False``,
+            ``state=unavailable``.
+          * probe raised ``OSError``  → ``available=False``,
+            ``state=offline``.
+
+        Never raises.
+        """
+        path = self._resolved_path()
+        timestamp = now_iso()
+        try:
+            present = path.is_file()
+        except OSError as exc:
+            logger.debug("SilentGuard path probe failed: %s", exc)
+            return SecurityStatus(
+                available=False,
+                service=self.name,
+                state=STATE_OFFLINE,
+                message="SilentGuard memory file is not accessible.",
+                timestamp=timestamp,
+            )
+        if not present:
+            return SecurityStatus(
+                available=False,
+                service=self.name,
+                state=STATE_UNAVAILABLE,
+                message=f"SilentGuard memory file not found at {path}.",
+                timestamp=timestamp,
+            )
+        return SecurityStatus(
+            available=True,
+            service=self.name,
+            state=STATE_AVAILABLE,
+            message=f"SilentGuard memory file detected at {path}.",
+            timestamp=timestamp,
+        )

--- a/tests/test_security_provider.py
+++ b/tests/test_security_provider.py
@@ -18,7 +18,6 @@ These tests pin the contract:
 from __future__ import annotations
 
 import ast
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/test_security_provider.py
+++ b/tests/test_security_provider.py
@@ -1,0 +1,280 @@
+"""
+Tests for the read-only security provider foundation.
+
+The provider layer (``core.security``) is intentionally narrow: it
+reports whether a security tool is reachable, and it never raises.
+These tests pin the contract:
+
+  * the dataclass shape is stable (``available`` / ``service`` /
+    ``state`` / ``message`` / ``timestamp``);
+  * the null provider is the safe default and reports unavailable;
+  * ``SilentGuardProvider`` returns the right state for present,
+    missing, and unreadable paths;
+  * ``get_security_context_summary`` falls back cleanly when no
+    provider is wired up;
+  * none of the new files import system-mutating modules.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from core import security as security_pkg
+from core.security import (
+    NullSecurityProvider,
+    SecurityProvider,
+    SecurityStatus,
+    SilentGuardProvider,
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE,
+    default_provider,
+    get_security_context_summary,
+)
+from core.security import provider as provider_module
+from core.security import silentguard as silentguard_module
+
+
+# ── SecurityStatus dataclass ────────────────────────────────────────
+
+class TestSecurityStatusShape:
+    def test_required_fields(self):
+        s = SecurityStatus(
+            available=True,
+            service="silentguard",
+            state=STATE_AVAILABLE,
+        )
+        assert s.available is True
+        assert s.service == "silentguard"
+        assert s.state == STATE_AVAILABLE
+        assert s.message == ""
+        assert s.timestamp is None
+
+    def test_as_dict_keys(self):
+        s = SecurityStatus(
+            available=False,
+            service="silentguard",
+            state=STATE_UNAVAILABLE,
+            message="not found",
+            timestamp="2026-05-08T12:00:00Z",
+        )
+        d = s.as_dict()
+        assert set(d.keys()) == {
+            "available", "service", "state", "message", "timestamp",
+        }
+        assert d["available"] is False
+        assert d["service"] == "silentguard"
+        assert d["state"] == STATE_UNAVAILABLE
+        assert d["message"] == "not found"
+        assert d["timestamp"] == "2026-05-08T12:00:00Z"
+
+    def test_is_frozen(self):
+        s = SecurityStatus(
+            available=False, service="x", state=STATE_UNAVAILABLE,
+        )
+        with pytest.raises(Exception):
+            s.available = True  # type: ignore[misc]
+
+
+# ── NullSecurityProvider ────────────────────────────────────────────
+
+class TestNullProvider:
+    def test_status_reports_unavailable(self):
+        status = NullSecurityProvider().get_status()
+        assert status.available is False
+        assert status.state == STATE_UNAVAILABLE
+        assert status.service == "none"
+        assert "no security provider" in status.message.lower()
+
+    def test_status_has_timestamp(self):
+        status = NullSecurityProvider().get_status()
+        # ISO-8601 UTC with seconds, ending in Z.
+        assert status.timestamp is not None
+        assert status.timestamp.endswith("Z")
+        assert "T" in status.timestamp
+
+    def test_satisfies_provider_protocol(self):
+        assert isinstance(NullSecurityProvider(), SecurityProvider)
+
+
+# ── SilentGuardProvider ─────────────────────────────────────────────
+
+class TestSilentGuardProviderStatus:
+    def test_unavailable_when_path_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        missing = tmp_path / "absent.json"
+        provider = SilentGuardProvider(feed_path=missing)
+        status = provider.get_status()
+        assert status.available is False
+        assert status.state == STATE_UNAVAILABLE
+        assert status.service == "silentguard"
+        assert str(missing) in status.message
+
+    def test_available_when_file_present(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        provider = SilentGuardProvider(feed_path=feed)
+        status = provider.get_status()
+        assert status.available is True
+        assert status.state == STATE_AVAILABLE
+        assert status.service == "silentguard"
+        assert str(feed) in status.message
+
+    def test_explicit_path_takes_precedence_over_env(
+        self, tmp_path, monkeypatch,
+    ):
+        env_path = tmp_path / "env.json"
+        explicit = tmp_path / "explicit.json"
+        explicit.write_text("[]", encoding="utf-8")
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(env_path))
+        provider = SilentGuardProvider(feed_path=explicit)
+        status = provider.get_status()
+        assert status.available is True
+        assert str(explicit) in status.message
+        assert str(env_path) not in status.message
+
+    def test_env_override_used_when_no_explicit_path(
+        self, tmp_path, monkeypatch,
+    ):
+        env_feed = tmp_path / "via-env.json"
+        env_feed.write_text("[]", encoding="utf-8")
+        monkeypatch.setenv("NOVA_SILENTGUARD_PATH", str(env_feed))
+        status = SilentGuardProvider().get_status()
+        assert status.available is True
+        assert str(env_feed) in status.message
+
+    def test_default_path_is_home_relative(self, monkeypatch):
+        # Without an explicit path or env override, the provider
+        # resolves to a path under the user's home directory. We do
+        # not require the file to exist; we only require the resolved
+        # path to be the documented default.
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        provider = SilentGuardProvider()
+        resolved = provider._resolved_path()
+        assert resolved == Path.home() / ".silentguard_memory.json"
+
+    def test_offline_when_path_probe_raises(self, monkeypatch):
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        provider = SilentGuardProvider(feed_path=Path("/nope/feed.json"))
+
+        def boom(self):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "is_file", boom)
+        status = provider.get_status()
+        assert status.available is False
+        assert status.state == STATE_OFFLINE
+        assert "not accessible" in status.message.lower()
+
+    def test_satisfies_provider_protocol(self):
+        assert isinstance(SilentGuardProvider(), SecurityProvider)
+
+    def test_get_status_does_not_raise_on_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        # Should never raise even when the file is absent.
+        status = SilentGuardProvider(feed_path=tmp_path / "nope.json").get_status()
+        assert isinstance(status, SecurityStatus)
+
+    def test_get_status_does_not_read_file_contents(self, tmp_path, monkeypatch):
+        """Provider only stat's the file; it does not open it for reading."""
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        feed = tmp_path / "feed.json"
+        # An invalid JSON body would explode any parser; the provider
+        # must not parse, only probe, so this still returns available.
+        feed.write_text("{ definitely not json", encoding="utf-8")
+        status = SilentGuardProvider(feed_path=feed).get_status()
+        assert status.available is True
+        assert status.state == STATE_AVAILABLE
+
+
+# ── Default-provider helper / context summary ───────────────────────
+
+class TestDefaults:
+    def test_default_provider_is_null(self):
+        assert isinstance(default_provider(), NullSecurityProvider)
+
+    def test_summary_falls_back_to_null_provider(self):
+        summary = get_security_context_summary()
+        assert summary["available"] is False
+        assert summary["state"] == STATE_UNAVAILABLE
+        assert summary["service"] == "none"
+        # Stable shape — same keys as SecurityStatus.as_dict().
+        assert set(summary.keys()) == {
+            "available", "service", "state", "message", "timestamp",
+        }
+
+    def test_summary_uses_supplied_provider(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        summary = get_security_context_summary(
+            SilentGuardProvider(feed_path=feed),
+        )
+        assert summary["available"] is True
+        assert summary["service"] == "silentguard"
+        assert summary["state"] == STATE_AVAILABLE
+
+
+# ── Read-only / safety guarantees ───────────────────────────────────
+
+_FORBIDDEN_IMPORTS = {
+    "subprocess", "socket", "shutil", "ctypes", "signal",
+}
+
+
+def _assert_module_is_read_only(module):
+    """Match the convention used by ``test_integrations_silentguard``."""
+    with open(module.__file__, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root not in _FORBIDDEN_IMPORTS, (
+                    f"{module.__name__} must not import {alias.name!r}"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".")[0]
+            assert root not in _FORBIDDEN_IMPORTS, (
+                f"{module.__name__} must not import from {node.module!r}"
+            )
+
+
+class TestReadOnlyGuarantees:
+    def test_provider_module_has_no_forbidden_imports(self):
+        _assert_module_is_read_only(provider_module)
+
+    def test_silentguard_module_has_no_forbidden_imports(self):
+        _assert_module_is_read_only(silentguard_module)
+
+    def test_package_init_has_no_forbidden_imports(self):
+        _assert_module_is_read_only(security_pkg)
+
+    def test_provider_does_not_mutate_feed_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        original_bytes = feed.read_bytes()
+        original_mtime = feed.stat().st_mtime
+
+        SilentGuardProvider(feed_path=feed).get_status()
+        # And again to make sure repeated probes do not write either.
+        SilentGuardProvider(feed_path=feed).get_status()
+
+        assert feed.read_bytes() == original_bytes
+        assert feed.stat().st_mtime == original_mtime
+
+    def test_module_exports_match_dunder_all(self):
+        # Sanity check: anything advertised in __all__ resolves on the
+        # package, so callers that do `from core.security import X` get
+        # what the docstring promises.
+        for name in security_pkg.__all__:
+            assert hasattr(security_pkg, name), (
+                f"core.security exports {name!r} but it is missing"
+            )


### PR DESCRIPTION
## Summary

This PR is **Phase 1 only** of the Nova ↔ SilentGuard integration roadmap (see `docs/silentguard-integration-roadmap.md`). It introduces a small, read-only foundation so future phases can plug in cleanly. **No behavioural changes outside the new package.**

- New `core/security/` package with a generic `SecurityProvider` Protocol, a `SecurityStatus` dataclass (`available`, `service`, `state`, `message`, `timestamp`), a `NullSecurityProvider` default, and a `SilentGuardProvider` that probes SilentGuard's local presence (file-based today; structured so a future loopback HTTP API can swap in behind the same Protocol).
- `default_provider()` returns the `NullSecurityProvider` so Nova works normally when nothing is configured. `get_security_context_summary()` returns a small, prompt-friendly dict suitable for future use.
- New `tests/test_security_provider.py` covers status shape, null fallback, file-present / file-missing / env-override / explicit-path / OS-error paths, and the read-only forbidden-imports guarantee on every new file.

## Boundaries (commitments)

Nova **does not**, and this PR does **not** add any of:

- blocking IPs, modifying firewall rules, or running privileged commands
- controlling SilentGuard or performing autonomous security actions
- writing to SilentGuard's files, opening sockets, spawning processes
- background polling, schedulers, or push notifications
- new HTTP endpoints, UI dashboards, or alert systems
- changes to chat, auth, memory, web, or settings paths
- new heavy dependencies

SilentGuard remains the security/network engine. Nova remains the cognitive/conversational layer. The existing per-user gate (`core/integrations/silentguard.py`) and chat-side summariser (`core/security_feed.py`) are untouched.

## What changed

```
core/security/
  __init__.py        # package surface, default_provider, get_security_context_summary
  provider.py        # SecurityStatus, SecurityProvider Protocol, NullSecurityProvider
  silentguard.py     # SilentGuardProvider (read-only host probe)
tests/
  test_security_provider.py
```

4 files, 593 insertions, 0 deletions.

## Test plan

- [x] `pytest tests/test_security_provider.py` — 23 new tests pass
- [x] `pytest tests/test_integrations_silentguard.py tests/test_security_feed.py` — 41 existing tests still pass
- [x] Broader pure-core suite (memory / users / router / nova_contract / time_context / weather / nexanote / etc.) — 367 tests pass cleanly
- [x] Forbidden-imports AST check applied to every new file (`subprocess`, `socket`, `shutil`, `ctypes`, `signal` rejected)
- [x] Provider returns a `SecurityStatus` on every error path (missing file, OS probe failure, no config) — never raises
- [x] `NullSecurityProvider` is the default; calling `default_provider()` does not require SilentGuard to be installed

Note: a handful of `auth`/`web` tests in this sandbox fail to collect because the system `cryptography` C-extension is missing — these are environment-only collection errors, not regressions from this PR.

https://claude.ai/code/session_019xe3mAPK6hRyZes4CmeVPW

---
_Generated by [Claude Code](https://claude.ai/code/session_019xe3mAPK6hRyZes4CmeVPW)_