### PR TITLE
feat(security): opt-in non-privileged starter for SilentGuard read-only API

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,16 +32,59 @@ NEXANOTE_TIMEOUT_SECONDS = float(os.getenv("NEXANOTE_TIMEOUT_SECONDS", "3.0"))
 
 # SilentGuard local read-only HTTP API (optional; off by default).
 # An empty value keeps the file-based probe in place. Setting a URL
-# (typically loopback, e.g. http://127.0.0.1:8765) enables the HTTP
+# (typically loopback, e.g. http://127.0.0.1:8767) enables the HTTP
 # probe in core.security.SilentGuardProvider. The transport stays
 # read-only — only GET against a fixed path list is ever issued.
-NOVA_SILENTGUARD_API_URL = os.getenv("NOVA_SILENTGUARD_API_URL", "").strip().rstrip("/")
+# ``NOVA_SILENTGUARD_API_BASE_URL`` is accepted as a synonym for the
+# original ``NOVA_SILENTGUARD_API_URL`` so the documented config name
+# matches the SilentGuard service contract.
+NOVA_SILENTGUARD_API_URL = (
+    os.getenv("NOVA_SILENTGUARD_API_BASE_URL")
+    or os.getenv("NOVA_SILENTGUARD_API_URL", "")
+).strip().rstrip("/")
 try:
     NOVA_SILENTGUARD_API_TIMEOUT_SECONDS = float(
         os.getenv("NOVA_SILENTGUARD_API_TIMEOUT_SECONDS", "2.0")
     )
 except ValueError:
     NOVA_SILENTGUARD_API_TIMEOUT_SECONDS = 2.0
+
+# ── SilentGuard host-level lifecycle (optional auto-start) ──────────
+# Server-level switches that gate Nova's optional, *non-privileged*
+# starter for SilentGuard's local read-only API. Every switch defaults
+# to "off" so unconfigured Nova installs never try to spawn anything.
+#
+# ``NOVA_SILENTGUARD_ENABLED``     — host-wide opt-in for the
+#   integration's lifecycle helper. The per-user
+#   ``silentguard_enabled`` setting still gates whether SilentGuard
+#   data is surfaced to that user; this flag governs whether the
+#   lifecycle helper may probe / auto-start at all.
+# ``NOVA_SILENTGUARD_AUTO_START``  — when both this and the host-level
+#   switch are true, the lifecycle helper may spawn the configured
+#   start command after a failed probe. Defaults to off.
+# ``NOVA_SILENTGUARD_START_MODE``  — selects the start backend.
+#   ``"systemd-user"`` is the only allowed non-disabled value, on
+#   purpose: it pins Nova to ``systemctl --user start <unit>``, which
+#   never escalates privilege and never touches firewall config.
+# ``NOVA_SILENTGUARD_SYSTEMD_UNIT`` — the user-level unit name to
+#   start. Validated against a strict ``[a-z0-9._-]+\.service``
+#   pattern; anything else is rejected before any spawn.
+#
+# See ``docs/silentguard-integration-roadmap.md`` for the safety
+# rationale and the explicit non-goals (no sudo, no firewall, no
+# system-level systemctl, no background polling).
+NOVA_SILENTGUARD_ENABLED = (
+    os.getenv("NOVA_SILENTGUARD_ENABLED", "false").strip().lower() == "true"
+)
+NOVA_SILENTGUARD_AUTO_START = (
+    os.getenv("NOVA_SILENTGUARD_AUTO_START", "false").strip().lower() == "true"
+)
+NOVA_SILENTGUARD_START_MODE = (
+    os.getenv("NOVA_SILENTGUARD_START_MODE", "disabled").strip().lower()
+)
+NOVA_SILENTGUARD_SYSTEMD_UNIT = (
+    os.getenv("NOVA_SILENTGUARD_SYSTEMD_UNIT", "silentguard-api.service").strip()
+)
 
 # ── Optional local TTS: Piper ─────────────────────────────────────────
 # Browser speechSynthesis remains the safe default. Piper is an opt-in

--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -42,8 +42,17 @@ from core.security.provider import (
 from core.security.silentguard import SilentGuardProvider
 from core.security.silentguard_client import SilentGuardClient
 from core.security.context import build_security_context_block
+# Lifecycle helper is the only file in this package permitted to import
+# ``subprocess`` / ``shutil``. It is exposed here so the web layer can
+# call it without reaching into a private submodule, but the read-only
+# provider, client, and context block remain unaffected.
+from core.security.lifecycle import (
+    LifecycleStatus,
+    ensure_running as ensure_silentguard_running,
+)
 
 __all__ = [
+    "LifecycleStatus",
     "NullSecurityProvider",
     "SecurityProvider",
     "SecurityStatus",
@@ -54,6 +63,7 @@ __all__ = [
     "STATE_UNAVAILABLE",
     "build_security_context_block",
     "default_provider",
+    "ensure_silentguard_running",
     "get_security_context_summary",
     "get_security_context_text",
     "now_iso",

--- a/core/security/lifecycle.py
+++ b/core/security/lifecycle.py
@@ -1,0 +1,477 @@
+"""
+SilentGuard local API service lifecycle helper (Phase 1 — opt-in).
+
+Nova is the cognitive layer; SilentGuard remains the security/network
+engine. This helper lets Nova *optionally* start SilentGuard's local
+**read-only** API service when the host operator has explicitly opted
+in, while keeping every safety boundary the rest of the integration
+already commits to:
+
+  * no ``sudo`` / ``pkexec`` / ``doas`` / ``su`` / ``runuser``,
+  * no system-level ``systemctl`` (only ``systemctl --user``),
+  * no firewall command (``iptables`` / ``nftables`` / ``ufw`` / …),
+  * no shell interpretation — argv only, never a string,
+  * no command sourced from chat input or remote URLs,
+  * no background polling, no retry loops, no notifications.
+
+The helper is the **only** module in ``core.security`` allowed to
+import :mod:`subprocess` and :mod:`shutil`. The read-only provider,
+the HTTP client, and the prompt context block stay forbidden from
+touching either, and the existing AST-based "no forbidden imports"
+test continues to assert that.
+
+The orchestration is single-pass and synchronous:
+
+  1. Look up the host-level enabled / auto-start / start-mode / unit
+     config.
+  2. If integration is disabled → ``state="disabled"``.
+  3. Probe :class:`SilentGuardProvider` once. If reachable →
+     ``state="connected"``.
+  4. If auto-start is off, or start-mode is not ``"systemd-user"``,
+     or the unit name fails validation → ``state="unavailable"`` /
+     ``state="could_not_start"`` as appropriate, with no spawn.
+  5. Otherwise spawn ``systemctl --user start <unit>`` with strict
+     argv, ``shell=False``, no inherited stdin, a short timeout, and
+     captured stdout/stderr. Wait one bounded delay, re-probe once,
+     and return ``connected`` / ``starting`` / ``could_not_start``.
+
+Every error path returns a calm :class:`LifecycleStatus` with a
+sanitized, user-safe ``message``. The function never raises into the
+chat or web layer.
+
+See ``docs/silentguard-integration-roadmap.md`` for the design
+rationale and the exhaustive non-goals.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from core.security.provider import SecurityProvider
+from core.security.silentguard import SilentGuardProvider
+
+logger = logging.getLogger(__name__)
+
+# Lifecycle states surfaced through ``/integrations/silentguard/lifecycle``
+# and embedded in ``/integrations/status``. Plain strings so the value
+# round-trips through JSON without bespoke encoders. The vocabulary is
+# intentionally small — adding a state is a deliberate review.
+STATE_DISABLED = "disabled"                # integration switched off
+STATE_CONNECTED = "connected"              # API reachable, read-only
+STATE_STARTING = "starting"                # spawn accepted; not yet reachable
+STATE_COULD_NOT_START = "could_not_start"  # spawn rejected / failed
+STATE_UNAVAILABLE = "unavailable"          # not reachable, no auto-start
+
+# Allowed values for ``NOVA_SILENTGUARD_START_MODE``. Anything else
+# normalises to ``"disabled"`` so a typo never opens a new spawn path.
+START_MODE_SYSTEMD_USER = "systemd-user"
+START_MODE_DISABLED = "disabled"
+_ALLOWED_START_MODES = frozenset({START_MODE_SYSTEMD_USER, START_MODE_DISABLED})
+
+# The default systemd user unit Nova will try to start when the
+# operator has opted in but not customised the unit name. Mirrors the
+# documented value in ``docs/silentguard-integration-roadmap.md``.
+DEFAULT_SYSTEMD_UNIT = "silentguard-api.service"
+
+# Time budget for the spawned ``systemctl --user start <unit>`` call.
+# Short by design — systemd queues the start and returns; the unit
+# itself comes up asynchronously. A hung systemctl maps to
+# "could_not_start".
+DEFAULT_START_TIMEOUT_SECONDS = 3.0
+# Bounded sleep between accepting the systemctl start and re-probing
+# the API. Single-shot, not a loop.
+DEFAULT_POST_START_DELAY_SECONDS = 1.0
+
+# Strict unit-name regex: must start with a lowercase alnum, may
+# contain alnum / dot / dash / underscore, must end in ``.service``.
+# No path separators, no shell metacharacters, no leading dots.
+_UNIT_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*\.service$")
+
+# Sequences forbidden anywhere in the unit name (defence in depth on
+# top of the regex). Any of these is an immediate validation failure.
+_UNIT_FORBIDDEN_SUBSTRINGS = (
+    "..",
+    "/",
+    "\\",
+    "\n",
+    "\r",
+    "\t",
+    " ",
+    ";",
+    "&",
+    "|",
+    "$",
+    "`",
+    "<",
+    ">",
+    "(",
+    ")",
+    "{",
+    "}",
+)
+
+
+@dataclass(frozen=True)
+class LifecycleStatus:
+    """Read-only snapshot of SilentGuard auto-start lifecycle state.
+
+    Returned by :func:`ensure_running`. Stable, JSON-friendly shape so
+    the web layer can surface it without a bespoke renderer. ``state``
+    is one of the ``STATE_*`` constants; ``message`` is a calm,
+    user-safe sentence (no stack traces, no raw paths, no exception
+    text).
+    """
+
+    state: str
+    enabled: bool
+    auto_start: bool
+    start_mode: str
+    unit: str
+    message: str
+
+    def as_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "enabled": self.enabled,
+            "auto_start": self.auto_start,
+            "start_mode": self.start_mode,
+            "unit": self.unit,
+            "message": self.message,
+        }
+
+
+# ── Config resolution ───────────────────────────────────────────────
+
+def _bool_env(name: str, *, default: bool) -> bool:
+    """Read a boolean from the environment with a strict allowlist."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _resolve_enabled() -> bool:
+    """Host-level integration switch. Env wins over config import."""
+    raw = os.environ.get("NOVA_SILENTGUARD_ENABLED")
+    if raw is not None:
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from config import NOVA_SILENTGUARD_ENABLED  # local import: avoid cycles
+    except Exception:  # pragma: no cover — config import is best-effort
+        return False
+    return bool(NOVA_SILENTGUARD_ENABLED)
+
+
+def _resolve_auto_start() -> bool:
+    """Whether Nova may spawn the configured start command."""
+    raw = os.environ.get("NOVA_SILENTGUARD_AUTO_START")
+    if raw is not None:
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from config import NOVA_SILENTGUARD_AUTO_START
+    except Exception:  # pragma: no cover
+        return False
+    return bool(NOVA_SILENTGUARD_AUTO_START)
+
+
+def _resolve_start_mode() -> str:
+    """Pick the start backend; unknown values normalise to disabled."""
+    raw = os.environ.get("NOVA_SILENTGUARD_START_MODE")
+    if raw is None:
+        try:
+            from config import NOVA_SILENTGUARD_START_MODE
+        except Exception:  # pragma: no cover
+            return START_MODE_DISABLED
+        raw = NOVA_SILENTGUARD_START_MODE
+    value = (raw or "").strip().lower()
+    return value if value in _ALLOWED_START_MODES else START_MODE_DISABLED
+
+
+def _resolve_unit() -> str:
+    """Look up the configured systemd user unit name."""
+    raw = os.environ.get("NOVA_SILENTGUARD_SYSTEMD_UNIT")
+    if raw is None:
+        try:
+            from config import NOVA_SILENTGUARD_SYSTEMD_UNIT
+        except Exception:  # pragma: no cover
+            return DEFAULT_SYSTEMD_UNIT
+        raw = NOVA_SILENTGUARD_SYSTEMD_UNIT
+    return (raw or "").strip()
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+def validate_unit_name(unit: str) -> bool:
+    """Return True only when ``unit`` is a safe systemd user unit name.
+
+    Defensive rules, in order:
+      * input is a string;
+      * length between 1 and 128 chars (real units are ≪ this);
+      * input equals its ``.strip()`` form — any leading/trailing
+        whitespace, including embedded newlines, is rejected;
+      * no forbidden substring (``..``, path separators, shell
+        metacharacters, whitespace, control characters);
+      * matches ``^[a-z0-9][a-z0-9._-]*\\.service$``.
+
+    The validator deliberately does **not** silently strip input: a
+    config with an embedded newline is suspicious, and surfacing that
+    as a rejection (``state="could_not_start"``) is more honest than
+    quietly normalising it. ``ensure_running`` resolves env vars via
+    its own ``str.strip()`` before calling this validator, so a
+    well-formed config still validates.
+
+    A rejected unit causes :func:`ensure_running` to surface
+    ``state="could_not_start"`` *before* any spawn is attempted.
+    """
+    if not isinstance(unit, str):
+        return False
+    if not unit or len(unit) > 128:
+        return False
+    if unit != unit.strip():
+        return False
+    if any(bad in unit for bad in _UNIT_FORBIDDEN_SUBSTRINGS):
+        return False
+    return bool(_UNIT_RE.match(unit))
+
+
+def _systemctl_path() -> Optional[str]:
+    """Return the absolute path to systemctl, or ``None`` if missing."""
+    return shutil.which("systemctl")
+
+
+# ── Spawner ─────────────────────────────────────────────────────────
+
+def _start_systemd_user_unit(unit: str) -> tuple[bool, str]:
+    """Run ``systemctl --user start <unit>`` with strict argv.
+
+    Never raises. Returns ``(success, sanitized_detail)``.
+
+    Safety properties (assertion-grade, not aspirational):
+      * argv list, ``shell=False`` — no shell interpretation by
+        Python or by the OS.
+      * absolute path to ``systemctl`` resolved via ``shutil.which``;
+        if that fails we never spawn.
+      * literal ``--user`` flag — no system-level systemctl, ever.
+      * literal ``start`` verb — no ``stop`` / ``restart`` /
+        ``reload`` / ``enable`` reachable from this code path.
+      * stdin redirected from /dev/null; stdout / stderr captured to
+        bounded buffers.
+      * short timeout — a hung systemctl is treated as failure, not
+        as something to wait on indefinitely.
+
+    The returned ``detail`` is a short, sanitized string suitable for
+    debug logging; it is **not** surfaced to the user verbatim so that
+    a hostile log line cannot leak into the UI.
+    """
+    binary = _systemctl_path()
+    if binary is None:
+        return False, "systemctl_not_found"
+
+    argv = [binary, "--user", "start", unit]
+    # Belt-and-braces: re-validate just before exec, in case a caller
+    # somehow reached this path without going through ensure_running.
+    if not validate_unit_name(unit):
+        return False, "unit_validation_failed"
+
+    try:
+        result = subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=DEFAULT_START_TIMEOUT_SECONDS,
+            check=False,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("systemctl --user start %s timed out", unit)
+        return False, "spawn_timeout"
+    except (OSError, ValueError) as exc:
+        logger.debug("systemctl --user start %s failed to spawn: %s", unit, exc)
+        return False, "spawn_error"
+
+    if result.returncode != 0:
+        logger.debug(
+            "systemctl --user start %s exited with code %s",
+            unit, result.returncode,
+        )
+        return False, "non_zero_exit"
+    return True, "spawn_accepted"
+
+
+# ── Public orchestration ────────────────────────────────────────────
+
+def _provider_status(provider: SecurityProvider):
+    """Call ``provider.get_status``; return ``None`` if it raises."""
+    try:
+        return provider.get_status()
+    except Exception:  # pragma: no cover — providers must not raise
+        logger.debug(
+            "security provider get_status raised; treating as unavailable",
+            exc_info=True,
+        )
+        return None
+
+
+def ensure_running(
+    provider: Optional[SecurityProvider] = None,
+    *,
+    sleep: Optional[callable] = None,
+) -> LifecycleStatus:
+    """Return the current SilentGuard lifecycle state, optionally
+    starting the local read-only API service if the operator has
+    opted in.
+
+    Parameters
+    ----------
+    provider:
+        An optional :class:`SecurityProvider` to use for reachability
+        probes. Defaults to :class:`SilentGuardProvider`, which reads
+        the configured API URL / file path itself.
+    sleep:
+        Optional sleep hook (defaults to :func:`time.sleep`). Tests
+        use this to keep the suite fast without changing the
+        production code path.
+
+    The function is single-pass and synchronous; there is no retry
+    loop, no thread, and no scheduler. It never raises.
+    """
+    enabled = _resolve_enabled()
+    auto_start = _resolve_auto_start()
+    start_mode = _resolve_start_mode()
+    unit = _resolve_unit()
+
+    if not enabled:
+        return LifecycleStatus(
+            state=STATE_DISABLED,
+            enabled=False,
+            auto_start=auto_start,
+            start_mode=start_mode,
+            unit=unit,
+            message="SilentGuard integration disabled.",
+        )
+
+    active = provider if provider is not None else SilentGuardProvider()
+
+    # ── First probe ────────────────────────────────────────────────
+    status = _provider_status(active)
+    if status is not None and status.available:
+        return LifecycleStatus(
+            state=STATE_CONNECTED,
+            enabled=True,
+            auto_start=auto_start,
+            start_mode=start_mode,
+            unit=unit,
+            message="SilentGuard connected in read-only mode.",
+        )
+
+    # ── Auto-start gating ──────────────────────────────────────────
+    if not auto_start or start_mode != START_MODE_SYSTEMD_USER:
+        return LifecycleStatus(
+            state=STATE_UNAVAILABLE,
+            enabled=True,
+            auto_start=auto_start,
+            start_mode=start_mode,
+            unit=unit,
+            message="SilentGuard unavailable.",
+        )
+
+    if not validate_unit_name(unit):
+        # Configured to auto-start, but the unit fails validation —
+        # surface this as "could not be started" (no spawn happened)
+        # rather than silently degrading to "unavailable", so the
+        # operator sees their config is wrong.
+        return LifecycleStatus(
+            state=STATE_COULD_NOT_START,
+            enabled=True,
+            auto_start=auto_start,
+            start_mode=start_mode,
+            unit=unit,
+            message="SilentGuard could not be started.",
+        )
+
+    # ── Spawn ──────────────────────────────────────────────────────
+    spawned, _detail = _start_systemd_user_unit(unit)
+    if not spawned:
+        return LifecycleStatus(
+            state=STATE_COULD_NOT_START,
+            enabled=True,
+            auto_start=auto_start,
+            start_mode=start_mode,
+            unit=unit,
+            message="SilentGuard could not be started.",
+        )
+
+    # ── Bounded re-probe ──────────────────────────────────────────
+    sleeper = sleep if callable(sleep) else time.sleep
+    try:
+        sleeper(DEFAULT_POST_START_DELAY_SECONDS)
+    except Exception:  # pragma: no cover — defensive
+        pass
+
+    status_after = _provider_status(active)
+    if status_after is not None and status_after.available:
+        return LifecycleStatus(
+            state=STATE_CONNECTED,
+            enabled=True,
+            auto_start=auto_start,
+            start_mode=start_mode,
+            unit=unit,
+            message="SilentGuard connected in read-only mode.",
+        )
+
+    # The systemctl call was accepted, but the API has not bound its
+    # socket yet. Honest middle state: "starting". The next status
+    # check will resolve to connected (or unavailable if the unit
+    # never came up).
+    return LifecycleStatus(
+        state=STATE_STARTING,
+        enabled=True,
+        auto_start=auto_start,
+        start_mode=start_mode,
+        unit=unit,
+        message="Starting SilentGuard…",
+    )
+
+
+def disabled_status(message: str = "SilentGuard integration disabled.") -> LifecycleStatus:
+    """Return a calm ``state="disabled"`` snapshot.
+
+    Useful when the per-user gate is off (so the host-level config is
+    not relevant to *this* user) and the web layer wants to short-
+    circuit before invoking :func:`ensure_running`. The returned
+    ``auto_start`` is hard-coded to ``False`` so the UI never claims
+    a disabled user can trigger a spawn; the unit / start_mode fields
+    still surface the host config so operators can debug.
+    """
+    return LifecycleStatus(
+        state=STATE_DISABLED,
+        enabled=False,
+        auto_start=False,
+        start_mode=_resolve_start_mode(),
+        unit=_resolve_unit(),
+        message=message,
+    )
+
+
+__all__ = [
+    "DEFAULT_SYSTEMD_UNIT",
+    "LifecycleStatus",
+    "STATE_CONNECTED",
+    "STATE_COULD_NOT_START",
+    "STATE_DISABLED",
+    "STATE_STARTING",
+    "STATE_UNAVAILABLE",
+    "START_MODE_DISABLED",
+    "START_MODE_SYSTEMD_USER",
+    "disabled_status",
+    "ensure_running",
+    "validate_unit_name",
+]

--- a/docs/silentguard-integration-roadmap.md
+++ b/docs/silentguard-integration-roadmap.md
@@ -127,6 +127,75 @@ commands.
 (state, detail, enabled flag). The settings panel surfaces a single
 on/off toggle for SilentGuard.
 
+### 2.4.bis `core/security/lifecycle.py` (opt-in non-privileged starter)
+
+A small, narrowly scoped helper that lets Nova *optionally* start
+SilentGuard's local read-only API service. Every gate defaults off,
+so unconfigured Nova installs never try to spawn anything.
+
+The helper is the **only** module in the security package allowed to
+import :mod:`subprocess` and :mod:`shutil`. The forbidden-imports
+test continues to pin every other file in the package to read-only.
+
+Configuration (env vars, all defaulting to safe values):
+
+  * ``NOVA_SILENTGUARD_ENABLED`` — host-level switch for the
+    lifecycle helper. Per-user ``silentguard_enabled`` still gates
+    whether SilentGuard data is surfaced to a given user.
+  * ``NOVA_SILENTGUARD_AUTO_START`` — when both this and the host
+    switch are true, the helper may spawn the configured start
+    command after a failed reachability probe. Defaults to off.
+  * ``NOVA_SILENTGUARD_API_BASE_URL`` — accepted as a synonym of the
+    pre-existing ``NOVA_SILENTGUARD_API_URL``. Loopback-only, e.g.
+    ``http://127.0.0.1:8767``.
+  * ``NOVA_SILENTGUARD_START_MODE`` — selects the start backend.
+    ``"systemd-user"`` is the only allowed non-disabled value, on
+    purpose: it pins Nova to ``systemctl --user start <unit>``.
+    Anything else (including typos) normalises to ``"disabled"``.
+  * ``NOVA_SILENTGUARD_SYSTEMD_UNIT`` — the user-level unit name to
+    start. Validated against ``^[a-z0-9][a-z0-9._-]*\.service$`` and
+    a forbidden-substring list (``..``, path separators, shell
+    metacharacters, whitespace, control characters); rejected
+    configurations surface as ``state="could_not_start"`` *before*
+    any spawn.
+
+Behaviour, in order:
+
+  1. If integration is disabled → ``state="disabled"``.
+  2. Probe :class:`SilentGuardProvider` once. If reachable →
+     ``state="connected"``.
+  3. If auto-start is off, or start-mode is not ``"systemd-user"``,
+     or the unit name fails validation → ``state="unavailable"`` /
+     ``state="could_not_start"`` as appropriate, with no spawn.
+  4. Otherwise spawn ``systemctl --user start <unit>`` with strict
+     argv (``shell=False``, no inherited stdin, captured stderr,
+     short timeout). If the spawn itself fails →
+     ``state="could_not_start"``. If it succeeds, wait one bounded
+     delay and re-probe once. Connected → ``state="connected"``;
+     still unreachable → ``state="starting"`` (the unit was
+     accepted but has not bound its socket yet).
+
+Hard guarantees, asserted in code and tests:
+
+  * No ``sudo`` / ``pkexec`` / ``doas`` / ``su`` / ``runuser``.
+  * No system-level ``systemctl`` — only ``systemctl --user``.
+  * No firewall command (``iptables`` / ``nftables`` / ``ufw`` …).
+  * No shell interpretation; argv list only.
+  * No command sourced from chat input or remote URLs.
+  * No background polling, no retry loop, no notifications.
+  * Single-pass and synchronous; never raises into chat or web.
+  * If SilentGuard is not installed / not configured, Nova continues
+    working normally — every gate falls back to a calm
+    ``state="disabled"`` / ``state="unavailable"`` snapshot.
+
+The helper is wired into the web layer via
+``GET /integrations/silentguard/lifecycle``, gated by the per-user
+``silentguard_enabled`` setting, and surfaced in the same calm
+``state`` vocabulary the Settings card renders. There is no
+auto-start on Nova boot, on session resume, or on tab focus — the
+helper runs only when the user (or operator-driven UI) explicitly
+asks for the lifecycle status.
+
 ### 2.5 `core/security/context.py` (read-only chat context)
 
 A small builder that produces the per-turn "Security context:" block

--- a/tests/test_security_lifecycle.py
+++ b/tests/test_security_lifecycle.py
@@ -1,0 +1,789 @@
+"""
+Tests for the SilentGuard lifecycle helper.
+
+The lifecycle helper is the *only* file in ``core.security`` allowed to
+import :mod:`subprocess` and :mod:`shutil`. These tests pin the safety
+contract:
+
+  * disabled integration is silent — no probe, no spawn;
+  * auto-start is firmly opt-in (off by default);
+  * only ``systemctl --user start <validated-unit>`` is ever spawned;
+  * unit-name validation rejects every shape that could escape the
+    intended argv (path traversal, shell metacharacters, sudo / firewall
+    aliases, whitespace, system-level systemctl);
+  * a failed spawn (timeout, non-zero exit, missing binary, OSError)
+    surfaces as a calm ``could_not_start`` snapshot;
+  * a successful spawn whose API has not yet bound surfaces as
+    ``starting`` — never as a fake ``connected``;
+  * the helper never raises into the caller, even when the provider
+    misbehaves.
+
+Provider behaviour (file / HTTP transport, prompt-context block,
+existing per-user gate) is unaffected by this module and continues to
+be covered by ``test_security_provider``, ``test_security_context``,
+and ``test_integrations_silentguard``.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+# Heavy / optional deps that ``web.py`` pulls in at module load. Stub
+# them before any test imports ``web`` so a missing wheel (e.g.
+# ``sgmllib`` removed in Python 3.10) cannot block this file. Only the
+# minimal attribute surface the importers actually touch is provided;
+# everything else degrades to a MagicMock.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.security import lifecycle as lifecycle_module
+from core.security.lifecycle import (
+    DEFAULT_SYSTEMD_UNIT,
+    LifecycleStatus,
+    STATE_CONNECTED,
+    STATE_COULD_NOT_START,
+    STATE_DISABLED,
+    STATE_STARTING,
+    STATE_UNAVAILABLE,
+    START_MODE_DISABLED,
+    START_MODE_SYSTEMD_USER,
+    disabled_status,
+    ensure_running,
+    validate_unit_name,
+)
+from core.security.provider import (
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE as PROVIDER_STATE_UNAVAILABLE,
+    SecurityStatus,
+)
+
+
+# ── Test doubles ────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeProbeProvider:
+    """Provider stub that records call counts and returns canned status."""
+
+    name: str = "silentguard"
+    status_sequence: tuple = ()
+    raise_on_call: bool = False
+    calls: int = 0
+
+    def get_status(self) -> SecurityStatus:
+        self.calls += 1
+        if self.raise_on_call:
+            raise RuntimeError("provider boom")
+        if not self.status_sequence:
+            return SecurityStatus(
+                available=False,
+                service=self.name,
+                state=STATE_OFFLINE,
+                message="stub offline",
+            )
+        idx = min(self.calls - 1, len(self.status_sequence) - 1)
+        return self.status_sequence[idx]
+
+
+def _available() -> SecurityStatus:
+    return SecurityStatus(
+        available=True,
+        service="silentguard",
+        state=STATE_AVAILABLE,
+        message="stub available",
+    )
+
+
+def _offline() -> SecurityStatus:
+    return SecurityStatus(
+        available=False,
+        service="silentguard",
+        state=STATE_OFFLINE,
+        message="stub offline",
+    )
+
+
+def _unconfigured() -> SecurityStatus:
+    return SecurityStatus(
+        available=False,
+        service="silentguard",
+        state=PROVIDER_STATE_UNAVAILABLE,
+        message="stub unconfigured",
+    )
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_lifecycle_env(monkeypatch):
+    """Strip every host-level env var so each test starts fresh."""
+    for var in (
+        "NOVA_SILENTGUARD_ENABLED",
+        "NOVA_SILENTGUARD_AUTO_START",
+        "NOVA_SILENTGUARD_START_MODE",
+        "NOVA_SILENTGUARD_SYSTEMD_UNIT",
+        "NOVA_SILENTGUARD_PATH",
+        "NOVA_SILENTGUARD_API_URL",
+        "NOVA_SILENTGUARD_API_BASE_URL",
+        "NOVA_SILENTGUARD_API_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def _no_sleep(monkeypatch):
+    """Replace the lifecycle module's sleeper with a no-op for speed."""
+    yield lambda _seconds: None
+
+
+@pytest.fixture
+def _spawn_recorder(monkeypatch):
+    """Record every ``subprocess.run`` invocation; never actually exec."""
+    calls: list[dict] = []
+
+    class _FakeCompleted:
+        def __init__(self, returncode: int = 0):
+            self.returncode = returncode
+            self.stdout = b""
+            self.stderr = b""
+
+    def _fake_run(argv, **kwargs):
+        calls.append({"argv": list(argv), "kwargs": dict(kwargs)})
+        rc = _fake_run.next_returncode
+        if _fake_run.next_exception is not None:
+            raise _fake_run.next_exception
+        return _FakeCompleted(returncode=rc)
+
+    _fake_run.next_returncode = 0
+    _fake_run.next_exception: Optional[BaseException] = None
+
+    monkeypatch.setattr(lifecycle_module.subprocess, "run", _fake_run)
+    # Pretend systemctl is on PATH so we don't depend on the host having it.
+    monkeypatch.setattr(
+        lifecycle_module.shutil, "which",
+        lambda name: f"/usr/bin/{name}" if name == "systemctl" else None,
+    )
+
+    return calls, _fake_run
+
+
+# ── Disabled integration ────────────────────────────────────────────
+
+
+class TestDisabledIntegration:
+    def test_disabled_when_env_unset(self, _spawn_recorder):
+        provider = _FakeProbeProvider(status_sequence=(_available(),))
+        result = ensure_running(provider=provider)
+        assert result.state == STATE_DISABLED
+        assert result.enabled is False
+        assert result.message == "SilentGuard integration disabled."
+        # Disabled means: no probe, no spawn.
+        assert provider.calls == 0
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_disabled_when_env_explicitly_false(self, monkeypatch, _spawn_recorder):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "false")
+        provider = _FakeProbeProvider(status_sequence=(_available(),))
+        result = ensure_running(provider=provider)
+        assert result.state == STATE_DISABLED
+        assert provider.calls == 0
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_disabled_status_helper_returns_safe_snapshot(self, monkeypatch):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        snapshot = disabled_status()
+        assert snapshot.state == STATE_DISABLED
+        assert snapshot.enabled is False
+        # auto_start is hard-coded False in the disabled snapshot — even
+        # if the host enabled it, a disabled-for-this-user view must
+        # never claim auto-start is reachable.
+        assert snapshot.auto_start is False
+        assert "disabled" in snapshot.message.lower()
+
+
+# ── Enabled, reachable ──────────────────────────────────────────────
+
+
+class TestEnabledReachable:
+    def test_connected_when_provider_available(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        provider = _FakeProbeProvider(status_sequence=(_available(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_CONNECTED
+        assert result.enabled is True
+        assert "read-only" in result.message.lower()
+        assert provider.calls == 1
+        # Reachable on first probe → no spawn ever.
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+
+# ── Enabled, unreachable, auto-start off ────────────────────────────
+
+
+class TestEnabledAutoStartOff:
+    def test_unavailable_when_auto_start_disabled(
+        self, monkeypatch, _spawn_recorder,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        # NOVA_SILENTGUARD_AUTO_START defaults off.
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider)
+        assert result.state == STATE_UNAVAILABLE
+        assert result.auto_start is False
+        assert "unavailable" in result.message.lower()
+        assert provider.calls == 1
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_unavailable_when_start_mode_disabled(
+        self, monkeypatch, _spawn_recorder,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_START_MODE", "disabled")
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider)
+        assert result.state == STATE_UNAVAILABLE
+        # Auto-start was on, but start_mode was disabled → no spawn.
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_unavailable_when_start_mode_unrecognised(
+        self, monkeypatch, _spawn_recorder,
+    ):
+        # A typo or unsupported backend (sudo / firewall / etc.) must
+        # normalise to disabled, never silently spawn something.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_START_MODE", "sudo-systemctl")
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider)
+        assert result.state == STATE_UNAVAILABLE
+        assert result.start_mode == START_MODE_DISABLED
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+
+# ── Enabled, unreachable, auto-start on, valid config ───────────────
+
+
+class TestEnabledAutoStartOn:
+    def _enable(self, monkeypatch, *, unit: str = DEFAULT_SYSTEMD_UNIT):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_START_MODE", "systemd-user")
+        monkeypatch.setenv("NOVA_SILENTGUARD_SYSTEMD_UNIT", unit)
+
+    def test_connected_when_post_probe_succeeds(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        provider = _FakeProbeProvider(
+            status_sequence=(_offline(), _available()),
+        )
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_CONNECTED
+        assert provider.calls == 2
+
+        calls, _ = _spawn_recorder
+        assert len(calls) == 1
+        assert calls[0]["argv"] == [
+            "/usr/bin/systemctl", "--user", "start", DEFAULT_SYSTEMD_UNIT,
+        ]
+        # Strict spawn discipline.
+        assert calls[0]["kwargs"]["shell"] is False
+        assert calls[0]["kwargs"]["check"] is False
+        assert calls[0]["kwargs"]["stdin"] == subprocess.DEVNULL
+
+    def test_starting_when_post_probe_still_offline(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        # Spawn returns 0 but the API does not bind in time.
+        provider = _FakeProbeProvider(
+            status_sequence=(_offline(), _offline()),
+        )
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_STARTING
+        assert "starting" in result.message.lower()
+        assert provider.calls == 2
+
+    def test_could_not_start_when_systemctl_returns_nonzero(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        _, fake_run = _spawn_recorder
+        fake_run.next_returncode = 1
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_COULD_NOT_START
+        assert "could not be started" in result.message.lower()
+        # No second probe — the spawn failed before we got there.
+        assert provider.calls == 1
+
+    def test_could_not_start_when_systemctl_times_out(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        _, fake_run = _spawn_recorder
+        fake_run.next_exception = subprocess.TimeoutExpired(
+            cmd="systemctl", timeout=3.0,
+        )
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_COULD_NOT_START
+        assert provider.calls == 1
+
+    def test_could_not_start_when_spawn_oserror(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        _, fake_run = _spawn_recorder
+        fake_run.next_exception = OSError("permission denied")
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_COULD_NOT_START
+
+    def test_could_not_start_when_systemctl_missing(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        # Override the recorder's "which" to return None, simulating a
+        # host without systemctl on PATH.
+        monkeypatch.setattr(lifecycle_module.shutil, "which", lambda _n: None)
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_COULD_NOT_START
+        # Without systemctl we never even attempted to spawn.
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_could_not_start_when_unit_invalid(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch, unit="../etc/passwd")
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_COULD_NOT_START
+        # Validation must reject *before* any spawn happens.
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_could_not_start_when_unit_empty(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch, unit="   ")
+        provider = _FakeProbeProvider(status_sequence=(_offline(),))
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_COULD_NOT_START
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+
+# ── Validator ───────────────────────────────────────────────────────
+
+
+class TestValidateUnitName:
+    @pytest.mark.parametrize("unit", [
+        "silentguard-api.service",
+        "silentguard.service",
+        "my-silentguard_api.service",
+        "sg.api.service",
+        "a.service",
+    ])
+    def test_accepts_safe_unit_names(self, unit):
+        assert validate_unit_name(unit) is True
+
+    @pytest.mark.parametrize("unit", [
+        "",
+        "   ",
+        ".service",                    # leading dot
+        "../etc/passwd",
+        "/etc/silentguard.service",    # absolute path
+        "silentguard.service\n",       # newline
+        "silentguard.service;rm -rf",  # shell metachar
+        "silentguard.service & sleep", # shell metachar
+        "silentguard.service|cat",     # pipe
+        "$(whoami).service",           # command substitution
+        "`id`.service",                # backtick
+        "silentguard service",         # whitespace
+        "silentguard.timer",           # wrong suffix
+        "SilentGuard.service",         # uppercase rejected by regex
+        "silentguard.service\\extra",  # backslash
+    ])
+    def test_rejects_unsafe_unit_names(self, unit):
+        assert validate_unit_name(unit) is False
+
+    def test_rejects_non_string(self):
+        assert validate_unit_name(None) is False  # type: ignore[arg-type]
+        assert validate_unit_name(123) is False  # type: ignore[arg-type]
+        assert validate_unit_name(["silentguard-api.service"]) is False  # type: ignore[arg-type]
+
+    def test_rejects_overlong_unit(self):
+        assert validate_unit_name("a" * 200 + ".service") is False
+
+
+# ── Spawner safety ──────────────────────────────────────────────────
+
+
+class TestSpawnerSafety:
+    def _enable(self, monkeypatch):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_START_MODE", "systemd-user")
+
+    def test_argv_uses_systemctl_user_start_only(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        provider = _FakeProbeProvider(
+            status_sequence=(_offline(), _available()),
+        )
+        ensure_running(provider=provider, sleep=_no_sleep)
+        calls, _ = _spawn_recorder
+        argv = calls[0]["argv"]
+        # Verbs and flags are pinned: no stop / restart / enable, no
+        # system-level systemctl, no extra arguments.
+        assert argv[0].endswith("systemctl")
+        assert argv[1] == "--user"
+        assert argv[2] == "start"
+        assert len(argv) == 4
+        for forbidden in ("stop", "restart", "reload", "enable", "disable",
+                          "daemon-reload", "kill", "mask"):
+            assert forbidden not in argv
+
+    def test_no_sudo_or_privilege_escalation_in_argv(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        provider = _FakeProbeProvider(
+            status_sequence=(_offline(), _available()),
+        )
+        ensure_running(provider=provider, sleep=_no_sleep)
+        calls, _ = _spawn_recorder
+        argv_str = " ".join(calls[0]["argv"]).lower()
+        for tool in ("sudo", "pkexec", "doas", "su ", "runuser", "setpriv"):
+            assert tool not in argv_str
+
+    def test_no_firewall_command_in_argv(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        provider = _FakeProbeProvider(
+            status_sequence=(_offline(), _available()),
+        )
+        ensure_running(provider=provider, sleep=_no_sleep)
+        calls, _ = _spawn_recorder
+        argv_str = " ".join(calls[0]["argv"]).lower()
+        for tool in ("iptables", "nftables", "firewalld", "ufw", "pf", "ipfw"):
+            assert tool not in argv_str
+
+    def test_subprocess_run_called_without_shell(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        self._enable(monkeypatch)
+        provider = _FakeProbeProvider(
+            status_sequence=(_offline(), _available()),
+        )
+        ensure_running(provider=provider, sleep=_no_sleep)
+        calls, _ = _spawn_recorder
+        kwargs = calls[0]["kwargs"]
+        assert kwargs["shell"] is False
+        assert kwargs["check"] is False
+        # Bounded timeout — never wait forever.
+        assert kwargs["timeout"] == lifecycle_module.DEFAULT_START_TIMEOUT_SECONDS
+        assert kwargs["timeout"] > 0
+        # No inherited stdin.
+        assert kwargs["stdin"] == subprocess.DEVNULL
+
+
+# ── Provider robustness ─────────────────────────────────────────────
+
+
+class TestProviderRobustness:
+    def test_provider_raise_treated_as_unavailable(
+        self, monkeypatch, _spawn_recorder, _no_sleep,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        provider = _FakeProbeProvider(raise_on_call=True)
+        result = ensure_running(provider=provider, sleep=_no_sleep)
+        assert result.state == STATE_UNAVAILABLE
+
+    def test_ensure_running_never_raises_on_provider_misbehaviour(
+        self, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        provider = _FakeProbeProvider(raise_on_call=True)
+        # Must return a value, not raise.
+        ensure_running(provider=provider)
+
+
+# ── Disabled-by-user disabled snapshot ──────────────────────────────
+
+
+class TestDisabledStatusHelper:
+    def test_shape(self, monkeypatch):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_START_MODE", "systemd-user")
+        monkeypatch.setenv("NOVA_SILENTGUARD_SYSTEMD_UNIT", "silentguard-api.service")
+        snap = disabled_status()
+        d = snap.as_dict()
+        assert set(d.keys()) == {
+            "state", "enabled", "auto_start", "start_mode", "unit", "message",
+        }
+        assert d["state"] == STATE_DISABLED
+        assert d["enabled"] is False
+        assert d["auto_start"] is False
+        # Host config still surfaces, for diagnostic value.
+        assert d["start_mode"] == START_MODE_SYSTEMD_USER
+        assert d["unit"] == "silentguard-api.service"
+
+
+# ── Module-level safety: forbidden imports ──────────────────────────
+
+
+_LIFECYCLE_ALLOWED_MUTATING_IMPORTS = {"subprocess", "shutil"}
+_LIFECYCLE_FORBIDDEN_IMPORTS = {"socket", "ctypes", "signal"}
+
+
+def _imports(module) -> set[str]:
+    """Return the top-level import roots in ``module.__file__``."""
+    with open(module.__file__, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            roots.add((node.module or "").split(".")[0])
+    return roots
+
+
+class TestLifecycleImportAllowlist:
+    def test_lifecycle_imports_only_allowed_mutating_modules(self):
+        roots = _imports(lifecycle_module)
+        # Lifecycle is allowed subprocess + shutil; no other mutating
+        # module is permitted to land here without an explicit review.
+        for name in _LIFECYCLE_FORBIDDEN_IMPORTS:
+            assert name not in roots, (
+                f"core.security.lifecycle must not import {name!r}"
+            )
+
+    def test_lifecycle_uses_subprocess_and_shutil(self):
+        # The whole point of this module — assert the imports we expect
+        # are actually present, so a refactor that quietly drops them
+        # also drops the test signal.
+        roots = _imports(lifecycle_module)
+        assert "subprocess" in roots
+        assert "shutil" in roots
+
+    def test_other_security_files_remain_subprocess_free(self):
+        # Belt-and-braces: every other file in core.security must stay
+        # off subprocess / shutil. We import them lazily here so this
+        # test still runs even if a sibling regresses.
+        from core.security import (
+            provider as provider_module,
+            silentguard as silentguard_module,
+            silentguard_client as silentguard_client_module,
+            context as context_module,
+        )
+        from core import security as security_pkg
+
+        for module in (
+            provider_module,
+            silentguard_module,
+            silentguard_client_module,
+            context_module,
+            security_pkg,
+        ):
+            roots = _imports(module)
+            assert "subprocess" not in roots, (
+                f"{module.__name__} must not import subprocess"
+            )
+            assert "shutil" not in roots, (
+                f"{module.__name__} must not import shutil"
+            )
+
+
+# ── Web endpoint integration ────────────────────────────────────────
+
+
+class TestWebLifecycleEndpoint:
+    """``GET /integrations/silentguard/lifecycle`` end-to-end behaviour.
+
+    Mirrors the pattern in ``test_admin_users.py``: a real FastAPI
+    TestClient, a real DB created in tmp_path, and patched
+    background-task entry points so the harness boots cleanly.
+    """
+
+    @pytest.fixture
+    def web_client(self, tmp_path, monkeypatch):
+        import contextlib
+        import sqlite3 as _sqlite3
+        from unittest.mock import MagicMock, patch
+        from fastapi.testclient import TestClient
+
+        from core import memory as core_memory, users
+        from memory import store as natural_store
+        from core.rate_limiter import _login_limiter
+
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        core_memory.initialize_db()
+        with _sqlite3.connect(path) as conn:
+            conn.execute("DELETE FROM users")
+            users.create_user(conn, "alice", "pw")
+
+        _login_limiter._store.clear()
+
+        import web
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("web.initialize_db"))
+            stack.enter_context(patch("web.learn_from_feeds"))
+            stack.enter_context(patch("web.scheduler", MagicMock()))
+            with TestClient(web.app, raise_server_exceptions=True) as client:
+                yield client
+
+    def _login(self, web_client):
+        resp = web_client.post("/login", json={"username": "alice", "password": "pw"})
+        assert resp.status_code == 200, resp.text
+        return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+    def _enable_for_alice(self, web_client, headers):
+        resp = web_client.post(
+            "/settings",
+            json={"silentguard_enabled": True},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_user_not_opted_in_returns_disabled_without_probe_or_spawn(
+        self, web_client, _spawn_recorder, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_AUTO_START", "true")
+        monkeypatch.setenv("NOVA_SILENTGUARD_START_MODE", "systemd-user")
+
+        # Counter to assert the provider is never instantiated.
+        instantiated: list[int] = []
+        from core.security import lifecycle as lc
+
+        class _ShouldNotBeUsedProvider:
+            def __init__(self, *args, **kwargs):
+                instantiated.append(1)
+
+            def get_status(self):  # pragma: no cover — should never run
+                raise AssertionError("provider must not be probed for disabled user")
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ShouldNotBeUsedProvider)
+
+        headers = self._login(web_client)
+        # alice has not enabled silentguard_enabled.
+        resp = web_client.get(
+            "/integrations/silentguard/lifecycle", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == STATE_DISABLED
+        assert body["enabled"] is False
+        assert body["auto_start"] is False
+        # No provider was instantiated, no spawn happened.
+        assert instantiated == []
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_opted_in_user_with_disabled_host_returns_disabled(
+        self, web_client, _spawn_recorder, monkeypatch,
+    ):
+        # Host-level switch off → ensure_running reports disabled
+        # regardless of per-user opt-in.
+        headers = self._login(web_client)
+        self._enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/lifecycle", headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == STATE_DISABLED
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_opted_in_user_with_reachable_provider_reports_connected(
+        self, web_client, _spawn_recorder, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+
+        from core.security import lifecycle as lc
+
+        class _ReachableProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ReachableProvider)
+
+        headers = self._login(web_client)
+        self._enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/lifecycle", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == STATE_CONNECTED
+        assert body["enabled"] is True
+        # Reachable on first probe → no spawn ever.
+        calls, _ = _spawn_recorder
+        assert calls == []
+
+    def test_unauthenticated_call_is_rejected(self, web_client):
+        resp = web_client.get("/integrations/silentguard/lifecycle")
+        assert resp.status_code in (401, 403)
+
+
+class TestLifecycleStatusShape:
+    def test_lifecycle_status_keys(self):
+        snap = LifecycleStatus(
+            state=STATE_CONNECTED,
+            enabled=True,
+            auto_start=False,
+            start_mode=START_MODE_DISABLED,
+            unit=DEFAULT_SYSTEMD_UNIT,
+            message="x",
+        )
+        d = snap.as_dict()
+        assert set(d.keys()) == {
+            "state", "enabled", "auto_start", "start_mode", "unit", "message",
+        }
+
+    def test_lifecycle_status_is_frozen(self):
+        snap = LifecycleStatus(
+            state=STATE_CONNECTED,
+            enabled=True,
+            auto_start=False,
+            start_mode=START_MODE_DISABLED,
+            unit=DEFAULT_SYSTEMD_UNIT,
+            message="x",
+        )
+        with pytest.raises(Exception):
+            snap.state = STATE_STARTING  # type: ignore[misc]

--- a/tests/test_security_lifecycle.py
+++ b/tests/test_security_lifecycle.py
@@ -44,8 +44,8 @@ for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock()
 
-from core.security import lifecycle as lifecycle_module
-from core.security.lifecycle import (
+from core.security import lifecycle as lifecycle_module  # noqa: E402
+from core.security.lifecycle import (  # noqa: E402
     DEFAULT_SYSTEMD_UNIT,
     LifecycleStatus,
     STATE_CONNECTED,
@@ -59,7 +59,7 @@ from core.security.lifecycle import (
     ensure_running,
     validate_unit_name,
 )
-from core.security.provider import (
+from core.security.provider import (  # noqa: E402
     STATE_AVAILABLE,
     STATE_OFFLINE,
     STATE_UNAVAILABLE as PROVIDER_STATE_UNAVAILABLE,
@@ -419,7 +419,7 @@ class TestValidateUnitName:
         "/etc/silentguard.service",    # absolute path
         "silentguard.service\n",       # newline
         "silentguard.service;rm -rf",  # shell metachar
-        "silentguard.service & sleep", # shell metachar
+        "silentguard.service & sleep",  # shell metachar
         "silentguard.service|cat",     # pipe
         "$(whoami).service",           # command substitution
         "`id`.service",                # backtick

--- a/web.py
+++ b/web.py
@@ -56,6 +56,8 @@ from core import local_models as _local_models
 from core.ollama_client import OllamaUnavailable
 from core.integrations import silentguard as _silentguard_integration
 from core.integrations import nexanote as _nexanote_integration
+from core.security import ensure_silentguard_running as _ensure_silentguard_running
+from core.security import lifecycle as _silentguard_lifecycle
 from core import voice as _voice
 import sqlite3 as _sqlite3
 from core import users as _users_mod
@@ -701,6 +703,29 @@ def integrations_status(user: CurrentUser = Depends(get_current_user)):
             "write_enabled": _nexanote_integration.is_write_enabled(user.id),
         },
     }
+
+
+@app.get("/integrations/silentguard/lifecycle")
+def silentguard_lifecycle(user: CurrentUser = Depends(get_current_user)):
+    """SilentGuard read-only API lifecycle state for the caller.
+
+    Surfaces — and, when the operator has explicitly opted in via
+    ``NOVA_SILENTGUARD_AUTO_START`` *and* a ``systemd-user`` start
+    mode, may attempt to start — the local SilentGuard read-only API
+    service. The endpoint is gated by the per-user
+    ``silentguard_enabled`` setting; users who have not opted in see
+    a ``state="disabled"`` payload and no spawn is attempted.
+
+    Read-only with one narrow exception: when every gate is on, the
+    helper may run a single ``systemctl --user start <unit>`` against
+    the configured unit. No ``sudo``, no firewall command, no shell
+    interpretation, no remote URLs, no input from chat. See
+    :mod:`core.security.lifecycle` and the SilentGuard roadmap for
+    the full safety contract.
+    """
+    if not _silentguard_integration.is_enabled(user.id):
+        return _silentguard_lifecycle.disabled_status().as_dict()
+    return _ensure_silentguard_running().as_dict()
 
 
 # ── VOICE / TTS ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `core/security/lifecycle.py` — a small, narrowly scoped helper that lets Nova *optionally* start SilentGuard's local **read-only** API service when the host operator has explicitly opted in, while keeping every safety boundary the rest of the integration commits to.

Wired into the web layer via `GET /integrations/silentguard/lifecycle`, gated by the existing per-user `silentguard_enabled` setting. The provider, the HTTP client, and the prompt-context block remain unchanged — and stay forbidden from importing `subprocess` / `shutil`.

## Behaviour

Single-pass and synchronous, no background polling:

1. Host integration disabled → `state="disabled"`.
2. Reachability probe succeeds → `state="connected"`.
3. Auto-start off / start-mode `disabled` / unit fails validation → `state="unavailable"` / `state="could_not_start"` with **no** spawn.
4. Otherwise spawn `systemctl --user start <unit>` with strict argv (`shell=False`, `/dev/null` stdin, captured stderr, short timeout). One bounded re-probe → `state="connected"` / `state="starting"` / `state="could_not_start"`.

## Configuration (env vars, all default off)

- `NOVA_SILENTGUARD_ENABLED` — host-level switch for the lifecycle helper.
- `NOVA_SILENTGUARD_AUTO_START` — when both this and the host switch are true, the helper may spawn the configured start command after a failed probe.
- `NOVA_SILENTGUARD_API_BASE_URL` — accepted as a synonym of the existing `NOVA_SILENTGUARD_API_URL`.
- `NOVA_SILENTGUARD_START_MODE` — `"systemd-user"` is the only allowed non-disabled value; anything else (typos, `sudo-foo`, …) normalises to `"disabled"`.
- `NOVA_SILENTGUARD_SYSTEMD_UNIT` — validated against `^[a-z0-9][a-z0-9._-]*\.service$` plus a forbidden-substring list (`..`, path separators, shell metacharacters, whitespace, control characters).

## Hard guarantees, asserted in tests

- No `sudo` / `pkexec` / `doas` / `su` / `runuser`, no system-level `systemctl`.
- No firewall command (`iptables` / `nftables` / `ufw` / …).
- No shell interpretation; argv list only.
- No command sourced from chat input or remote URLs.
- No background polling, no retry loop, no notifications.
- Never raises into chat or web — always returns a calm `LifecycleStatus`.
- Lifecycle is the only file in `core.security` permitted to import `subprocess` / `shutil`; every other file in the package is asserted to remain subprocess-free.
- If SilentGuard is not installed / not configured, Nova continues working normally.

## Out of scope (deliberately)

- No notifications, no toast popups, no badges.
- No firewall / blocking / unblocking controls.
- No SilentGuard rule writes — the integration stays read-only.
- No dashboard or autonomous recommendations.
- No merging of SilentGuard code into Nova.
- No `/stop` / `/restart` / `/reload` endpoint, no auto-start on Nova boot.

## Test plan

- [x] Lifecycle disabled when env unset / explicitly false — no probe, no spawn.
- [x] Reachable provider → `state="connected"`, no spawn.
- [x] Unreachable provider, auto-start off → `state="unavailable"`, no spawn.
- [x] Unreachable provider, auto-start on but start-mode `disabled` / unrecognised → `state="unavailable"`, no spawn.
- [x] Auto-start on + valid config + post-probe succeeds → `state="connected"`.
- [x] Auto-start on + spawn returns 0 but post-probe still offline → `state="starting"`.
- [x] Spawn returns non-zero → `state="could_not_start"`.
- [x] Spawn raises `TimeoutExpired` / `OSError` → `state="could_not_start"`.
- [x] systemctl missing on PATH → `state="could_not_start"`, no spawn attempted.
- [x] Invalid unit name (`../etc/passwd`, empty, leading dot, shell metacharacters, uppercase, wrong suffix, etc.) → `state="could_not_start"`, no spawn.
- [x] Validator pins the safe / unsafe corpus.
- [x] Spawner argv is exactly `[<systemctl>, "--user", "start", <unit>]` — no extra verbs, no privilege-escalation tools, no firewall paths.
- [x] `subprocess.run` called with `shell=False`, `check=False`, `stdin=DEVNULL`, bounded timeout.
- [x] Provider misbehaviour (raise) maps to `state="unavailable"` without raising.
- [x] Web endpoint: unauthenticated call rejected; user not opted in returns `state="disabled"` *without* probing or spawning; opted-in user with reachable provider gets `state="connected"`; opted-in user with disabled host gets `state="disabled"`.
- [x] Forbidden-imports test extended: `lifecycle.py` may import `subprocess` + `shutil`; every other file in `core.security` (provider, silentguard, silentguard_client, context, package init) is asserted subprocess-free.
- [x] Existing 924 tests still pass.

## Documentation

`docs/silentguard-integration-roadmap.md` gains a new §2.4.bis explaining the helper, the full configuration surface, the safety contract, and the explicit non-goals (no privileged commands, no firewall, no background polling).

🤖 Generated with [Claude Code](https://claude.com/claude-code) on [Cloud](https://claude.ai/code/session_016u7BGeaxd8vcejBatvh6zc).

---
_Generated by [Claude Code](https://claude.ai/code/session_016u7BGeaxd8vcejBatvh6zc)_