### PR TITLE
fix(silentguard): expose per-user toggle so env-enabled installs render connected

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,13 @@ NOVA_AUTO_WEB_LEARNING=false
 
 # ── Optional integrations ─────────────────────────────────────────────
 # SilentGuard and NexaNote are disabled per-user by default and must be
-# turned on from Settings → Integrations. The variables below only set
-# the *transport* — they never enable an integration on their own.
+# turned on from the Settings panel after the env vars below are set.
+# For SilentGuard: open Settings → General → SilentGuard card and flip
+# the per-user toggle next to the Refresh button. The variables below
+# only set the *transport* — they never enable an integration on their
+# own and never opt a user in. Without the per-user toggle ON, the
+# Settings card shows "Turn on SilentGuard in Settings to use it" so
+# the gap between host config and per-user opt-in is visible.
 #
 # SilentGuard reads ~/.silentguard_memory.json; override the path with:
 # NOVA_SILENTGUARD_PATH=/custom/path/to/feed.json

--- a/core/security/lifecycle.py
+++ b/core/security/lifecycle.py
@@ -169,6 +169,17 @@ def _resolve_enabled() -> bool:
     return bool(NOVA_SILENTGUARD_ENABLED)
 
 
+def host_enabled() -> bool:
+    """Public read of the host-level ``NOVA_SILENTGUARD_ENABLED`` switch.
+
+    Re-evaluated on every call so a systemd-provided env var that is
+    set when the process starts (the documented setup) and a value
+    flipped via ``monkeypatch.setenv`` in tests both resolve correctly.
+    Read-only — never mutates state, never spawns anything.
+    """
+    return _resolve_enabled()
+
+
 def _resolve_auto_start() -> bool:
     """Whether Nova may spawn the configured start command."""
     raw = os.environ.get("NOVA_SILENTGUARD_AUTO_START")
@@ -473,5 +484,6 @@ __all__ = [
     "START_MODE_SYSTEMD_USER",
     "disabled_status",
     "ensure_running",
+    "host_enabled",
     "validate_unit_name",
 ]

--- a/docs/silentguard-background-service.md
+++ b/docs/silentguard-background-service.md
@@ -240,10 +240,20 @@ What each variable does:
 | `NOVA_SILENTGUARD_SYSTEMD_UNIT` | The user-level unit name to start. Validated against `^[a-z0-9][a-z0-9._-]*\.service$` and a forbidden-substring list before any spawn. |
 
 Restart Nova so it picks up the new variables, sign in, and turn on
-the per-user toggle in *Settings → Integrations → SilentGuard*. Nova
-will probe `127.0.0.1:8767`, surface a calm "connected in read-only
-mode" snapshot when it succeeds, and fall back to a calm "unavailable"
+the per-user toggle on the **SilentGuard** card in *Settings →
+General*. The toggle sits next to the **Refresh** button on the same
+status card; flipping it ON persists `silentguard_enabled` for your
+account and refreshes the status immediately. Nova will probe
+`127.0.0.1:8767`, surface a calm "connected in read-only mode"
+snapshot when it succeeds, and fall back to a calm "unavailable"
 snapshot otherwise.
+
+If the toggle is OFF *and* the host config is on, the card explicitly
+says **"Turn on SilentGuard in Settings to use it"** so it is clear
+that the env vars alone are not enough — flipping the toggle is the
+last step. If the host config is off, the card says **"SilentGuard
+integration disabled in server config"** instead, which means the env
+vars themselves still need attention.
 
 ---
 

--- a/static/index.html
+++ b/static/index.html
@@ -2422,16 +2422,23 @@
                     </div>
                     <!-- SilentGuard read-only status card. Calm by design:
                          shows lifecycle state + optional summary counts, with
-                         a manual Refresh button. No background polling. -->
+                         a per-user on/off toggle and a manual Refresh button.
+                         No background polling. -->
                     <div class="settings-row" id="silentguard-status-row" data-state="loading">
                         <div class="settings-row-head">
                             <div class="settings-row-label">
                                 <span class="settings-row-title" id="settings-silentguard-title">SilentGuard</span>
                                 <span class="settings-row-hint" id="settings-silentguard-headline">Checking SilentGuard status…</span>
                             </div>
-                            <button type="button" class="memory-btn" id="silentguard-refresh-btn" style="white-space:nowrap;">
-                                <span id="silentguard-refresh-label">Refresh</span>
-                            </button>
+                            <div style="display:flex;gap:8px;align-items:center;">
+                                <button type="button" id="silentguard-toggle-btn"
+                                    style="font-family:monospace;font-size:0.75rem;padding:4px 12px;border-radius:6px;cursor:pointer;border:1px solid var(--border);background:var(--bg);color:var(--text-dim);min-width:52px;">
+                                    OFF
+                                </button>
+                                <button type="button" class="memory-btn" id="silentguard-refresh-btn" style="white-space:nowrap;">
+                                    <span id="silentguard-refresh-label">Refresh</span>
+                                </button>
+                            </div>
                         </div>
                         <div class="silentguard-status-foot">
                             <span class="silentguard-mode-badge" id="silentguard-mode-badge" style="display:none;">Read-only</span>
@@ -2720,6 +2727,8 @@
             silentguard_mode_readonly: "Lecture seule",
             silentguard_loading: "Vérification de SilentGuard…",
             silentguard_disabled: "Intégration SilentGuard désactivée",
+            silentguard_disabled_host_off: "Intégration SilentGuard désactivée dans la configuration du serveur",
+            silentguard_disabled_user_off: "Activez SilentGuard dans Paramètres pour l'utiliser",
             silentguard_not_configured: "SilentGuard n'est pas configuré",
             silentguard_connected: "SilentGuard connecté en lecture seule",
             silentguard_starting: "Démarrage de l'API locale SilentGuard…",
@@ -2853,6 +2862,8 @@
             silentguard_mode_readonly: "Read-only",
             silentguard_loading: "Checking SilentGuard status…",
             silentguard_disabled: "SilentGuard integration disabled",
+            silentguard_disabled_host_off: "SilentGuard integration disabled in server config",
+            silentguard_disabled_user_off: "Turn on SilentGuard in Settings to use it",
             silentguard_not_configured: "SilentGuard not configured",
             silentguard_connected: "SilentGuard connected in read-only mode",
             silentguard_starting: "Starting local SilentGuard API…",
@@ -4850,6 +4861,10 @@
         if (nameInput && data.nova_model_name) {
             nameInput.value = data.nova_model_name;
         }
+        // Reflect the saved per-user SilentGuard toggle in the button
+        // before any user interaction, so the visible state matches
+        // what the backend will report on the summary call.
+        applySilentGuardToggleUI(!!data.silentguard_enabled);
         applyPersonalizationUI(data);
     }
 
@@ -4858,14 +4873,27 @@
     // backend at /integrations/silentguard/summary already gates on the
     // per-user setting, runs the lifecycle helper, and (when reachable)
     // attaches the optional summary counts. The UI just renders the
-    // calm result. There is no background polling: refresh runs once
-    // when Settings opens and once per Refresh-button click.
+    // calm result and exposes a per-user on/off toggle so a user can
+    // opt in once the operator has configured the host-level env vars.
+    // There is no background polling: refresh runs once when Settings
+    // opens, once per Refresh-button click, and once per toggle change.
     let lastSilentGuardSummary = null;
+    let lastSilentGuardUserEnabled = false;
     let silentGuardRefreshInFlight = false;
+    let silentGuardToggleInFlight = false;
 
     function setSilentGuardCardState(state) {
         const row = document.getElementById("silentguard-status-row");
         if (row) row.dataset.state = state;
+    }
+
+    function applySilentGuardToggleUI(enabled) {
+        const btn = document.getElementById("silentguard-toggle-btn");
+        if (!btn) return;
+        lastSilentGuardUserEnabled = !!enabled;
+        btn.textContent = enabled ? "ON" : "OFF";
+        btn.style.color = enabled ? "var(--cyan)" : "var(--text-dim)";
+        btn.style.borderColor = enabled ? "var(--cyan)" : "var(--border)";
     }
 
     function applySilentGuardSummaryUI(payload) {
@@ -4878,7 +4906,15 @@
 
         const lifecycle = (payload && payload.lifecycle) || {};
         const state = lifecycle.state || "unavailable";
-        const enabled = !!lifecycle.enabled;
+        // ``lifecycle.enabled`` is the host-level switch as the
+        // lifecycle helper saw it; for the per-user-disabled path the
+        // backend's ``host_enabled`` top-level field is the honest
+        // signal because ``disabled_status()`` always sets
+        // ``lifecycle.enabled = False``.
+        const lifecycleEnabled = !!lifecycle.enabled;
+        const hostEnabled = (payload && typeof payload.host_enabled === "boolean")
+            ? payload.host_enabled
+            : lifecycleEnabled;
         const autoStart = !!lifecycle.auto_start;
         const summaryCounts = (payload && payload.counts) || null;
 
@@ -4889,10 +4925,13 @@
         counts.textContent = "";
         sub.textContent = "";
 
-        // Pick the calm headline. ``state="disabled"`` covers both the
-        // host-level switch and the per-user opt-in being off; the same
-        // wording is fine for both since the user's path forward (the
-        // per-user toggle / operator config) is the same.
+        // Pick the calm headline. The disabled state has two distinct
+        // sub-cases the user needs to be able to tell apart:
+        //   * host config off  → operator must set NOVA_SILENTGUARD_*;
+        //   * host config on, per-user off → user must flip the toggle.
+        // Conflating them (the previous behaviour) made the card
+        // misleading: an operator who had correctly set the env vars
+        // saw the same "disabled" text as one who had not.
         let headlineKey;
         if (state === "connected") {
             headlineKey = "silentguard_connected";
@@ -4901,7 +4940,15 @@
         } else if (state === "could_not_start") {
             headlineKey = "silentguard_could_not_start";
         } else if (state === "disabled") {
-            headlineKey = enabled ? "silentguard_not_configured" : "silentguard_disabled";
+            if (hostEnabled) {
+                // Host operator enabled the integration; this user
+                // hasn't flipped their per-user toggle yet.
+                headlineKey = "silentguard_disabled_user_off";
+            } else {
+                // Host config is off; setting the per-user toggle
+                // alone won't help.
+                headlineKey = "silentguard_disabled_host_off";
+            }
         } else {
             // STATE_UNAVAILABLE or any unknown future state.
             headlineKey = "silentguard_unavailable";
@@ -4921,10 +4968,10 @@
                     .replace("{connections}", String(summaryCounts.connections ?? 0));
                 counts.style.display = "";
             }
-        } else if (state === "unavailable" && enabled && !autoStart) {
-            // Per the UX brief: when integration is on but auto-start is
-            // off, surface that calmly so the operator knows why nothing
-            // is being started in the background.
+        } else if (state === "unavailable" && lifecycleEnabled && !autoStart) {
+            // Per the UX brief: when integration is on but auto-start
+            // is off, surface that calmly so the operator knows why
+            // nothing is being started in the background.
             sub.textContent = t("silentguard_autostart_off");
         }
     }
@@ -4935,6 +4982,7 @@
         applySilentGuardSummaryUI({
             lifecycle: { state: "unavailable", enabled: false, auto_start: false },
             counts: null,
+            host_enabled: false,
         });
         const sub = document.getElementById("silentguard-substatus");
         if (sub) sub.textContent = t("silentguard_check_failed");
@@ -4971,23 +5019,67 @@
         }
     }
 
-    // Wire the Refresh button explicitly once the script runs (the
-    // script tag sits at the end of <body>, so the button already
-    // exists in the DOM at this point). An inline ``onclick=...``
-    // would be silently dropped by any future stricter CSP, and made
-    // the click handler invisible to test fixtures that load this
-    // page without executing inline attributes — the explicit listener
-    // makes the wiring testable and CSP-safe. Errors inside the click
-    // handler are surfaced through the card's failure UI instead of
-    // being swallowed by the event-dispatch path.
-    (function wireSilentGuardRefreshButton() {
-        const btn = document.getElementById("silentguard-refresh-btn");
+    async function toggleSilentGuardEnabled() {
+        // Per-user opt-in. Persists ``silentguard_enabled`` via the
+        // shared /settings endpoint and then re-renders the status
+        // card so the user immediately sees the new state. Errors fall
+        // through into the visible failure UI instead of vanishing.
+        if (silentGuardToggleInFlight) return;
+        const btn = document.getElementById("silentguard-toggle-btn");
         if (!btn) return;
-        btn.addEventListener("click", () => {
-            refreshSilentGuardStatus().catch(() => {
-                applySilentGuardCheckFailedUI();
+        silentGuardToggleInFlight = true;
+        btn.disabled = true;
+        const newVal = !lastSilentGuardUserEnabled;
+        try {
+            const res = await fetch("/settings", {
+                method: "POST",
+                credentials: "include",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${token}`,
+                },
+                body: JSON.stringify({ silentguard_enabled: newVal }),
             });
-        });
+            if (!res.ok) {
+                applySilentGuardCheckFailedUI();
+                return;
+            }
+            applySilentGuardToggleUI(newVal);
+            await refreshSilentGuardStatus();
+        } catch (e) {
+            applySilentGuardCheckFailedUI();
+        } finally {
+            silentGuardToggleInFlight = false;
+            btn.disabled = false;
+        }
+    }
+
+    // Wire the Refresh and Toggle buttons explicitly once the script
+    // runs (the script tag sits at the end of <body>, so the buttons
+    // already exist in the DOM at this point). An inline
+    // ``onclick=...`` would be silently dropped by any future stricter
+    // CSP, and makes the click handler invisible to test fixtures that
+    // load this page without executing inline attributes — the
+    // explicit listener makes the wiring testable and CSP-safe. Errors
+    // inside the click handlers are surfaced through the card's
+    // failure UI instead of being swallowed by the event-dispatch path.
+    (function wireSilentGuardButtons() {
+        const refreshBtn = document.getElementById("silentguard-refresh-btn");
+        if (refreshBtn) {
+            refreshBtn.addEventListener("click", () => {
+                refreshSilentGuardStatus().catch(() => {
+                    applySilentGuardCheckFailedUI();
+                });
+            });
+        }
+        const toggleBtn = document.getElementById("silentguard-toggle-btn");
+        if (toggleBtn) {
+            toggleBtn.addEventListener("click", () => {
+                toggleSilentGuardEnabled().catch(() => {
+                    applySilentGuardCheckFailedUI();
+                });
+            });
+        }
     })();
 
     // ── PERSONALIZATION ──

--- a/tests/test_silentguard_settings_card_wiring.py
+++ b/tests/test_silentguard_settings_card_wiring.py
@@ -48,6 +48,34 @@ def script(html: str) -> str:
     return max(blocks, key=len)
 
 
+def _function_body(script: str, name: str) -> str:
+    """Return the full source of a top-level JS function in ``script``.
+
+    Walks brace depth from the opening ``{`` so nested object literals
+    or try/catch blocks do not confuse the close. Asserts when the
+    function is missing — every caller treats absence as a hard fail.
+    """
+    decl = re.search(
+        r"(?:async\s+)?function\s+" + re.escape(name) + r"\s*\([^)]*\)\s*{",
+        script,
+    )
+    assert decl, f"function {name!r} not found in script"
+    start = decl.start()
+    open_brace = script.index("{", decl.end() - 1)
+    depth = 0
+    i = open_brace
+    while i < len(script):
+        ch = script[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return script[start:i + 1]
+        i += 1
+    raise AssertionError(f"unterminated function body for {name!r}")
+
+
 # ── Button + listener wiring ────────────────────────────────────────
 
 
@@ -154,3 +182,129 @@ class TestRefreshFetchContract:
             "openSettings must call refreshSilentGuardStatus on every "
             "Settings open."
         )
+
+
+# ── Per-user toggle wiring ──────────────────────────────────────────
+#
+# The bug report's "env says enabled but UI says disabled" failure
+# mode hinged on the missing per-user toggle: the summary endpoint
+# requires ``silentguard_enabled`` to be true for a given user, the
+# /settings endpoint accepts that flag, but the UI never exposed a
+# control to flip it. Without this wiring, an operator who set every
+# host-level env var correctly would still see "disabled" forever.
+
+
+class TestPerUserToggleWiring:
+    def test_toggle_button_exists_with_documented_id(self, html: str) -> None:
+        # The JS queries the toggle by id; without it, the button is
+        # invisible to every code path and the bug returns.
+        assert 'id="silentguard-toggle-btn"' in html
+
+    def test_toggle_button_does_not_rely_on_inline_onclick(
+        self, html: str,
+    ) -> None:
+        # Same reasoning as the Refresh button: inline onclick is
+        # CSP-fragile and untestable.
+        toggle_match = re.search(
+            r'<button[^>]*id="silentguard-toggle-btn"[^>]*>',
+            html,
+        )
+        assert toggle_match, "Toggle button tag not found"
+        assert "onclick=" not in toggle_match.group(0), (
+            "Toggle button must use addEventListener, not inline onclick."
+        )
+
+    def test_toggle_listener_calls_async_handler(self, script: str) -> None:
+        assert 'getElementById("silentguard-toggle-btn")' in script
+        listener_block = re.search(
+            r'getElementById\("silentguard-toggle-btn"\)[\s\S]{0,400}?'
+            r'addEventListener\("click",[\s\S]{0,400}?'
+            r'toggleSilentGuardEnabled\(\)',
+            script,
+        )
+        assert listener_block, (
+            "Expected an explicit addEventListener('click', ...) that "
+            "calls toggleSilentGuardEnabled() on the toggle button."
+        )
+
+    def test_toggle_handler_posts_to_settings_with_credentials(
+        self, script: str,
+    ) -> None:
+        # The handler must POST to /settings with silentguard_enabled
+        # and ``credentials: "include"`` so the session cookie path
+        # works alongside the bearer token. Anything less and a flip
+        # silently drops the change.
+        body = _function_body(script, "toggleSilentGuardEnabled")
+        assert 'fetch("/settings"' in body, (
+            "toggleSilentGuardEnabled must POST to /settings."
+        )
+        assert 'method: "POST"' in body
+        assert 'credentials: "include"' in body
+        assert "silentguard_enabled" in body, (
+            "Toggle must persist the silentguard_enabled key."
+        )
+
+    def test_toggle_refreshes_status_after_save(self, script: str) -> None:
+        # After a successful flip, the card must re-pull so the user
+        # immediately sees the new state — otherwise they have to hunt
+        # for the Refresh button to confirm the change took effect.
+        body = _function_body(script, "toggleSilentGuardEnabled")
+        assert "refreshSilentGuardStatus(" in body, (
+            "toggleSilentGuardEnabled must call refreshSilentGuardStatus "
+            "after a successful save so the card paints the new state."
+        )
+
+    def test_initial_toggle_state_is_loaded_from_settings(
+        self, script: str,
+    ) -> None:
+        # Settings open calls loadSystemSettings which reads /settings
+        # and must paint the toggle's initial state. Without this, a
+        # user who has flipped the toggle in a previous session sees
+        # OFF until they trigger a refresh — a confusing regression.
+        body = _function_body(script, "loadSystemSettings")
+        assert "applySilentGuardToggleUI" in body, (
+            "loadSystemSettings must paint the SilentGuard toggle's "
+            "initial state from the saved setting."
+        )
+        assert "silentguard_enabled" in body, (
+            "loadSystemSettings must read silentguard_enabled from the "
+            "/settings payload."
+        )
+
+
+# ── Disabled-state UI text differentiation ──────────────────────────
+#
+# The bug's most visible symptom: the headline always said
+# "SilentGuard integration disabled", regardless of whether the
+# operator needed to set env vars or just flip a per-user toggle.
+# These tests pin the new headline behaviour: the UI renders distinct
+# text for the two cases, driven by the new ``host_enabled`` field.
+
+
+class TestDisabledHeadlineDifferentiation:
+    def test_host_enabled_drives_headline_choice(self, script: str) -> None:
+        # The render path must consult ``host_enabled`` (or fall back
+        # to lifecycle.enabled) to pick between the two distinct
+        # disabled headlines.
+        assert "host_enabled" in script, (
+            "Frontend must consume the new host_enabled field to pick "
+            "the right disabled headline."
+        )
+        # Both headline keys must be present in the render path.
+        assert "silentguard_disabled_user_off" in script
+        assert "silentguard_disabled_host_off" in script
+
+    def test_disabled_user_off_string_is_translated(self, html: str) -> None:
+        # The new keys must exist in both language packs so a French
+        # user does not see an English fallback. Spot-check both
+        # languages without coupling to the exact wording.
+        assert "silentguard_disabled_user_off:" in html, (
+            "silentguard_disabled_user_off must be defined in i18n."
+        )
+        assert "silentguard_disabled_host_off:" in html, (
+            "silentguard_disabled_host_off must be defined in i18n."
+        )
+        # Both languages should have at least one entry per key — the
+        # file currently contains EN + FR packs side by side.
+        assert html.count("silentguard_disabled_user_off:") >= 2
+        assert html.count("silentguard_disabled_host_off:") >= 2

--- a/tests/test_silentguard_summary_endpoint.py
+++ b/tests/test_silentguard_summary_endpoint.py
@@ -185,6 +185,9 @@ class TestDisabledStates:
         # Even if the host operator turned the host-level switch on, a
         # user who has not opted in must still see ``state="disabled"``
         # and ``counts=None``. The provider must not be instantiated.
+        # The new ``host_enabled`` top-level field still surfaces the
+        # honest host-level state so the UI can tell the operator that
+        # only the per-user toggle is missing.
         monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
 
         instantiated: list[int] = []
@@ -205,10 +208,14 @@ class TestDisabledStates:
         )
         assert resp.status_code == 200
         body = resp.json()
-        assert set(body.keys()) == {"lifecycle", "counts"}
+        assert set(body.keys()) == {"lifecycle", "counts", "host_enabled"}
         assert body["lifecycle"]["state"] == STATE_DISABLED
         assert body["lifecycle"]["enabled"] is False
         assert body["counts"] is None
+        # ``host_enabled`` reflects the env var, not the per-user
+        # toggle — it tells the UI "the host config is on; the user
+        # just hasn't flipped their toggle".
+        assert body["host_enabled"] is True
         # Defence-in-depth: confirm no provider was instantiated.
         assert instantiated == []
 
@@ -226,6 +233,8 @@ class TestDisabledStates:
         body = resp.json()
         assert body["lifecycle"]["state"] == STATE_DISABLED
         assert body["counts"] is None
+        # No env var set, so the host-level switch reads as off.
+        assert body["host_enabled"] is False
 
 
 # ── Unavailable state ───────────────────────────────────────────────
@@ -409,19 +418,26 @@ class TestAuthAndShape:
     def test_response_keys_are_stable(
         self, web_client, _spawn_disabled,
     ):
-        # The Settings UI relies on exactly two keys at the top level.
+        # The Settings UI relies on a fixed top-level key set:
+        # ``lifecycle`` (the full LifecycleStatus), ``counts`` (the
+        # optional summary numbers), and ``host_enabled`` (the
+        # operator-level switch the UI uses to distinguish a host-off
+        # disabled state from a per-user-off disabled state).
         headers = _login(web_client)
         resp = web_client.get(
             "/integrations/silentguard/summary", headers=headers,
         )
         assert resp.status_code == 200
         body = resp.json()
-        assert set(body.keys()) == {"lifecycle", "counts"}
+        assert set(body.keys()) == {"lifecycle", "counts", "host_enabled"}
         # Lifecycle must carry the full LifecycleStatus shape so the UI
         # can render any state without checking for missing keys.
         assert set(body["lifecycle"].keys()) == {
             "state", "enabled", "auto_start", "start_mode", "unit", "message",
         }
+        # ``host_enabled`` is always a bool (never null / missing) so
+        # the UI never has to defend against an undefined value.
+        assert isinstance(body["host_enabled"], bool)
 
     def test_existing_lifecycle_endpoint_shape_unchanged(
         self, web_client, _spawn_disabled,
@@ -438,3 +454,242 @@ class TestAuthAndShape:
         assert set(body.keys()) == {
             "state", "enabled", "auto_start", "start_mode", "unit", "message",
         }
+
+
+# ── Real failure mode: env says enabled but UI says disabled ────────
+#
+# The bug report: an operator sets every host-level env var, sees the
+# SilentGuard API responding to ``curl /status``, and still gets
+# "SilentGuard integration disabled" in Settings. The previous summary
+# response could not tell the UI *why* the integration was disabled —
+# was the host config off, or just the per-user toggle? The new
+# ``host_enabled`` field plus the per-user opt-in path together let
+# the UI render the right calm message and let the user fix it from
+# the Settings card alone.
+
+
+class TestEnvSaysEnabledButUserSeesDisabled:
+    def test_env_enabled_per_user_off_surfaces_host_enabled_true(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # The exact failure mode from the bug report. ``NOVA_SILENTGUARD_ENABLED``
+        # is "true", a SilentGuard API would be reachable, but Alice
+        # has not flipped her per-user toggle. The endpoint must:
+        #   * still return ``state="disabled"`` (the per-user gate is
+        #     authoritative for this user), and
+        #   * surface ``host_enabled=True`` so the UI can show "Turn
+        #     on SilentGuard in Settings to use it" instead of the
+        #     misleading "integration disabled" headline.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        headers = _login(web_client)
+        # NOTE: deliberately do NOT call _enable_for_alice — Alice is
+        # the operator who set env vars but hasn't found the UI toggle.
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_DISABLED
+        assert body["host_enabled"] is True
+        assert body["counts"] is None
+
+    def test_env_disabled_surfaces_host_enabled_false(
+        self, web_client, _spawn_disabled,
+    ):
+        # The other half of the same disambiguation: when the host
+        # config is off, ``host_enabled`` must be False so the UI can
+        # tell the user the *server* config needs changing, not just
+        # the toggle.
+        headers = _login(web_client)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_DISABLED
+        assert body["host_enabled"] is False
+        assert body["counts"] is None
+
+    def test_env_accepts_string_true_lowercase_uppercase_and_aliases(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # The bug report flagged boolean parsing as a possible cause.
+        # Confirm the lifecycle helper accepts the documented set of
+        # truthy values surfaced by every common env-var convention.
+        headers = _login(web_client)
+        for raw in ("true", "True", "TRUE", "1", "yes", "on"):
+            monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", raw)
+            resp = web_client.get(
+                "/integrations/silentguard/summary", headers=headers,
+            )
+            assert resp.status_code == 200, raw
+            body = resp.json()
+            assert body["host_enabled"] is True, (
+                f"NOVA_SILENTGUARD_ENABLED={raw!r} did not parse as truthy"
+            )
+
+    def test_env_enabled_plus_per_user_toggle_with_reachable_api_reports_connected(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # End-to-end happy path the bug report describes: env on, API
+        # reachable, user opted in → state="connected" with counts
+        # attached, ``host_enabled`` honest at True. This is the path
+        # the Settings card paints as "SilentGuard connected in
+        # read-only mode".
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+
+        from core.security import lifecycle as lc
+        import web as web_module
+
+        class _ReachableLifecycleProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+        class _CountingProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def get_status(self):
+                return _available()
+
+            def get_summary_counts(self):
+                return {
+                    "alerts": 0,
+                    "blocked": 0,
+                    "trusted": 0,
+                    "connections": 0,
+                }
+
+        monkeypatch.setattr(lc, "SilentGuardProvider", _ReachableLifecycleProvider)
+        monkeypatch.setattr(web_module, "_SilentGuardProvider", _CountingProvider)
+
+        headers = _login(web_client)
+        _enable_for_alice(web_client, headers)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["lifecycle"]["state"] == STATE_CONNECTED
+        assert body["host_enabled"] is True
+        assert body["counts"] == {
+            "alerts": 0, "blocked": 0, "trusted": 0, "connections": 0,
+        }
+
+    def test_per_user_toggle_can_be_flipped_on_via_settings_endpoint(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # The fix for the bug also requires that a user actually has
+        # a way to opt in. The /settings endpoint already accepts
+        # ``silentguard_enabled``; this test pins that contract end-
+        # to-end so the new UI toggle has a backend it can call.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        headers = _login(web_client)
+
+        # Before opt-in: disabled.
+        before = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        ).json()
+        assert before["lifecycle"]["state"] == STATE_DISABLED
+
+        # Flip the per-user toggle via the same JSON endpoint the UI
+        # calls. The response is the standard ``{"ok": True}`` ack.
+        ack = web_client.post(
+            "/settings",
+            json={"silentguard_enabled": True},
+            headers=headers,
+        )
+        assert ack.status_code == 200, ack.text
+
+        # Read it back via GET /settings — the UI uses this to render
+        # the toggle's initial state on Settings open.
+        echoed = web_client.get("/settings", headers=headers).json()
+        assert echoed["silentguard_enabled"] is True
+
+        # Now the summary either reports ``connected``/``unavailable``
+        # depending on the API reachability stub; the key invariant is
+        # that the per-user gate no longer short-circuits to disabled.
+        after = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        ).json()
+        assert after["lifecycle"]["state"] != STATE_DISABLED
+
+    def test_host_enabled_field_is_a_bool_in_every_path(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # Defensive: the UI guards against ``host_enabled``
+        # disappearing or going non-bool. Verify that across the four
+        # major code paths (host off + user off, host off + user on,
+        # host on + user off, host on + user on) the field is always a
+        # plain Python bool — never null, never a string.
+        headers = _login(web_client)
+
+        # host off + user off
+        body = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        ).json()
+        assert isinstance(body["host_enabled"], bool)
+        assert body["host_enabled"] is False
+
+        # host off + user on
+        _enable_for_alice(web_client, headers)
+        body = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        ).json()
+        assert isinstance(body["host_enabled"], bool)
+        assert body["host_enabled"] is False
+
+        # host on + user on
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        body = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        ).json()
+        assert isinstance(body["host_enabled"], bool)
+        assert body["host_enabled"] is True
+
+        # host on + user off
+        ack = web_client.post(
+            "/settings",
+            json={"silentguard_enabled": False},
+            headers=headers,
+        )
+        assert ack.status_code == 200
+        body = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        ).json()
+        assert isinstance(body["host_enabled"], bool)
+        assert body["host_enabled"] is True
+
+
+class TestHostEnabledHelper:
+    """Direct tests for the public ``host_enabled()`` helper.
+
+    The helper is the only sanctioned way to read the host-level
+    ``NOVA_SILENTGUARD_ENABLED`` switch outside the lifecycle module.
+    The summary endpoint depends on it; pinning the parsing rules here
+    catches regressions without having to spin up the full app.
+    """
+
+    def test_unset_env_returns_false(self, monkeypatch):
+        from core.security import lifecycle as lc
+        monkeypatch.delenv("NOVA_SILENTGUARD_ENABLED", raising=False)
+        # Also defang the config import path so a stray real .env
+        # cannot pollute the assertion.
+        import config as config_mod
+        monkeypatch.setattr(config_mod, "NOVA_SILENTGUARD_ENABLED", False)
+        assert lc.host_enabled() is False
+
+    def test_truthy_strings_resolve_true(self, monkeypatch):
+        from core.security import lifecycle as lc
+        for raw in ("1", "true", "True", "TRUE", "yes", "YES", "on", "ON"):
+            monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", raw)
+            assert lc.host_enabled() is True, raw
+
+    def test_falsy_strings_resolve_false(self, monkeypatch):
+        from core.security import lifecycle as lc
+        for raw in ("0", "false", "no", "off", "", "  ", "maybe"):
+            monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", raw)
+            assert lc.host_enabled() is False, raw

--- a/web.py
+++ b/web.py
@@ -745,6 +745,7 @@ def silentguard_summary(user: CurrentUser = Depends(get_current_user)):
             "lifecycle": LifecycleStatus.as_dict(),
             "counts": {"alerts": int, "blocked": int,
                        "trusted": int, "connections": int} | None,
+            "host_enabled": bool,
         }
 
     ``counts`` is ``None`` whenever the lifecycle state is anything
@@ -753,15 +754,26 @@ def silentguard_summary(user: CurrentUser = Depends(get_current_user)):
     fails. The endpoint never raises; every failure path maps to a
     calm payload the UI renders without alarm.
 
+    ``host_enabled`` mirrors the host-level
+    ``NOVA_SILENTGUARD_ENABLED`` switch *as Nova currently sees it*.
+    The Settings UI uses it to tell the user *why* the integration is
+    off when ``state="disabled"``: the host config is off, or the host
+    config is on but the per-user toggle is still off. Without this
+    hint the disabled headline conflates the two, and an operator who
+    has correctly set the env vars cannot tell that they only need to
+    flip their per-user toggle in Settings.
+
     Read-only and gated by the per-user ``silentguard_enabled``
     setting, exactly like the lifecycle endpoint. No background
     polling — the UI calls this once per Settings open / Refresh
     click, mirroring the trigger set documented in the roadmap.
     """
+    host_enabled = _silentguard_lifecycle.host_enabled()
     if not _silentguard_integration.is_enabled(user.id):
         return {
             "lifecycle": _silentguard_lifecycle.disabled_status().as_dict(),
             "counts": None,
+            "host_enabled": host_enabled,
         }
     lifecycle_status = _ensure_silentguard_running()
     counts = None
@@ -773,6 +785,7 @@ def silentguard_summary(user: CurrentUser = Depends(get_current_user)):
     return {
         "lifecycle": lifecycle_status.as_dict(),
         "counts": counts,
+        "host_enabled": host_enabled,
     }
 
 


### PR DESCRIPTION
## Summary

The SilentGuard Settings card always read **"integration disabled"** even when an operator had set every host-level env var correctly and the read-only API was responding on `127.0.0.1:8767`. The summary endpoint correctly gates on the per-user `silentguard_enabled` setting (which defaults to `false`), but the Settings UI never surfaced a control to flip it — so the only way to opt in was a direct `POST /settings` call. The roadmap (§2.4) documented this toggle but it was never built.

This PR ships two coordinated changes that together make the real local setup work:

- **Per-user on/off toggle next to the SilentGuard status card.** Wired through `addEventListener` (CSP-safe, testable), persists via `POST /settings` with `credentials: "include"`, and refreshes the status card immediately so the user sees the new state.
- **`host_enabled: bool` added to the summary response** so the UI can tell apart the two distinct "disabled" cases:
  - host config off → *"SilentGuard integration disabled in server config"* (set the env vars)
  - per-user toggle off → *"Turn on SilentGuard in Settings to use it"* (flip the toggle)

A new public helper `core.security.lifecycle.host_enabled()` is the sanctioned read of `NOVA_SILENTGUARD_ENABLED`. It re-evaluates on every call so a systemd-provided env var (the documented setup) and `monkeypatch.setenv` in tests both resolve correctly.

The integration stays read-only. No firewall actions, no autonomous behaviour, no background polling, no shell/sudo — only the existing `systemctl --user start <unit>` lifecycle path that was already gated and validated.

## Files changed

| File | Why |
|---|---|
| `web.py` | `/integrations/silentguard/summary` now returns `{lifecycle, counts, host_enabled}` |
| `core/security/lifecycle.py` | New public `host_enabled()` helper + `__all__` entry |
| `static/index.html` | Per-user toggle button, JS handler, `loadSystemSettings` paints initial state, headline mapping uses `host_enabled`, two new EN+FR i18n strings |
| `.env.example` | Cross-reference the per-user toggle so operators know it is the last step |
| `docs/silentguard-background-service.md` | Step 6 now explains the toggle's location and the two distinct disabled headlines |
| `tests/test_silentguard_summary_endpoint.py` | Updated existing key-set assertions; added `TestEnvSaysEnabledButUserSeesDisabled` (the bug's failure mode) and `TestHostEnabledHelper` |
| `tests/test_silentguard_settings_card_wiring.py` | Added `TestPerUserToggleWiring` and `TestDisabledHeadlineDifferentiation` plus a brace-counting helper for robust JS function-body extraction |

## Test plan

- [x] `pytest tests/test_silentguard_settings_card_wiring.py tests/test_silentguard_summary_endpoint.py` — 33 passed (15 wiring + 18 endpoint)
- [x] Full suite (split across two runs to fit timeouts): **1045 passed, 0 failed**
- [x] Manual contract sanity-check of `lifecycle.host_enabled()` (False with no env, True with `NOVA_SILENTGUARD_ENABLED=true`)
- [x] Confirmed every wiring symbol present in `static/index.html`
- [ ] Manual smoke test on a real local setup (env vars + user toggle → "connected in read-only mode" with counts)

## Verification against the bug report

| Requirement | Status |
|---|---|
| Existing security/provider/context/lifecycle tests pass | ✅ |
| Existing SilentGuard summary endpoint tests pass (with the documented contract extension) | ✅ |
| New tests cover the real "env says enabled but UI says disabled" failure mode | ✅ `TestEnvSaysEnabledButUserSeesDisabled` (5 tests) |
| No auth/admin/channel regressions | ✅ |
| No Alpha exposure regressions | ✅ |
| Failures surface as readable status text, not silent no-ops | ✅ existing failure UI extended; toggle errors route to `applySilentGuardCheckFailedUI` |
| Stays read-only — no firewall, no block/unblock, no notifications, no background polling, no shell/sudo, no dashboard features | ✅ no new code in those areas |

https://claude.ai/code/session_015TbuEzoVybMYWgkUCJAG3z

---
_Generated by [Claude Code](https://claude.ai/code/session_015TbuEzoVybMYWgkUCJAG3z)_