### PR TITLE
feat(security): surface SilentGuard read-only context in chat prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ For the read-only, opt-in integration with SilentGuard (the dedicated network mo
 
 The integration is **optional** and **off by default**. Nova works normally whether SilentGuard is installed or not. The security provider in `core/security/` probes SilentGuard's on-disk memory file; if `NOVA_SILENTGUARD_API_URL` is set, it instead probes SilentGuard's optional **read-only loopback API** (`GET /status` and a small fixed endpoint list — no writes, no firewall actions, no shell calls). Either way, a missing, unreachable, or malformed response maps to a calm `available=False` snapshot.
 
+Nova's chat layer surfaces the provider's state as a small **read-only "Security context:" block** appended to the system prompt (`core/security/context.py`). The block tells the model whether SilentGuard is *not configured*, *unavailable*, or *connected in read-only mode* — and, when the optional HTTP transport is responsive, summarises four counts (`alerts`, `blocked items`, `trusted items`, `active connections`). Every variant restates that Nova may **explain and summarize only**; it must not perform firewall or rule actions. There is no notification surface, no background polling, and no autonomous alerting attached to this — the block is built on demand from the same provider as the existing settings status.
+
 ## License
 
 [Mozilla Public License 2.0](LICENSE)

--- a/core/chat.py
+++ b/core/chat.py
@@ -11,6 +11,7 @@ from core.settings import get_personalization
 from core.router import route
 from core.search import web_search, should_search
 from core.security_feed import is_security_query
+from core.security import SilentGuardProvider, build_security_context_block
 from core.integrations import silentguard as silentguard_integration
 from core.time_context import format_time_context
 from core.weather import detect_weather_city, get_weather
@@ -122,6 +123,18 @@ def build_messages(
     if pers_block:
         parts.append(pers_block)
     parts.append(format_time_context())
+
+    # Read-only SilentGuard context. Probes the local provider on
+    # demand (no background polling), produces a short bullet block,
+    # and never raises. The block always re-states that Nova may
+    # explain but must not perform security actions.
+    try:
+        sec_block = build_security_context_block(SilentGuardProvider())
+    except Exception:  # pragma: no cover — the helper is contract-bound to never raise
+        logger.debug("security context block raised; omitting", exc_info=True)
+        sec_block = ""
+    if sec_block:
+        parts.append(sec_block)
 
     messages = [{"role": "system", "content": "\n\n".join(parts)}]
     messages += history[-CHAT_HISTORY_LIMIT:]

--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -41,6 +41,7 @@ from core.security.provider import (
 )
 from core.security.silentguard import SilentGuardProvider
 from core.security.silentguard_client import SilentGuardClient
+from core.security.context import build_security_context_block
 
 __all__ = [
     "NullSecurityProvider",
@@ -51,6 +52,7 @@ __all__ = [
     "STATE_AVAILABLE",
     "STATE_OFFLINE",
     "STATE_UNAVAILABLE",
+    "build_security_context_block",
     "default_provider",
     "get_security_context_summary",
     "get_security_context_text",

--- a/core/security/context.py
+++ b/core/security/context.py
@@ -1,0 +1,220 @@
+"""
+Read-only security context block for prompt injection (Phase 1).
+
+Nova's chat layer needs a small, deterministic way to tell the model
+*"is SilentGuard configured here, is it reachable, and what is its
+read-only summary?"* — without bloating every prompt and without
+inviting Nova to take action.
+
+This module is the single place that wording lives. It produces a
+short, bullet-shaped block:
+
+    Security context:
+    - SilentGuard integration: connected in read-only mode.
+    - Current summary: 0 alerts, 0 blocked items, 0 trusted items,
+      0 active connections.
+    - Allowed behavior: explain and summarize only; do not perform
+      firewall or rule actions.
+
+The wording is intentionally calm. It never invents numbers it does
+not have. It never suggests an action. It always restates that Nova
+is read-only.
+
+Boundaries enforced here (commitments, not aspirations):
+
+  * **Read-only.** The builder calls only the provider's read-only
+    surface (``get_status`` and the optional ``get_summary_counts``).
+    No writes, no shell calls, no firewall actions.
+  * **Deterministic.** No LLM in the loop. The sentences are fixed;
+    only the four counts vary.
+  * **Graceful.** Every error path returns a short, calm block. The
+    builder never raises into the chat path.
+  * **Minimal by default.** When no provider is configured the block
+    is three short lines, so unconfigured Nova installs pay near-zero
+    token cost.
+  * **No raw payload leakage.** Only counts and a fixed wording set
+    enter the block. Process names, IPs, exception messages, and
+    timestamps are *not* surfaced here — they belong to the existing
+    ``core.security_feed`` summariser when (and only when) the user
+    asks a security-shaped question.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from core.security.provider import (
+    NullSecurityProvider,
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE,
+    SecurityProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+_HEADER = "Security context:"
+_BEHAVIOR_LINE = (
+    "Allowed behavior: explain and summarize only; do not perform "
+    "firewall or rule actions."
+)
+
+# The four count keys the block surfaces. Kept as a tuple so an
+# implementation that returns a dict with extra keys does not silently
+# leak them into the prompt.
+_REQUIRED_COUNT_KEYS = ("alerts", "blocked", "trusted", "connections")
+
+
+def _format_block(*lines: str) -> str:
+    """Join ``Security context:`` + bullets into one block."""
+    return _HEADER + "\n" + "\n".join(f"- {line}" for line in lines)
+
+
+def _safe_get_status(provider):
+    """Call ``provider.get_status``; return ``None`` if it raises."""
+    try:
+        return provider.get_status()
+    except Exception:  # pragma: no cover — providers must not raise
+        logger.debug(
+            "security provider get_status raised; treating as unavailable",
+            exc_info=True,
+        )
+        return None
+
+
+def _safe_counts(provider) -> Optional[dict]:
+    """Return read-only counts, or ``None`` when unavailable.
+
+    A provider may optionally expose ``get_summary_counts`` returning a
+    dict with ``alerts`` / ``blocked`` / ``trusted`` / ``connections``
+    integer fields. Missing method, exception, wrong shape, or
+    negative numbers all map to ``None`` — the caller falls back to
+    the count-less wording.
+    """
+    getter = getattr(provider, "get_summary_counts", None)
+    if not callable(getter):
+        return None
+    try:
+        counts = getter()
+    except Exception:  # pragma: no cover — defensive
+        logger.debug(
+            "security provider get_summary_counts raised", exc_info=True,
+        )
+        return None
+    if not isinstance(counts, dict):
+        return None
+    if not all(key in counts for key in _REQUIRED_COUNT_KEYS):
+        return None
+    if not all(
+        isinstance(counts[key], int) and counts[key] >= 0
+        for key in _REQUIRED_COUNT_KEYS
+    ):
+        return None
+    return {key: counts[key] for key in _REQUIRED_COUNT_KEYS}
+
+
+def _is_null_provider(provider, name: str) -> bool:
+    """Return True for the safe-default null provider.
+
+    Detected either by isinstance check (preferred) or by the stable
+    ``name`` sentinel; both are documented in
+    ``core.security.provider``.
+    """
+    return isinstance(provider, NullSecurityProvider) or name in ("", "none")
+
+
+def build_security_context_block(
+    provider: Optional[SecurityProvider] = None,
+) -> str:
+    """Return a small, deterministic security-context block.
+
+    Falls back to ``core.security.default_provider()`` (currently the
+    safe null provider) when no argument is supplied. Always returns a
+    non-empty string — callers append it like
+    ``format_time_context()``.
+
+    Outcomes:
+
+      * No provider / null provider     → "SilentGuard integration:
+                                          not configured."
+      * SilentGuard, ``state=unavailable`` → "SilentGuard integration:
+                                              not configured."
+      * SilentGuard, ``state=offline``     → "SilentGuard integration:
+                                              read-only API is unavailable."
+      * SilentGuard, ``state=available``   → "SilentGuard integration:
+                                              connected in read-only
+                                              mode." (+ counts when the
+                                              provider exposes them)
+
+    Read-only. Never raises. Never includes raw payloads, exceptions,
+    process names, IPs, or timestamps.
+    """
+    if provider is None:
+        # Local import to avoid a hard cycle with ``core.security.__init__``,
+        # which imports this module to re-export the helper.
+        from core.security import default_provider
+        provider = default_provider()
+
+    name = (getattr(provider, "name", "") or "").strip().lower()
+
+    if _is_null_provider(provider, name):
+        return _format_block(
+            "SilentGuard integration: not configured.",
+            _BEHAVIOR_LINE,
+        )
+
+    status = _safe_get_status(provider)
+    if status is None:
+        # Provider misbehaved; treat as unavailable. We do not surface
+        # the underlying error in the prompt.
+        return _format_block(
+            "SilentGuard integration: read-only API is unavailable.",
+            _BEHAVIOR_LINE,
+        )
+
+    # ``status.available`` is the source of truth for the available path;
+    # the state strings split the unavailable path into "not configured"
+    # (``unavailable`` — nothing to talk to) and "read-only API is
+    # unavailable" (``offline`` — configured but unreachable).
+    if not status.available:
+        if status.state == STATE_OFFLINE:
+            return _format_block(
+                "SilentGuard integration: read-only API is unavailable.",
+                _BEHAVIOR_LINE,
+            )
+        # STATE_UNAVAILABLE or any other unavailable state.
+        return _format_block(
+            "SilentGuard integration: not configured.",
+            _BEHAVIOR_LINE,
+        )
+
+    # Available. Try to enrich with counts when the provider can supply
+    # them; fall back to the count-less wording otherwise.
+    counts = _safe_counts(provider)
+    if counts is None:
+        return _format_block(
+            "SilentGuard integration: connected in read-only mode.",
+            _BEHAVIOR_LINE,
+        )
+
+    return _format_block(
+        "SilentGuard integration: connected in read-only mode.",
+        (
+            f"Current summary: {counts['alerts']} alerts, "
+            f"{counts['blocked']} blocked items, "
+            f"{counts['trusted']} trusted items, "
+            f"{counts['connections']} active connections."
+        ),
+        _BEHAVIOR_LINE,
+    )
+
+
+# Re-exports so the unused-import lints stay happy and so callers can
+# do ``from core.security.context import STATE_*`` if they need to.
+__all__ = [
+    "build_security_context_block",
+    "STATE_AVAILABLE",
+    "STATE_OFFLINE",
+    "STATE_UNAVAILABLE",
+]

--- a/core/security/silentguard.py
+++ b/core/security/silentguard.py
@@ -297,6 +297,56 @@ class SilentGuardProvider:
             )
         return "SilentGuard read-only API is available."
 
+    # ── Optional structured counts ──────────────────────────────────
+
+    def get_summary_counts(self) -> Optional[dict]:
+        """Return read-only counts, or ``None`` when unavailable.
+
+        When the HTTP transport is configured *and* SilentGuard is
+        reachable, returns::
+
+            {"alerts": int, "blocked": int, "trusted": int, "connections": int}
+
+        Returns ``None`` in every other case:
+
+          * provider unavailable (file missing, API offline, …),
+          * no API client configured (file-only fallback),
+          * any read returned a non-list payload,
+          * any read raised (defensive — the client itself does not
+            raise, but a misbehaving substitute might).
+
+        Used by the prompt-injected security context block in
+        ``core.security.context``. Read-only — only ``GET`` calls are
+        ever issued, only against the fixed read-only path list.
+        """
+        status = self.get_status()
+        if not status.available:
+            return None
+        client = self._resolved_client()
+        if client is None:
+            return None
+        try:
+            alerts = client.get_alerts()
+            blocked = client.get_blocked()
+            trusted = client.get_trusted()
+            connections = client.get_connections()
+        except Exception:  # pragma: no cover — defensive belt-and-braces
+            logger.debug(
+                "SilentGuard summary count enrichment failed", exc_info=True,
+            )
+            return None
+        if not all(
+            isinstance(value, list)
+            for value in (alerts, blocked, trusted, connections)
+        ):
+            return None
+        return {
+            "alerts": len(alerts),
+            "blocked": len(blocked),
+            "trusted": len(trusted),
+            "connections": len(connections),
+        }
+
 
 def _normalise_url(value: str) -> str:
     """Trim whitespace and a trailing slash from an API base URL."""

--- a/docs/silentguard-integration-roadmap.md
+++ b/docs/silentguard-integration-roadmap.md
@@ -127,7 +127,41 @@ commands.
 (state, detail, enabled flag). The settings panel surfaces a single
 on/off toggle for SilentGuard.
 
-### 2.5 What is missing today
+### 2.5 `core/security/context.py` (read-only chat context)
+
+A small builder that produces the per-turn "Security context:" block
+appended to Nova's chat system prompt. The block is short,
+deterministic, read-only, and intentionally calm:
+
+- when nothing is configured → *"SilentGuard integration: not
+  configured."* + the read-only behaviour line.
+- when configured but unreachable → *"SilentGuard integration:
+  read-only API is unavailable."* + the same read-only line.
+- when reachable → *"SilentGuard integration: connected in read-only
+  mode."*, optionally followed by *"Current summary: N alerts, N
+  blocked items, N trusted items, N active connections."* (counts
+  appear only when the optional HTTP transport is configured and
+  responsive; the file fallback omits them).
+
+Every variant ends with the same fixed clause:
+*"Allowed behavior: explain and summarize only; do not perform
+firewall or rule actions."* So Nova always knows what state the
+provider is in **and** that it must not act on it.
+
+The block is built on every turn from the existing
+`core/security/SilentGuardProvider`. There is no background polling,
+no scheduled refresh, no notification. It is a pull, on the same
+trigger that already builds the time context. Failures inside the
+provider map to the calm "unavailable" wording; raw exception text,
+IPs, process names, and timestamps never enter the prompt.
+
+This is what *"surface SilentGuard read-only context"* ships as in
+this PR. It is **not** notification behaviour, **not** a firewall
+control surface, **not** an autonomous alerting layer. The
+"Capabilities" line in §11.1 above stays accurate: actions are still
+explicitly out of scope.
+
+### 2.6 What is missing today
 
 - **Trusted IPs and blocked IPs** are not exposed. SilentGuard persists
   them in `~/.silentguard_rules.json` (see §3); Nova does not read that
@@ -150,7 +184,12 @@ on/off toggle for SilentGuard.
   user-visible affordance to start SilentGuard from Nova when the
   user is the one who decides to.
 
-Phase 1 is exactly the set of changes that closes those five gaps.
+The chat-prompt presence gap (Nova not knowing whether SilentGuard
+exists at all) is closed by the read-only context block in §2.5.
+The remaining gaps below — rules, alerts, connector abstraction,
+HTTP surface, lifecycle — are still the Phase 1 scope.
+
+Phase 1 is exactly the set of changes that closes those gaps.
 
 ---
 

--- a/tests/test_security_context.py
+++ b/tests/test_security_context.py
@@ -1,0 +1,503 @@
+"""
+Tests for the read-only security context block.
+
+The block is what Nova injects into the chat system prompt so the
+model can accurately know whether SilentGuard is configured,
+reachable, or reporting basic state. These tests pin the contract:
+
+  * the block is short, deterministic, and read-only;
+  * it states "not configured" for the null provider, for SilentGuard
+    with no file / no API, and when the provider misbehaves;
+  * it states "read-only API is unavailable" when configured but
+    offline;
+  * it states "connected in read-only mode" when reachable, and
+    surfaces zero-or-more counts when the optional ``get_summary_counts``
+    method is available;
+  * it never includes raw payloads, exception text, IPs, process
+    names, or timestamps;
+  * it always restates that Nova may explain but must not perform
+    firewall or rule actions;
+  * malformed counts dicts degrade to the count-less wording rather
+    than crashing or leaking the bad shape;
+  * the chat ``build_messages`` path appends the block after the time
+    context and never duplicates it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Heavy network deps the chat module imports at module load. Stub them
+# before the import so a missing wheel never blocks this test file.
+for _mod in ("ddgs", "ollama"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+
+from core.security import (  # noqa: E402
+    NullSecurityProvider,
+    SecurityStatus,
+    SilentGuardProvider,
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE,
+    build_security_context_block,
+)
+from core.security.context import _BEHAVIOR_LINE, _HEADER  # noqa: E402
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _isolate_silentguard_env(monkeypatch):
+    """Keep host env vars from leaking into provider behaviour."""
+    monkeypatch.delenv("NOVA_SILENTGUARD_PATH", raising=False)
+    monkeypatch.delenv("NOVA_SILENTGUARD_API_URL", raising=False)
+    monkeypatch.delenv("NOVA_SILENTGUARD_API_TIMEOUT_SECONDS", raising=False)
+
+
+class _FakeStatusClient:
+    """Stand-in client used by provider-with-counts tests."""
+
+    def __init__(
+        self,
+        status_payload=None,
+        alerts=None,
+        blocked=None,
+        trusted=None,
+        connections=None,
+        base_url="http://stub",
+    ):
+        self._status = status_payload
+        self._alerts = alerts or []
+        self._blocked = blocked or []
+        self._trusted = trusted or []
+        self._connections = connections or []
+        self.base_url = base_url
+
+    def get_status(self):
+        return self._status
+
+    def get_alerts(self):
+        return list(self._alerts)
+
+    def get_blocked(self):
+        return list(self._blocked)
+
+    def get_trusted(self):
+        return list(self._trusted)
+
+    def get_connections(self):
+        return list(self._connections)
+
+
+# ── No provider / null provider ─────────────────────────────────────
+
+class TestNullProvider:
+    def test_default_argument_yields_not_configured(self):
+        """No argument falls through to the null default provider."""
+        block = build_security_context_block()
+        assert block.startswith(_HEADER)
+        assert "not configured" in block
+        assert _BEHAVIOR_LINE in block
+
+    def test_null_provider_says_silentguard_not_configured(self):
+        block = build_security_context_block(NullSecurityProvider())
+        # Must reference SilentGuard explicitly so a user reading the
+        # prompt understands what is missing.
+        assert "SilentGuard integration: not configured." in block
+        assert _BEHAVIOR_LINE in block
+
+    def test_block_is_short_when_unconfigured(self):
+        block = build_security_context_block(NullSecurityProvider())
+        # Header + two bullets: should be at most a small handful of
+        # lines, so unconfigured installs pay near-zero token cost.
+        assert len(block.splitlines()) <= 4
+
+
+# ── SilentGuardProvider — file transport (no API URL) ────────────────
+
+class TestFileTransportContext:
+    def test_missing_file_says_not_configured(self, tmp_path):
+        provider = SilentGuardProvider(feed_path=tmp_path / "nope.json")
+        block = build_security_context_block(provider)
+        assert "SilentGuard integration: not configured." in block
+        assert _BEHAVIOR_LINE in block
+        # No leak of the resolved path or any other detail.
+        assert str(tmp_path) not in block
+
+    def test_present_file_says_connected(self, tmp_path):
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        provider = SilentGuardProvider(feed_path=feed)
+        block = build_security_context_block(provider)
+        assert "connected in read-only mode" in block
+        assert _BEHAVIOR_LINE in block
+        # File transport has no counts surface; the block must not
+        # invent a "Current summary:" line.
+        assert "Current summary" not in block
+        # And must not leak the file path into the prompt.
+        assert str(feed) not in block
+
+    def test_offline_says_unavailable(self, tmp_path, monkeypatch):
+        provider = SilentGuardProvider(feed_path=Path("/no/such/path.json"))
+
+        def boom(_self):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "is_file", boom)
+        block = build_security_context_block(provider)
+        assert "read-only API is unavailable" in block
+        assert _BEHAVIOR_LINE in block
+
+    def test_block_never_includes_exception_text(self, tmp_path, monkeypatch):
+        provider = SilentGuardProvider(feed_path=Path("/no/such/path.json"))
+
+        def boom(_self):
+            raise OSError("super-secret host detail")
+
+        monkeypatch.setattr(Path, "is_file", boom)
+        block = build_security_context_block(provider)
+        assert "super-secret" not in block
+        assert "OSError" not in block
+        assert "Traceback" not in block
+
+
+# ── SilentGuardProvider — HTTP transport with counts ────────────────
+
+class TestHttpTransportContext:
+    def test_connected_with_zero_counts(self, tmp_path):
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "missing.json",
+            client=_FakeStatusClient(
+                status_payload={"ok": True},
+                base_url="http://127.0.0.1:8765",
+            ),
+        )
+        block = build_security_context_block(provider)
+        assert "connected in read-only mode" in block
+        assert (
+            "Current summary: 0 alerts, 0 blocked items, "
+            "0 trusted items, 0 active connections."
+        ) in block
+        assert _BEHAVIOR_LINE in block
+        # API URL must not leak into the prompt.
+        assert "127.0.0.1" not in block
+
+    def test_connected_with_nonzero_counts(self, tmp_path):
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "missing.json",
+            client=_FakeStatusClient(
+                status_payload={"ok": True},
+                alerts=[{"id": 1}, {"id": 2}],
+                blocked=[{"ip": "1.1.1.1"}],
+                trusted=[{"ip": "9.9.9.9"}, {"ip": "8.8.8.8"}, {"ip": "1.0.0.1"}],
+                connections=[{"ip": "5.6.7.8"}, {"ip": "1.2.3.4"}],
+                base_url="http://127.0.0.1:8765",
+            ),
+        )
+        block = build_security_context_block(provider)
+        assert (
+            "Current summary: 2 alerts, 1 blocked items, "
+            "3 trusted items, 2 active connections."
+        ) in block
+        # Raw payload must not enter the prompt — only the counts do.
+        for leak in ("1.1.1.1", "9.9.9.9", "8.8.8.8", "5.6.7.8", "1.2.3.4"):
+            assert leak not in block
+
+    def test_offline_api_says_unavailable(self, tmp_path):
+        # API client where /status returns None → STATE_OFFLINE.
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "missing.json",
+            client=_FakeStatusClient(
+                status_payload=None,
+                base_url="http://127.0.0.1:8765",
+            ),
+        )
+        block = build_security_context_block(provider)
+        assert "read-only API is unavailable" in block
+        assert _BEHAVIOR_LINE in block
+        assert "Current summary" not in block
+        # The probed URL must not leak to the prompt.
+        assert "127.0.0.1" not in block
+
+
+# ── Resilience: malformed counts ─────────────────────────────────────
+
+class _BadCountsClient(_FakeStatusClient):
+    """Client that returns the expected status but malformed lists."""
+
+    def get_alerts(self):
+        return "not a list"  # noqa: pragma — malformed on purpose
+
+    def get_blocked(self):
+        return None  # noqa: pragma — malformed on purpose
+
+
+class TestMalformedCountsAreGraceful:
+    def test_falls_back_to_count_less_wording(self, tmp_path):
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "missing.json",
+            client=_BadCountsClient(
+                status_payload={"ok": True},
+                base_url="http://127.0.0.1:8765",
+            ),
+        )
+        block = build_security_context_block(provider)
+        # We are still connected per /status, just without trustworthy
+        # counts. The block should say so without inventing numbers.
+        assert "connected in read-only mode" in block
+        assert "Current summary" not in block
+        assert _BEHAVIOR_LINE in block
+
+    def test_provider_get_summary_counts_returns_none_on_bad_lists(self, tmp_path):
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "missing.json",
+            client=_BadCountsClient(
+                status_payload={"ok": True},
+                base_url="http://127.0.0.1:8765",
+            ),
+        )
+        assert provider.get_summary_counts() is None
+
+    def test_negative_counts_dict_is_rejected(self):
+        """An out-of-band ``get_summary_counts`` returning negatives is dropped."""
+
+        class _BogusProvider:
+            name = "silentguard"
+
+            def get_status(self):
+                return SecurityStatus(
+                    available=True, service=self.name, state=STATE_AVAILABLE,
+                )
+
+            def get_summary_counts(self):
+                return {
+                    "alerts": -1, "blocked": 0, "trusted": 0, "connections": 0,
+                }
+
+        block = build_security_context_block(_BogusProvider())
+        assert "connected in read-only mode" in block
+        assert "Current summary" not in block
+
+    def test_missing_keys_in_counts_dict_is_rejected(self):
+        class _PartialProvider:
+            name = "silentguard"
+
+            def get_status(self):
+                return SecurityStatus(
+                    available=True, service=self.name, state=STATE_AVAILABLE,
+                )
+
+            def get_summary_counts(self):
+                # Missing "trusted" and "connections".
+                return {"alerts": 1, "blocked": 1}
+
+        block = build_security_context_block(_PartialProvider())
+        assert "connected in read-only mode" in block
+        assert "Current summary" not in block
+
+    def test_non_dict_counts_is_rejected(self):
+        class _NonDictProvider:
+            name = "silentguard"
+
+            def get_status(self):
+                return SecurityStatus(
+                    available=True, service=self.name, state=STATE_AVAILABLE,
+                )
+
+            def get_summary_counts(self):
+                return [1, 2, 3]  # type: ignore[return-value]
+
+        block = build_security_context_block(_NonDictProvider())
+        assert "connected in read-only mode" in block
+        assert "Current summary" not in block
+
+
+# ── Resilience: provider misbehaves ─────────────────────────────────
+
+class TestProviderRaisesIsHandled:
+    def test_status_raise_maps_to_unavailable(self):
+        class _RaisingProvider:
+            name = "silentguard"
+
+            def get_status(self):
+                raise RuntimeError("explosive provider")
+
+        block = build_security_context_block(_RaisingProvider())
+        assert "read-only API is unavailable" in block
+        assert "explosive provider" not in block
+        assert _BEHAVIOR_LINE in block
+
+    def test_summary_counts_raise_falls_back_silently(self, tmp_path):
+        class _CountsRaisingProvider:
+            name = "silentguard"
+
+            def get_status(self):
+                return SecurityStatus(
+                    available=True, service=self.name, state=STATE_AVAILABLE,
+                )
+
+            def get_summary_counts(self):
+                raise RuntimeError("countdown")
+
+        block = build_security_context_block(_CountsRaisingProvider())
+        assert "connected in read-only mode" in block
+        assert "Current summary" not in block
+        assert "countdown" not in block
+
+
+# ── State mapping table ─────────────────────────────────────────────
+
+class TestStateMapping:
+    @pytest.mark.parametrize(
+        "state,expected_phrase",
+        [
+            (STATE_UNAVAILABLE, "not configured"),
+            (STATE_OFFLINE, "read-only API is unavailable"),
+            (STATE_AVAILABLE, "connected in read-only mode"),
+        ],
+    )
+    def test_each_state_maps_to_documented_phrase(self, state, expected_phrase):
+        class _StubProvider:
+            name = "silentguard"
+
+            def __init__(self, state):
+                self._state = state
+
+            def get_status(self):
+                return SecurityStatus(
+                    available=(self._state == STATE_AVAILABLE),
+                    service=self.name,
+                    state=self._state,
+                )
+
+        block = build_security_context_block(_StubProvider(state))
+        assert expected_phrase in block
+        assert _BEHAVIOR_LINE in block
+
+
+# ── Wording invariants ──────────────────────────────────────────────
+
+class TestWordingInvariants:
+    def test_block_always_starts_with_header(self):
+        # Across all three states.
+        for provider in (
+            NullSecurityProvider(),
+            SilentGuardProvider(feed_path=Path("/tmp/__nope__sg.json")),
+        ):
+            block = build_security_context_block(provider)
+            assert block.startswith(_HEADER)
+
+    def test_block_always_includes_read_only_behavior_clause(self):
+        for provider in (
+            NullSecurityProvider(),
+            SilentGuardProvider(feed_path=Path("/tmp/__nope__sg.json")),
+        ):
+            block = build_security_context_block(provider)
+            assert _BEHAVIOR_LINE in block
+            # Sanity check that the wording is not scary.
+            assert "URGENT" not in block
+            assert "ALERT" not in block.upper().replace("ALERTS", "")
+
+    def test_block_does_not_promise_actions(self):
+        for provider in (
+            NullSecurityProvider(),
+            SilentGuardProvider(feed_path=Path("/tmp/__nope__sg.json")),
+        ):
+            block = build_security_context_block(provider).lower()
+            # No verbs that imply Nova will act.
+            for forbidden in ("block ", "unblock", "kill ", "firewall rule",
+                              "iptables", "nftables", "sudo "):
+                assert forbidden not in block, (
+                    f"security context must not promise the action {forbidden!r}"
+                )
+
+
+# ── Integration with chat.build_messages ────────────────────────────
+
+# Bring in chat module *after* the heavy-import stubs at the top of
+# the file. ``ddgs`` and ``ollama`` are stubbed; the chat module is
+# safe to import.
+from core import chat as chat_module  # noqa: E402
+from core.chat import build_messages  # noqa: E402
+
+
+class TestChatBuildMessagesAppendsBlock:
+    def test_block_lands_in_system_prompt(self, tmp_path, monkeypatch):
+        # Force the SilentGuard file probe to miss so the block reports
+        # "not configured." We patch the env var rather than the
+        # default path so the test stays independent of host state.
+        monkeypatch.setenv(
+            "NOVA_SILENTGUARD_PATH", str(tmp_path / "absent.json"),
+        )
+        msgs = build_messages([], "hi", [])
+        assert msgs[0]["role"] == "system"
+        sys_prompt = msgs[0]["content"]
+        assert "Security context:" in sys_prompt
+        assert "SilentGuard integration: not configured." in sys_prompt
+        assert _BEHAVIOR_LINE in sys_prompt
+
+    def test_block_lands_after_time_context(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "NOVA_SILENTGUARD_PATH", str(tmp_path / "absent.json"),
+        )
+        msgs = build_messages([], "hi", [])
+        sys_prompt = msgs[0]["content"]
+        # Time context block precedes the security block in the
+        # assembled prompt — the security block is the last thing.
+        assert sys_prompt.index("[Time context]") < sys_prompt.index(
+            "Security context:"
+        )
+
+    def test_block_appears_only_once(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "NOVA_SILENTGUARD_PATH", str(tmp_path / "absent.json"),
+        )
+        msgs = build_messages([], "hi", [])
+        # No duplicate injection across context_type branches either.
+        sys_prompt = msgs[0]["content"]
+        assert sys_prompt.count("Security context:") == 1
+
+    def test_block_present_for_security_context_branch(self, tmp_path, monkeypatch):
+        # Even when the chat path passes a SilentGuard summary as
+        # `extra_context`, the read-only context block is still
+        # appended — the two are different surfaces.
+        monkeypatch.setenv(
+            "NOVA_SILENTGUARD_PATH", str(tmp_path / "absent.json"),
+        )
+        msgs = build_messages(
+            [], "any", [], extra_context="some summary text",
+            context_type="security",
+        )
+        sys_prompt = msgs[0]["content"]
+        assert "Security context:" in sys_prompt
+
+    def test_chat_path_swallows_provider_failure(self, tmp_path, monkeypatch):
+        """A misbehaving provider must not break chat prompt assembly."""
+
+        class _Boom:
+            name = "silentguard"
+
+            def __init__(self, *_, **__):
+                pass
+
+            def get_status(self):
+                raise RuntimeError("not today")
+
+        # Patch the chat module's reference, not the security package's,
+        # so the patch lands on the call site.
+        monkeypatch.setattr(chat_module, "SilentGuardProvider", _Boom)
+        msgs = build_messages([], "hi", [])
+        sys_prompt = msgs[0]["content"]
+        # The block ends up "read-only API is unavailable" via the
+        # provider's safe-fail path. Either that or the block is
+        # omitted entirely. Both are acceptable; the test asserts the
+        # chat path never bubbled the exception.
+        assert msgs[0]["role"] == "system"
+        assert "[Time context]" in sys_prompt


### PR DESCRIPTION
## Summary

Adds a small, controlled SilentGuard security context layer to Nova's chat system prompt so the model accurately knows whether SilentGuard is configured, reachable, or unavailable — without bloating prompts and without inviting Nova to act.

The block lands after the existing time-context block in `build_messages` and looks like this:

```
Security context:
- SilentGuard integration: connected in read-only mode.
- Current summary: 0 alerts, 0 blocked items, 0 trusted items, 0 active connections.
- Allowed behavior: explain and summarize only; do not perform firewall or rule actions.
```

State mapping (deterministic, no LLM in the loop):
- No provider / null default / SilentGuard file missing → *"SilentGuard integration: not configured."*
- Configured but unreachable (file probe raised, API offline) → *"SilentGuard integration: read-only API is unavailable."*
- Reachable → *"SilentGuard integration: connected in read-only mode."* + counts when the optional HTTP transport is wired up.

Every variant ends with the same fixed read-only behaviour clause.

## What changed

- **New** `core/security/context.py` — `build_security_context_block(provider=None)` produces the deterministic block. Never raises. Never includes raw payloads (no IPs, no process names, no exception text, no API URLs).
- **`core/security/silentguard.py`** — adds `SilentGuardProvider.get_summary_counts()` which returns `{alerts, blocked, trusted, connections}` (or `None`) when the HTTP transport is configured and reachable. Mirrors the existing `get_summary_text()` pattern; reuses the same `SilentGuardClient` read-only surface (GET-only against `/status`, `/connections`, `/blocked`, `/trusted`, `/alerts`).
- **`core/security/__init__.py`** — exports `build_security_context_block` from the package.
- **`core/chat.py`** — `build_messages` appends the block after `format_time_context()`. The call is wrapped in a defensive `try/except` so a provider regression can never break chat assembly.
- **`README.md` / `docs/silentguard-integration-roadmap.md`** — explain that Nova surfaces SilentGuard read-only context, that this is **not** notification behaviour, **not** firewall control, and that no actions are performed.
- **`tests/test_security_context.py`** — 28 new tests covering: state mapping, malformed counts dicts, provider exceptions, raw-payload leak prevention, wording invariants, integration with `build_messages`, and the resilience to a misbehaving `SilentGuardProvider`.

## Read-only / safety guarantees (preserved)

- No writes, no shell, no firewall, no `systemctl`, no privileged subprocess.
- No background polling, no scheduler, no notifications.
- No remote/cloud calls. Local-first only.
- Per-user `silentguard_enabled` gate is unchanged.
- Existing `core/security/` forbidden-imports test (no `subprocess`, `socket`, `shutil`, `ctypes`, `signal`) still passes — the new `context.py` adds zero forbidden imports.
- The SilentGuard memory file is not mutated by any new code path.

## Out of scope (explicitly)

- No `/block`, `/unblock`, `/start`, `/stop` endpoints.
- No write surface to SilentGuard's data files.
- No autonomous alert engine.
- No Settings dashboard expansion.
- No new admin / family-controls tier.
- No SilentGuard code merged into Nova.

## Test plan

- [x] `pytest tests/test_security_context.py` — 28 passed
- [x] `pytest tests/test_security_provider.py` — 55 passed (existing security provider contract preserved)
- [x] `pytest tests/test_security_feed.py` — 28 passed
- [x] `pytest tests/test_integrations_silentguard.py` — 13 passed (per-user gate intact)
- [x] `pytest tests/test_personalization_chat_wiring.py` — 10 passed (chat prompt assembly intact)
- [x] `flake8 core/security/ core/chat.py tests/test_security_context.py` — clean
- [x] Block reports *not configured* when SilentGuard isn't installed
- [x] Block reports *unavailable* when configured but unreachable (file `OSError`, API offline, malformed JSON, timeout, provider raises)
- [x] Block reports *connected* with zero / non-zero counts when reachable
- [x] Block never leaks IPs, process names, file paths, API URLs, or exception text
- [x] Block always restates the read-only behaviour clause


---
_Generated by [Claude Code](https://claude.ai/code/session_01TCi5kakmHHouK66adiJ8WG)_