### PR TITLE
feat(chat): stream Nova replies and tighten assistant bubble layout

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -61,6 +61,7 @@ def _iter_content_chunks(stream) -> Iterator[str]:
         if chunk:
             yield chunk
 
+
 MEMORY_EXTRACTION_PROMPT = """Analyse cette conversation et extrait UNIQUEMENT les informations personnelles importantes sur l'utilisateur.
 
 Si tu trouves quelque chose d'important, réponds avec ce format exact:

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Iterator
 import httpx
 import ollama
 from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
@@ -23,6 +24,42 @@ from memory.store import save_memory as save_natural_memory
 logger = logging.getLogger(__name__)
 
 OLLAMA_UNAVAILABLE = "Ollama is unreachable. Make sure Ollama is running, then try again."
+
+# Phrases that, when present in a first-pass reply, mean Nova does not
+# actually know the answer. The non-streaming chat() retries with web
+# search; chat_stream() emits a `replace` event then re-streams. Kept
+# as a module-level tuple so both code paths stay in lockstep.
+UNCERTAINTY_TRIGGERS = (
+    "je ne sais pas", "je n'ai pas", "je n'ai aucune",
+    "je ne peux pas", "je ne dispose pas", "je n'ai pas accès",
+    "i don't know", "i don't have", "i cannot",
+    "je ne trouve pas", "aucune information",
+    "je ne suis pas sûr", "je ne suis pas certain",
+)
+
+
+def _reply_is_uncertain(reply: str) -> bool:
+    """True iff `reply` contains one of the uncertainty trigger phrases."""
+    lowered = reply.lower()
+    return any(trigger in lowered for trigger in UNCERTAINTY_TRIGGERS)
+
+
+def _iter_content_chunks(stream) -> Iterator[str]:
+    """Yield non-empty `message.content` strings from an Ollama stream.
+
+    Ollama's chat-stream generator yields dicts shaped like
+    ``{"message": {"content": "..."}, "done": bool}``. Some intermediate
+    events have empty content (e.g. metadata frames) and the final
+    ``done`` event also carries a synthetic empty content — skipping
+    empties keeps the wire format tidy without affecting correctness.
+    """
+    for event in stream:
+        if not isinstance(event, dict):
+            continue
+        msg = event.get("message") or {}
+        chunk = msg.get("content") or ""
+        if chunk:
+            yield chunk
 
 MEMORY_EXTRACTION_PROMPT = """Analyse cette conversation et extrait UNIQUEMENT les informations personnelles importantes sur l'utilisateur.
 
@@ -230,15 +267,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
         reply = response["message"]["content"]
 
         # Si Nova sait pas → cherche sur le web automatiquement
-        uncertainty_triggers = [
-            "je ne sais pas", "je n'ai pas", "je n'ai aucune",
-            "je ne peux pas", "je ne dispose pas", "je n'ai pas accès",
-            "i don't know", "i don't have", "i cannot",
-            "je ne trouve pas", "aucune information",
-            "je ne suis pas sûr", "je ne suis pas certain",
-        ]
-
-        if policy.web_search_enabled and any(t in reply.lower() for t in uncertainty_triggers):
+        if policy.web_search_enabled and _reply_is_uncertain(reply):
             search_results = web_search(user_input)
             if search_results and "Aucun résultat" not in search_results:
                 messages = build_messages(history, user_input, memories, search_results, "search", personalization=personalization)
@@ -253,6 +282,176 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
         logger.warning("Ollama unreachable during chat: %s", e)
         return OLLAMA_UNAVAILABLE, MODELS["default"]
+
+
+def chat_stream(
+    history: list[dict],
+    user_input: str,
+    memories: list[dict],
+    user_id: int,
+    forced_model: str = None,
+    force_search: bool = False,
+    image: str = None,
+    policy: Policy | None = None,
+) -> Iterator[dict]:
+    """Generator twin of :func:`chat` that yields incremental events.
+
+    The shape mirrors what `/chat/stream` forwards to the browser:
+
+      ``{"type": "meta", "model": "..."}``      — first event, fixed model id
+      ``{"type": "delta", "content": "..."}``  — one or more text fragments
+      ``{"type": "replace"}``                   — clear bubble (uncertainty
+                                                  fallback only; followed by
+                                                  further `delta` events)
+      ``{"type": "done", "reply": "...",
+          "model": "..."}``                     — final event, full text
+      ``{"type": "error", "detail": "..."}``    — fatal, no `done` follows
+
+    Memory extraction runs after the stream completes, identical to the
+    non-streaming path. Callers are responsible for persisting the user
+    message + the final assistant reply once they have seen ``done``;
+    nothing is persisted on the `error` path.
+
+    The image / vision branch is **not** streamed — Ollama returns
+    vision results as a single response. We emit the full reply as one
+    ``delta`` followed by ``done`` so the wire format stays uniform.
+    """
+    if policy is None:
+        policy = ADMIN_POLICY
+
+    try:
+        # Image → vision model, no routing, no streaming.
+        if image:
+            logger.debug("Processing streaming-image request, encoded length=%d", len(image))
+            messages = build_image_messages(user_input, image)
+            response = client.chat(model=MODELS["default"], messages=messages)
+            reply = response["message"]["content"]
+            if policy.memory_save_enabled:
+                extract_and_save_memory(user_input or "image", reply, user_id)
+            yield {"type": "meta", "model": MODELS["default"]}
+            if reply:
+                yield {"type": "delta", "content": reply}
+            yield {"type": "done", "reply": reply, "model": MODELS["default"]}
+            return
+
+        model = forced_model if forced_model else route(user_input)
+        yield {"type": "meta", "model": model}
+
+        natural_mems = get_relevant_memories(user_input, user_id)
+        try:
+            personalization = get_personalization(user_id)
+        except Exception:
+            personalization = None
+
+        # Weather branch — single short reply, stream it.
+        if policy.weather_enabled:
+            weather_result = detect_weather_city(user_input)
+            if isinstance(weather_result, tuple):
+                lat, lon, city = weather_result
+                weather_data = get_weather(lat, lon, city)
+                messages = build_messages(
+                    history, user_input, memories, weather_data,
+                    "weather", personalization=personalization,
+                )
+                reply = yield from _stream_and_accumulate(model, messages)
+                yield {"type": "done", "reply": reply, "model": model}
+                return
+
+            if weather_result == "no_city" or weather_result == "multiple":
+                reply = "Quelle ville ?"
+                yield {"type": "delta", "content": reply}
+                yield {"type": "done", "reply": reply, "model": model}
+                return
+
+            if weather_result == "unknown_city":
+                reply = "Je n'ai pas accès à la météo pour cette ville."
+                yield {"type": "delta", "content": reply}
+                yield {"type": "done", "reply": reply, "model": model}
+                return
+
+        # SilentGuard read-only feed — same gating as the non-streaming path.
+        if is_security_query(user_input):
+            security_data = silentguard_integration.recent_events_summary(user_id)
+            if security_data:
+                messages = build_messages(
+                    history, user_input, memories, security_data,
+                    "security", personalization=personalization,
+                )
+                reply = yield from _stream_and_accumulate(model, messages)
+                yield {"type": "done", "reply": reply, "model": model}
+                return
+
+        # Forced or auto-detected web search.
+        if policy.web_search_enabled and (force_search or should_search(user_input)):
+            search_results = web_search(user_input)
+            messages = build_messages(
+                history, user_input, memories, search_results,
+                "search", personalization=personalization,
+            )
+            reply = yield from _stream_and_accumulate(model, messages)
+            yield {"type": "done", "reply": reply, "model": model}
+            return
+
+        # Regular chat path — stream the first pass.
+        messages = build_messages(
+            history, user_input, memories,
+            natural_memories=natural_mems, personalization=personalization,
+        )
+        reply = yield from _stream_and_accumulate(model, messages)
+
+        # Uncertainty fallback (same trigger set as the non-streaming
+        # path). We clear the bubble via `replace` then stream the
+        # search-augmented retry so the user only ends up reading the
+        # search answer, not "I don't know" + the answer.
+        if policy.web_search_enabled and _reply_is_uncertain(reply):
+            search_results = web_search(user_input)
+            if search_results and "Aucun résultat" not in search_results:
+                yield {"type": "replace"}
+                messages = build_messages(
+                    history, user_input, memories, search_results,
+                    "search", personalization=personalization,
+                )
+                reply = yield from _stream_and_accumulate(model, messages)
+
+        if policy.memory_save_enabled:
+            extract_and_save_memory(user_input, reply, user_id)
+            _extract_and_save_natural_memories(user_input, user_id)
+
+        yield {"type": "done", "reply": reply, "model": model}
+
+    except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
+        logger.warning("Ollama unreachable during chat stream: %s", e)
+        yield {"type": "error", "detail": OLLAMA_UNAVAILABLE}
+
+
+def _stream_and_accumulate(model: str, messages: list[dict]) -> Iterator[dict]:
+    """Stream a single Ollama chat call and re-emit each token as `delta`.
+
+    The generator behaves as a coroutine: ``reply = yield from
+    _stream_and_accumulate(...)`` lets the caller inspect the full
+    concatenated text once the upstream stream is exhausted, while the
+    intermediate events propagate to whoever is iterating chat_stream.
+
+    Falls back gracefully if the installed Ollama client predates the
+    streaming kwarg — the request degrades to a single-shot reply
+    surfaced as one `delta`.
+    """
+    parts: list[str] = []
+    try:
+        stream = client.chat(model=model, messages=messages, stream=True)
+    except TypeError:
+        # Older ollama clients lacked the streaming kwarg. Fall back to a
+        # single, non-streaming call so the endpoint still works.
+        response = client.chat(model=model, messages=messages)
+        reply = response["message"]["content"]
+        if reply:
+            yield {"type": "delta", "content": reply}
+        return reply
+
+    for chunk in _iter_content_chunks(stream):
+        parts.append(chunk)
+        yield {"type": "delta", "content": chunk}
+    return "".join(parts)
 
 
 def get_history_limit() -> int:

--- a/static/index.html
+++ b/static/index.html
@@ -543,17 +543,17 @@
         #messages {
             flex: 1;
             overflow-y: auto;
-            padding: 28px 26px 16px;
+            padding: 24px 26px 14px;
             display: flex;
             flex-direction: column;
-            gap: 18px;
+            gap: 14px;
             scroll-behavior: smooth;
         }
 
         .message-row {
             display: flex;
             flex-direction: column;
-            gap: 6px;
+            gap: 4px;
             animation: fadeUp 360ms var(--ease) both;
         }
 
@@ -576,9 +576,9 @@
 
         .message {
             max-width: 75%;
-            padding: 12px 16px;
+            padding: 10px 14px;
             border-radius: var(--r-lg);
-            line-height: 1.65;
+            line-height: 1.55;
             white-space: pre-wrap;
             word-break: break-word;
             font-size: 0.92rem;
@@ -611,6 +611,28 @@
         @keyframes pulse {
             0%, 100% { opacity: 0.95; }
             50% { opacity: 0.45; }
+        }
+
+        /* ── STREAMING CARET ──
+           A small, calm cursor appended at the end of an assistant bubble
+           while tokens are arriving. It vanishes once the response is
+           rendered as markdown, so the final message looks identical to a
+           non-streamed one. The caret never re-flows the layout because
+           it is inline and its dimensions match the surrounding text. */
+        .streaming-caret {
+            display: inline-block;
+            width: 6px;
+            height: 0.95em;
+            margin-left: 2px;
+            vertical-align: text-bottom;
+            background: var(--cyan-dim);
+            border-radius: 1px;
+            opacity: 0.85;
+            animation: caret-blink 1.05s steps(2, end) infinite;
+        }
+
+        @keyframes caret-blink {
+            50% { opacity: 0; }
         }
 
         #empty-state {
@@ -1064,19 +1086,28 @@
             .message-actions { max-width: 65%; }
         }
 
-        /* ── MARKDOWN ── */
+        /* ── MARKDOWN ──
+           Markdown spacing inside Nova bubbles is intentionally tight: the
+           bubble itself already has comfortable padding and the
+           1.55 line-height makes prose readable without large block gaps.
+           Headings, paragraphs and lists collapse first-/last-child margins
+           so the bubble never reserves empty vertical space at the edges. */
         .message.nova h1, .message.nova h2, .message.nova h3 {
             color: var(--text);
-            margin: 12px 0 6px;
+            margin: 10px 0 4px;
             font-weight: 600;
             letter-spacing: -0.005em;
         }
         .message.nova h1 { font-size: 1.15rem; }
         .message.nova h2 { font-size: 1.02rem; }
         .message.nova h3 { font-size: 0.95rem; color: var(--cyan); }
-        .message.nova p { margin: 6px 0; }
-        .message.nova ul, .message.nova ol { padding-left: 22px; margin: 6px 0; }
-        .message.nova li { margin: 3px 0; }
+        .message.nova p { margin: 4px 0; }
+        .message.nova ul, .message.nova ol { padding-left: 20px; margin: 4px 0; }
+        .message.nova li { margin: 2px 0; }
+        .message.nova > div > *:first-child,
+        .message.nova > *:first-child { margin-top: 0; }
+        .message.nova > div > *:last-child,
+        .message.nova > *:last-child { margin-bottom: 0; }
         .message.nova code {
             background: rgba(124, 197, 212, 0.10);
             padding: 1px 6px;
@@ -1087,11 +1118,11 @@
         }
         .message.nova pre {
             background: var(--bg);
-            padding: 14px 14px;
-            padding-top: 34px;
+            padding: 12px 14px;
+            padding-top: 32px;
             border-radius: var(--r-md);
             overflow-x: auto;
-            margin: 10px 0;
+            margin: 8px 0;
             border: 1px solid var(--border);
             position: relative;
             box-shadow: var(--shadow-sm);
@@ -1168,8 +1199,8 @@
             display: flex;
             align-items: center;
             gap: 2px;
-            padding: 8px 4px 2px;
-            margin-top: 4px;
+            padding: 6px 4px 2px;
+            margin-top: 2px;
             width: 100%;
             max-width: 75%;
             position: relative;
@@ -3250,6 +3281,7 @@
     let currentImage = null;
     let activeChatController = null;
     let activeThinkingRow = null;
+    let activeStreamBubble = null;
     let userCancelledChat = false;
     let allConversations = [];
     let convSearchQuery = "";
@@ -3339,6 +3371,13 @@
             activeThinkingRow.remove();
         }
         activeThinkingRow = null;
+        // Drop the in-flight streaming bubble — partial output should
+        // never be left mounted without an action row, and the server
+        // discards the unfinished reply on disconnect.
+        if (activeStreamBubble && activeStreamBubble.row.isConnected) {
+            activeStreamBubble.row.remove();
+        }
+        activeStreamBubble = null;
         appendStoppedNotice();
         isThinking = false;
         activeChatController = null;
@@ -4903,11 +4942,123 @@
         return bubble;
     }
 
+    // Append an empty Nova bubble that the streaming reader will fill in
+    // token-by-token. Action buttons (copy, read-aloud, feedback) are
+    // deliberately NOT attached here — they only appear once the stream
+    // completes successfully, so they can never be clicked against an
+    // incomplete response. The returned object exposes the helpers the
+    // caller needs to push tokens and finalise the message.
+    function createStreamingAssistantBubble() {
+        const emptyState = document.getElementById("empty-state");
+        if (emptyState) emptyState.remove();
+
+        const messagesEl = document.getElementById("messages");
+        const row = document.createElement("div");
+        row.className = "message-row nova";
+
+        const label = document.createElement("div");
+        label.className = "message-label";
+        label.textContent = "Nova";
+
+        const bubble = document.createElement("div");
+        bubble.className = "message nova streaming";
+        bubble.dataset.rawText = "";
+
+        // Raw text node we append plain tokens to. Markdown is only
+        // resolved once the stream completes — rendering on every
+        // token would re-parse the whole reply on each chunk and
+        // produce flickering, especially around half-written fences.
+        const textNode = document.createTextNode("");
+        bubble.appendChild(textNode);
+
+        const caret = document.createElement("span");
+        caret.className = "streaming-caret";
+        caret.setAttribute("aria-hidden", "true");
+        bubble.appendChild(caret);
+
+        row.appendChild(label);
+        row.appendChild(bubble);
+        messagesEl.appendChild(row);
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+
+        let buffer = "";
+
+        return {
+            row,
+            bubble,
+            appendDelta(chunk) {
+                buffer += chunk;
+                textNode.data = buffer;
+                bubble.dataset.rawText = buffer;
+                // Auto-scroll only when the user is already pinned to
+                // the bottom; otherwise leave their scroll position
+                // alone so they can read earlier messages while Nova
+                // is still writing.
+                if (isScrolledNearBottom(messagesEl)) {
+                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                }
+            },
+            reset() {
+                buffer = "";
+                textNode.data = "";
+                bubble.dataset.rawText = "";
+            },
+            finalise(model) {
+                bubble.classList.remove("streaming");
+                if (caret.parentNode) caret.parentNode.removeChild(caret);
+
+                if (model) {
+                    row.dataset.model = model;
+                    const badge = document.getElementById("model-badge");
+                    if (badge) {
+                        badge.textContent = "Nova";
+                        badge.dataset.model = model;
+                    }
+                }
+
+                if (!buffer) return;
+
+                // Swap raw text for rendered markdown in a single pass
+                // so the final layout matches a non-streamed reply.
+                bubble.removeChild(textNode);
+                const rendered = document.createElement("div");
+                rendered.innerHTML = marked.parse(buffer);
+                bubble.appendChild(rendered);
+                attachCodeBlockCopyButtons(rendered);
+
+                buildAssistantActions(row, bubble, buffer);
+                if (isScrolledNearBottom(messagesEl)) {
+                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                }
+            },
+            getBuffer() {
+                return buffer;
+            },
+        };
+    }
+
+    function isScrolledNearBottom(el) {
+        // 80px tolerance: typical token-by-token growth never exceeds
+        // a couple of lines, so we'd rather stay pinned than fight a
+        // user who scrolled up intentionally.
+        return el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    }
+
     // ── CHAT ──
+    //
+    // sendMessage() consumes the NDJSON stream from /chat/stream so the
+    // user sees Nova writing token-by-token. The thinking bubble stays
+    // visible until the first chunk arrives, then is replaced by a
+    // streaming bubble that the reader fills in.
+    //
+    // The action row (like / dislike / copy / read-aloud) is built only
+    // after the stream's `done` event, so partial responses are never
+    // copyable or readable-aloud. On cancellation we discard the
+    // streaming bubble entirely and show the existing stopped-notice
+    // for visual parity with the pre-streaming UX.
     async function sendMessage() {
         if (isThinking) return;
         const input = document.getElementById("user-input");
-        const btn = document.getElementById("send-btn");
         const text = input.value.trim();
         if (!text && !currentImage) return;
 
@@ -4930,9 +5081,10 @@
         messagesEl.scrollTop = messagesEl.scrollHeight;
         activeThinkingRow = thinkingRow;
         activeChatController = new AbortController();
+        activeStreamBubble = null;
 
         try {
-            const res = await fetch("/chat", {
+            const res = await fetch("/chat/stream", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -4948,33 +5100,44 @@
                 signal: activeChatController.signal
             });
 
-            if (thinkingRow.isConnected) {
-                thinkingRow.remove();
-            }
-            activeThinkingRow = null;
-
             if (res.status === 401) { logout(); return; }
+            if (!res.ok || !res.body) {
+                // Surface server-side policy denials etc. as a plain
+                // assistant message rather than dropping the request
+                // on the floor.
+                if (thinkingRow.isConnected) thinkingRow.remove();
+                activeThinkingRow = null;
+                let detail = "";
+                try { detail = (await res.json())?.detail || ""; } catch {}
+                appendMessage(
+                    "nova",
+                    detail || "Ollama is unreachable. Make sure Ollama is running, then try again."
+                );
+                return;
+            }
 
-            const data = await res.json();
-            currentConvId = data.conversation_id;
-            // If the user pressed Stop while the response was in flight,
-            // the stopped-notice has already been shown; suppress the
-            // response render so the two visuals don't fight. The reply
-            // is still persisted server-side — see issue #96 for true
-            // backend cancellation.
-            if (!userCancelledChat) {
-                appendMessage("nova", data.response, data.model);
+            const result = await consumeChatStream(res.body, thinkingRow);
+
+            if (!userCancelledChat && result.conversationId) {
+                currentConvId = result.conversationId;
+            }
+            if (result.errored && !userCancelledChat) {
+                appendMessage("nova", result.errorDetail
+                    || "Ollama is unreachable. Make sure Ollama is running, then try again.");
             }
             loadConversations();
         } catch (e) {
-            if (thinkingRow.isConnected) {
-                thinkingRow.remove();
-            }
+            if (thinkingRow.isConnected) thinkingRow.remove();
             activeThinkingRow = null;
+            if (activeStreamBubble && activeStreamBubble.row.isConnected
+                && !activeStreamBubble.getBuffer()) {
+                // Empty streaming bubble — drop it, it would only show
+                // as a stray Nova label with no content.
+                activeStreamBubble.row.remove();
+            }
             if (e?.name === "AbortError") {
-                // The stopMessage() handler already rendered the stopped
-                // notice; nothing more to do here. We deliberately do not
-                // claim the backend computation was cancelled — see #96.
+                // stopMessage() already rendered the stopped notice and
+                // pulled the streaming bubble. Nothing left to do.
             } else {
                 appendMessage("nova", "Ollama is unreachable. Make sure Ollama is running, then try again.");
             }
@@ -4982,12 +5145,131 @@
             isThinking = false;
             userCancelledChat = false;
             activeChatController = null;
+            activeStreamBubble = null;
             setSendButtonToSend();
             searchEnabled = false;
             document.getElementById("search-btn").classList.remove("active");
             removeImage();
             input.focus();
         }
+    }
+
+    // Reads an NDJSON stream of {type, ...} events from the backend and
+    // drives the streaming bubble. Returns a small summary the caller
+    // uses to decide post-stream actions (refresh sidebar, surface
+    // errors). Resolves cleanly on `done`, `error`, or end-of-stream;
+    // throws only on AbortError (handled upstream).
+    async function consumeChatStream(body, thinkingRow) {
+        const reader = body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let pending = "";
+
+        const result = {
+            conversationId: null,
+            model: null,
+            errored: false,
+            errorDetail: "",
+            completed: false,
+        };
+
+        const handleEvent = (event) => {
+            if (!event || typeof event !== "object") return;
+            switch (event.type) {
+                case "meta": {
+                    if (event.conversation_id) {
+                        result.conversationId = event.conversation_id;
+                    }
+                    if (event.model) result.model = event.model;
+                    break;
+                }
+                case "delta": {
+                    if (userCancelledChat) return;
+                    if (!activeStreamBubble) {
+                        if (thinkingRow.isConnected) thinkingRow.remove();
+                        activeThinkingRow = null;
+                        activeStreamBubble = createStreamingAssistantBubble();
+                    }
+                    activeStreamBubble.appendDelta(event.content || "");
+                    break;
+                }
+                case "replace": {
+                    if (activeStreamBubble) activeStreamBubble.reset();
+                    break;
+                }
+                case "done": {
+                    result.completed = true;
+                    if (event.conversation_id) {
+                        result.conversationId = event.conversation_id;
+                    }
+                    if (event.model) result.model = event.model;
+                    if (userCancelledChat) break;
+                    if (!activeStreamBubble) {
+                        // No deltas reached us (e.g. short-circuit reply
+                        // delivered as a single payload, or empty
+                        // response). Promote the thinking row into a
+                        // bubble now so finalise() can settle layout.
+                        if (thinkingRow.isConnected) thinkingRow.remove();
+                        activeThinkingRow = null;
+                        activeStreamBubble = createStreamingAssistantBubble();
+                    }
+                    activeStreamBubble.finalise(result.model);
+                    break;
+                }
+                case "error": {
+                    result.errored = true;
+                    result.errorDetail = event.detail || "";
+                    if (activeStreamBubble && activeStreamBubble.row.isConnected
+                        && !activeStreamBubble.getBuffer()) {
+                        activeStreamBubble.row.remove();
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        };
+
+        // Decoded line buffer. We process newline-delimited JSON so a
+        // single chunk may yield multiple events and a partial line is
+        // carried across chunks until its terminating '\n' arrives.
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            pending += decoder.decode(value, { stream: true });
+
+            let nl;
+            while ((nl = pending.indexOf("\n")) !== -1) {
+                const line = pending.slice(0, nl).trim();
+                pending = pending.slice(nl + 1);
+                if (!line) continue;
+                try {
+                    handleEvent(JSON.parse(line));
+                } catch {
+                    // Malformed line — skip silently rather than break
+                    // the whole conversation. The stream usually only
+                    // contains well-formed JSON we emitted ourselves.
+                }
+            }
+        }
+
+        // Flush any trailing buffered text once the stream is done.
+        const tail = (pending + decoder.decode()).trim();
+        if (tail) {
+            try { handleEvent(JSON.parse(tail)); } catch {}
+        }
+
+        // If the stream ended without a `done` event and without an
+        // explicit error, treat what we have as the final reply so the
+        // bubble still settles into its final layout (no caret, with
+        // actions). The server would also have persisted nothing in
+        // that case — matches existing /chat behaviour on connection
+        // drop mid-reply.
+        if (!result.completed && !result.errored && activeStreamBubble && !userCancelledChat) {
+            activeStreamBubble.finalise(result.model);
+        }
+        if (thinkingRow.isConnected) thinkingRow.remove();
+        activeThinkingRow = null;
+        return result;
     }
 
     // ── SETTINGS ──

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -1,0 +1,312 @@
+"""
+Tests for the streaming chat path introduced alongside the compact chat UI.
+
+Covers both layers:
+  * ``core.chat.chat_stream`` — the generator that turns an Ollama stream
+    into ``meta`` / ``delta`` / ``replace`` / ``done`` events.
+  * ``/chat/stream`` (HTTP) — the FastAPI endpoint that forwards those
+    events as NDJSON and persists exactly one assistant message on a
+    clean completion.
+
+The Ollama client and tool-calling helpers are stubbed end-to-end so
+these tests never touch the network or the routing logic of the live
+chat() function.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import chat as chat_module  # noqa: E402
+from core import memory as core_memory, users  # noqa: E402
+from core.chat import chat_stream  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password, role=role)
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@contextlib.contextmanager
+def stub_chat_stream_runtime(chunks):
+    """Replace Ollama's chat() with a fake streaming iterator.
+
+    ``chunks`` is a list of strings to surface as message.content
+    fragments. Routing, weather, search, security and memory hooks are
+    all neutralised so the generator follows the plain chat path.
+    """
+    def fake_chat(*args, **kwargs):
+        if kwargs.get("stream"):
+            def gen():
+                for c in chunks:
+                    yield {"message": {"content": c}, "done": False}
+                yield {"message": {"content": ""}, "done": True}
+            return gen()
+        # Non-streaming fallback (e.g. memory extractor) — return single shot.
+        return {"message": {"content": "".join(chunks)}}
+
+    with patch.object(chat_module.client, "chat", side_effect=fake_chat), \
+            patch.object(chat_module, "route", lambda _msg: "default"), \
+            patch.object(chat_module, "should_search", lambda _msg: False), \
+            patch.object(chat_module, "is_security_query", lambda _msg: False), \
+            patch.object(chat_module, "detect_weather_city", lambda _msg: None), \
+            patch.object(chat_module, "get_relevant_memories", lambda *_a, **_k: []), \
+            patch.object(chat_module, "extract_and_save_memory", lambda *_a, **_k: None), \
+            patch.object(
+                chat_module, "_extract_and_save_natural_memories",
+                lambda *_a, **_k: None,
+            ):
+        yield
+
+
+# ── core.chat.chat_stream ───────────────────────────────────────────────────
+
+class TestChatStreamGenerator:
+    def test_yields_meta_then_deltas_then_done(self, db_path):
+        alice = _make_user(db_path, "alice")
+        with stub_chat_stream_runtime(["Hel", "lo, ", "world!"]):
+            events = list(chat_stream([], "hi", [], alice))
+
+        assert events[0]["type"] == "meta"
+        assert events[0]["model"]  # whatever the route stub returns
+        deltas = [e["content"] for e in events if e["type"] == "delta"]
+        assert deltas == ["Hel", "lo, ", "world!"]
+
+        last = events[-1]
+        assert last["type"] == "done"
+        assert last["reply"] == "Hello, world!"
+
+    def test_empty_stream_still_emits_done(self, db_path):
+        alice = _make_user(db_path, "alice")
+        with stub_chat_stream_runtime([]):
+            events = list(chat_stream([], "hi", [], alice))
+        assert events[0]["type"] == "meta"
+        assert events[-1]["type"] == "done"
+        assert events[-1]["reply"] == ""
+
+    def test_ollama_unreachable_yields_error(self, db_path):
+        alice = _make_user(db_path, "alice")
+        import ollama as _ollama  # MagicMock in this env
+
+        # Real ollama.ResponseError is what core.chat catches; the conftest
+        # stubs ollama as a MagicMock, so we wire its ResponseError attr
+        # to a concrete Exception subclass so the except-clause matches.
+        class _FakeResponseError(Exception):
+            pass
+        with patch.object(_ollama, "ResponseError", _FakeResponseError), \
+                patch.object(
+                    chat_module.client, "chat",
+                    side_effect=_FakeResponseError("nope"),
+                ), \
+                patch.object(chat_module, "route", lambda _msg: "default"), \
+                patch.object(chat_module, "should_search", lambda _msg: False), \
+                patch.object(chat_module, "is_security_query", lambda _msg: False), \
+                patch.object(chat_module, "detect_weather_city", lambda _msg: None), \
+                patch.object(chat_module, "get_relevant_memories", lambda *_a, **_k: []):
+            events = list(chat_stream([], "hi", [], alice))
+
+        assert any(e["type"] == "error" for e in events)
+        assert not any(e["type"] == "done" for e in events)
+
+
+# ── /chat/stream endpoint ──────────────────────────────────────────────────
+
+def _decode_ndjson(body: bytes) -> list[dict]:
+    out = []
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+class TestChatStreamEndpoint:
+    def test_streams_ndjson_and_persists_one_assistant_message(
+        self, db_path, web_client
+    ):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime(["he", "llo"]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "salut", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        types = [e["type"] for e in events]
+
+        assert "meta" in types
+        assert "done" in types
+        deltas = [e["content"] for e in events if e["type"] == "delta"]
+        assert "".join(deltas) == "hello"
+
+        # Exactly one user message and one assistant message persisted.
+        conv_id = next(e["conversation_id"] for e in events if e["type"] == "done")
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT role, content FROM messages "
+                "WHERE conversation_id = ? ORDER BY id",
+                (conv_id,),
+            ).fetchall()
+        assert rows == [("user", "salut"), ("assistant", "hello")]
+
+    def test_first_message_updates_conversation_title(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime(["ok"]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "premier message complet et long", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        conv_id = next(
+            e["conversation_id"] for e in _decode_ndjson(resp.content) if e["type"] == "done"
+        )
+        with sqlite3.connect(db_path) as conn:
+            title = conn.execute(
+                "SELECT title FROM conversations WHERE id = ?", (conv_id,)
+            ).fetchone()[0]
+        # Title trimmed to first 40 chars of the user prompt.
+        assert title == "premier message complet et long"
+
+    def test_short_circuit_memory_command_streams_one_chunk(
+        self, db_path, web_client
+    ):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        # The "what do you remember" shortcut never reaches Ollama. The
+        # endpoint still surfaces it as a normal NDJSON stream so the
+        # frontend can use a single consumer for every path.
+        resp = web_client.post(
+            "/chat/stream",
+            json={
+                "message": "what do you remember about me?",
+                "mode": "chat",
+            },
+            headers=_h(token),
+        )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        types = [e["type"] for e in events]
+        assert types[0] == "meta"
+        assert types[-1] == "done"
+        assert any(e["type"] == "delta" for e in events)
+
+    def test_unowned_conversation_returns_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a_token = _login(web_client, "alice")
+        b_token = _login(web_client, "bob")
+
+        cid = web_client.post(
+            "/conversations", json={"title": "alice"}, headers=_h(a_token)
+        ).json()["id"]
+
+        with stub_chat_stream_runtime(["nope"]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "hi", "conversation_id": cid, "mode": "chat"},
+                headers=_h(b_token),
+            )
+        assert resp.status_code == 404
+
+    def test_missing_auth_returns_401(self, web_client):
+        # No Bearer token — should not start a stream.
+        resp = web_client.post(
+            "/chat/stream",
+            json={"message": "hello", "mode": "chat"},
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_reload_shows_one_assistant_message(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime(["full ", "reply"]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "ping", "mode": "chat"},
+                headers=_h(token),
+            )
+        conv_id = next(
+            e["conversation_id"] for e in _decode_ndjson(resp.content) if e["type"] == "done"
+        )
+
+        msgs = web_client.get(
+            f"/conversations/{conv_id}/messages", headers=_h(token)
+        ).json()
+        assistant = [m for m in msgs if m["role"] == "assistant"]
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "full reply"
+
+
+# ── /chat fallback still works ──────────────────────────────────────────────
+
+class TestNonStreamingFallback:
+    def test_chat_endpoint_still_returns_full_reply(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with patch("web.chat", return_value=("classic reply", "stub-model")):
+            resp = web_client.post(
+                "/chat",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "classic reply"

--- a/web.py
+++ b/web.py
@@ -662,14 +662,12 @@ def chat_stream_endpoint(
 
         final_reply = ""
         final_model: str | None = None
-        sent_conversation_id = False
 
         try:
             for event in events:
                 etype = event.get("type")
                 if etype == "meta":
                     final_model = event.get("model") or final_model
-                    sent_conversation_id = True
                     yield _stream_event({
                         "type": "meta",
                         "model": final_model,

--- a/web.py
+++ b/web.py
@@ -1,9 +1,10 @@
+import json
 import time
 import secrets as _secrets
 import uvicorn
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Depends, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field, field_validator
@@ -18,7 +19,7 @@ from core.rate_limiter import check_login_rate_limit
 from apscheduler.schedulers.background import BackgroundScheduler
 from core.learner import learn_from_feeds
 from core.updater import check_and_update_models
-from core.chat import chat
+from core.chat import chat, chat_stream
 from core.memory_command import handle_manual_memory_command
 from core.session_continuity import build_session_continuity
 from core.memory import (
@@ -425,8 +426,20 @@ def remove_conversation(
     return {"ok": True}
 
 
-@app.post("/chat")
-def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_user)):
+def _chat_preflight(request: ChatRequest, user: CurrentUser):
+    """Shared validation + memory-command handling for chat endpoints.
+
+    Runs the family-controls / mode-access / daily-limit checks and
+    intercepts the small set of message strings that resolve without
+    ever reaching Ollama (manual memory commands, "forget X",
+    "what do you remember"). On a short-circuit match, returns a tuple
+    ``(reply, "system")``. Otherwise returns ``None`` and the caller
+    proceeds to invoke the model.
+
+    Raises ``HTTPException`` for any policy denial — the streaming
+    endpoint catches that before opening the chunked response so
+    failures surface as a clean HTTP error.
+    """
     policy = get_policy(user)
 
     denial = check_chat_request(
@@ -438,10 +451,6 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
     if denial is not None:
         _raise_policy_denial(denial)
 
-    # Per-user / per-role mode access (#112). Layered on top of the base
-    # policy so a crafted request for a mode the admin has scoped away
-    # from this account is refused even if the family-controls row would
-    # otherwise allow it.
     access_denial = _model_access.check_mode_access(user, request.mode)
     if access_denial is not None:
         raise HTTPException(
@@ -452,8 +461,6 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
     denial = enforce_daily_limit(policy, user.id)
     if denial is not None:
         _raise_policy_denial(denial)
-
-    memories = load_memories(user.id)
 
     msg_lower = request.message.lower().strip()
     is_manual_memory_command = any(
@@ -468,19 +475,28 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
 
     reply = handle_manual_memory_command(request.message, user.id)
     if reply is not None:
-        return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
+        return policy, reply, "system"
 
     if msg_lower.startswith("forget that ") or msg_lower.startswith("oublie que "):
         query = request.message.split(" ", 2)[2].strip()
         count = delete_memories_matching(query, user.id)
-        reply = f"Done. Removed {count} memory(ies) matching '{query}'." if count else "No matching memories found."
-        return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
+        reply = (
+            f"Done. Removed {count} memory(ies) matching '{query}'."
+            if count else "No matching memories found."
+        )
+        return policy, reply, "system"
 
-    if msg_lower.startswith("forget everything about ") or msg_lower.startswith("oublie tout sur "):
+    if (
+        msg_lower.startswith("forget everything about ")
+        or msg_lower.startswith("oublie tout sur ")
+    ):
         query = request.message.split(" ", 3)[-1].strip()
         count = delete_memories_matching(query, user.id)
-        reply = f"Done. Removed {count} memory(ies) about '{query}'." if count else "No matching memories found."
-        return {"response": reply, "model": "system", "conversation_id": request.conversation_id}
+        reply = (
+            f"Done. Removed {count} memory(ies) about '{query}'."
+            if count else "No matching memories found."
+        )
+        return policy, reply, "system"
 
     if msg_lower in (
         "what do you remember about me?", "show my memories", "show memories",
@@ -489,45 +505,80 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
     ):
         mems = list_natural_memories(user.id)
         if not mems:
-            return {"response": "I don't have any natural memories stored yet.", "model": "system", "conversation_id": request.conversation_id}
+            return policy, "I don't have any natural memories stored yet.", "system"
         lines = ["Here's what I remember about you:\n"]
         for m in mems:
             lines.append(f"- [{m.kind}/{m.topic}] {m.content}")
-        return {"response": "\n".join(lines), "model": "system", "conversation_id": request.conversation_id}
+        return policy, "\n".join(lines), "system"
 
+    return policy, None, None
+
+
+def _resolve_forced_model(request: ChatRequest, user: CurrentUser) -> str | None:
+    """Resolve the concrete model id (or None for auto-routing).
+
+    Mirrors the precedence rules from the non-streaming endpoint:
+    a per-user nova_model_enabled override beats the request mode,
+    which beats the auto fallback. Returns the resolved string or
+    ``None`` to leave the choice to ``core.router.route``.
+    """
+    nova_enabled = get_user_setting(user.id, "nova_model_enabled", "false") == "true"
+    if nova_enabled:
+        return get_user_setting(
+            user.id, "nova_model_name", NOVA_MODEL_DEFAULT_NAME
+        )
+    return MODE_MAP.get(request.mode)
+
+
+def _check_forced_model_access(forced_model: str | None, user: CurrentUser) -> None:
+    if forced_model is None:
+        return
+    model_denial = _model_access.check_model_access(user, forced_model)
+    if model_denial is not None:
+        raise HTTPException(
+            status_code=model_denial.status_code,
+            detail=model_denial.detail,
+        )
+
+
+def _resolve_conversation_id(request: ChatRequest, user: CurrentUser) -> int:
+    """Either validate ownership of an existing conversation or create one."""
     conversation_id = request.conversation_id
     if conversation_id:
         if not conversation_belongs_to(conversation_id, user.id):
             raise HTTPException(status_code=404, detail="Conversation introuvable.")
-    else:
-        conversation_id = create_conversation(request.message[:40], user.id)
+        return conversation_id
+    return create_conversation(request.message[:40], user.id)
+
+
+@app.post("/chat")
+def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_user)):
+    policy, short_reply, short_model = _chat_preflight(request, user)
+    if short_reply is not None:
+        return {
+            "response": short_reply,
+            "model": short_model,
+            "conversation_id": request.conversation_id,
+        }
+
+    memories = load_memories(user.id)
+    conversation_id = _resolve_conversation_id(request, user)
 
     history = [
         {"role": m["role"], "content": m["content"]}
         for m in load_conversation_messages(conversation_id, user.id) or []
     ]
 
-    nova_enabled = get_user_setting(user.id, "nova_model_enabled", "false") == "true"
-    if nova_enabled:
-        forced_model = get_user_setting(
-            user.id, "nova_model_name", NOVA_MODEL_DEFAULT_NAME
-        )
-    else:
-        forced_model = MODE_MAP.get(request.mode)
+    forced_model = _resolve_forced_model(request, user)
+    _check_forced_model_access(forced_model, user)
 
-    # Per-user / per-role model access (#112). Only validated when a
-    # concrete forced_model is resolved (mode=auto leaves it None and
-    # delegates to the router, which already picks from configured
-    # models). The mode check above is the primary control for auto.
-    if forced_model is not None:
-        model_denial = _model_access.check_model_access(user, forced_model)
-        if model_denial is not None:
-            raise HTTPException(
-                status_code=model_denial.status_code,
-                detail=model_denial.detail,
-            )
-
-    response, model_used = chat(history, request.message, memories, user.id, forced_model=forced_model, force_search=request.search, image=request.image, policy=policy)
+    response, model_used = chat(
+        history, request.message, memories, user.id,
+        forced_model=forced_model,
+        force_search=request.search,
+        image=request.image,
+        policy=policy,
+    )
 
     save_message(conversation_id, "user", request.message)
     save_message(conversation_id, "assistant", response, model_used)
@@ -538,8 +589,154 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
     return {
         "response": response,
         "model": model_used,
-        "conversation_id": conversation_id
+        "conversation_id": conversation_id,
     }
+
+
+def _stream_event(payload: dict) -> bytes:
+    """Encode one streaming event as a single NDJSON line.
+
+    NDJSON keeps the wire format trivial to parse on the browser:
+    decode bytes incrementally, split on '\\n', JSON.parse each line.
+    No EventSource quirks (no Authorization header support), no SSE
+    framing overhead, and the same shape works for delta / replace /
+    done / error events.
+    """
+    return (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+@app.post("/chat/stream")
+def chat_stream_endpoint(
+    request: ChatRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Incrementally streams Nova's reply as newline-delimited JSON.
+
+    Identical pre-flight + persistence semantics to ``/chat``; the
+    difference is that text tokens are forwarded to the client as they
+    arrive from Ollama. The user message + final assistant reply are
+    persisted only on a clean ``done`` event — a mid-stream error or
+    a client disconnect leaves the DB untouched, so reloading the
+    conversation never shows a half-baked response.
+    """
+    policy, short_reply, short_model = _chat_preflight(request, user)
+
+    if short_reply is not None:
+        # Short-circuit replies (memory commands, "what do you remember")
+        # do not touch the model. Surface them as a one-shot stream so
+        # the frontend uses the same code path as a real generation.
+        conv_id = request.conversation_id
+
+        def _short_circuit():
+            yield _stream_event({"type": "meta", "model": short_model,
+                                 "conversation_id": conv_id})
+            yield _stream_event({"type": "delta", "content": short_reply})
+            yield _stream_event({"type": "done", "model": short_model,
+                                 "conversation_id": conv_id})
+
+        return StreamingResponse(_short_circuit(), media_type="application/x-ndjson")
+
+    memories = load_memories(user.id)
+    conversation_id = _resolve_conversation_id(request, user)
+    is_first_message = len(load_conversation_messages(conversation_id, user.id) or []) == 0
+
+    history = [
+        {"role": m["role"], "content": m["content"]}
+        for m in load_conversation_messages(conversation_id, user.id) or []
+    ]
+
+    forced_model = _resolve_forced_model(request, user)
+    _check_forced_model_access(forced_model, user)
+
+    def _generate():
+        # `chat_stream` mirrors the synchronous `chat()` path: it does
+        # routing, weather/search/security gating, and uncertainty
+        # fallback — but yields events instead of returning a string.
+        events = chat_stream(
+            history, request.message, memories, user.id,
+            forced_model=forced_model,
+            force_search=request.search,
+            image=request.image,
+            policy=policy,
+        )
+
+        final_reply = ""
+        final_model: str | None = None
+        sent_conversation_id = False
+
+        try:
+            for event in events:
+                etype = event.get("type")
+                if etype == "meta":
+                    final_model = event.get("model") or final_model
+                    sent_conversation_id = True
+                    yield _stream_event({
+                        "type": "meta",
+                        "model": final_model,
+                        "conversation_id": conversation_id,
+                    })
+                elif etype == "delta":
+                    yield _stream_event(event)
+                elif etype == "replace":
+                    # Uncertainty fallback: clear the bubble and start the
+                    # search-augmented retry. The final accumulated reply
+                    # is whatever the upstream chat_stream returns last.
+                    final_reply = ""
+                    yield _stream_event({"type": "replace"})
+                elif etype == "done":
+                    final_reply = event.get("reply", "") or ""
+                    final_model = event.get("model") or final_model
+                    # Persist only once we know the full reply landed
+                    # cleanly. A client disconnect at this point is
+                    # acceptable: the response is already saved.
+                    save_message(conversation_id, "user", request.message)
+                    save_message(
+                        conversation_id, "assistant",
+                        final_reply, final_model,
+                    )
+                    if is_first_message:
+                        update_conversation_title(
+                            conversation_id, request.message[:40]
+                        )
+                    yield _stream_event({
+                        "type": "done",
+                        "model": final_model,
+                        "conversation_id": conversation_id,
+                    })
+                elif etype == "error":
+                    yield _stream_event({
+                        "type": "error",
+                        "detail": event.get("detail", "stream error"),
+                    })
+                    return
+        except Exception as exc:  # pragma: no cover — defensive
+            # Whatever happens we must terminate the stream tidily so
+            # the client unblocks and shows a calm error state.
+            yield _stream_event({"type": "error", "detail": str(exc) or "stream error"})
+            return
+
+        # Defensive fallthrough — chat_stream should always end with
+        # either `done` or `error`, but if it doesn't, signal completion
+        # so the frontend won't hang forever.
+        if not final_reply:
+            yield _stream_event({
+                "type": "done",
+                "model": final_model,
+                "conversation_id": conversation_id,
+            })
+
+    headers = {
+        # Disable any reverse-proxy buffering that would batch our chunks
+        # back together (nginx defaults to buffering, killing perceived
+        # latency). The X-Accel-Buffering hint is the nginx-native opt-out.
+        "X-Accel-Buffering": "no",
+        "Cache-Control": "no-cache",
+    }
+    return StreamingResponse(
+        _generate(),
+        media_type="application/x-ndjson",
+        headers=headers,
+    )
 
 
 # ── MEMORY ENDPOINTS ──


### PR DESCRIPTION
## Summary

Nova replies now stream token-by-token through a new `/chat/stream`
NDJSON endpoint, and assistant bubbles take less vertical space without
losing readability or the calm, premium feel.

### Backend
- `core.chat.chat_stream` — generator twin of `chat()` that yields
  `meta` / `delta` / `replace` / `done` / `error` events. Mirrors the
  routing, weather, search, security and uncertainty-fallback branches;
  falls back to a single-shot call if the installed Ollama client lacks
  the streaming kwarg.
- `web.py` — new `/chat/stream` endpoint re-uses the same policy /
  mode-access / daily-limit pre-flight as `/chat` (extracted to
  `_chat_preflight`) and forwards events as `application/x-ndjson` with
  `X-Accel-Buffering: no`. The user message and final assistant message
  are persisted **only** on a clean `done` event, so a mid-stream error
  or client disconnect never leaves a half-baked reply in the DB. The
  legacy `/chat` route is preserved for fallback and existing tests.
- Memory-command short-circuits (e.g. "what do you remember about me?")
  are surfaced as a one-shot stream so the frontend uses a single
  consumer for every path.

### Frontend
- `createStreamingAssistantBubble()` builds an empty bubble with a calm
  blinking caret and exposes `appendDelta` / `reset` / `finalise`.
  Tokens are appended into a plain text node — markdown is rendered
  only on `done`, so there's no flicker around half-written code
  fences. The action row (like / dislike / copy / read-aloud) is built
  only after completion: partial replies are never copyable, readable-
  aloud, or like/dislike-able.
- `sendMessage()` reads `/chat/stream` via `fetch` + `ReadableStream`,
  decoding NDJSON line-by-line. Cancellation removes the streaming
  bubble and shows the existing stopped notice; HTTP errors surface as
  a calm assistant message.
- Bubble spacing trimmed for a more compact look: `#messages` gap
  18→14px, `.message` padding 12→10px / line-height 1.65→1.55,
  paragraph/list margins reduced, code-block padding reduced. Markdown
  first/last-child margins collapse so a bubble never reserves empty
  vertical space at its edges.

### Tests
- New `tests/test_chat_stream.py` (10 cases): generator emits
  meta+deltas+done, empty stream still ends cleanly, Ollama outage
  surfaces as `error`; endpoint streams NDJSON, persists exactly one
  assistant message, updates the conversation title on the first
  message, handles short-circuit memory commands, rejects cross-user
  conversation IDs (404), refuses missing auth (401), and reload shows
  one message.
- Existing `/chat` path is untouched at the network shape level and
  the full pre-existing **1235-test** suite still passes.

## Test plan

- [x] `pytest tests/` — 1235 existing tests pass
- [x] `pytest tests/test_chat_stream.py` — 10/10 new tests pass
- [x] `pytest tests/test_conversation_scoping.py tests/test_personalization_chat_wiring.py tests/test_model_access.py tests/test_family_controls.py tests/test_memory_scoping.py tests/test_security_context.py tests/test_natural_memory.py` — 232 chat-adjacent tests pass
- [ ] Manual browser check: long response streams smoothly, short
      response still works, Stop button leaves no broken UI, reload
      shows one final assistant message, copy / read-aloud / feedback
      light up only after completion
- [ ] Manual check: markdown (code blocks, tables, headings) renders
      cleanly post-stream

https://claude.ai/code/session_01RPCNmy6fugY4q8dorDVwBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPCNmy6fugY4q8dorDVwBd)_