### PR TITLE
feat(security): expose SilentGuard lifecycle/status in Settings

### DIFF
--- a/docs/silentguard-integration-roadmap.md
+++ b/docs/silentguard-integration-roadmap.md
@@ -196,6 +196,69 @@ auto-start on Nova boot, on session resume, or on tab focus — the
 helper runs only when the user (or operator-driven UI) explicitly
 asks for the lifecycle status.
 
+### 2.4.ter Settings status surface (visibility only)
+
+The Settings panel grows a small calm SilentGuard status row in the
+General pane. It is **not** a security dashboard, **not** an alert
+surface, and **not** a control surface — it is a single read-only
+card that tells the user, in one sentence, what the lifecycle helper
+believes the integration's current state is.
+
+The row is fed by ``GET /integrations/silentguard/summary``, a small
+endpoint that combines two existing read-only paths:
+
+  * the per-user gate + lifecycle state already returned by
+    ``/integrations/silentguard/lifecycle``, and
+  * the optional summary counts already produced by
+    :meth:`SilentGuardProvider.get_summary_counts` (alerts, blocked,
+    trusted, connections — only when the read-only HTTP transport is
+    configured *and* reachable).
+
+Stable response shape::
+
+    {
+      "lifecycle": {state, enabled, auto_start, start_mode, unit, message},
+      "counts": {"alerts", "blocked", "trusted", "connections"} | null
+    }
+
+The existing ``/integrations/silentguard/lifecycle`` and
+``/integrations/status`` endpoint shapes are unchanged — the summary
+endpoint is purely additive so the prompt-context, chat, and admin
+flows that already depend on those payloads keep working byte for byte.
+
+Headline mapping (state → calm sentence):
+
+  * ``disabled`` (per-user opt-in off, or host switch off) →
+    *"SilentGuard integration disabled"* (or *"SilentGuard not
+    configured"* when the user has opted in but the host has not).
+  * ``connected`` → *"SilentGuard connected in read-only mode"* with
+    a *"Read-only"* badge and, when counts are available, the line
+    *"N alerts · N blocked · N trusted · N connections"*.
+  * ``starting`` → *"Starting local SilentGuard API…"*.
+  * ``could_not_start`` → *"Could not start SilentGuard"*.
+  * ``unavailable`` → *"SilentGuard unavailable"*. When the operator
+    has integration on but auto-start off, the calm subtext
+    *"Auto-start disabled"* surfaces alongside it.
+
+The card carries one explicit *Refresh* button. There is **no**
+background polling, no ``setInterval``, no scheduler, no auto-refresh
+on tab focus — the only triggers are (1) opening the Settings
+overlay and (2) clicking *Refresh*. This honours the
+"reachability probe triggers" exhaust-list in §10.11: the summary
+endpoint runs ``ensure_running`` once per call, never on a timer.
+
+What the surface deliberately does **not** do:
+
+  * No firewall control, no block / unblock buttons, no rule editor.
+  * No notifications, toasts, or "you have alerts" badges.
+  * No remote / cloud / telemetry calls.
+  * No raw exception text in the UI; provider failures map to the
+    same calm "unavailable" wording the lifecycle helper already
+    uses.
+  * No Alpha-only state — the surface follows the same auth /
+    per-user / channel gates as every other ``/integrations/*``
+    endpoint.
+
 ### 2.5 `core/security/context.py` (read-only chat context)
 
 A small builder that produces the per-turn "Security context:" block

--- a/static/index.html
+++ b/static/index.html
@@ -1554,6 +1554,48 @@
         .voice-status.is-visible { opacity: 1; }
         .voice-status.is-warn { color: var(--text-mid); }
 
+        /* SilentGuard status card — calm, read-only.
+           Colour shifts with state but never alarms. */
+        .silentguard-status-foot {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px 12px;
+            font-size: 0.74rem;
+            color: var(--text-dim);
+            min-height: 1em;
+        }
+        .silentguard-mode-badge {
+            font-size: 0.65rem;
+            color: var(--text-dim);
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            border-radius: var(--r-pill);
+            padding: 2px 8px;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            white-space: nowrap;
+            font-weight: 500;
+        }
+        .silentguard-counts {
+            font-family: monospace;
+            color: var(--text-mid);
+        }
+        .silentguard-substatus { color: var(--text-dim); }
+        #silentguard-status-row[data-state="connected"] {
+            border-color: var(--cyan-glow);
+            background: var(--cyan-soft);
+        }
+        #silentguard-status-row[data-state="connected"] .silentguard-mode-badge {
+            color: var(--cyan);
+            border-color: var(--cyan-glow);
+            background: var(--cyan-soft);
+        }
+        #silentguard-status-row[data-state="starting"] .silentguard-substatus,
+        #silentguard-status-row[data-state="could_not_start"] .silentguard-substatus {
+            color: var(--text-mid);
+        }
+
         #mem-search {
             width: 100%;
             box-sizing: border-box;
@@ -2378,6 +2420,25 @@
                             </button>
                         </div>
                     </div>
+                    <!-- SilentGuard read-only status card. Calm by design:
+                         shows lifecycle state + optional summary counts, with
+                         a manual Refresh button. No background polling. -->
+                    <div class="settings-row" id="silentguard-status-row" data-state="loading">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-silentguard-title">SilentGuard</span>
+                                <span class="settings-row-hint" id="settings-silentguard-headline">Checking SilentGuard status…</span>
+                            </div>
+                            <button type="button" class="memory-btn" id="silentguard-refresh-btn" onclick="refreshSilentGuardStatus()" style="white-space:nowrap;">
+                                <span id="silentguard-refresh-label">Refresh</span>
+                            </button>
+                        </div>
+                        <div class="silentguard-status-foot">
+                            <span class="silentguard-mode-badge" id="silentguard-mode-badge" style="display:none;">Read-only</span>
+                            <span class="silentguard-counts" id="silentguard-counts" style="display:none;"></span>
+                            <span class="silentguard-substatus" id="silentguard-substatus" aria-live="polite"></span>
+                        </div>
+                    </div>
                 </section>
 
                 <!-- PERSONALIZATION -->
@@ -2654,6 +2715,19 @@
             ram_title: "Budget RAM",
             ram_hint: "Contrôle la taille de l'historique et des mémoires",
             update_title: "Mise à jour automatique des modèles",
+            silentguard_title: "SilentGuard",
+            silentguard_refresh: "Actualiser",
+            silentguard_mode_readonly: "Lecture seule",
+            silentguard_loading: "Vérification de SilentGuard…",
+            silentguard_disabled: "Intégration SilentGuard désactivée",
+            silentguard_not_configured: "SilentGuard n'est pas configuré",
+            silentguard_connected: "SilentGuard connecté en lecture seule",
+            silentguard_starting: "Démarrage de l'API locale SilentGuard…",
+            silentguard_could_not_start: "Impossible de démarrer SilentGuard",
+            silentguard_unavailable: "SilentGuard indisponible",
+            silentguard_autostart_off: "Démarrage automatique désactivé",
+            silentguard_check_failed: "Statut SilentGuard indisponible",
+            silentguard_counts_label: "{alerts} alertes · {blocked} bloqués · {trusted} approuvés · {connections} connexions",
             personalization_note: "Ces préférences ajusteront le ton de Nova dans tes conversations. Stockées par utilisateur, visibles uniquement par toi.",
             pers_style_title: "Style de réponse",
             pers_style_hint: "Niveau de détail des réponses de Nova.",
@@ -2774,6 +2848,19 @@
             ram_title: "RAM Budget",
             ram_hint: "Controls conversation history size and memory limits",
             update_title: "Auto-update models",
+            silentguard_title: "SilentGuard",
+            silentguard_refresh: "Refresh",
+            silentguard_mode_readonly: "Read-only",
+            silentguard_loading: "Checking SilentGuard status…",
+            silentguard_disabled: "SilentGuard integration disabled",
+            silentguard_not_configured: "SilentGuard not configured",
+            silentguard_connected: "SilentGuard connected in read-only mode",
+            silentguard_starting: "Starting local SilentGuard API…",
+            silentguard_could_not_start: "Could not start SilentGuard",
+            silentguard_unavailable: "SilentGuard unavailable",
+            silentguard_autostart_off: "Auto-start disabled",
+            silentguard_check_failed: "SilentGuard status unavailable",
+            silentguard_counts_label: "{alerts} alerts · {blocked} blocked · {trusted} trusted · {connections} connections",
             personalization_note: "These preferences will shape Nova's tone in your conversations. Saved per-user; visible only to you.",
             pers_style_title: "Response style",
             pers_style_hint: "How detailed Nova's answers should be.",
@@ -2925,6 +3012,14 @@
         _setText("settings-ram-title", t("ram_title"));
         _setText("settings-ram-hint", t("ram_hint"));
         _setText("settings-update-title", t("update_title"));
+
+        _setText("settings-silentguard-title", t("silentguard_title"));
+        _setText("silentguard-refresh-label", t("silentguard_refresh"));
+        // Re-render the status card so headline / counts pick up the new
+        // language without re-issuing the network call.
+        if (typeof applySilentGuardSummaryUI === "function" && lastSilentGuardSummary) {
+            applySilentGuardSummaryUI(lastSilentGuardSummary);
+        }
 
         _setText("settings-personalization-note", t("personalization_note"));
         _setText("pers-style-title", t("pers_style_title"));
@@ -4758,6 +4853,120 @@
         applyPersonalizationUI(data);
     }
 
+    // ── SILENTGUARD STATUS CARD ──
+    // Read-only Settings surface for the SilentGuard integration. The
+    // backend at /integrations/silentguard/summary already gates on the
+    // per-user setting, runs the lifecycle helper, and (when reachable)
+    // attaches the optional summary counts. The UI just renders the
+    // calm result. There is no background polling: refresh runs once
+    // when Settings opens and once per Refresh-button click.
+    let lastSilentGuardSummary = null;
+    let silentGuardRefreshInFlight = false;
+
+    function setSilentGuardCardState(state) {
+        const row = document.getElementById("silentguard-status-row");
+        if (row) row.dataset.state = state;
+    }
+
+    function applySilentGuardSummaryUI(payload) {
+        const row = document.getElementById("silentguard-status-row");
+        const headline = document.getElementById("settings-silentguard-headline");
+        const badge = document.getElementById("silentguard-mode-badge");
+        const counts = document.getElementById("silentguard-counts");
+        const sub = document.getElementById("silentguard-substatus");
+        if (!row || !headline || !badge || !counts || !sub) return;
+
+        const lifecycle = (payload && payload.lifecycle) || {};
+        const state = lifecycle.state || "unavailable";
+        const enabled = !!lifecycle.enabled;
+        const autoStart = !!lifecycle.auto_start;
+        const summaryCounts = (payload && payload.counts) || null;
+
+        // Reset slot defaults so a re-render of a different state never
+        // leaves stale text behind.
+        badge.style.display = "none";
+        counts.style.display = "none";
+        counts.textContent = "";
+        sub.textContent = "";
+
+        // Pick the calm headline. ``state="disabled"`` covers both the
+        // host-level switch and the per-user opt-in being off; the same
+        // wording is fine for both since the user's path forward (the
+        // per-user toggle / operator config) is the same.
+        let headlineKey;
+        if (state === "connected") {
+            headlineKey = "silentguard_connected";
+        } else if (state === "starting") {
+            headlineKey = "silentguard_starting";
+        } else if (state === "could_not_start") {
+            headlineKey = "silentguard_could_not_start";
+        } else if (state === "disabled") {
+            headlineKey = enabled ? "silentguard_not_configured" : "silentguard_disabled";
+        } else {
+            // STATE_UNAVAILABLE or any unknown future state.
+            headlineKey = "silentguard_unavailable";
+        }
+        headline.textContent = t(headlineKey);
+        setSilentGuardCardState(state);
+
+        if (state === "connected") {
+            // Make read-only mode explicit, per the UX brief.
+            badge.textContent = t("silentguard_mode_readonly");
+            badge.style.display = "";
+            if (summaryCounts && typeof summaryCounts === "object") {
+                counts.textContent = t("silentguard_counts_label")
+                    .replace("{alerts}", String(summaryCounts.alerts ?? 0))
+                    .replace("{blocked}", String(summaryCounts.blocked ?? 0))
+                    .replace("{trusted}", String(summaryCounts.trusted ?? 0))
+                    .replace("{connections}", String(summaryCounts.connections ?? 0));
+                counts.style.display = "";
+            }
+        } else if (state === "unavailable" && enabled && !autoStart) {
+            // Per the UX brief: when integration is on but auto-start is
+            // off, surface that calmly so the operator knows why nothing
+            // is being started in the background.
+            sub.textContent = t("silentguard_autostart_off");
+        }
+    }
+
+    function applySilentGuardCheckFailedUI() {
+        // Network / parse failure: render the same calm shape as a
+        // disabled snapshot so the user never sees a raw error.
+        applySilentGuardSummaryUI({
+            lifecycle: { state: "unavailable", enabled: false, auto_start: false },
+            counts: null,
+        });
+        const sub = document.getElementById("silentguard-substatus");
+        if (sub) sub.textContent = t("silentguard_check_failed");
+    }
+
+    async function refreshSilentGuardStatus() {
+        if (silentGuardRefreshInFlight) return;
+        const btn = document.getElementById("silentguard-refresh-btn");
+        const headline = document.getElementById("settings-silentguard-headline");
+        silentGuardRefreshInFlight = true;
+        if (btn) btn.disabled = true;
+        if (headline) headline.textContent = t("silentguard_loading");
+        setSilentGuardCardState("loading");
+        try {
+            const res = await fetch("/integrations/silentguard/summary", {
+                headers: { "Authorization": `Bearer ${token}` },
+            });
+            if (!res.ok) {
+                applySilentGuardCheckFailedUI();
+                return;
+            }
+            const data = await res.json();
+            lastSilentGuardSummary = data;
+            applySilentGuardSummaryUI(data);
+        } catch (e) {
+            applySilentGuardCheckFailedUI();
+        } finally {
+            silentGuardRefreshInFlight = false;
+            if (btn) btn.disabled = false;
+        }
+    }
+
     // ── PERSONALIZATION ──
     // Maps each /settings field to the DOM control that surfaces it. The
     // map is the single source of truth for both the load and save paths.
@@ -4898,6 +5107,10 @@
         // load that first, then render. The browser-only case hides the
         // row entirely, so this is also free in the common path.
         loadVoiceConfig().then(() => renderVoiceEngineSelect()).catch(() => {});
+        // Refresh the SilentGuard status card on every Settings open. No
+        // background polling — the card stays fresh because every open
+        // re-pulls and the Refresh button is the only other trigger.
+        refreshSilentGuardStatus().catch(() => {});
         await loadSystemSettings();
         await loadMemories();
     }

--- a/tests/test_silentguard_summary_endpoint.py
+++ b/tests/test_silentguard_summary_endpoint.py
@@ -1,0 +1,442 @@
+"""
+Tests for ``GET /integrations/silentguard/summary``.
+
+The summary endpoint is the single call the Settings UI's SilentGuard
+status card makes. It wraps the existing lifecycle helper and the
+existing :class:`SilentGuardProvider` count surface so the frontend
+can render a calm read-only status without changing any existing
+endpoint shape.
+
+These tests pin the user-visible contract:
+
+  * the response shape is stable: ``{lifecycle: {...}, counts: ... | None}``;
+  * the per-user gate is honoured (disabled user → ``state="disabled"``,
+    ``counts=None``, no provider instantiation, no spawn);
+  * the host-level switch and auto-start gating mirror the lifecycle
+    endpoint exactly — this endpoint must not introduce a second policy;
+  * counts are only attached when lifecycle.state == ``connected`` and
+    the provider exposes them;
+  * provider failures (raises, malformed payload, count probe boom) all
+    map to ``counts=None`` with the lifecycle still honest;
+  * the endpoint never raises — every error path is a calm 200 with a
+    coherent payload.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Heavy / optional deps that ``web.py`` pulls in at module load. Mirror
+# the stub pattern in ``test_security_lifecycle`` so a missing wheel
+# cannot block this file.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.security.lifecycle import (  # noqa: E402
+    STATE_CONNECTED,
+    STATE_COULD_NOT_START,
+    STATE_DISABLED,
+    STATE_STARTING,
+    STATE_UNAVAILABLE,
+)
+from core.security.provider import (  # noqa: E402
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    STATE_UNAVAILABLE as PROVIDER_STATE_UNAVAILABLE,
+    SecurityStatus,
+)
+
+
+# ── Test doubles ────────────────────────────────────────────────────
+
+
+def _available() -> SecurityStatus:
+    return SecurityStatus(
+        available=True,
+        service="silentguard",
+        state=STATE_AVAILABLE,
+        message="stub available",
+    )
+
+
+def _offline() -> SecurityStatus:
+    return SecurityStatus(
+        available=False,
+        service="silentguard",
+        state=STATE_OFFLINE,
+        message="stub offline",
+    )
+
+
+def _unconfigured() -> SecurityStatus:
+    return SecurityStatus(
+        available=False,
+        service="silentguard",
+        state=PROVIDER_STATE_UNAVAILABLE,
+        message="stub unconfigured",
+    )
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Strip every host-level env var so each test starts fresh."""
+    for var in (
+        "NOVA_SILENTGUARD_ENABLED",
+        "NOVA_SILENTGUARD_AUTO_START",
+        "NOVA_SILENTGUARD_START_MODE",
+        "NOVA_SILENTGUARD_SYSTEMD_UNIT",
+        "NOVA_SILENTGUARD_PATH",
+        "NOVA_SILENTGUARD_API_URL",
+        "NOVA_SILENTGUARD_API_BASE_URL",
+        "NOVA_SILENTGUARD_API_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def _no_sleep(monkeypatch):
+    """Replace the lifecycle module's sleeper with a no-op for speed."""
+    from core.security import lifecycle as lifecycle_module
+    monkeypatch.setattr(lifecycle_module.time, "sleep", lambda _s: None)
+    yield
+
+
+@pytest.fixture
+def _spawn_disabled(monkeypatch):
+    """Make ``subprocess.run`` raise to assert no spawn happens.
+
+    Tests that expect zero spawn activity inject this fixture; tests
+    that need spawn behaviour use the recorder fixture instead.
+    """
+    from core.security import lifecycle as lifecycle_module
+
+    def _no_spawn(*_args, **_kwargs):
+        raise AssertionError("subprocess.run must not be called in this test")
+
+    monkeypatch.setattr(lifecycle_module.subprocess, "run", _no_spawn)
+    monkeypatch.setattr(
+        lifecycle_module.shutil, "which",
+        lambda name: f"/usr/bin/{name}" if name == "systemctl" else None,
+    )
+    yield
+
+
+@pytest.fixture
+def web_client(tmp_path, monkeypatch):
+    """Spin up a real FastAPI TestClient against a tmp DB."""
+    import contextlib
+    import sqlite3 as _sqlite3
+    from unittest.mock import MagicMock, patch
+    from fastapi.testclient import TestClient
+
+    from core import memory as core_memory, users
+    from memory import store as natural_store
+    from core.rate_limiter import _login_limiter
+
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with _sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+        users.create_user(conn, "alice", "pw")
+
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(web_client):
+    resp = web_client.post(
+        "/login", json={"username": "alice", "password": "pw"},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def _enable_for_alice(web_client, headers):
+    resp = web_client.post(
+        "/settings",
+        json={"silentguard_enabled": True},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ── Disabled state ──────────────────────────────────────────────────
+
+
+class TestDisabledStates:
+    def test_user_not_opted_in_returns_disabled_with_no_counts(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # Even if the host operator turned the host-level switch on, a
+        # user who has not opted in must still see ``state="disabled"``
+        # and ``counts=None``. The provider must not be instantiated.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+
+        instantiated: list[int] = []
+        from core.security import lifecycle as lc
+
+        class _ShouldNotBeUsedProvider:
+            def __init__(self, *args, **kwargs):
+                instantiated.append(1)
+
+            def get_status(self):  # pragma: no cover — must not run
+                raise AssertionError("must not probe for disabled user")
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ShouldNotBeUsedProvider)
+
+        headers = _login(web_client)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"lifecycle", "counts"}
+        assert body["lifecycle"]["state"] == STATE_DISABLED
+        assert body["lifecycle"]["enabled"] is False
+        assert body["counts"] is None
+        # Defence-in-depth: confirm no provider was instantiated.
+        assert instantiated == []
+
+    def test_host_switch_off_returns_disabled_even_when_user_opted_in(
+        self, web_client, _spawn_disabled,
+    ):
+        # Per-user opt-in alone is not enough — the host switch must
+        # also be on for the lifecycle to do anything beyond "disabled".
+        headers = _login(web_client)
+        _enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_DISABLED
+        assert body["counts"] is None
+
+
+# ── Unavailable state ───────────────────────────────────────────────
+
+
+class TestUnavailable:
+    def test_offline_provider_with_autostart_off_reports_unavailable(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        # NOVA_SILENTGUARD_AUTO_START defaults off, so the lifecycle
+        # helper must short-circuit to "unavailable" with no spawn.
+        from core.security import lifecycle as lc
+
+        class _OfflineProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _offline()
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _OfflineProvider)
+
+        headers = _login(web_client)
+        _enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_UNAVAILABLE
+        assert body["lifecycle"]["enabled"] is True
+        assert body["lifecycle"]["auto_start"] is False
+        assert body["counts"] is None
+
+
+# ── Connected state with counts ─────────────────────────────────────
+
+
+class TestConnectedWithCounts:
+    def test_counts_attached_when_provider_exposes_them(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        from core.security import lifecycle as lc
+        import web as web_module
+
+        class _ReachableLifecycleProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+        # The lifecycle helper instantiates ``SilentGuardProvider`` from
+        # the lifecycle module; the summary endpoint instantiates a
+        # second one (via ``_SilentGuardProvider`` in ``web``) for the
+        # counts probe. Patch both names so each path returns counts
+        # from a controlled stub.
+        class _CountingProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+            def get_summary_counts(self):
+                return {
+                    "alerts": 0,
+                    "blocked": 0,
+                    "trusted": 2,
+                    "connections": 5,
+                }
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ReachableLifecycleProvider)
+        monkeypatch.setattr(web_module, "_SilentGuardProvider", _CountingProvider)
+
+        headers = _login(web_client)
+        _enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_CONNECTED
+        assert body["counts"] == {
+            "alerts": 0,
+            "blocked": 0,
+            "trusted": 2,
+            "connections": 5,
+        }
+
+    def test_counts_none_when_provider_returns_none(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # File-only fallback: provider is reachable, but
+        # get_summary_counts returns None because no HTTP transport is
+        # configured. Lifecycle still says connected.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        from core.security import lifecycle as lc
+        import web as web_module
+
+        class _ReachableLifecycleProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+        class _NoCountsProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+            def get_summary_counts(self):
+                return None
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ReachableLifecycleProvider)
+        monkeypatch.setattr(web_module, "_SilentGuardProvider", _NoCountsProvider)
+
+        headers = _login(web_client)
+        _enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_CONNECTED
+        assert body["counts"] is None
+
+    def test_counts_none_when_count_probe_raises(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # A misbehaving counts implementation must not propagate; the
+        # endpoint must absorb the exception and surface counts=None.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        from core.security import lifecycle as lc
+        import web as web_module
+
+        class _ReachableLifecycleProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+        class _BoomProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+            def get_summary_counts(self):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ReachableLifecycleProvider)
+        monkeypatch.setattr(web_module, "_SilentGuardProvider", _BoomProvider)
+
+        headers = _login(web_client)
+        _enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_CONNECTED
+        assert body["counts"] is None
+
+
+# ── Auth and shape ──────────────────────────────────────────────────
+
+
+class TestAuthAndShape:
+    def test_unauthenticated_call_is_rejected(self, web_client):
+        resp = web_client.get("/integrations/silentguard/summary")
+        assert resp.status_code in (401, 403)
+
+    def test_response_keys_are_stable(
+        self, web_client, _spawn_disabled,
+    ):
+        # The Settings UI relies on exactly two keys at the top level.
+        headers = _login(web_client)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"lifecycle", "counts"}
+        # Lifecycle must carry the full LifecycleStatus shape so the UI
+        # can render any state without checking for missing keys.
+        assert set(body["lifecycle"].keys()) == {
+            "state", "enabled", "auto_start", "start_mode", "unit", "message",
+        }
+
+    def test_existing_lifecycle_endpoint_shape_unchanged(
+        self, web_client, _spawn_disabled,
+    ):
+        # Adding the summary endpoint must not change the existing
+        # lifecycle endpoint shape — the Settings card and any external
+        # caller depend on it. This test pins the contract.
+        headers = _login(web_client)
+        resp = web_client.get(
+            "/integrations/silentguard/lifecycle", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {
+            "state", "enabled", "auto_start", "start_mode", "unit", "message",
+        }

--- a/tests/test_silentguard_summary_endpoint.py
+++ b/tests/test_silentguard_summary_endpoint.py
@@ -38,9 +38,7 @@ for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
 
 from core.security.lifecycle import (  # noqa: E402
     STATE_CONNECTED,
-    STATE_COULD_NOT_START,
     STATE_DISABLED,
-    STATE_STARTING,
     STATE_UNAVAILABLE,
 )
 from core.security.provider import (  # noqa: E402

--- a/web.py
+++ b/web.py
@@ -58,6 +58,7 @@ from core.integrations import silentguard as _silentguard_integration
 from core.integrations import nexanote as _nexanote_integration
 from core.security import ensure_silentguard_running as _ensure_silentguard_running
 from core.security import lifecycle as _silentguard_lifecycle
+from core.security import SilentGuardProvider as _SilentGuardProvider
 from core import voice as _voice
 import sqlite3 as _sqlite3
 from core import users as _users_mod
@@ -726,6 +727,53 @@ def silentguard_lifecycle(user: CurrentUser = Depends(get_current_user)):
     if not _silentguard_integration.is_enabled(user.id):
         return _silentguard_lifecycle.disabled_status().as_dict()
     return _ensure_silentguard_running().as_dict()
+
+
+@app.get("/integrations/silentguard/summary")
+def silentguard_summary(user: CurrentUser = Depends(get_current_user)):
+    """SilentGuard Settings status summary for the caller.
+
+    One-call snapshot the Settings UI renders into a small calm status
+    card: the same lifecycle state surfaced by
+    ``/integrations/silentguard/lifecycle`` plus, when the read-only
+    API is reachable, the four optional summary counts produced by
+    :class:`SilentGuardProvider.get_summary_counts`.
+
+    Stable shape::
+
+        {
+            "lifecycle": LifecycleStatus.as_dict(),
+            "counts": {"alerts": int, "blocked": int,
+                       "trusted": int, "connections": int} | None,
+        }
+
+    ``counts`` is ``None`` whenever the lifecycle state is anything
+    other than ``connected``, when the HTTP transport is not
+    configured (file-only fallback), or when the optional count probe
+    fails. The endpoint never raises; every failure path maps to a
+    calm payload the UI renders without alarm.
+
+    Read-only and gated by the per-user ``silentguard_enabled``
+    setting, exactly like the lifecycle endpoint. No background
+    polling — the UI calls this once per Settings open / Refresh
+    click, mirroring the trigger set documented in the roadmap.
+    """
+    if not _silentguard_integration.is_enabled(user.id):
+        return {
+            "lifecycle": _silentguard_lifecycle.disabled_status().as_dict(),
+            "counts": None,
+        }
+    lifecycle_status = _ensure_silentguard_running()
+    counts = None
+    if lifecycle_status.state == _silentguard_lifecycle.STATE_CONNECTED:
+        try:
+            counts = _SilentGuardProvider().get_summary_counts()
+        except Exception:  # pragma: no cover — defensive belt-and-braces
+            counts = None
+    return {
+        "lifecycle": lifecycle_status.as_dict(),
+        "counts": counts,
+    }
 
 
 # ── VOICE / TTS ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a small calm SilentGuard status row to the General pane of Settings so users can see at a glance whether the integration is disabled, starting, unavailable, or connected in read-only mode — without leaving Settings.

This is **visibility / lifecycle status only**. Nova still does not block IPs, modify firewall rules, run privileged commands, take autonomous security actions, send notifications, or render a security dashboard.

## What changed

**Backend** — one small additive endpoint.

- `GET /integrations/silentguard/summary` wraps two existing read-only paths:
  - the lifecycle helper (`ensure_silentguard_running` / `disabled_status`) already returned by `/integrations/silentguard/lifecycle`, and
  - `SilentGuardProvider.get_summary_counts()` for the optional `{alerts, blocked, trusted, connections}` line.
- Stable shape: `{ "lifecycle": {state, enabled, auto_start, start_mode, unit, message}, "counts": {...} | null }`.
- Existing `/integrations/silentguard/lifecycle` and `/integrations/status` shapes are unchanged.
- Read-only, gated by the per-user `silentguard_enabled` setting; never raises.

**Frontend** — one new row in the existing General pane.

- Shows a calm headline per state:
  - `disabled` → *"SilentGuard integration disabled"* / *"SilentGuard not configured"* (when user opted in but host has not).
  - `connected` → *"SilentGuard connected in read-only mode"* + *Read-only* badge + counts line when available.
  - `starting` → *"Starting local SilentGuard API…"*.
  - `could_not_start` → *"Could not start SilentGuard"*.
  - `unavailable` → *"SilentGuard unavailable"* (with *"Auto-start disabled"* subtext when applicable).
- Manual *Refresh* button. **No background polling**, no `setInterval`, no auto-refresh on tab focus — the only triggers are opening Settings and pressing Refresh.
- French + English i18n strings; existing settings UI patterns reused (no new visual primitives).

**Docs** — extends `docs/silentguard-integration-roadmap.md` with a new §2.4.ter that documents the Settings status surface and pins the visibility-only scope.

**Tests** — new `tests/test_silentguard_summary_endpoint.py` (9 tests) covering disabled / unavailable / connected with counts / connected-without-counts / count-probe-raises / unauthenticated / response-shape stability. The existing `/integrations/silentguard/lifecycle` shape is also pinned so the additive endpoint cannot silently drift it.

## Safety posture (commitments)

- Read-only visibility only.
- No write actions, no firewall controls, no shell commands from UI input.
- No remote / cloud calls, no telemetry.
- No new privileged code paths — the lifecycle helper remains the only file in `core.security` that imports `subprocess` / `shutil`, and that allowlist is still asserted by the existing forbidden-imports test.
- Auth / per-user gate / channel behaviour preserved; no Alpha-only functionality exposed.

## Test plan

- [x] `python -m pytest tests/test_silentguard_summary_endpoint.py` — 9/9 pass.
- [x] `python -m pytest tests/test_security_lifecycle.py tests/test_security_provider.py tests/test_security_context.py tests/test_security_feed.py tests/test_integrations_silentguard.py tests/test_settings_scoping.py tests/test_personalization_settings.py` — 238/238 pass.
- [x] Existing `/integrations/silentguard/lifecycle` shape still pinned (covered in the new tests).
- [ ] Manually open Settings → SilentGuard row renders the disabled/unavailable/connected states; Refresh button works; no console errors.

https://claude.ai/code/session_01F8DxiEfXKodeKEad7VEhCc

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8DxiEfXKodeKEad7VEhCc)_