### PR TITLE
feat(silentguard): confirmation-gated temporary mitigation flow

### DIFF
--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -41,6 +41,17 @@ from core.security.provider import (
 )
 from core.security.silentguard import SilentGuardProvider
 from core.security.silentguard_client import SilentGuardClient
+from core.security.silentguard_mitigation import (
+    ACKNOWLEDGE_KEY,
+    ACKNOWLEDGE_PAYLOAD,
+    MODE_ASK_BEFORE_BLOCKING,
+    MODE_DETECTION_ONLY,
+    MODE_TEMPORARY_AUTO_BLOCK,
+    MODE_UNKNOWN,
+    MitigationActionResult,
+    MitigationState,
+    SilentGuardMitigationClient,
+)
 from core.security.context import build_security_context_block
 # Lifecycle helper is the only file in this package permitted to import
 # ``subprocess`` / ``shutil``. It is exposed here so the web layer can
@@ -52,11 +63,20 @@ from core.security.lifecycle import (
 )
 
 __all__ = [
+    "ACKNOWLEDGE_KEY",
+    "ACKNOWLEDGE_PAYLOAD",
     "LifecycleStatus",
+    "MODE_ASK_BEFORE_BLOCKING",
+    "MODE_DETECTION_ONLY",
+    "MODE_TEMPORARY_AUTO_BLOCK",
+    "MODE_UNKNOWN",
+    "MitigationActionResult",
+    "MitigationState",
     "NullSecurityProvider",
     "SecurityProvider",
     "SecurityStatus",
     "SilentGuardClient",
+    "SilentGuardMitigationClient",
     "SilentGuardProvider",
     "STATE_AVAILABLE",
     "STATE_OFFLINE",

--- a/core/security/silentguard.py
+++ b/core/security/silentguard.py
@@ -57,6 +57,11 @@ from core.security.silentguard_client import (
     DEFAULT_TIMEOUT_SECONDS,
     SilentGuardClient,
 )
+from core.security.silentguard_mitigation import (
+    MitigationActionResult,
+    MitigationState,
+    SilentGuardMitigationClient,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +216,7 @@ class SilentGuardProvider:
         api_url: Optional[str] = None,
         api_timeout_seconds: Optional[float] = None,
         client: Optional[SilentGuardClient] = None,
+        mitigation_client: Optional[SilentGuardMitigationClient] = None,
     ) -> None:
         self._explicit_path: Optional[Path] = (
             Path(feed_path) if feed_path is not None else None
@@ -219,6 +225,13 @@ class SilentGuardProvider:
         self._explicit_api_url: Optional[str] = api_url
         self._explicit_timeout: Optional[float] = api_timeout_seconds
         self._explicit_client: Optional[SilentGuardClient] = client
+        # Opt-in: only constructed when a caller asks for mitigation
+        # state or an action. Keeping it ``None`` by default ensures
+        # the read-only status / counts / connection-summary code paths
+        # cannot accidentally instantiate a POST-capable client.
+        self._explicit_mitigation_client: Optional[SilentGuardMitigationClient] = (
+            mitigation_client
+        )
 
     # ── Path / API resolution ───────────────────────────────────────
 
@@ -514,6 +527,141 @@ class SilentGuardProvider:
             "trusted": len(trusted),
             "connections": len(connections),
         }
+
+
+    # ── Optional mitigation surface ─────────────────────────────────
+    #
+    # SilentGuard owns enforcement. These methods are the *only* place
+    # the provider exposes write capability, and every one of them is
+    # behind an explicit user-confirmation flow at the Nova endpoint
+    # layer. They are intentionally small:
+    #
+    #   * ``get_mitigation_state``     — read-only snapshot.
+    #   * ``enable_temporary_mitigation`` — opt-in, requires SilentGuard's
+    #                                       acknowledgement payload.
+    #   * ``disable_mitigation``       — opt-in, same acknowledgement.
+    #
+    # The methods never raise; failures map to ``None`` (state read)
+    # or a calm :class:`MitigationActionResult` (action). The read-only
+    # ``get_status`` / ``get_summary_counts`` / ``get_connection_summary``
+    # paths above are unchanged and never invoke any of these.
+
+    def _resolved_mitigation_client(self) -> Optional[SilentGuardMitigationClient]:
+        """Return a ready mitigation client, or ``None`` if HTTP is off.
+
+        The mitigation client speaks to the same loopback API base URL
+        as the read-only client, but lives in its own module so the
+        forbidden-verb assertion on ``silentguard_client.py`` can stay
+        in place.
+        """
+        if self._explicit_mitigation_client is not None:
+            return self._explicit_mitigation_client
+        url = self._resolved_api_url()
+        if not url:
+            return None
+        return SilentGuardMitigationClient(
+            base_url=url,
+            timeout_seconds=self._resolved_timeout(),
+        )
+
+    def get_mitigation_state(self) -> Optional[MitigationState]:
+        """Return SilentGuard's current mitigation snapshot, or ``None``.
+
+        ``None`` means the read-only API is not configured, the
+        provider is currently unavailable, or SilentGuard returned a
+        payload Nova could not parse at all. The Nova endpoint above
+        translates ``None`` into a calm "mitigation status unavailable"
+        response — callers must not treat ``None`` as "no mitigation
+        is configured".
+
+        Read-only. Issues at most one ``GET /mitigation`` against the
+        loopback API.
+        """
+        status = self.get_status()
+        if not status.available:
+            return None
+        client = self._resolved_mitigation_client()
+        if client is None:
+            return None
+        try:
+            return client.get_state()
+        except Exception:  # pragma: no cover — defensive belt-and-braces
+            logger.debug(
+                "SilentGuard mitigation state fetch failed", exc_info=True,
+            )
+            return None
+
+    def enable_temporary_mitigation(self) -> MitigationActionResult:
+        """Ask SilentGuard to enable temporary mitigation.
+
+        Sends SilentGuard's required acknowledgement payload. This
+        method must only be called after the user has explicitly
+        confirmed the action — that gating lives at the Nova endpoint
+        layer (``POST /integrations/silentguard/mitigation/enable-
+        temporary``). The provider does not record consent and does
+        not re-derive it.
+
+        Never raises. Returns a calm
+        :class:`MitigationActionResult` describing the outcome — the
+        endpoint above this layer surfaces the result as JSON without
+        further translation.
+        """
+        client = self._resolved_mitigation_client()
+        if client is None:
+            return MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard mitigation API is not configured.",
+            )
+        # Defence in depth: refuse to attempt the action when the
+        # underlying read-only probe says SilentGuard is unreachable.
+        # Saves us from posting into the void and confusing the user
+        # with a SilentGuard-side error message.
+        status = self.get_status()
+        if not status.available:
+            return MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard is not reachable right now.",
+            )
+        try:
+            return client.enable_temporary()
+        except Exception:  # pragma: no cover — defensive belt-and-braces
+            logger.debug(
+                "SilentGuard mitigation enable-temporary failed", exc_info=True,
+            )
+            return MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard mitigation request failed.",
+            )
+
+    def disable_mitigation(self) -> MitigationActionResult:
+        """Ask SilentGuard to disable mitigation.
+
+        Same gating contract as :meth:`enable_temporary_mitigation`:
+        the user-confirmation step lives at the Nova endpoint layer.
+        Never raises.
+        """
+        client = self._resolved_mitigation_client()
+        if client is None:
+            return MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard mitigation API is not configured.",
+            )
+        status = self.get_status()
+        if not status.available:
+            return MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard is not reachable right now.",
+            )
+        try:
+            return client.disable()
+        except Exception:  # pragma: no cover — defensive belt-and-braces
+            logger.debug(
+                "SilentGuard mitigation disable failed", exc_info=True,
+            )
+            return MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard mitigation request failed.",
+            )
 
 
 def _normalise_url(value: str) -> str:

--- a/core/security/silentguard.py
+++ b/core/security/silentguard.py
@@ -528,7 +528,6 @@ class SilentGuardProvider:
             "connections": len(connections),
         }
 
-
     # ── Optional mitigation surface ─────────────────────────────────
     #
     # SilentGuard owns enforcement. These methods are the *only* place

--- a/core/security/silentguard_mitigation.py
+++ b/core/security/silentguard_mitigation.py
@@ -1,0 +1,392 @@
+"""
+Tiny, narrowly-scoped mitigation client for SilentGuard's local API.
+
+SilentGuard owns detection and enforcement. Nova is the cognitive layer
+and does **not** become the firewall. This module is the smallest
+possible bridge that lets Nova:
+
+  * read the current mitigation mode SilentGuard is in
+    (``detection_only`` / ``ask_before_blocking`` / ``temporary_auto_block``);
+  * after the user has explicitly confirmed, ask SilentGuard to enable
+    temporary mitigation;
+  * after the user has explicitly confirmed, ask SilentGuard to disable
+    mitigation.
+
+Boundaries (commitments, not aspirations):
+
+  * **Local-first.** The client only ever talks to a loopback URL the
+    operator has configured for the read-only API
+    (``NOVA_SILENTGUARD_API_URL``). There is no auto-discovery, no
+    remote fallback, and no second URL just for mitigation.
+  * **Acknowledge-or-refuse.** Every POST carries the SilentGuard
+    acknowledgement payload (``{"acknowledge": true}``). The client
+    refuses to send a POST without it; the Nova endpoint above this
+    layer refuses to call without the acknowledgement coming in
+    explicitly from the user request.
+  * **Strict timeouts.** Every call is bounded by a short timeout.
+  * **Defensive parsing.** Non-JSON or unexpected payload shapes map
+    to ``None`` (state) or a calm ``MitigationActionResult(ok=False,
+    ...)``; raw transport errors never reach the caller.
+  * **No shell, no subprocess, no firewall.** This module reads /
+    writes nothing on disk, runs no commands, and touches no firewall
+    rule directly. SilentGuard does the enforcement; Nova only asks.
+  * **Separate from the read-only client.** ``silentguard_client.py``
+    stays GET-only and is pinned by ``test_security_provider``'s
+    forbidden-verb assertion. Mitigation lives here on purpose so that
+    ``GET /status`` / ``GET /alerts`` paths cannot accidentally grow
+    a write capability.
+
+Scope is intentionally tiny. The full set of operations:
+
+  * ``GET  /mitigation``               — read the current mode.
+  * ``POST /mitigation/enable-temporary`` — opt-in temporary mitigation.
+  * ``POST /mitigation/disable``       — turn it off.
+
+Anything else (per-IP unblock, persistent rule writes, schedule
+windows) is out of scope for this PR. Add a new method here only via
+deliberate review — adding a method is the moment Nova grows a new
+mitigation capability.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Short by design — the API is loopback-only.
+DEFAULT_TIMEOUT_SECONDS = 3.0
+
+# Mitigation paths Nova knows about. Adding to this list is a
+# deliberate review.
+PATH_MITIGATION = "/mitigation"
+PATH_MITIGATION_ENABLE_TEMPORARY = "/mitigation/enable-temporary"
+PATH_MITIGATION_DISABLE = "/mitigation/disable"
+
+# Mitigation modes Nova surfaces. Anything else SilentGuard returns
+# normalises to ``MODE_UNKNOWN`` so the UI never paints an unreviewed
+# value. Order is *not* significant — these are flat enum values.
+MODE_DETECTION_ONLY = "detection_only"
+MODE_ASK_BEFORE_BLOCKING = "ask_before_blocking"
+MODE_TEMPORARY_AUTO_BLOCK = "temporary_auto_block"
+MODE_UNKNOWN = "unknown"
+
+_RECOGNISED_MODES = frozenset({
+    MODE_DETECTION_ONLY,
+    MODE_ASK_BEFORE_BLOCKING,
+    MODE_TEMPORARY_AUTO_BLOCK,
+})
+
+# Modes that count as "mitigation is currently active" for surfacing
+# purposes. ``ask_before_blocking`` is *not* in this set: it is a
+# detection mode that prompts before any block, so the user has not
+# yet authorised an active block.
+_ACTIVE_MODES = frozenset({MODE_TEMPORARY_AUTO_BLOCK})
+
+# Acknowledgement payload SilentGuard requires on every mitigation
+# write. Nova mirrors the same key at its own endpoint so a stray POST
+# without the user's explicit acknowledgement is rejected at the Nova
+# layer too.
+ACKNOWLEDGE_KEY = "acknowledge"
+ACKNOWLEDGE_PAYLOAD = {ACKNOWLEDGE_KEY: True}
+
+# ISO-8601 timestamp shape SilentGuard is expected to return for the
+# ``expires_at`` field. We only accept strings that match this pattern
+# so the UI can render them without re-parsing into a ``datetime``.
+_ISO_TIMESTAMP_RE = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(\.[0-9]+)?(Z|[+-][0-9]{2}:?[0-9]{2})?$"
+)
+_MAX_TIMESTAMP_LENGTH = 40
+
+# Calm, user-safe message shown when SilentGuard is unreachable or
+# returns an unexpected shape. The Nova endpoint surfaces this verbatim
+# so a hostile log line never leaks into the UI.
+_GENERIC_UNAVAILABLE_MESSAGE = "SilentGuard mitigation is currently unavailable."
+_GENERIC_REFUSED_MESSAGE = "SilentGuard refused the mitigation request."
+
+
+def _normalise_base_url(value: Optional[str]) -> str:
+    """Trim whitespace and the trailing slash from a base URL."""
+    if not value:
+        return ""
+    return str(value).strip().rstrip("/")
+
+
+def _normalise_mode(raw: object) -> str:
+    """Map an external mode string into Nova's small allow-list.
+
+    Anything that is not one of the three documented modes (including
+    ``None``, non-strings, mixed case, surrounding whitespace, or new
+    SilentGuard modes Nova has not reviewed yet) maps to
+    :data:`MODE_UNKNOWN`. The UI then renders it as a calm
+    *"unknown"* state rather than echoing arbitrary text.
+    """
+    if not isinstance(raw, str):
+        return MODE_UNKNOWN
+    cleaned = raw.strip().lower()
+    if cleaned in _RECOGNISED_MODES:
+        return cleaned
+    return MODE_UNKNOWN
+
+
+def _normalise_timestamp(raw: object) -> Optional[str]:
+    """Return a short ISO-8601 string, or ``None`` on bad input.
+
+    Defence in depth: the value flows into Nova's response and may be
+    rendered in the UI. Only well-formed ISO-8601 timestamps under a
+    short length cap are accepted; everything else is dropped silently.
+    """
+    if not isinstance(raw, str):
+        return None
+    cleaned = raw.strip()
+    if not cleaned or len(cleaned) > _MAX_TIMESTAMP_LENGTH:
+        return None
+    if not _ISO_TIMESTAMP_RE.match(cleaned):
+        return None
+    return cleaned
+
+
+def _normalise_bool(raw: object, *, default: Optional[bool] = None) -> Optional[bool]:
+    """Coerce a JSON-safe boolean, dropping numeric / string truthiness."""
+    if isinstance(raw, bool):
+        return raw
+    return default
+
+
+# ── Result dataclasses ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MitigationState:
+    """Read-only snapshot of SilentGuard's mitigation mode.
+
+    Fields are intentionally minimal: a normalised ``mode``, a derived
+    ``active`` boolean (so the UI does not have to know the mode →
+    active mapping), and an optional ``expires_at`` for temporary
+    modes. SilentGuard's raw payload may include richer fields; this
+    snapshot intentionally drops them so a future field cannot reach
+    the UI without a deliberate review.
+    """
+
+    mode: str
+    active: bool
+    expires_at: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "mode": self.mode,
+            "active": self.active,
+            "expires_at": self.expires_at,
+        }
+
+
+@dataclass(frozen=True)
+class MitigationActionResult:
+    """Outcome of an enable / disable mitigation call.
+
+    ``ok`` is the single source of truth for whether SilentGuard
+    accepted the action. ``state`` carries the post-action mitigation
+    snapshot when available, so the UI can repaint in a single
+    round-trip. ``message`` is calm, user-safe text — never a raw
+    exception or HTTP body — chosen by this module so the Nova
+    endpoint above can surface it verbatim.
+    """
+
+    ok: bool
+    state: Optional[MitigationState]
+    message: str
+
+    def as_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "state": self.state.as_dict() if self.state else None,
+            "message": self.message,
+        }
+
+
+def _parse_state(payload: object) -> Optional[MitigationState]:
+    """Coerce a SilentGuard ``/mitigation`` payload into a ``MitigationState``.
+
+    Returns ``None`` only when the payload is so malformed that even a
+    mode field cannot be extracted. An unrecognised mode coerces to
+    :data:`MODE_UNKNOWN` so the caller still gets a snapshot it can
+    render. Callers must therefore type-check the return value rather
+    than treat ``None`` as "no mitigation."
+    """
+    if not isinstance(payload, dict):
+        return None
+    mode = _normalise_mode(payload.get("mode"))
+    # ``active`` may be supplied explicitly by SilentGuard or derived.
+    derived_active = mode in _ACTIVE_MODES
+    explicit_active = _normalise_bool(payload.get("active"), default=None)
+    if explicit_active is None:
+        active = derived_active
+    else:
+        # Defence in depth: even if SilentGuard claims ``active=true``
+        # we only honour it when paired with an active mode. This keeps
+        # the UI from ever showing "active" for a mode Nova has not
+        # vetted.
+        active = explicit_active and derived_active
+    expires_at = _normalise_timestamp(payload.get("expires_at"))
+    return MitigationState(mode=mode, active=active, expires_at=expires_at)
+
+
+# ── Client ──────────────────────────────────────────────────────────
+
+
+class SilentGuardMitigationClient:
+    """Narrow HTTP client for SilentGuard's mitigation endpoints.
+
+    Construction is cheap; ``httpx.Client`` is created per request so a
+    transient hang cannot wedge long-lived state. The client never
+    raises into the caller — failures map to ``None`` (read) or a calm
+    :class:`MitigationActionResult` with ``ok=False`` (write).
+
+    The client refuses to make a POST without the SilentGuard
+    acknowledgement payload. Callers cannot smuggle in a different
+    body shape: the body is constructed inside this class.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout_seconds: Optional[float] = None,
+    ) -> None:
+        self.base_url: str = _normalise_base_url(base_url)
+        try:
+            timeout = (
+                float(timeout_seconds)
+                if timeout_seconds is not None
+                else DEFAULT_TIMEOUT_SECONDS
+            )
+        except (TypeError, ValueError):
+            timeout = DEFAULT_TIMEOUT_SECONDS
+        if timeout <= 0:
+            timeout = DEFAULT_TIMEOUT_SECONDS
+        self.timeout_seconds: float = timeout
+
+    def is_configured(self) -> bool:
+        return bool(self.base_url)
+
+    # ── Internal helpers ────────────────────────────────────────────
+
+    def _open(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.base_url,
+            timeout=self.timeout_seconds,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+
+    def _request_state(
+        self, method: str, path: str,
+    ) -> Optional[MitigationState]:
+        """Issue one request that is expected to return a state payload."""
+        if not self.is_configured():
+            return None
+        try:
+            with self._open() as client:
+                if method == "GET":
+                    resp = client.get(path)
+                elif method == "POST":
+                    resp = client.post(path, json=ACKNOWLEDGE_PAYLOAD)
+                else:  # pragma: no cover — defensive
+                    return None
+        except (httpx.HTTPError, OSError) as exc:
+            logger.debug(
+                "SilentGuard mitigation %s %s failed: %s", method, path, exc,
+            )
+            return None
+        if not (200 <= resp.status_code < 300):
+            logger.debug(
+                "SilentGuard mitigation %s %s returned HTTP %s",
+                method, path, resp.status_code,
+            )
+            return None
+        try:
+            payload = resp.json()
+        except (ValueError, TypeError) as exc:
+            logger.debug(
+                "SilentGuard mitigation %s %s returned invalid JSON: %s",
+                method, path, exc,
+            )
+            return None
+        return _parse_state(payload)
+
+    # ── Public surface (three methods, on purpose) ──────────────────
+
+    def get_state(self) -> Optional[MitigationState]:
+        """Return SilentGuard's current mitigation snapshot, or ``None``.
+
+        ``None`` means the read-only API is not configured, the call
+        failed, or SilentGuard returned a payload Nova could not parse
+        at all. The provider above this layer turns ``None`` into a
+        calm "unavailable" snapshot — callers must not treat ``None``
+        as "no mitigation is configured."
+        """
+        return self._request_state("GET", PATH_MITIGATION)
+
+    def enable_temporary(self) -> MitigationActionResult:
+        """Ask SilentGuard to enable temporary mitigation.
+
+        Sends the required acknowledgement payload. Never raises.
+        Returns ``MitigationActionResult(ok=True, ...)`` on success
+        with a fresh state snapshot, or ``ok=False`` with a calm,
+        user-safe message on any failure.
+        """
+        state = self._request_state(
+            "POST", PATH_MITIGATION_ENABLE_TEMPORARY,
+        )
+        if state is None:
+            return MitigationActionResult(
+                ok=False, state=None,
+                message=_GENERIC_UNAVAILABLE_MESSAGE,
+            )
+        return MitigationActionResult(
+            ok=True, state=state,
+            message="Temporary mitigation enabled.",
+        )
+
+    def disable(self) -> MitigationActionResult:
+        """Ask SilentGuard to disable mitigation.
+
+        Sends the required acknowledgement payload. Never raises.
+        Returns ``MitigationActionResult(ok=True, ...)`` on success
+        with a fresh state snapshot, or ``ok=False`` with a calm,
+        user-safe message on any failure.
+        """
+        state = self._request_state("POST", PATH_MITIGATION_DISABLE)
+        if state is None:
+            return MitigationActionResult(
+                ok=False, state=None,
+                message=_GENERIC_UNAVAILABLE_MESSAGE,
+            )
+        return MitigationActionResult(
+            ok=True, state=state,
+            message="Mitigation disabled.",
+        )
+
+
+__all__ = [
+    "ACKNOWLEDGE_KEY",
+    "ACKNOWLEDGE_PAYLOAD",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MODE_ASK_BEFORE_BLOCKING",
+    "MODE_DETECTION_ONLY",
+    "MODE_TEMPORARY_AUTO_BLOCK",
+    "MODE_UNKNOWN",
+    "MitigationActionResult",
+    "MitigationState",
+    "PATH_MITIGATION",
+    "PATH_MITIGATION_DISABLE",
+    "PATH_MITIGATION_ENABLE_TEMPORARY",
+    "SilentGuardMitigationClient",
+]

--- a/docs/silentguard-integration-roadmap.md
+++ b/docs/silentguard-integration-roadmap.md
@@ -279,6 +279,169 @@ What the surface deliberately does **not** do:
     per-user / channel gates as every other ``/integrations/*``
     endpoint.
 
+### 2.4.quater Confirmation-gated SilentGuard mitigation surface
+
+Nova's Settings card grew a small **mitigation block** in this PR.
+SilentGuard owns detection and enforcement; Nova is the cognitive
+layer. The block lets the user *ask SilentGuard* — explicitly, after
+confirming — to enable temporary mitigation, or to disable it again.
+Nova never blocks IPs directly, never runs firewall commands, never
+runs `sudo`, never executes shell, never silently auto-blocks.
+
+The mitigation surface lives in two new files:
+
+  * `core/security/silentguard_mitigation.py` — a tiny POST-capable
+    HTTP client for SilentGuard's mitigation endpoints, plus the
+    sanitiser helpers (`_normalise_mode`, `_normalise_timestamp`,
+    `_parse_state`) that protect Nova's UI from any unreviewed field
+    SilentGuard might one day return. The client ships exactly three
+    methods (`get_state`, `enable_temporary`, `disable`), and every
+    POST carries the SilentGuard acknowledgement payload
+    (`{"acknowledge": true}`). Errors collapse to `None` (read) or
+    `MitigationActionResult(ok=False, ...)` (action) — no exception
+    ever reaches the caller.
+  * `core/security/silentguard.py::SilentGuardProvider` grew three
+    matching methods (`get_mitigation_state`,
+    `enable_temporary_mitigation`, `disable_mitigation`) that delegate
+    to the new client. The provider refuses to issue a write when its
+    own status probe says SilentGuard is unavailable, so a stray POST
+    cannot fire into a void. The existing read-only `get_status`,
+    `get_summary_counts`, and `get_connection_summary` paths stay
+    byte-identical; pinned tests assert they never invoke any
+    mitigation method.
+
+The read-only `core/security/silentguard_client.py` stays read-only.
+The forbidden-verb assertion in `tests/test_security_provider.py`
+still passes (no `.post(`/`.put(`/`.delete(`/`.patch(` calls in that
+file). Splitting the POST capability into its own module on purpose
+keeps the existing read paths' safety contract intact.
+
+#### Modes Nova knows about
+
+The mitigation client recognises exactly three modes; anything else
+SilentGuard returns coerces to `"unknown"` so the UI never paints an
+unreviewed value:
+
+  * **`detection_only`** — the default. SilentGuard observes and logs
+    but takes no enforcement action. The Settings card surfaces this
+    as *"Detection only"* with the calm explainer *"SilentGuard
+    detected activity that may resemble a flood pattern. Temporary
+    mitigation is available, but it is not active yet."*
+  * **`ask_before_blocking`** — SilentGuard prompts before any block.
+    Surfaced as *"Ask before blocking"*; no action is taken until the
+    user confirms.
+  * **`temporary_auto_block`** — SilentGuard's temporary mitigation is
+    active. Surfaced as *"Temporary auto-block active"*. The Settings
+    card shows the optional `expires_at` timestamp verbatim when
+    SilentGuard provides one (sanitiser-validated, length-capped, no
+    re-parsing).
+
+#### Confirmation flow (two clicks per mutation)
+
+  1. The user opens Settings or clicks Refresh on the SilentGuard
+     status card → Nova issues `GET /integrations/silentguard/mitigation`
+     once. The block hides itself when SilentGuard returns no parsed
+     state, so a non-mitigation install never sees a misleading half-
+     painted control.
+  2. The user clicks *Enable temporary mitigation* (or *Disable
+     mitigation* when a temporary block is already active) → Nova
+     shows an inline confirmation prompt. **No HTTP call is issued
+     yet.**
+  3. The user clicks *Confirm* → Nova issues
+     `POST /integrations/silentguard/mitigation/enable-temporary`
+     (or `/disable`) with the body `{"acknowledge": true}`. SilentGuard
+     applies the change and returns the new state; Nova repaints the
+     mode badge and shows a calm *"Temporary mitigation enabled."* /
+     *"Mitigation disabled."* status line.
+
+The third button — *Keep detection only* — is purely a UX
+acknowledgement. It does **not** call any endpoint, because
+detection-only is the default mode. A pinned test (`UI controller
+tests`) asserts this remains true: turning *Keep detection only* into
+a network call would be a *new* mitigation capability that needs its
+own review.
+
+#### Nova-side endpoint contract
+
+| Method | Path                                                         | Effect                                                     |
+| ------ | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| GET    | `/integrations/silentguard/mitigation`                       | Read-only mitigation snapshot for the caller.              |
+| POST   | `/integrations/silentguard/mitigation/enable-temporary`      | Acknowledged enable; relays to SilentGuard's `/mitigation/enable-temporary`. |
+| POST   | `/integrations/silentguard/mitigation/disable`               | Acknowledged disable; relays to SilentGuard's `/mitigation/disable`. |
+
+Stable response shape (all four endpoints):
+
+```json
+{
+  "ok": true,
+  "available": true,
+  "state": {
+    "mode":       "detection_only" | "ask_before_blocking"
+                  | "temporary_auto_block" | "unknown",
+    "active":     true,
+    "expires_at": "2026-05-10T13:00:00Z" | null
+  },
+  "message": "Temporary mitigation enabled."
+}
+```
+
+`available` is `false` whenever SilentGuard's mitigation API is not
+reachable / not configured / returned an unparseable payload. The
+`message` field is calm, user-safe wording — never a raw exception or
+HTTP body — chosen by the provider layer so the endpoint can surface
+it verbatim.
+
+Safety contract:
+
+  * Every endpoint requires an authenticated session.
+  * Both POST endpoints require the body `{"acknowledge": true}`. Without
+    it, the endpoint returns **400** and never issues any call to
+    SilentGuard. This is a hard server-side checkpoint independent of
+    the UI confirmation step.
+  * Both endpoints honour the per-user `silentguard_enabled` gate. A
+    user who has not opted in sees a calm
+    `{"ok": false, "available": false, "state": null, ...}` payload
+    and the provider is **not instantiated**.
+  * The `_SilentGuardMitigationRequest` body model declares only
+    `acknowledge` and ignores extra fields — there is nothing for an
+    attacker to smuggle in (no IP list, no command string, no mode
+    selector).
+  * Disable does **not** mean Nova writes to SilentGuard's data files.
+    Nova never touches `~/.silentguard_rules.json` or
+    `~/.silentguard_memory.json`. Mitigation mode lives inside
+    SilentGuard.
+  * The read-only `/integrations/silentguard/summary` endpoint is
+    unchanged. A pinned test (`TestReadOnlyEndpointsDoNotCallMitigation`)
+    asserts that hitting `/summary` never triggers any mitigation
+    read or write. The mitigation block on the Settings card pulls
+    from its own URL on the same trigger set as the existing summary
+    refresh (Settings open + Refresh click) — there is **no
+    background polling** added by this PR.
+
+#### What this PR explicitly does **not** ship
+
+  * No notifications, toasts, or "you have alerts" badges. The
+    mitigation block is rendered inside the existing Settings card
+    only when the user opens it.
+  * No permanent blocking control. The SilentGuard
+    `POST /blocked/{ip}/unblock` path mentioned in the original brief
+    is intentionally out of scope; it would only land in a later PR
+    after its own review.
+  * No autonomous behaviour — mitigation never enables itself, never
+    auto-disables, never re-arms after a failure.
+  * No new aggressive language. The copy stays calm; a forbidden-
+    word assertion in `test_silentguard_mitigation_card_wiring`
+    rejects strings like *"under attack"*, *"alert!"*, *"danger"*,
+    *"urgent"* in the mitigation i18n set.
+  * No subprocess, no shell, no firewall command. The mitigation
+    module imports neither `subprocess` nor `shutil`; a forbidden-
+    imports test pins this.
+
+The default behaviour Nova ships in this PR is therefore *unchanged
+from before*: a fresh install starts with detection-only and never
+issues a mitigation POST until the user explicitly clicks *Enable
+temporary mitigation* and then confirms.
+
 ### 2.5 `core/security/context.py` (read-only chat context)
 
 A small builder that produces the per-turn "Security context:" block
@@ -1397,6 +1560,19 @@ auto-retries. The user retries by clicking the button again.
   the read-only subtext, the optional Start button, and the "View
   setup instructions" link. The existing read-only data tab (four
   lists with "explain" buttons) is added under the same panel.
+- The **confirmation-gated mitigation flow** described in §2.4.quater:
+  three new endpoints
+  (`GET /integrations/silentguard/mitigation` and the two
+  acknowledged POSTs), three new provider methods
+  (`get_mitigation_state`, `enable_temporary_mitigation`,
+  `disable_mitigation`), a new POST-capable client module
+  (`core/security/silentguard_mitigation.py`) — with the read-only
+  client kept POST-free so its forbidden-verb assertion still holds —
+  and a Settings card mitigation block whose default copy is calm,
+  whose actions require explicit confirmation, and which surfaces no
+  notifications. Detection-only remains the default: Nova never
+  enables temporary mitigation without an explicit user click +
+  confirm.
 - Test coverage:
   - Setting disabled means Nova issues *zero* calls to SilentGuard
     (asserted with a fake connector that records call counts and a
@@ -1619,6 +1795,17 @@ the following, and proposals that require them should be rejected.
 - A new permission tier in `family_controls` specifically for
   SilentGuard. The existing per-user switch is the entire
   authorisation surface.
+- Nova becoming the firewall engine. The mitigation surface in
+  §2.4.quater **only** asks SilentGuard, after the user has
+  explicitly confirmed, to enable or disable temporary mitigation.
+  Nova does not block IPs directly, does not run firewall commands,
+  does not auto-block, does not silently enable mitigation, and does
+  not keep mitigation enabled when the user has not asked for it.
+  The SilentGuard `POST /blocked/{ip}/unblock` path is intentionally
+  out of scope for this PR; even when added, it would only land
+  behind the same explicit-confirmation contract as
+  `/mitigation/enable-temporary` and would never be invoked
+  autonomously.
 
 If a PR description starts with "to enable this we just need to
 relax constraint X from §10," the answer is no.

--- a/static/index.html
+++ b/static/index.html
@@ -1596,6 +1596,58 @@
             color: var(--text-mid);
         }
 
+        /* SilentGuard mitigation block — calm, opt-in. The colour
+           palette stays neutral so the block never reads as alarming. */
+        .silentguard-mitigation {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-top: 10px;
+            padding-top: 10px;
+            border-top: 1px solid var(--border);
+        }
+        .silentguard-mitigation-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.74rem;
+            color: var(--text-dim);
+        }
+        .silentguard-mitigation-mode-label {
+            color: var(--text-mid);
+        }
+        .silentguard-mitigation-explainer {
+            font-size: 0.74rem;
+            color: var(--text-dim);
+            line-height: 1.45;
+        }
+        .silentguard-mitigation-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+        .silentguard-mitigation-confirm {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            padding: 8px 10px;
+            border: 1px solid var(--border);
+            border-radius: var(--r-md);
+            background: var(--bg-elev);
+            font-size: 0.74rem;
+            color: var(--text-mid);
+        }
+        .silentguard-mitigation-confirm-actions {
+            display: flex;
+            gap: 6px;
+        }
+        .silentguard-mitigation-status {
+            font-size: 0.72rem;
+            color: var(--text-dim);
+            min-height: 1em;
+        }
+        .silentguard-mitigation-status.is-error { color: var(--text-mid); }
+
         #mem-search {
             width: 100%;
             box-sizing: border-box;
@@ -2449,6 +2501,41 @@
                             <span class="silentguard-counts" id="silentguard-connection-summary" style="display:none;"></span>
                             <span class="silentguard-substatus" id="silentguard-substatus" aria-live="polite"></span>
                         </div>
+                        <!-- SilentGuard mitigation block. SilentGuard owns
+                             enforcement; Nova only explains and asks for
+                             confirmation. The whole block is hidden until
+                             the integration is connected and SilentGuard
+                             reports a mitigation state. -->
+                        <div class="silentguard-mitigation" id="silentguard-mitigation-block" style="display:none;">
+                            <div class="silentguard-mitigation-row">
+                                <span class="silentguard-mitigation-mode-label" id="silentguard-mitigation-mode-label">Mitigation</span>
+                                <span class="silentguard-mode-badge" id="silentguard-mitigation-mode-badge"></span>
+                            </div>
+                            <div class="silentguard-mitigation-explainer" id="silentguard-mitigation-explainer" aria-live="polite"></div>
+                            <div class="silentguard-mitigation-actions" id="silentguard-mitigation-actions">
+                                <button type="button" class="memory-btn" id="silentguard-mitigation-enable-btn" style="display:none;">
+                                    <span id="silentguard-mitigation-enable-label">Enable temporary mitigation</span>
+                                </button>
+                                <button type="button" class="memory-btn" id="silentguard-mitigation-keep-btn" style="display:none;">
+                                    <span id="silentguard-mitigation-keep-label">Keep detection only</span>
+                                </button>
+                                <button type="button" class="memory-btn" id="silentguard-mitigation-disable-btn" style="display:none;">
+                                    <span id="silentguard-mitigation-disable-label">Disable mitigation</span>
+                                </button>
+                            </div>
+                            <div class="silentguard-mitigation-confirm" id="silentguard-mitigation-confirm" role="status" aria-live="polite" style="display:none;">
+                                <span class="silentguard-mitigation-confirm-text" id="silentguard-mitigation-confirm-text"></span>
+                                <div class="silentguard-mitigation-confirm-actions">
+                                    <button type="button" class="memory-btn" id="silentguard-mitigation-confirm-yes">
+                                        <span id="silentguard-mitigation-confirm-yes-label">Confirm</span>
+                                    </button>
+                                    <button type="button" class="memory-btn" id="silentguard-mitigation-confirm-no">
+                                        <span id="silentguard-mitigation-confirm-no-label">Cancel</span>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="silentguard-mitigation-status" id="silentguard-mitigation-status" aria-live="polite"></div>
+                        </div>
                     </div>
                 </section>
 
@@ -2746,6 +2833,28 @@
             silentguard_check_failed: "Statut SilentGuard indisponible",
             silentguard_counts_label: "{alerts} alertes · {blocked} bloqués · {trusted} approuvés · {connections} connexions",
             silentguard_connection_breakdown_label: "{local} locales · {known} connues · {unknown} inconnues",
+            silentguard_mitigation_label: "Atténuation",
+            silentguard_mitigation_mode_detection_only: "Détection seule",
+            silentguard_mitigation_mode_ask_before_blocking: "Demander avant de bloquer",
+            silentguard_mitigation_mode_temporary_auto_block: "Blocage temporaire actif",
+            silentguard_mitigation_mode_unknown: "Mode inconnu",
+            silentguard_mitigation_explainer_detection_only: "SilentGuard a détecté une activité pouvant ressembler à un schéma de type flood. Une atténuation temporaire est disponible, mais elle n'est pas encore active.",
+            silentguard_mitigation_explainer_ask_before_blocking: "SilentGuard est en mode « demander avant de bloquer ». Aucune action de pare-feu n'est prise tant que tu ne confirmes pas.",
+            silentguard_mitigation_explainer_temporary_auto_block: "L'atténuation temporaire de SilentGuard est active. Tu peux la désactiver à tout moment.",
+            silentguard_mitigation_explainer_unknown: "SilentGuard signale un mode d'atténuation que Nova ne reconnaît pas. Aucune action n'est entreprise.",
+            silentguard_mitigation_enable: "Activer l'atténuation temporaire",
+            silentguard_mitigation_keep: "Conserver la détection seule",
+            silentguard_mitigation_disable: "Désactiver l'atténuation",
+            silentguard_mitigation_confirm_yes: "Confirmer",
+            silentguard_mitigation_confirm_no: "Annuler",
+            silentguard_mitigation_confirm_enable: "Confirmer : SilentGuard activera une atténuation temporaire. Nova ne touche pas au pare-feu.",
+            silentguard_mitigation_confirm_disable: "Confirmer : SilentGuard désactivera l'atténuation et reviendra à la détection seule.",
+            silentguard_mitigation_keep_ack: "D'accord — SilentGuard reste en mode détection seule.",
+            silentguard_mitigation_status_unavailable: "État de l'atténuation indisponible.",
+            silentguard_mitigation_status_failed: "L'atténuation n'a pas pu être modifiée. Réessaie plus tard.",
+            silentguard_mitigation_status_enabled: "Atténuation temporaire activée.",
+            silentguard_mitigation_status_disabled: "Atténuation désactivée.",
+            silentguard_mitigation_expires_at: "Expire à {time}.",
             personalization_note: "Ces préférences ajusteront le ton de Nova dans tes conversations. Stockées par utilisateur, visibles uniquement par toi.",
             pers_style_title: "Style de réponse",
             pers_style_hint: "Niveau de détail des réponses de Nova.",
@@ -2886,6 +2995,28 @@
             silentguard_check_failed: "SilentGuard status unavailable",
             silentguard_counts_label: "{alerts} alerts · {blocked} blocked · {trusted} trusted · {connections} connections",
             silentguard_connection_breakdown_label: "{local} local · {known} known · {unknown} unknown",
+            silentguard_mitigation_label: "Mitigation",
+            silentguard_mitigation_mode_detection_only: "Detection only",
+            silentguard_mitigation_mode_ask_before_blocking: "Ask before blocking",
+            silentguard_mitigation_mode_temporary_auto_block: "Temporary auto-block active",
+            silentguard_mitigation_mode_unknown: "Unknown mode",
+            silentguard_mitigation_explainer_detection_only: "SilentGuard detected activity that may resemble a flood pattern. Temporary mitigation is available, but it is not active yet.",
+            silentguard_mitigation_explainer_ask_before_blocking: "SilentGuard is in \"ask before blocking\" mode. No firewall action is taken until you confirm.",
+            silentguard_mitigation_explainer_temporary_auto_block: "SilentGuard's temporary mitigation is active. You can disable it at any time.",
+            silentguard_mitigation_explainer_unknown: "SilentGuard reports a mitigation mode Nova doesn't recognise. No action is taken.",
+            silentguard_mitigation_enable: "Enable temporary mitigation",
+            silentguard_mitigation_keep: "Keep detection only",
+            silentguard_mitigation_disable: "Disable mitigation",
+            silentguard_mitigation_confirm_yes: "Confirm",
+            silentguard_mitigation_confirm_no: "Cancel",
+            silentguard_mitigation_confirm_enable: "Confirm: SilentGuard will enable temporary mitigation. Nova does not touch the firewall itself.",
+            silentguard_mitigation_confirm_disable: "Confirm: SilentGuard will disable mitigation and return to detection only.",
+            silentguard_mitigation_keep_ack: "Got it — SilentGuard stays in detection-only mode.",
+            silentguard_mitigation_status_unavailable: "Mitigation status unavailable.",
+            silentguard_mitigation_status_failed: "Mitigation could not be changed. Try again later.",
+            silentguard_mitigation_status_enabled: "Temporary mitigation enabled.",
+            silentguard_mitigation_status_disabled: "Mitigation disabled.",
+            silentguard_mitigation_expires_at: "Expires at {time}.",
             personalization_note: "These preferences will shape Nova's tone in your conversations. Saved per-user; visible only to you.",
             pers_style_title: "Response style",
             pers_style_hint: "How detailed Nova's answers should be.",
@@ -3041,12 +3172,21 @@
         _setText("settings-silentguard-title", t("silentguard_title"));
         _setText("silentguard-refresh-label", t("silentguard_refresh"));
         _setText("silentguard-retry-label", t("silentguard_retry"));
+        _setText("silentguard-mitigation-mode-label", t("silentguard_mitigation_label"));
+        _setText("silentguard-mitigation-enable-label", t("silentguard_mitigation_enable"));
+        _setText("silentguard-mitigation-keep-label", t("silentguard_mitigation_keep"));
+        _setText("silentguard-mitigation-disable-label", t("silentguard_mitigation_disable"));
+        _setText("silentguard-mitigation-confirm-yes-label", t("silentguard_mitigation_confirm_yes"));
+        _setText("silentguard-mitigation-confirm-no-label", t("silentguard_mitigation_confirm_no"));
         // Re-render the status card so headline / counts / action button
         // labels pick up the new language without re-issuing the network
         // call. The action button label is state-driven, so the summary
         // re-render is the single owner of its text.
         if (typeof applySilentGuardSummaryUI === "function" && lastSilentGuardSummary) {
             applySilentGuardSummaryUI(lastSilentGuardSummary);
+        }
+        if (typeof applySilentGuardMitigationUI === "function" && lastSilentGuardMitigation) {
+            applySilentGuardMitigationUI(lastSilentGuardMitigation);
         }
 
         _setText("settings-personalization-note", t("personalization_note"));
@@ -5079,6 +5219,13 @@
             counts: null,
             host_enabled: false,
         });
+        // Mitigation state is also unknown after a failure; collapse
+        // the block so the user never sees stale "active" wording from
+        // a previous successful read.
+        if (typeof applySilentGuardMitigationUI === "function") {
+            lastSilentGuardMitigation = null;
+            applySilentGuardMitigationUI(null);
+        }
         const sub = document.getElementById("silentguard-substatus");
         if (sub) sub.textContent = t("silentguard_check_failed");
     }
@@ -5106,6 +5253,15 @@
             const data = await res.json();
             lastSilentGuardSummary = data;
             applySilentGuardSummaryUI(data);
+            // Mitigation state piggybacks on the same trigger set as
+            // the read-only summary refresh — Settings open and the
+            // Refresh button. We deliberately do *not* call this from
+            // the read-only summary endpoint itself; mitigation lives
+            // behind its own URL so the no-poll guarantee on /summary
+            // stays intact.
+            if (typeof refreshSilentGuardMitigation === "function") {
+                refreshSilentGuardMitigation().catch(() => {});
+            }
         } catch (e) {
             applySilentGuardCheckFailedUI();
         } finally {
@@ -5169,6 +5325,19 @@
                 const data = await res.json();
                 lastSilentGuardSummary = data;
                 applySilentGuardSummaryUI(data);
+                // After enable: pull mitigation state so the new card
+                // includes it without a manual Refresh. After disable:
+                // collapse the mitigation block — the user has opted
+                // out and Nova should not surface a mode it is no
+                // longer authorised to read.
+                if (newVal) {
+                    if (typeof refreshSilentGuardMitigation === "function") {
+                        refreshSilentGuardMitigation().catch(() => {});
+                    }
+                } else if (typeof applySilentGuardMitigationUI === "function") {
+                    lastSilentGuardMitigation = null;
+                    applySilentGuardMitigationUI(null);
+                }
             } catch (parseErr) {
                 applySilentGuardToggleUI(newVal);
                 await refreshSilentGuardStatus();
@@ -5206,6 +5375,9 @@
             const data = await res.json();
             lastSilentGuardSummary = data;
             applySilentGuardSummaryUI(data);
+            if (typeof refreshSilentGuardMitigation === "function") {
+                refreshSilentGuardMitigation().catch(() => {});
+            }
         } catch (e) {
             applySilentGuardCheckFailedUI();
         } finally {
@@ -5246,6 +5418,270 @@
                 retrySilentGuardStartup().catch(() => {
                     applySilentGuardCheckFailedUI();
                 });
+            });
+        }
+    })();
+
+    // ── SILENTGUARD MITIGATION ──
+    // Calm, opt-in confirmation flow over SilentGuard's mitigation
+    // endpoints. SilentGuard owns enforcement; Nova only explains and
+    // asks for confirmation. The flow is two clicks per action:
+    //   1. User clicks "Enable temporary mitigation" / "Disable
+    //      mitigation" → an inline confirmation prompt appears.
+    //   2. User clicks "Confirm" → Nova POSTs to its endpoint with
+    //      ``{"acknowledge": true}``.
+    // No background polling. Mitigation state is read once per
+    // Settings open / Refresh click (piggybacking on the existing
+    // refresh trigger set), and re-read after a successful
+    // enable / disable so the UI repaints with the fresh mode.
+    let lastSilentGuardMitigation = null;
+    let silentGuardMitigationFetchInFlight = false;
+    let silentGuardMitigationActionInFlight = false;
+    // ``pending`` is the action the user has asked for but not yet
+    // confirmed: "enable", "disable", or null. The Confirm button
+    // executes this action; Cancel clears it. State stays local — no
+    // network call happens until Confirm is clicked.
+    let silentGuardMitigationPending = null;
+
+    const SILENTGUARD_MITIGATION_MODE_LABELS = {
+        detection_only: "silentguard_mitigation_mode_detection_only",
+        ask_before_blocking: "silentguard_mitigation_mode_ask_before_blocking",
+        temporary_auto_block: "silentguard_mitigation_mode_temporary_auto_block",
+        unknown: "silentguard_mitigation_mode_unknown",
+    };
+    const SILENTGUARD_MITIGATION_EXPLAINER_KEYS = {
+        detection_only: "silentguard_mitigation_explainer_detection_only",
+        ask_before_blocking: "silentguard_mitigation_explainer_ask_before_blocking",
+        temporary_auto_block: "silentguard_mitigation_explainer_temporary_auto_block",
+        unknown: "silentguard_mitigation_explainer_unknown",
+    };
+
+    function _setMitigationStatus(text, isError) {
+        const status = document.getElementById("silentguard-mitigation-status");
+        if (!status) return;
+        status.textContent = text || "";
+        if (isError) {
+            status.classList.add("is-error");
+        } else {
+            status.classList.remove("is-error");
+        }
+    }
+
+    function _hideMitigationConfirm() {
+        silentGuardMitigationPending = null;
+        const confirm = document.getElementById("silentguard-mitigation-confirm");
+        if (confirm) confirm.style.display = "none";
+    }
+
+    function applySilentGuardMitigationUI(payload) {
+        // Render the mitigation block from a Nova payload (or null when
+        // the integration is disabled / not yet fetched). The whole
+        // block is hidden when there is nothing meaningful to show — we
+        // never paint a half-state.
+        const block = document.getElementById("silentguard-mitigation-block");
+        const badge = document.getElementById("silentguard-mitigation-mode-badge");
+        const modeLabel = document.getElementById("silentguard-mitigation-mode-label");
+        const explainer = document.getElementById("silentguard-mitigation-explainer");
+        const enableBtn = document.getElementById("silentguard-mitigation-enable-btn");
+        const keepBtn = document.getElementById("silentguard-mitigation-keep-btn");
+        const disableBtn = document.getElementById("silentguard-mitigation-disable-btn");
+        if (!block || !badge || !explainer || !enableBtn || !keepBtn || !disableBtn) {
+            return;
+        }
+        if (modeLabel) modeLabel.textContent = t("silentguard_mitigation_label");
+
+        // Hide the whole block on disabled / unavailable so it never
+        // sits on the page in a misleading "loading" state.
+        if (!payload || payload.available !== true || !payload.state) {
+            block.style.display = "none";
+            _hideMitigationConfirm();
+            _setMitigationStatus("");
+            return;
+        }
+        block.style.display = "";
+
+        const state = payload.state;
+        const mode = (state && state.mode) || "unknown";
+        const modeKey = SILENTGUARD_MITIGATION_MODE_LABELS[mode]
+            || "silentguard_mitigation_mode_unknown";
+        badge.textContent = t(modeKey);
+        const explainerKey = SILENTGUARD_MITIGATION_EXPLAINER_KEYS[mode]
+            || "silentguard_mitigation_explainer_unknown";
+        let explainerText = t(explainerKey);
+        if (mode === "temporary_auto_block" && state.expires_at) {
+            // ``state.expires_at`` is a sanitised ISO-8601 string from
+            // the backend; rendering it verbatim keeps the timezone /
+            // offset visible to the user without any client-side
+            // re-parsing surprises.
+            explainerText = explainerText
+                + " "
+                + t("silentguard_mitigation_expires_at").replace("{time}", state.expires_at);
+        }
+        explainer.textContent = explainerText;
+
+        // Action button visibility is mode-driven so the user only sees
+        // actions that make sense in the current state. The Confirm
+        // step gates each action; nothing happens on a single click.
+        enableBtn.style.display = "none";
+        keepBtn.style.display = "none";
+        disableBtn.style.display = "none";
+        if (mode === "temporary_auto_block") {
+            disableBtn.style.display = "";
+        } else {
+            // For detection_only, ask_before_blocking, and unknown:
+            // offer the calm "enable" + "keep detection only"
+            // affordances. The "keep" button is a no-op at the API
+            // layer — it just confirms the user's choice in the UI.
+            enableBtn.style.display = "";
+            keepBtn.style.display = "";
+        }
+
+        // If the user had a pending confirmation (e.g. they clicked
+        // Enable, then Refresh), clear it: the action they asked for
+        // may no longer match the new state.
+        _hideMitigationConfirm();
+    }
+
+    async function refreshSilentGuardMitigation() {
+        // Read the current mode. Skips the call when a previous fetch
+        // is still in flight so a quick double-click never queues
+        // duplicate requests. Failure renders as the calm "unavailable"
+        // state — never as a thrown error.
+        if (silentGuardMitigationFetchInFlight) return;
+        silentGuardMitigationFetchInFlight = true;
+        try {
+            const res = await fetch("/integrations/silentguard/mitigation", {
+                credentials: "include",
+                headers: { "Authorization": `Bearer ${token}` },
+            });
+            if (!res.ok) {
+                lastSilentGuardMitigation = null;
+                applySilentGuardMitigationUI(null);
+                return;
+            }
+            const data = await res.json();
+            lastSilentGuardMitigation = data;
+            applySilentGuardMitigationUI(data);
+        } catch (e) {
+            lastSilentGuardMitigation = null;
+            applySilentGuardMitigationUI(null);
+        } finally {
+            silentGuardMitigationFetchInFlight = false;
+        }
+    }
+
+    function showSilentGuardMitigationConfirm(action) {
+        // Show the inline confirmation prompt for the requested action.
+        // No network call happens here — the user must click Confirm
+        // before anything is sent to Nova's endpoint.
+        const confirm = document.getElementById("silentguard-mitigation-confirm");
+        const text = document.getElementById("silentguard-mitigation-confirm-text");
+        if (!confirm || !text) return;
+        if (action === "enable") {
+            text.textContent = t("silentguard_mitigation_confirm_enable");
+        } else if (action === "disable") {
+            text.textContent = t("silentguard_mitigation_confirm_disable");
+        } else {
+            return;
+        }
+        silentGuardMitigationPending = action;
+        confirm.style.display = "";
+        _setMitigationStatus("");
+    }
+
+    function acknowledgeSilentGuardKeepDetectionOnly() {
+        // "Keep detection only" is a calm UX affordance — it does not
+        // call any endpoint, because detection-only is the default.
+        // We just acknowledge the user's choice so they have feedback
+        // for the click and the confirmation prompt is dismissed.
+        _hideMitigationConfirm();
+        _setMitigationStatus(t("silentguard_mitigation_keep_ack"), false);
+    }
+
+    async function executeSilentGuardMitigationAction() {
+        // Send the pending action to Nova's endpoint with the required
+        // acknowledgement payload. Single-use: the pending state is
+        // cleared as soon as we start the call, so a stray click after
+        // Confirm cannot queue a second mutation.
+        if (silentGuardMitigationActionInFlight) return;
+        const action = silentGuardMitigationPending;
+        if (action !== "enable" && action !== "disable") {
+            _hideMitigationConfirm();
+            return;
+        }
+        silentGuardMitigationActionInFlight = true;
+        silentGuardMitigationPending = null;
+        const path = action === "enable"
+            ? "/integrations/silentguard/mitigation/enable-temporary"
+            : "/integrations/silentguard/mitigation/disable";
+        try {
+            const res = await fetch(path, {
+                method: "POST",
+                credentials: "include",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${token}`,
+                },
+                body: JSON.stringify({ acknowledge: true }),
+            });
+            if (!res.ok) {
+                _setMitigationStatus(t("silentguard_mitigation_status_failed"), true);
+                return;
+            }
+            const data = await res.json();
+            lastSilentGuardMitigation = data;
+            applySilentGuardMitigationUI(data);
+            if (data && data.ok) {
+                const okKey = action === "enable"
+                    ? "silentguard_mitigation_status_enabled"
+                    : "silentguard_mitigation_status_disabled";
+                _setMitigationStatus(t(okKey), false);
+            } else {
+                _setMitigationStatus(
+                    (data && data.message) || t("silentguard_mitigation_status_failed"),
+                    true,
+                );
+            }
+        } catch (e) {
+            _setMitigationStatus(t("silentguard_mitigation_status_failed"), true);
+        } finally {
+            silentGuardMitigationActionInFlight = false;
+            _hideMitigationConfirm();
+        }
+    }
+
+    (function wireSilentGuardMitigationButtons() {
+        const enableBtn = document.getElementById("silentguard-mitigation-enable-btn");
+        if (enableBtn) {
+            enableBtn.addEventListener("click", () => {
+                showSilentGuardMitigationConfirm("enable");
+            });
+        }
+        const keepBtn = document.getElementById("silentguard-mitigation-keep-btn");
+        if (keepBtn) {
+            keepBtn.addEventListener("click", () => {
+                acknowledgeSilentGuardKeepDetectionOnly();
+            });
+        }
+        const disableBtn = document.getElementById("silentguard-mitigation-disable-btn");
+        if (disableBtn) {
+            disableBtn.addEventListener("click", () => {
+                showSilentGuardMitigationConfirm("disable");
+            });
+        }
+        const confirmYes = document.getElementById("silentguard-mitigation-confirm-yes");
+        if (confirmYes) {
+            confirmYes.addEventListener("click", () => {
+                executeSilentGuardMitigationAction().catch(() => {
+                    _setMitigationStatus(t("silentguard_mitigation_status_failed"), true);
+                });
+            });
+        }
+        const confirmNo = document.getElementById("silentguard-mitigation-confirm-no");
+        if (confirmNo) {
+            confirmNo.addEventListener("click", () => {
+                _hideMitigationConfirm();
+                _setMitigationStatus("");
             });
         }
     })();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest conftest: stub heavy / optional deps that the env may not ship.
+
+Several existing test files (e.g. ``test_silentguard_summary_endpoint``)
+already stub these modules at import time. Centralising the workaround
+here lets suites that touch ``web.py`` collect cleanly even when one of
+the optional wheels is missing on the host. The stub is **only**
+installed when the real module fails to import — on a normal CI worker
+where the package exists, the real module is used and the conftest is
+a no-op.
+"""
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+# Heavy / optional deps that ``web.py`` and its transitive imports
+# pull in. Each is replaced by a ``MagicMock`` only when the genuine
+# import fails, so a CI environment with the real package installed
+# behaves identically to before this conftest existed.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod in sys.modules:
+        continue
+    try:
+        importlib.import_module(_mod)
+    except Exception:
+        sys.modules[_mod] = MagicMock()

--- a/tests/test_silentguard_mitigation_card_wiring.py
+++ b/tests/test_silentguard_mitigation_card_wiring.py
@@ -1,0 +1,264 @@
+"""
+Static-asset wiring tests for the SilentGuard mitigation block.
+
+The Settings card grows a small mitigation surface in this PR:
+
+  * a mode badge that shows the current SilentGuard mitigation mode;
+  * three buttons — *Enable temporary mitigation*, *Keep detection
+    only*, *Disable mitigation* — that surface based on the mode;
+  * an inline confirmation prompt that gates every mutating call;
+  * an i18n string set covering the calm wording.
+
+These tests parse ``static/index.html`` and pin the structural
+contract so a renaming or accidental drop of an id is caught here
+rather than in the browser. They are deliberately structural — the
+JS is not executed.
+
+Pinned commitments:
+
+  * every documented element id exists in the markup;
+  * the click handlers are attached via explicit listeners (not inline
+    ``onclick="..."``), matching the existing SilentGuard wiring tests;
+  * the enable / disable handlers send the SilentGuard acknowledgement
+    payload (``{"acknowledge": true}``);
+  * a single click on Enable / Disable does *not* call SilentGuard:
+    it only opens the confirmation prompt;
+  * the read endpoint URL is the documented one;
+  * "Keep detection only" never calls any endpoint;
+  * the calm wording strings exist in both supported locales.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "static" / "index.html"
+
+
+@pytest.fixture(scope="module")
+def html() -> str:
+    return INDEX_HTML.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def script(html: str) -> str:
+    blocks = re.findall(r"<script[^>]*>(.*?)</script>", html, flags=re.S)
+    assert blocks, "expected at least one inline <script> in index.html"
+    return max(blocks, key=len)
+
+
+def _function_body(script: str, name: str) -> str:
+    """Return the source of a top-level JS function in ``script``."""
+    decl = re.search(
+        r"(?:async\s+)?function\s+" + re.escape(name) + r"\s*\([^)]*\)\s*{",
+        script,
+    )
+    assert decl, f"function {name!r} not found in script"
+    open_brace = script.index("{", decl.end() - 1)
+    depth = 0
+    i = open_brace
+    while i < len(script):
+        ch = script[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return script[decl.start():i + 1]
+        i += 1
+    raise AssertionError(f"unterminated function body for {name!r}")
+
+
+# ── Markup ──────────────────────────────────────────────────────────
+
+
+REQUIRED_IDS = (
+    "silentguard-mitigation-block",
+    "silentguard-mitigation-mode-label",
+    "silentguard-mitigation-mode-badge",
+    "silentguard-mitigation-explainer",
+    "silentguard-mitigation-actions",
+    "silentguard-mitigation-enable-btn",
+    "silentguard-mitigation-keep-btn",
+    "silentguard-mitigation-disable-btn",
+    "silentguard-mitigation-confirm",
+    "silentguard-mitigation-confirm-text",
+    "silentguard-mitigation-confirm-yes",
+    "silentguard-mitigation-confirm-no",
+    "silentguard-mitigation-status",
+)
+
+
+class TestMarkup:
+    @pytest.mark.parametrize("element_id", REQUIRED_IDS)
+    def test_required_id_present(self, html: str, element_id: str) -> None:
+        assert f'id="{element_id}"' in html, (
+            f"mitigation block must keep the {element_id!r} id; "
+            "renaming it silently breaks the JS controller"
+        )
+
+    def test_block_starts_hidden(self, html: str) -> None:
+        # The block must render hidden until SilentGuard has supplied
+        # a real mitigation state. Painting "Enable temporary
+        # mitigation" before the integration is connected would be
+        # misleading.
+        match = re.search(
+            r'<div[^>]*id="silentguard-mitigation-block"[^>]*>',
+            html,
+        )
+        assert match, "mitigation block element not found"
+        assert "display:none" in match.group(0), (
+            "mitigation block must start hidden — only paint after "
+            "the read endpoint returns a recognised state"
+        )
+
+    def test_buttons_do_not_use_inline_onclick(self, html: str) -> None:
+        for btn_id in (
+            "silentguard-mitigation-enable-btn",
+            "silentguard-mitigation-keep-btn",
+            "silentguard-mitigation-disable-btn",
+            "silentguard-mitigation-confirm-yes",
+            "silentguard-mitigation-confirm-no",
+        ):
+            match = re.search(
+                rf'<button[^>]*id="{btn_id}"[^>]*>',
+                html,
+            )
+            assert match, f"button {btn_id!r} not found"
+            assert "onclick=" not in match.group(0), (
+                f"{btn_id} must use addEventListener wiring, not inline onclick"
+            )
+
+
+# ── JS controller ───────────────────────────────────────────────────
+
+
+class TestController:
+    def test_refresh_function_calls_documented_endpoint(self, script: str) -> None:
+        body = _function_body(script, "refreshSilentGuardMitigation")
+        assert "/integrations/silentguard/mitigation" in body
+        # Read path must use GET — there's no need to spell GET
+        # explicitly because ``fetch`` defaults to it, but a stray
+        # ``method: "POST"`` would mean the read silently mutates.
+        assert 'method: "POST"' not in body
+        # And it must include the bearer token so the auth gate fires.
+        assert "Authorization" in body
+        assert "Bearer" in body
+
+    def test_execute_action_uses_acknowledge_payload(self, script: str) -> None:
+        body = _function_body(script, "executeSilentGuardMitigationAction")
+        # Both write paths are referenced.
+        assert "/integrations/silentguard/mitigation/enable-temporary" in body
+        assert "/integrations/silentguard/mitigation/disable" in body
+        # Body literally contains ``acknowledge: true`` so the
+        # SilentGuard / Nova acknowledgement contract is honoured.
+        assert "acknowledge: true" in body
+        # Method must be POST.
+        assert 'method: "POST"' in body
+        # And the bearer token must travel with the request.
+        assert "Authorization" in body
+
+    def test_show_confirm_does_not_make_network_call(self, script: str) -> None:
+        # Clicking Enable / Disable opens the confirmation prompt; it
+        # must not fetch anything — that would defeat the explicit
+        # confirmation step.
+        body = _function_body(script, "showSilentGuardMitigationConfirm")
+        assert "fetch(" not in body, (
+            "showSilentGuardMitigationConfirm must not call fetch — "
+            "the confirmation step gates every mutation"
+        )
+
+    def test_keep_detection_only_does_not_call_endpoint(self, script: str) -> None:
+        # The "Keep detection only" affordance is purely a UI ack —
+        # detection-only is the default mode, so there is nothing to
+        # call. A future change that turns this into a network call
+        # is a *new* mitigation capability and must be reviewed.
+        body = _function_body(script, "acknowledgeSilentGuardKeepDetectionOnly")
+        assert "fetch(" not in body, (
+            "Keep detection only must not call any endpoint"
+        )
+        assert "/mitigation" not in body
+
+    def test_apply_ui_falls_back_to_hidden_on_unavailable(
+        self, script: str,
+    ) -> None:
+        body = _function_body(script, "applySilentGuardMitigationUI")
+        # The function must explicitly hide the block on a
+        # non-available payload — never paint a stale active state.
+        assert 'block.style.display = "none"' in body
+
+    def test_refresh_runs_after_a_settings_open_or_refresh(
+        self, script: str,
+    ) -> None:
+        # The mitigation refresh piggybacks on the existing Settings
+        # refresh trigger set: opening Settings or clicking Refresh.
+        body = _function_body(script, "refreshSilentGuardStatus")
+        assert "refreshSilentGuardMitigation" in body, (
+            "refreshSilentGuardStatus must also pull the mitigation "
+            "state so the Settings card stays consistent"
+        )
+
+
+# ── i18n ────────────────────────────────────────────────────────────
+
+
+class TestI18n:
+    REQUIRED_KEYS = (
+        "silentguard_mitigation_label",
+        "silentguard_mitigation_mode_detection_only",
+        "silentguard_mitigation_mode_ask_before_blocking",
+        "silentguard_mitigation_mode_temporary_auto_block",
+        "silentguard_mitigation_mode_unknown",
+        "silentguard_mitigation_explainer_detection_only",
+        "silentguard_mitigation_explainer_ask_before_blocking",
+        "silentguard_mitigation_explainer_temporary_auto_block",
+        "silentguard_mitigation_explainer_unknown",
+        "silentguard_mitigation_enable",
+        "silentguard_mitigation_keep",
+        "silentguard_mitigation_disable",
+        "silentguard_mitigation_confirm_yes",
+        "silentguard_mitigation_confirm_no",
+        "silentguard_mitigation_confirm_enable",
+        "silentguard_mitigation_confirm_disable",
+        "silentguard_mitigation_keep_ack",
+        "silentguard_mitigation_status_unavailable",
+        "silentguard_mitigation_status_failed",
+        "silentguard_mitigation_status_enabled",
+        "silentguard_mitigation_status_disabled",
+        "silentguard_mitigation_expires_at",
+    )
+
+    @pytest.mark.parametrize("key", REQUIRED_KEYS)
+    def test_key_exists_in_both_locales(self, html: str, key: str) -> None:
+        # Each translation block must define every key. We assert by
+        # counting occurrences — at minimum two definitions (one per
+        # locale). A single occurrence usually means a key was
+        # added in only one locale, which leaves the other showing
+        # the raw key in the UI.
+        occurrences = re.findall(rf"\b{re.escape(key)}\s*:", html)
+        assert len(occurrences) >= 2, (
+            f"i18n key {key!r} must be defined in both fr and en; "
+            f"found {len(occurrences)} occurrences"
+        )
+
+    def test_calm_wording_avoids_alarming_language(self, html: str) -> None:
+        # Calm UX over flashy alerts, per the roadmap §4.5. The
+        # mitigation copy must not contain alarm words. We pull only
+        # the mitigation translation lines (anchored on the
+        # ``silentguard_mitigation_`` prefix) so unrelated CSS or id
+        # tokens like ``--danger`` cannot trip the assertion.
+        mitigation_lines = re.findall(
+            r"silentguard_mitigation_[a-z_]+\s*:\s*\"([^\"]*)\"",
+            html,
+        )
+        assert mitigation_lines, "no mitigation i18n lines found"
+        joined = " ".join(mitigation_lines).lower()
+        for forbidden in ("under attack", "alert!", "danger", "urgent"):
+            assert forbidden not in joined, (
+                f"{forbidden!r} appears in mitigation copy; the "
+                "wording must stay calm and non-alarming"
+            )

--- a/tests/test_silentguard_mitigation_client.py
+++ b/tests/test_silentguard_mitigation_client.py
@@ -1,0 +1,377 @@
+"""
+Tests for ``core.security.silentguard_mitigation``.
+
+The mitigation client is the *only* file in ``core.security`` allowed
+to make POST calls to SilentGuard. These tests pin the safety contract
+that lets it do that without breaking the rest of the package's
+read-only posture:
+
+  * the existing read-only client (``silentguard_client.py``) is left
+    untouched — its forbidden-verb assertion in
+    ``test_security_provider`` keeps holding;
+  * every POST carries ``{"acknowledge": true}`` and refuses without it;
+  * mode strings outside the allow-list normalise to ``"unknown"``;
+  * malformed timestamps drop to ``None`` instead of leaking into the
+    Nova response;
+  * transport / decoding / non-2xx all map to calm fallback values
+    (``None`` for read, ``ok=False`` for action) — no exception ever
+    reaches the caller;
+  * the active flag is mode-derived and never honours an
+    ``active=true`` claim from SilentGuard for a mode Nova has not
+    vetted.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from core.security import silentguard_mitigation as mitigation_module
+from core.security.silentguard_mitigation import (
+    ACKNOWLEDGE_PAYLOAD,
+    DEFAULT_TIMEOUT_SECONDS,
+    MODE_ASK_BEFORE_BLOCKING,
+    MODE_DETECTION_ONLY,
+    MODE_TEMPORARY_AUTO_BLOCK,
+    MODE_UNKNOWN,
+    MitigationActionResult,
+    MitigationState,
+    PATH_MITIGATION,
+    PATH_MITIGATION_DISABLE,
+    PATH_MITIGATION_ENABLE_TEMPORARY,
+    SilentGuardMitigationClient,
+    _normalise_mode,
+    _normalise_timestamp,
+    _parse_state,
+)
+
+
+# ── Helpers / doubles ───────────────────────────────────────────────
+
+
+class _RecordingTransport(httpx.BaseTransport):
+    """Stub HTTP transport that records every request and returns scripted replies."""
+
+    def __init__(self, replies):
+        # ``replies`` is a list of tuples ``(status_code, json_body)``
+        # consumed in order. Extra calls beyond the script raise so
+        # tests notice unexpected traffic.
+        self._replies = list(replies)
+        self.calls: list[dict] = []
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        body = None
+        if request.content:
+            try:
+                import json
+                body = json.loads(request.content.decode("utf-8"))
+            except Exception:
+                body = request.content
+        self.calls.append({
+            "method": request.method,
+            "url": str(request.url),
+            "path": request.url.path,
+            "body": body,
+            "headers": dict(request.headers),
+        })
+        if not self._replies:
+            raise AssertionError(
+                "unexpected extra HTTP call to %s %s" % (request.method, request.url)
+            )
+        status, payload = self._replies.pop(0)
+        if isinstance(payload, str):
+            return httpx.Response(status, text=payload)
+        return httpx.Response(status, json=payload)
+
+
+def _make_client_with_transport(transport, *, base_url="http://127.0.0.1:8765"):
+    """Wire a ``SilentGuardMitigationClient`` whose calls go through ``transport``."""
+    client = SilentGuardMitigationClient(base_url=base_url)
+    real_open = client._open
+
+    def _open_with_transport():
+        # Build an httpx.Client that uses our recording transport, but
+        # keep every other knob (timeout, headers) identical to the
+        # production path.
+        return httpx.Client(
+            base_url=client.base_url,
+            timeout=client.timeout_seconds,
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            transport=transport,
+        )
+
+    client._open = _open_with_transport  # type: ignore[assignment]
+    return client
+
+
+# ── Construction / configuration ────────────────────────────────────
+
+
+class TestConstruction:
+    def test_empty_base_url_is_not_configured(self):
+        client = SilentGuardMitigationClient(base_url="")
+        assert client.is_configured() is False
+        assert client.get_state() is None
+        # Action calls never reach the wire when not configured.
+        result = client.enable_temporary()
+        assert result.ok is False
+        assert result.state is None
+
+    def test_base_url_is_normalised(self):
+        client = SilentGuardMitigationClient(
+            base_url="  http://127.0.0.1:8765/  ",
+        )
+        assert client.base_url == "http://127.0.0.1:8765"
+        assert client.is_configured() is True
+
+    def test_invalid_timeout_falls_back_to_default(self):
+        # Negative, zero, and non-numeric timeouts all collapse to the
+        # documented default — a hostile config cannot disable the
+        # safety bound that keeps SilentGuard from wedging Nova.
+        for bad in (-1, 0, None, "not-a-number"):
+            c = SilentGuardMitigationClient(
+                base_url="http://x", timeout_seconds=bad,
+            )
+            assert c.timeout_seconds == DEFAULT_TIMEOUT_SECONDS
+
+
+# ── Sanitisers ──────────────────────────────────────────────────────
+
+
+class TestNormaliseMode:
+    @pytest.mark.parametrize("raw,expected", [
+        ("detection_only", MODE_DETECTION_ONLY),
+        (" Detection_Only ", MODE_DETECTION_ONLY),
+        ("ask_before_blocking", MODE_ASK_BEFORE_BLOCKING),
+        ("temporary_auto_block", MODE_TEMPORARY_AUTO_BLOCK),
+    ])
+    def test_known_modes_normalise(self, raw, expected):
+        assert _normalise_mode(raw) == expected
+
+    @pytest.mark.parametrize("raw", [
+        None, "", "permanent_block", "off", 0, True, [], {}, "blocking",
+    ])
+    def test_unknown_modes_collapse_to_unknown(self, raw):
+        assert _normalise_mode(raw) == MODE_UNKNOWN
+
+
+class TestNormaliseTimestamp:
+    def test_accepts_iso_8601(self):
+        assert _normalise_timestamp("2026-05-10T12:34:56Z") == "2026-05-10T12:34:56Z"
+        assert _normalise_timestamp("2026-05-10T12:34:56.789+00:00") == (
+            "2026-05-10T12:34:56.789+00:00"
+        )
+
+    @pytest.mark.parametrize("raw", [
+        None, 0, True, [], {},
+        "yesterday",
+        "2026-05-10",
+        "2026-05-10 12:34:56",  # space, not T
+        "x" * 200,              # too long
+        # Non-whitespace garbage in the middle of the value must
+        # collapse to ``None`` so a hostile log line cannot reach the UI.
+        "2026-05-10T12:34:56Z;DROP TABLE",
+        "2026-05-10T12:34:56Z<script>",
+    ])
+    def test_rejects_bad_input(self, raw):
+        assert _normalise_timestamp(raw) is None
+
+
+class TestParseState:
+    def test_detection_only_payload(self):
+        state = _parse_state({"mode": "detection_only"})
+        assert state == MitigationState(
+            mode=MODE_DETECTION_ONLY, active=False, expires_at=None,
+        )
+
+    def test_temporary_auto_block_is_active(self):
+        state = _parse_state({"mode": "temporary_auto_block"})
+        assert state.mode == MODE_TEMPORARY_AUTO_BLOCK
+        assert state.active is True
+
+    def test_active_flag_does_not_override_unvetted_mode(self):
+        # SilentGuard claims active=True on a mode Nova has not vetted.
+        # The parser must refuse to surface "active" for an unknown
+        # mode — the UI never paints "active" for an unreviewed value.
+        state = _parse_state({"mode": "permanent_block", "active": True})
+        assert state.mode == MODE_UNKNOWN
+        assert state.active is False
+
+    def test_active_flag_does_not_override_detection_only(self):
+        # Even an explicit ``active=True`` on detection_only is
+        # ignored, because detection_only is a non-active mode by
+        # definition.
+        state = _parse_state({"mode": "detection_only", "active": True})
+        assert state.mode == MODE_DETECTION_ONLY
+        assert state.active is False
+
+    def test_expires_at_is_propagated(self):
+        state = _parse_state({
+            "mode": "temporary_auto_block",
+            "expires_at": "2026-05-10T13:00:00Z",
+        })
+        assert state.expires_at == "2026-05-10T13:00:00Z"
+
+    def test_extra_fields_are_dropped(self):
+        # SilentGuard may include richer fields in the future. Until
+        # they are reviewed, ``MitigationState.as_dict`` must surface
+        # only the documented keys.
+        state = _parse_state({
+            "mode": "detection_only",
+            "internal_debug": "secret",
+            "blocked_subnets": ["1.2.3.0/24"],
+        })
+        assert state is not None
+        assert set(state.as_dict().keys()) == {"mode", "active", "expires_at"}
+
+    def test_non_dict_payload_returns_none(self):
+        assert _parse_state(None) is None
+        assert _parse_state([]) is None
+        assert _parse_state("detection_only") is None
+        assert _parse_state(42) is None
+
+
+# ── Read path ───────────────────────────────────────────────────────
+
+
+class TestGetState:
+    def test_returns_parsed_state_on_success(self):
+        transport = _RecordingTransport([
+            (200, {"mode": "detection_only"}),
+        ])
+        client = _make_client_with_transport(transport)
+
+        state = client.get_state()
+        assert state == MitigationState(
+            mode=MODE_DETECTION_ONLY, active=False, expires_at=None,
+        )
+        assert len(transport.calls) == 1
+        assert transport.calls[0]["method"] == "GET"
+        assert transport.calls[0]["path"] == PATH_MITIGATION
+        # No body on the read path.
+        assert transport.calls[0]["body"] in (None, b"")
+
+    def test_non_2xx_returns_none(self):
+        transport = _RecordingTransport([(503, {"error": "down"})])
+        client = _make_client_with_transport(transport)
+        assert client.get_state() is None
+
+    def test_non_json_body_returns_none(self):
+        transport = _RecordingTransport([(200, "not json")])
+        client = _make_client_with_transport(transport)
+        assert client.get_state() is None
+
+    def test_transport_error_returns_none(self):
+        class _Boom(httpx.BaseTransport):
+            def handle_request(self, request):
+                raise httpx.ConnectError("refused", request=request)
+
+        client = _make_client_with_transport(_Boom())
+        assert client.get_state() is None
+
+
+# ── Write paths ─────────────────────────────────────────────────────
+
+
+class TestEnableTemporary:
+    def test_sends_acknowledge_payload(self):
+        transport = _RecordingTransport([
+            (200, {"mode": "temporary_auto_block"}),
+        ])
+        client = _make_client_with_transport(transport)
+
+        result = client.enable_temporary()
+        assert isinstance(result, MitigationActionResult)
+        assert result.ok is True
+        assert result.state is not None
+        assert result.state.mode == MODE_TEMPORARY_AUTO_BLOCK
+        # The single call carried the acknowledgement payload exactly.
+        assert len(transport.calls) == 1
+        call = transport.calls[0]
+        assert call["method"] == "POST"
+        assert call["path"] == PATH_MITIGATION_ENABLE_TEMPORARY
+        assert call["body"] == ACKNOWLEDGE_PAYLOAD
+
+    def test_failure_returns_calm_result(self):
+        transport = _RecordingTransport([(500, {"error": "boom"})])
+        client = _make_client_with_transport(transport)
+
+        result = client.enable_temporary()
+        assert result.ok is False
+        assert result.state is None
+        # The message must be user-safe — no raw HTTP body or
+        # exception text. We only assert it is a non-empty string.
+        assert isinstance(result.message, str) and result.message
+
+    def test_unconfigured_client_returns_calm_failure(self):
+        client = SilentGuardMitigationClient(base_url="")
+        result = client.enable_temporary()
+        assert result.ok is False
+        assert result.state is None
+
+    def test_transport_error_returns_calm_result(self):
+        class _Boom(httpx.BaseTransport):
+            def handle_request(self, request):
+                raise httpx.ReadTimeout("too slow", request=request)
+
+        client = _make_client_with_transport(_Boom())
+        result = client.enable_temporary()
+        assert result.ok is False
+        assert result.state is None
+
+
+class TestDisable:
+    def test_sends_acknowledge_payload(self):
+        transport = _RecordingTransport([
+            (200, {"mode": "detection_only"}),
+        ])
+        client = _make_client_with_transport(transport)
+
+        result = client.disable()
+        assert result.ok is True
+        assert result.state is not None
+        assert result.state.mode == MODE_DETECTION_ONLY
+        assert len(transport.calls) == 1
+        call = transport.calls[0]
+        assert call["method"] == "POST"
+        assert call["path"] == PATH_MITIGATION_DISABLE
+        assert call["body"] == ACKNOWLEDGE_PAYLOAD
+
+    def test_failure_returns_calm_result(self):
+        transport = _RecordingTransport([(503, {"error": "down"})])
+        client = _make_client_with_transport(transport)
+
+        result = client.disable()
+        assert result.ok is False
+        assert result.state is None
+        assert isinstance(result.message, str) and result.message
+
+
+# ── Module surface ──────────────────────────────────────────────────
+
+
+class TestModuleSurface:
+    def test_acknowledge_payload_is_immutable_shape(self):
+        # The acknowledgement payload is fixed: exactly
+        # ``{"acknowledge": True}``. The client must not be able to
+        # smuggle in an alternate shape.
+        assert ACKNOWLEDGE_PAYLOAD == {"acknowledge": True}
+
+    def test_only_three_paths_are_exposed(self):
+        # The mitigation surface stays tiny by design. Adding a new
+        # path is a deliberate review — this test fails loudly so
+        # whoever adds one knows to update the docs and tests.
+        assert PATH_MITIGATION == "/mitigation"
+        assert PATH_MITIGATION_ENABLE_TEMPORARY == "/mitigation/enable-temporary"
+        assert PATH_MITIGATION_DISABLE == "/mitigation/disable"
+
+    def test_module_does_not_define_an_unblock_helper(self):
+        # The roadmap mentions ``POST /blocked/{ip}/unblock`` as a
+        # later-only addition. This PR must not ship a helper for it;
+        # adding one needs its own review.
+        assert not hasattr(
+            mitigation_module, "unblock_ip",
+        ), "unblock helper is intentionally out of scope for this PR"
+        assert not hasattr(
+            mitigation_module.SilentGuardMitigationClient, "unblock_ip",
+        )

--- a/tests/test_silentguard_mitigation_client.py
+++ b/tests/test_silentguard_mitigation_client.py
@@ -87,7 +87,6 @@ class _RecordingTransport(httpx.BaseTransport):
 def _make_client_with_transport(transport, *, base_url="http://127.0.0.1:8765"):
     """Wire a ``SilentGuardMitigationClient`` whose calls go through ``transport``."""
     client = SilentGuardMitigationClient(base_url=base_url)
-    real_open = client._open
 
     def _open_with_transport():
         # Build an httpx.Client that uses our recording transport, but

--- a/tests/test_silentguard_mitigation_endpoints.py
+++ b/tests/test_silentguard_mitigation_endpoints.py
@@ -1,0 +1,679 @@
+"""
+Tests for the SilentGuard mitigation HTTP surface in ``web.py``.
+
+Three new endpoints sit between the Settings UI and SilentGuard's
+mitigation API:
+
+  * ``GET  /integrations/silentguard/mitigation``                 — read
+  * ``POST /integrations/silentguard/mitigation/enable-temporary``— write
+  * ``POST /integrations/silentguard/mitigation/disable``         — write
+
+These tests pin the safety contract:
+
+  * authentication is required on every endpoint;
+  * the per-user ``silentguard_enabled`` setting gates every read
+    *and* every write — a disabled user never causes Nova to issue
+    HTTP traffic to SilentGuard;
+  * write endpoints refuse without ``{"acknowledge": true}`` in the
+    body and never call SilentGuard before that gate is satisfied;
+  * write endpoints relay results from the provider verbatim and
+    surface a calm "currently unavailable" message on any failure;
+  * the read endpoint never triggers a write, even by accident;
+  * the existing ``/summary`` / ``/enable`` / ``/disable`` / ``/retry``
+    response shapes are *unchanged* so the existing UI keeps working.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Heavy / optional deps that ``web.py`` pulls in at module load.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.security import (  # noqa: E402
+    MitigationActionResult,
+    MitigationState,
+)
+from core.security.provider import (  # noqa: E402
+    STATE_AVAILABLE,
+    STATE_OFFLINE,
+    SecurityStatus,
+)
+from core.security.silentguard_mitigation import (  # noqa: E402
+    MODE_DETECTION_ONLY,
+    MODE_TEMPORARY_AUTO_BLOCK,
+)
+
+
+MITIGATION_KEYS = {"ok", "available", "state", "message"}
+STATE_KEYS = {"mode", "active", "expires_at"}
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _available() -> SecurityStatus:
+    return SecurityStatus(
+        available=True,
+        service="silentguard",
+        state=STATE_AVAILABLE,
+        message="stub available",
+    )
+
+
+def _offline() -> SecurityStatus:
+    return SecurityStatus(
+        available=False,
+        service="silentguard",
+        state=STATE_OFFLINE,
+        message="stub offline",
+    )
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in (
+        "NOVA_SILENTGUARD_ENABLED",
+        "NOVA_SILENTGUARD_AUTO_START",
+        "NOVA_SILENTGUARD_START_MODE",
+        "NOVA_SILENTGUARD_SYSTEMD_UNIT",
+        "NOVA_SILENTGUARD_PATH",
+        "NOVA_SILENTGUARD_API_URL",
+        "NOVA_SILENTGUARD_API_BASE_URL",
+        "NOVA_SILENTGUARD_API_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def _spawn_disabled(monkeypatch):
+    """Make sure no test in this file accidentally spawns systemctl."""
+    from core.security import lifecycle as lifecycle_module
+
+    def _no_spawn(*_args, **_kwargs):
+        raise AssertionError("subprocess.run must not be called in this test")
+
+    monkeypatch.setattr(lifecycle_module.subprocess, "run", _no_spawn)
+    monkeypatch.setattr(
+        lifecycle_module.shutil,
+        "which",
+        lambda name: f"/usr/bin/{name}" if name == "systemctl" else None,
+    )
+    yield
+
+
+@pytest.fixture
+def web_client(tmp_path, monkeypatch):
+    import contextlib
+    import sqlite3 as _sqlite3
+    from unittest.mock import MagicMock, patch
+    from fastapi.testclient import TestClient
+
+    from core import memory as core_memory, users
+    from memory import store as natural_store
+    from core.rate_limiter import _login_limiter
+
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with _sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+        users.create_user(conn, "alice", "pw")
+        users.create_user(conn, "bob", "pw")
+
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(web_client, username: str = "alice", password: str = "pw"):
+    resp = web_client.post(
+        "/login", json={"username": username, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def _enable(web_client, headers):
+    resp = web_client.post(
+        "/integrations/silentguard/enable", headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ── Test doubles for the provider ───────────────────────────────────
+
+
+class _ProviderRecorder:
+    """Replacement for ``SilentGuardProvider`` that records every call."""
+
+    def __init__(
+        self,
+        *,
+        status=None,
+        mitigation_state=None,
+        enable_result=None,
+        disable_result=None,
+    ):
+        self._status = status or _available()
+        self._mitigation_state = mitigation_state
+        self._enable_result = enable_result or MitigationActionResult(
+            ok=True,
+            state=MitigationState(
+                mode=MODE_TEMPORARY_AUTO_BLOCK, active=True,
+            ),
+            message="enabled",
+        )
+        self._disable_result = disable_result or MitigationActionResult(
+            ok=True,
+            state=MitigationState(
+                mode=MODE_DETECTION_ONLY, active=False,
+            ),
+            message="disabled",
+        )
+        self.calls: list[str] = []
+
+    def get_status(self):
+        self.calls.append("get_status")
+        return self._status
+
+    def get_summary_counts(self):
+        self.calls.append("get_summary_counts")
+        return None
+
+    def get_connection_summary(self):
+        self.calls.append("get_connection_summary")
+        return None
+
+    def get_mitigation_state(self):
+        self.calls.append("get_mitigation_state")
+        return self._mitigation_state
+
+    def enable_temporary_mitigation(self):
+        self.calls.append("enable_temporary_mitigation")
+        return self._enable_result
+
+    def disable_mitigation(self):
+        self.calls.append("disable_mitigation")
+        return self._disable_result
+
+
+def _patch_provider(monkeypatch, provider_factory):
+    """Replace ``web._SilentGuardProvider`` with a factory in the test."""
+    import web as web_module
+    monkeypatch.setattr(web_module, "_SilentGuardProvider", provider_factory)
+
+
+# ── Authentication ──────────────────────────────────────────────────
+
+
+class TestAuthentication:
+    def test_get_state_requires_auth(self, web_client):
+        resp = web_client.get("/integrations/silentguard/mitigation")
+        assert resp.status_code in (401, 403)
+
+    def test_enable_requires_auth(self, web_client):
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            json={"acknowledge": True},
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_disable_requires_auth(self, web_client):
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/disable",
+            json={"acknowledge": True},
+        )
+        assert resp.status_code in (401, 403)
+
+
+# ── Per-user gate ───────────────────────────────────────────────────
+
+
+class TestPerUserGate:
+    def test_disabled_user_get_state_returns_calm_payload_no_provider_call(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # Even when the host operator turned on SilentGuard, a user
+        # who has not opted in must see a calm "disabled" payload
+        # with no provider instantiation. We assert that by failing
+        # the test if the provider gets constructed at all.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+
+        instantiated: list[int] = []
+
+        class _ShouldNotBeUsed(_ProviderRecorder):
+            def __init__(self, *args, **kwargs):
+                instantiated.append(1)
+                super().__init__()
+
+        _patch_provider(monkeypatch, _ShouldNotBeUsed)
+
+        headers = _login(web_client)
+        resp = web_client.get(
+            "/integrations/silentguard/mitigation", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == MITIGATION_KEYS
+        assert body["available"] is False
+        assert body["state"] is None
+        assert body["ok"] is False
+        assert instantiated == []
+
+    def test_disabled_user_enable_returns_calm_payload_no_provider_call(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        instantiated: list[int] = []
+
+        class _ShouldNotBeUsed(_ProviderRecorder):
+            def __init__(self, *args, **kwargs):
+                instantiated.append(1)
+                super().__init__()
+
+        _patch_provider(monkeypatch, _ShouldNotBeUsed)
+
+        headers = _login(web_client)
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            json={"acknowledge": True},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["available"] is False
+        assert body["ok"] is False
+        assert instantiated == []
+
+    def test_disabled_user_disable_returns_calm_payload_no_provider_call(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        instantiated: list[int] = []
+
+        class _ShouldNotBeUsed(_ProviderRecorder):
+            def __init__(self, *args, **kwargs):
+                instantiated.append(1)
+                super().__init__()
+
+        _patch_provider(monkeypatch, _ShouldNotBeUsed)
+
+        headers = _login(web_client)
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/disable",
+            json={"acknowledge": True},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["available"] is False
+        assert body["ok"] is False
+        assert instantiated == []
+
+
+# ── Acknowledgement gating ──────────────────────────────────────────
+
+
+class TestAcknowledgementGating:
+    def test_enable_without_body_is_rejected(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            headers=headers,
+        )
+        # FastAPI will accept the empty body and parse it as
+        # ``acknowledge=False``; Nova's gate then refuses with 400.
+        assert resp.status_code == 400
+        # The provider's mitigation method must never have run.
+        assert "enable_temporary_mitigation" not in recorder.calls
+
+    def test_enable_with_acknowledge_false_is_rejected(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            json={"acknowledge": False, "evil": "payload"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "enable_temporary_mitigation" not in recorder.calls
+
+    def test_disable_without_acknowledge_is_rejected(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/disable",
+            json={"acknowledge": False},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "disable_mitigation" not in recorder.calls
+
+    def test_extra_fields_in_body_are_ignored(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            # Extra fields the model does not declare must be ignored;
+            # the only honoured field is ``acknowledge``.
+            json={
+                "acknowledge": True,
+                "mode": "permanent_block",
+                "command": "rm -rf /",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        # The provider was called exactly once for the mitigation
+        # action (and once for status, but the action itself is the
+        # important assertion).
+        assert "enable_temporary_mitigation" in recorder.calls
+
+
+# ── Read endpoint ───────────────────────────────────────────────────
+
+
+class TestGetMitigationState:
+    def test_returns_mitigation_state_when_available(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder(
+            mitigation_state=MitigationState(
+                mode=MODE_DETECTION_ONLY, active=False,
+            ),
+        )
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.get(
+            "/integrations/silentguard/mitigation", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == MITIGATION_KEYS
+        assert body["available"] is True
+        assert body["ok"] is True
+        assert body["state"] is not None
+        assert set(body["state"].keys()) == STATE_KEYS
+        assert body["state"]["mode"] == MODE_DETECTION_ONLY
+        assert body["state"]["active"] is False
+        # The read endpoint must never invoke a write method.
+        assert "enable_temporary_mitigation" not in recorder.calls
+        assert "disable_mitigation" not in recorder.calls
+
+    def test_returns_unavailable_when_provider_returns_none(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder(mitigation_state=None)
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.get(
+            "/integrations/silentguard/mitigation", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["available"] is False
+        assert body["state"] is None
+        # Calm message — never a raw exception.
+        assert isinstance(body["message"], str) and body["message"]
+
+    def test_swallows_provider_exception(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+
+        class _ExplodingProvider(_ProviderRecorder):
+            def get_mitigation_state(self):
+                raise RuntimeError("boom")
+
+        recorder = _ExplodingProvider()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.get(
+            "/integrations/silentguard/mitigation", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["available"] is False
+
+
+# ── Enable / disable happy paths ────────────────────────────────────
+
+
+class TestEnableTemporary:
+    def test_acknowledged_call_relays_to_provider(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            json={"acknowledge": True},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["state"]["mode"] == MODE_TEMPORARY_AUTO_BLOCK
+        assert recorder.calls.count("enable_temporary_mitigation") == 1
+
+    def test_failed_provider_action_returns_calm_payload(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder(
+            enable_result=MitigationActionResult(
+                ok=False, state=None,
+                message="SilentGuard mitigation is currently unavailable.",
+            ),
+        )
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/enable-temporary",
+            json={"acknowledge": True},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["state"] is None
+        # Must surface the calm provider message verbatim — no raw
+        # transport text is in there because the provider already
+        # sanitised it.
+        assert isinstance(body["message"], str) and body["message"]
+
+
+class TestDisable:
+    def test_acknowledged_call_relays_to_provider(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder()
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+
+        resp = web_client.post(
+            "/integrations/silentguard/mitigation/disable",
+            json={"acknowledge": True},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["state"]["mode"] == MODE_DETECTION_ONLY
+        assert recorder.calls.count("disable_mitigation") == 1
+
+
+# ── Read-only summary stays read-only ───────────────────────────────
+
+
+class TestReadOnlyEndpointsDoNotCallMitigation:
+    def test_summary_endpoint_does_not_call_mitigation(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # Pin the no-poll guarantee from the roadmap: refreshing the
+        # status / summary card never triggers any mitigation call.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+        recorder = _ProviderRecorder(
+            mitigation_state=MitigationState(
+                mode=MODE_TEMPORARY_AUTO_BLOCK, active=True,
+            ),
+        )
+        _patch_provider(monkeypatch, lambda: recorder)
+
+        headers = _login(web_client)
+        _enable(web_client, headers)
+        # Drop everything captured by the /enable round-trip — we
+        # only care about what /summary triggers.
+        recorder.calls.clear()
+
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        # No mitigation read or write fired off the summary path.
+        assert "get_mitigation_state" not in recorder.calls
+        assert "enable_temporary_mitigation" not in recorder.calls
+        assert "disable_mitigation" not in recorder.calls
+
+    def test_existing_summary_shape_unchanged(
+        self, web_client, _spawn_disabled,
+    ):
+        # Regression: the four-key summary payload must keep its shape
+        # so the existing UI keeps painting correctly.
+        headers = _login(web_client)
+        resp = web_client.get(
+            "/integrations/silentguard/summary", headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert {"lifecycle", "counts", "connection_summary", "host_enabled"} == set(
+            body.keys()
+        )
+
+
+# ── Per-user isolation ──────────────────────────────────────────────
+
+
+class TestPerUserIsolation:
+    def test_alice_enable_does_not_let_bob_in(
+        self, web_client, _spawn_disabled, monkeypatch,
+    ):
+        # Alice opting in must not let Bob hit the mitigation
+        # endpoint without his own opt-in. The instantiation counter
+        # asserts the provider never runs for Bob's call.
+        monkeypatch.setenv("NOVA_SILENTGUARD_ENABLED", "true")
+
+        instantiated_for_bob: list[int] = []
+        alice_calls: list[str] = []
+
+        class _Recorder(_ProviderRecorder):
+            def __init__(self, *args, **kwargs):
+                # We can't tell which user instantiated us from the
+                # provider class; the test sets up the same
+                # constructor for both and asserts the count.
+                instantiated_for_bob.append(1)
+                super().__init__()
+
+            def get_mitigation_state(self):
+                alice_calls.append("get_mitigation_state")
+                return MitigationState(
+                    mode=MODE_DETECTION_ONLY, active=False,
+                )
+
+        _patch_provider(monkeypatch, _Recorder)
+
+        alice = _login(web_client, "alice", "pw")
+        bob = _login(web_client, "bob", "pw")
+        _enable(web_client, alice)
+
+        # Track instantiations *only* during Bob's call.
+        instantiated_for_bob.clear()
+        bob_resp = web_client.get(
+            "/integrations/silentguard/mitigation", headers=bob,
+        )
+        assert bob_resp.status_code == 200
+        bob_body = bob_resp.json()
+        assert bob_body["available"] is False
+        assert instantiated_for_bob == [], (
+            "provider must not be instantiated for a user who hasn't opted in"
+        )
+
+        # Alice still gets her real read.
+        instantiated_for_bob.clear()
+        alice_resp = web_client.get(
+            "/integrations/silentguard/mitigation", headers=alice,
+        )
+        assert alice_resp.status_code == 200
+        alice_body = alice_resp.json()
+        assert alice_body["available"] is True
+        assert alice_body["state"]["mode"] == MODE_DETECTION_ONLY

--- a/tests/test_silentguard_mitigation_provider.py
+++ b/tests/test_silentguard_mitigation_provider.py
@@ -1,0 +1,361 @@
+"""
+Tests for the mitigation methods on ``SilentGuardProvider``.
+
+The provider exposes three opt-in mitigation methods on top of the
+existing read-only surface:
+
+  * ``get_mitigation_state``         — read SilentGuard's current mode.
+  * ``enable_temporary_mitigation``  — relay an enable request.
+  * ``disable_mitigation``           — relay a disable request.
+
+These tests pin the safety contract:
+
+  * the methods never raise, even when SilentGuard is unreachable or
+    misbehaving;
+  * the provider refuses to issue a write when its own status probe
+    says SilentGuard is unavailable;
+  * the read-only ``get_status`` / ``get_summary_counts`` /
+    ``get_connection_summary`` paths never instantiate a mitigation
+    client and never issue a POST;
+  * a custom mitigation client can be injected for tests so production
+    code paths stay isolated;
+  * the existing read-only client (``silentguard_client.py``) still
+    has zero ``.post(`` / ``.put(`` / ``.delete(`` / ``.patch(`` calls
+    so the forbidden-verb assertion in ``test_security_provider``
+    keeps holding.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from core.security import (
+    MitigationActionResult,
+    MitigationState,
+    SilentGuardClient,
+    SilentGuardProvider,
+)
+from core.security.silentguard_mitigation import (
+    MODE_DETECTION_ONLY,
+    MODE_TEMPORARY_AUTO_BLOCK,
+)
+
+
+# ── Test doubles ────────────────────────────────────────────────────
+
+
+class _RecordingMitigationClient:
+    """Records every call and returns scripted responses."""
+
+    def __init__(
+        self,
+        state=None,
+        enable_result=None,
+        disable_result=None,
+    ):
+        self.state = state
+        self.enable_result = enable_result or MitigationActionResult(
+            ok=True,
+            state=MitigationState(
+                mode=MODE_TEMPORARY_AUTO_BLOCK, active=True,
+            ),
+            message="enabled",
+        )
+        self.disable_result = disable_result or MitigationActionResult(
+            ok=True,
+            state=MitigationState(
+                mode=MODE_DETECTION_ONLY, active=False,
+            ),
+            message="disabled",
+        )
+        self.calls: list[str] = []
+
+    def get_state(self):
+        self.calls.append("get_state")
+        return self.state
+
+    def enable_temporary(self):
+        self.calls.append("enable_temporary")
+        return self.enable_result
+
+    def disable(self):
+        self.calls.append("disable")
+        return self.disable_result
+
+
+# ── Read path ───────────────────────────────────────────────────────
+
+
+class TestGetMitigationState:
+    def test_returns_state_when_provider_available(self, tmp_path):
+        # ``feed_path`` exists so the file-based status probe reports
+        # ``available=True`` without an HTTP transport.
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        client = _RecordingMitigationClient(
+            state=MitigationState(mode=MODE_DETECTION_ONLY, active=False),
+        )
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=client)
+
+        state = provider.get_mitigation_state()
+        assert state is not None
+        assert state.mode == MODE_DETECTION_ONLY
+        assert client.calls == ["get_state"]
+
+    def test_returns_none_when_provider_unavailable(self, tmp_path):
+        # Missing feed file → provider unavailable → mitigation read
+        # short-circuits before issuing any HTTP call.
+        client = _RecordingMitigationClient(
+            state=MitigationState(mode=MODE_DETECTION_ONLY, active=False),
+        )
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "absent.json",
+            mitigation_client=client,
+        )
+        assert provider.get_mitigation_state() is None
+        assert client.calls == []
+
+    def test_returns_none_when_no_mitigation_client_configured(self, tmp_path):
+        # No mitigation_client argument and no API URL configured →
+        # provider has no way to reach SilentGuard's mitigation
+        # endpoints. The read returns ``None`` calmly.
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        provider = SilentGuardProvider(feed_path=feed, api_url="")
+        assert provider.get_mitigation_state() is None
+
+    def test_swallows_misbehaving_client(self, tmp_path):
+        # A custom client that raises must not propagate the error.
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+
+        class _Boom:
+            def get_state(self):
+                raise RuntimeError("boom")
+
+            def enable_temporary(self):  # pragma: no cover — not invoked
+                raise RuntimeError("boom")
+
+            def disable(self):  # pragma: no cover — not invoked
+                raise RuntimeError("boom")
+
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=_Boom())
+        assert provider.get_mitigation_state() is None
+
+
+# ── Action paths ────────────────────────────────────────────────────
+
+
+class TestEnableTemporaryMitigation:
+    def test_enables_when_provider_available(self, tmp_path):
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=client)
+
+        result = provider.enable_temporary_mitigation()
+        assert result.ok is True
+        assert result.state is not None
+        assert result.state.mode == MODE_TEMPORARY_AUTO_BLOCK
+        assert client.calls == ["enable_temporary"]
+
+    def test_refuses_when_provider_unavailable(self, tmp_path):
+        # No feed file → the provider's own status probe returns
+        # unavailable. The mitigation method must refuse without
+        # touching the client (no point posting into a void).
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "absent.json",
+            mitigation_client=client,
+        )
+        result = provider.enable_temporary_mitigation()
+        assert result.ok is False
+        assert result.state is None
+        assert client.calls == []
+
+    def test_refuses_when_no_client_configured(self, tmp_path):
+        # No mitigation client and no API URL → calm refusal.
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        provider = SilentGuardProvider(feed_path=feed, api_url="")
+        result = provider.enable_temporary_mitigation()
+        assert result.ok is False
+        assert result.state is None
+        # Message must be a non-empty user-safe string.
+        assert isinstance(result.message, str) and result.message
+
+    def test_swallows_misbehaving_client(self, tmp_path):
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+
+        class _Boom:
+            def get_state(self):  # pragma: no cover — not invoked
+                raise RuntimeError("boom")
+
+            def enable_temporary(self):
+                raise RuntimeError("boom")
+
+            def disable(self):  # pragma: no cover — not invoked
+                raise RuntimeError("boom")
+
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=_Boom())
+        result = provider.enable_temporary_mitigation()
+        assert result.ok is False
+        assert result.state is None
+
+
+class TestDisableMitigation:
+    def test_disables_when_provider_available(self, tmp_path):
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=client)
+
+        result = provider.disable_mitigation()
+        assert result.ok is True
+        assert result.state is not None
+        assert result.state.mode == MODE_DETECTION_ONLY
+        assert client.calls == ["disable"]
+
+    def test_refuses_when_provider_unavailable(self, tmp_path):
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(
+            feed_path=tmp_path / "absent.json",
+            mitigation_client=client,
+        )
+        result = provider.disable_mitigation()
+        assert result.ok is False
+        assert client.calls == []
+
+
+# ── Read-only paths must not invoke mitigation ──────────────────────
+
+
+class TestReadOnlyPathsStaySafe:
+    def test_get_status_does_not_invoke_mitigation_client(self, tmp_path):
+        # The existing status probe is the cheapest read path; it must
+        # not touch the mitigation surface. We inject a client that
+        # records every call and assert it stays silent.
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=client)
+
+        provider.get_status()
+        provider.get_status()  # second call too — defence in depth
+        assert client.calls == []
+
+    def test_get_summary_text_does_not_invoke_mitigation_client(self, tmp_path):
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=client)
+
+        provider.get_summary_text()
+        assert client.calls == []
+
+    def test_get_summary_counts_does_not_invoke_mitigation_client(self, tmp_path):
+        feed = tmp_path / "feed.json"
+        feed.write_text("[]", encoding="utf-8")
+        client = _RecordingMitigationClient()
+        provider = SilentGuardProvider(feed_path=feed, mitigation_client=client)
+
+        provider.get_summary_counts()
+        assert client.calls == []
+
+
+# ── The read-only client stays read-only ────────────────────────────
+
+
+def _read_module_source(module) -> str:
+    return Path(module.__file__).read_text(encoding="utf-8")
+
+
+class TestReadOnlyClientForbidsWriteVerbs:
+    """Pin the same forbidden-verb assertion as test_security_provider."""
+
+    def test_no_post_put_delete_patch_calls(self):
+        from core.security import silentguard_client as client_module
+        source = _read_module_source(client_module)
+        for verb in (
+            "client.post", "client.put", "client.delete", "client.patch",
+            ".post(", ".put(", ".delete(", ".patch(",
+        ):
+            assert verb not in source, (
+                f"silentguard_client must not call {verb!r}; "
+                "POST capability lives in silentguard_mitigation only."
+            )
+
+
+class TestMitigationModuleSurfaceIsTiny:
+    """Pin the small public surface so adding to it is a deliberate review."""
+
+    def test_module_only_defines_three_paths(self):
+        # The mitigation surface stays tiny by design. Adding a
+        # ``PATH_X`` constant means Nova grew a new write capability —
+        # this assertion makes the addition a deliberate, reviewed
+        # change rather than a quiet drive-by edit.
+        from core.security import silentguard_mitigation as mitigation_module
+        with open(mitigation_module.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        path_constants = []
+        for node in tree.body:
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id.startswith("PATH_"):
+                    path_constants.append(target.id)
+        assert sorted(path_constants) == [
+            "PATH_MITIGATION",
+            "PATH_MITIGATION_DISABLE",
+            "PATH_MITIGATION_ENABLE_TEMPORARY",
+        ], (
+            "mitigation module must define exactly three writable paths; "
+            "adding a fourth needs roadmap + test updates"
+        )
+
+    def test_module_does_not_import_subprocess_or_shell(self):
+        # The mitigation module is allowed POST capability but must
+        # never run shell commands, spawn processes, or touch the
+        # firewall directly. This mirrors the package-wide ban for
+        # everything except the lifecycle helper.
+        from core.security import silentguard_mitigation as mitigation_module
+        with open(mitigation_module.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        forbidden = {"subprocess", "shutil", "ctypes", "signal", "os.system"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    assert root not in forbidden, (
+                        f"silentguard_mitigation must not import {alias.name!r}"
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                root = (node.module or "").split(".")[0]
+                assert root not in forbidden, (
+                    f"silentguard_mitigation must not import from {node.module!r}"
+                )
+
+
+# ── Sanity: read-only client construction is unchanged ──────────────
+
+
+class TestReadOnlyClientUnchanged:
+    def test_construction_signature_unchanged(self):
+        # The existing client still constructs the same way it did
+        # before — the mitigation work must not have leaked write
+        # capability through the read-only client's public API.
+        client = SilentGuardClient(base_url="http://127.0.0.1:8765")
+        # ``is_configured`` and read methods must still exist.
+        assert client.is_configured() is True
+        assert callable(client.get_status)
+        assert callable(client.get_alerts)
+        # And no enable / disable / mitigation methods snuck in.
+        for forbidden in (
+            "enable_temporary", "disable", "get_mitigation_state",
+            "post", "put", "delete", "patch",
+        ):
+            assert not hasattr(client, forbidden), (
+                f"read-only client unexpectedly grew {forbidden!r}"
+            )

--- a/web.py
+++ b/web.py
@@ -888,6 +888,200 @@ def silentguard_retry(user: CurrentUser = Depends(get_current_user)):
     return _silentguard_summary_payload(user)
 
 
+# ── SILENTGUARD MITIGATION (opt-in, confirmation-gated) ─────────────
+#
+# SilentGuard owns enforcement. Nova does not become the firewall: it
+# only explains, asks for confirmation, and — *only after explicit user
+# acknowledgement* — relays the user's decision to SilentGuard's
+# narrow ``/mitigation/*`` endpoints. The endpoints below are the
+# entire surface of that bridge, and every one of them:
+#
+#   * requires an authenticated session;
+#   * requires the per-user ``silentguard_enabled`` opt-in;
+#   * for the mutating endpoints, requires an explicit
+#     ``{"acknowledge": true}`` body — Nova refuses to forward without it,
+#     even though the underlying SilentGuard call would also reject;
+#   * never runs sudo, shell, or firewall commands, and never opens a
+#     non-loopback connection;
+#   * sanitises every error path into calm, user-safe wording.
+#
+# There is no background polling and no auto-enable. The default
+# remains detection-only.
+
+
+class _SilentGuardMitigationRequest(BaseModel):
+    """Body for the mitigation enable / disable endpoints.
+
+    The single recognised field is ``acknowledge``. Anything else is
+    silently ignored — there is nothing for an attacker to smuggle in.
+    The endpoint refuses the request unless the caller has explicitly
+    sent ``acknowledge=True``, mirroring SilentGuard's own
+    acknowledgement contract.
+    """
+
+    model_config = {"extra": "ignore"}
+
+    acknowledge: bool = False
+
+
+def _silentguard_mitigation_disabled_payload() -> dict:
+    """Calm payload returned when the per-user gate is off."""
+    return {
+        "ok": False,
+        "available": False,
+        "state": None,
+        "message": "SilentGuard integration is disabled.",
+    }
+
+
+def _silentguard_mitigation_payload(state, *, ok=True, message=""):
+    """Render a Nova-side mitigation response.
+
+    Always returns the same shape — ``ok``, ``available``, ``state``,
+    ``message`` — so the UI can render reads and action results with
+    one renderer.
+    """
+    state_dict = state.as_dict() if state is not None else None
+    return {
+        "ok": bool(ok),
+        "available": state is not None,
+        "state": state_dict,
+        "message": message or "",
+    }
+
+
+@app.get("/integrations/silentguard/mitigation")
+def silentguard_mitigation_state(user: CurrentUser = Depends(get_current_user)):
+    """Return the current SilentGuard mitigation snapshot for the caller.
+
+    Read-only. Gated by the per-user ``silentguard_enabled`` setting,
+    just like every other SilentGuard surface. When the user has not
+    opted in, the endpoint returns a calm
+    ``{"available": false, "state": null, ...}`` payload instead of
+    issuing any HTTP call to SilentGuard.
+
+    The response shape is::
+
+        {
+            "ok": bool,
+            "available": bool,        # SilentGuard returned a parsed state
+            "state": {                # null when not available
+                "mode":       "detection_only" | "ask_before_blocking"
+                              | "temporary_auto_block" | "unknown",
+                "active":     bool,
+                "expires_at": str | null,   # ISO-8601, when known
+            } | null,
+            "message": str,           # calm, user-safe wording
+        }
+
+    No background polling, no notifications. The endpoint runs only
+    when the UI explicitly asks (Settings card mount or Refresh
+    click). It never triggers any mitigation enable / disable call.
+    """
+    if not _silentguard_integration.is_enabled(user.id):
+        return _silentguard_mitigation_disabled_payload()
+    provider = _SilentGuardProvider()
+    try:
+        state = provider.get_mitigation_state()
+    except Exception:  # pragma: no cover — defensive belt-and-braces
+        state = None
+    if state is None:
+        return _silentguard_mitigation_payload(
+            None, ok=True,
+            message="SilentGuard mitigation status is currently unavailable.",
+        )
+    return _silentguard_mitigation_payload(state, ok=True)
+
+
+@app.post("/integrations/silentguard/mitigation/enable-temporary")
+def silentguard_mitigation_enable_temporary(
+    user: CurrentUser = Depends(get_current_user),
+    body: _SilentGuardMitigationRequest = _SilentGuardMitigationRequest(),
+):
+    """Enable SilentGuard temporary mitigation, after explicit confirmation.
+
+    Gating, in order:
+
+      1. The request must be authenticated.
+      2. The caller's ``silentguard_enabled`` setting must be ``true``.
+      3. The request body must contain ``"acknowledge": true``. Without
+         it the endpoint returns 400 and **never** issues a call to
+         SilentGuard. This mirrors SilentGuard's own acknowledgement
+         contract and gives the UI a hard server-side checkpoint
+         independent of any client-side confirmation flow.
+
+    On success the response carries the post-action mitigation state
+    so the UI can repaint without a follow-up read. On failure the
+    endpoint returns a calm, user-safe message — never a raw exception
+    or HTTP body from SilentGuard.
+
+    Safety contract:
+
+      * Nova does not run sudo / firewall / shell commands.
+      * Nova does not call SilentGuard until the body has been
+        explicitly acknowledged by the user.
+      * The acknowledgement is single-use: a fresh request must
+        re-acknowledge before any further action.
+      * Errors never leak raw transport text; SilentGuard-side
+        failures map to a calm "currently unavailable" message.
+    """
+    if not _silentguard_integration.is_enabled(user.id):
+        return _silentguard_mitigation_disabled_payload()
+    if not body.acknowledge:
+        # 400 here is intentional: every other mitigation gate returns
+        # 200 with a calm payload, but a missing acknowledgement is a
+        # client-side bug — the UI must always send ``acknowledge=true``
+        # after the user clicks Confirm.
+        raise HTTPException(
+            status_code=400,
+            detail="Acknowledgement required to enable mitigation.",
+        )
+    provider = _SilentGuardProvider()
+    try:
+        result = provider.enable_temporary_mitigation()
+    except Exception:  # pragma: no cover — defensive belt-and-braces
+        return _silentguard_mitigation_payload(
+            None, ok=False,
+            message="SilentGuard mitigation request failed.",
+        )
+    return _silentguard_mitigation_payload(
+        result.state, ok=result.ok, message=result.message,
+    )
+
+
+@app.post("/integrations/silentguard/mitigation/disable")
+def silentguard_mitigation_disable(
+    user: CurrentUser = Depends(get_current_user),
+    body: _SilentGuardMitigationRequest = _SilentGuardMitigationRequest(),
+):
+    """Disable SilentGuard mitigation, after explicit confirmation.
+
+    Same gating contract as the enable endpoint above: authenticated
+    user, per-user opt-in, and ``acknowledge=true`` in the body.
+    Returning to detection-only is still a user-visible change, so
+    Nova requires the same explicit confirmation rather than offering
+    a one-click disable.
+    """
+    if not _silentguard_integration.is_enabled(user.id):
+        return _silentguard_mitigation_disabled_payload()
+    if not body.acknowledge:
+        raise HTTPException(
+            status_code=400,
+            detail="Acknowledgement required to disable mitigation.",
+        )
+    provider = _SilentGuardProvider()
+    try:
+        result = provider.disable_mitigation()
+    except Exception:  # pragma: no cover — defensive belt-and-braces
+        return _silentguard_mitigation_payload(
+            None, ok=False,
+            message="SilentGuard mitigation request failed.",
+        )
+    return _silentguard_mitigation_payload(
+        result.state, ok=result.ok, message=result.message,
+    )
+
+
 # ── VOICE / TTS ─────────────────────────────────────────────────────
 # Opt-in "read aloud" surface on assistant replies. The server returns
 # voice preferences, validates input, and (when a local engine is


### PR DESCRIPTION
## Summary

SilentGuard owns detection and enforcement; Nova stays the cognitive
layer. This PR adds the smallest safe path for Nova to *ask*
SilentGuard — only after explicit user confirmation — to enable or
disable temporary mitigation, plus a calm Settings surface that shows
the current mitigation mode and an inline two-click confirmation flow.

Detection-only remains the default. Nova does not become the
firewall: no auto-block, no autonomous behaviour, no notifications, no
firewall commands, no shell, no `sudo`, no background polling.

## What ships

- **`core/security/silentguard_mitigation.py`** — new POST-capable
  HTTP client for the three mitigation endpoints
  (`GET /mitigation`, `POST /mitigation/enable-temporary`,
  `POST /mitigation/disable`). Every POST carries the SilentGuard
  acknowledgement payload `{"acknowledge": true}`. Mode strings
  outside the documented allow-list collapse to `"unknown"`;
  timestamps are sanitiser-validated; transport / decoding / non-2xx
  errors all map to calm fallback values rather than exceptions.
- **`SilentGuardProvider`** grew three opt-in mitigation methods
  (`get_mitigation_state`, `enable_temporary_mitigation`,
  `disable_mitigation`) that delegate to the new client. The provider
  refuses to issue a write when its own status probe says SilentGuard
  is unavailable. The existing read-only `get_status` /
  `get_summary_counts` / `get_connection_summary` paths are unchanged
  and never invoke any mitigation method (pinned by a regression
  test).
- **Three new web endpoints** under `/integrations/silentguard/mitigation`:
  - `GET /mitigation` — read-only state, gated by per-user
    `silentguard_enabled`.
  - `POST /mitigation/enable-temporary` — requires
    `{"acknowledge": true}` in the body; otherwise returns **400**
    without calling SilentGuard.
  - `POST /mitigation/disable` — same acknowledgement gate.
- **Settings UI mitigation block**: shows the current mode badge and
  surfaces three buttons (*Enable temporary mitigation* / *Keep
  detection only* / *Disable mitigation*) gated by an inline
  confirmation prompt. *Keep detection only* is a UX-only ack and
  never calls any endpoint. The mitigation refresh piggybacks on the
  existing Settings open + Refresh trigger set; **no background
  polling is introduced**. Calm i18n copy in both supported locales,
  with a forbidden-word assertion to keep tone in check.
- **Roadmap update** (`docs/silentguard-integration-roadmap.md`):
  new §2.4.quater documenting the mitigation surface and its safety
  contract, a §11.1 in-scope entry, and a §14 non-goal restating that
  Nova does not become the firewall.

## Safety boundaries (all asserted by tests)

- The read-only client (`silentguard_client.py`) keeps zero
  `.post(`/`.put(`/`.delete(`/`.patch(` calls; the existing
  `test_security_provider` forbidden-verb assertion still passes.
- `silentguard_mitigation.py` does not import `subprocess`, `shutil`,
  `ctypes`, `signal`, or `os.system` (pinned by an AST forbidden-
  imports test).
- Mitigation surface is exactly three paths
  (`PATH_MITIGATION` / `PATH_MITIGATION_ENABLE_TEMPORARY` /
  `PATH_MITIGATION_DISABLE`); adding a fourth fails the test loudly.
- Per-user `silentguard_enabled` gate fires before any provider
  instantiation; disabled users never trigger HTTP traffic to
  SilentGuard (instantiation counter test).
- Writes refuse without `acknowledge: true` and never invoke the
  provider's mitigation method.
- The summary endpoint never triggers any mitigation read or write
  (`TestReadOnlyEndpointsDoNotCallMitigation`).

## Test plan

- [ ] `pytest tests/test_silentguard_mitigation_client.py` — sanitisers,
      acknowledgement payload, transport-failure handling.
- [ ] `pytest tests/test_silentguard_mitigation_provider.py` —
      provider methods, read-only paths stay safe, forbidden imports.
- [ ] `pytest tests/test_silentguard_mitigation_endpoints.py` — auth
      gate, per-user gate, acknowledgement gate, per-user isolation,
      no mitigation calls from `/summary`.
- [ ] `pytest tests/test_silentguard_mitigation_card_wiring.py` —
      markup ids, listener wiring (no inline `onclick`), confirm step
      makes no network call, calm i18n copy in both locales.
- [ ] `pytest tests/test_security_provider.py
      tests/test_security_lifecycle.py tests/test_security_context.py
      tests/test_integrations_silentguard.py
      tests/test_silentguard_summary_endpoint.py
      tests/test_silentguard_enable_endpoint.py
      tests/test_silentguard_settings_card_wiring.py` — existing
      SilentGuard suite stays green (372 tests).
- [ ] `pytest tests/test_auth.py tests/test_admin_users.py
      tests/test_alpha_auth.py tests/test_family_controls.py` —
      auth/admin/channel/family-controls suites stay green (115
      tests).
- [ ] Manually open Settings, toggle *Enable SilentGuard*, observe
      that the mitigation block stays hidden until SilentGuard
      reports a parseable state.
- [ ] With a stub SilentGuard returning `detection_only`, click
      *Enable temporary mitigation*, observe the confirm prompt,
      click *Confirm*, watch the mode badge flip to *"Temporary
      auto-block active"* and the calm status line render.
- [ ] Click *Disable mitigation* → confirm → mode flips back to
      *"Detection only"*.
- [ ] Click *Enable* → *Cancel*: the prompt disappears and no POST
      fires (verified in DevTools network tab).

## Out of scope (per roadmap)

- No `POST /blocked/{ip}/unblock` surface yet.
- No notifications, toasts, or "you have alerts" badges.
- No autonomous mitigation enable / disable.
- No firewall commands, shell, or subprocess from Nova.
- No remote / cloud calls; SilentGuard's local API only.

https://claude.ai/code/session_01EKqfqZtciDqX3iBWeXCXwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKqfqZtciDqX3iBWeXCXwA)_