### PR TITLE
feat: harden systemd unit and polish Linux voice experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,15 @@ sudo systemctl start nova
 ```
 
 For an optional hardened unit file with systemd sandbox restrictions
-(`NoNewPrivileges`, `ProtectSystem=strict`, capability drop, etc.), see
-[deploy/systemd/README.md](deploy/systemd/README.md). It is a drop-in
-replacement for the minimal unit above and does not change Nova's behavior.
+(`NoNewPrivileges`, `ProtectSystem=strict`, capability drop, syscall
+filter, etc.), see [deploy/systemd/README.md](deploy/systemd/README.md).
+It is a drop-in replacement for the minimal unit above and does not
+change Nova's behavior.
+
+For the broader deployment story — recommended local-only setups,
+VPN / Zero Trust gateways, least privilege, backups, and the explicit
+list of things Nova will never do (no firewall changes, no `sudo`, no
+cloud TTS, …) — see [docs/secure-deployment.md](docs/secure-deployment.md).
 
 ## Voice / read-aloud
 
@@ -164,11 +170,26 @@ the browser's built-in `speechSynthesis` API — zero install, fully
 local, and pleasant on most platforms (Apple Samantha, Microsoft Aria,
 Google Female, …).
 
+While Nova is reading, a small calm indicator with a soft cyan orb and
+waveform appears beside the message ("Nova is speaking" / "Lecture en
+cours") with an inline Stop control. The animation is lightweight CSS
+and respects `prefers-reduced-motion`; it disappears the moment
+playback stops, the user switches conversations, or they log out.
+
 On Fedora and other Linux desktops the platform voices sometimes fall
-back to a robotic engine. In that case Nova can drive a local
+back to a robotic engine. Nova detects that and surfaces a gentle
+hint under Settings → Voice recommending the optional local Piper
+path; it never auto-installs anything. The hint is informational only.
+
+In that case Nova can drive a local
 [Piper](https://github.com/rhasspy/piper) neural voice instead. Piper
 is opt-in, runs entirely on this host, and is never downloaded
 automatically.
+
+Settings → Voice also shows an **Active engine** chip next to the
+engine selector so the active TTS pipeline (Browser or Piper) is
+unambiguous, plus a **Test voice** button to compare voices
+side-by-side without leaving the panel.
 
 ### Optional: enable Piper
 
@@ -218,6 +239,8 @@ the read-aloud experience is never lost.
 
 - Piper runs offline. No audio bytes leave this host.
 - Nova never auto-installs a Piper binary or voice model.
+- Nova does not use any cloud TTS service — neither for the
+  "Read aloud" button nor for the Settings preview.
 - No telemetry, no microphone capture, no always-on listening — the
   read-aloud button is the only voice surface in Nova today.
 

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -73,7 +73,17 @@ this hardening to the container/VM host as well.
 | `RestrictSUIDSGID=true` | The unit cannot create files with the SUID/SGID bits or acquire them on exec. |
 | `ProtectKernelTunables=true` | `/proc/sys`, `/sys`, `/proc/sysrq-trigger` and similar kernel tunables become read-only or invisible. |
 | `ProtectKernelModules=true` | The unit cannot load or unload kernel modules. |
+| `ProtectKernelLogs=true` | Blocks access to the kernel log ring buffer (`dmesg` / `/dev/kmsg`). Nova never reads kernel messages. |
 | `ProtectControlGroups=true` | The cgroup hierarchy becomes read-only, so the unit cannot rewrite or escape its own resource limits. |
+| `PrivateDevices=true` | Hides raw block devices and most of `/dev`; Nova only needs the standard streams and pseudo-terminals. |
+| `RestrictNamespaces=true` | Blocks creation of user / mount / ipc / pid / net / uts / cgroup namespaces — a common building block for container-escape and self-sandboxing tricks. |
+| `RemoveIPC=true` | Drops SysV IPC objects (shared memory, semaphores, message queues) on stop. Nova has no IPC peers. |
+| `ProtectProc=invisible` + `ProcSubset=pid` | Hides other users' processes in `/proc` and exposes only PID directories. Stops Nova (or a spawned tool) from enumerating unrelated host processes. |
+| `ProtectClock=true` | Refuses syscalls that would set the system clock. |
+| `RestrictRealtime=true` | Blocks acquisition of realtime scheduling priorities — a frequent DoS vector. |
+| `ProtectHostname=true` | The hostname becomes read-only for the unit. |
+| `UMask=0077` | Files Nova writes (nova.db, backups, logs) are owner-only by default instead of world-readable. |
+| `SystemCallFilter=@system-service` (+ denylist) | Allow-list of syscalls Nova needs (`@system-service`), with `@debug @mount @swap @reboot @raw-io @cpu-emulation @obsolete` explicitly removed. Filtered syscalls return `EPERM` rather than killing the process. |
 
 For the authoritative reference, see
 [`systemd.exec(5)`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html).
@@ -116,6 +126,20 @@ better). Use it to confirm the directives above are picked up, and to spot
 anything you may want to tighten further on your specific host. A non-zero
 score is normal — it does not mean the unit is misconfigured.
 
+The unit shipped in this repo scores in the low single digits when
+analysed offline:
+
+```
+→ Overall exposure level for nova.service: 1.9 OK :-)
+```
+
+The remaining points are deliberate trade-offs — Nova needs IPv4/IPv6
+networking to reach Ollama, the weather API, and any optional
+read-only SilentGuard endpoint, so the families and `PrivateNetwork=`
+must stay open. If your host has no need for outbound traffic, you
+can add an egress allow-list with `IPAddressAllow=` / `IPAddressDeny=`
+on top of this unit.
+
 ## Troubleshooting
 
 - **`Read-only file system` on startup.** `nova.db` is being written
@@ -125,6 +149,16 @@ score is normal — it does not mean the unit is misconfigured.
   the Ollama service is up (`systemctl status ollama`). Network access
   itself is not blocked by this unit.
 - **Service fails immediately with no useful log.** Temporarily comment out
-  the `MemoryDenyWriteExecute=` and `SystemCallArchitectures=` lines and
-  restart; some Python extensions built with JIT or non-native wheels can
-  trip those. Re-enable one at a time once you've identified the culprit.
+  the `MemoryDenyWriteExecute=`, `SystemCallArchitectures=`, and
+  `SystemCallFilter=` lines and restart; some Python extensions built
+  with JIT or non-native wheels can trip those. Re-enable one at a time
+  once you've identified the culprit. The denylist
+  (`~@debug @mount @swap @reboot @raw-io @cpu-emulation @obsolete`)
+  rejects syscalls a userspace app should never reach for — if you need
+  a tool from one of those groups, audit the dependency before relaxing
+  the filter.
+- **Files written by Nova look unreadable from another account.** The
+  hardened unit ships with `UMask=0077`, so newly created files are
+  owner-only. That is intentional — `nova.db` contains conversation
+  history. If you actively need group-readable backups, override with
+  `UMask=0027` (group-readable) and document the choice.

--- a/deploy/systemd/nova.service
+++ b/deploy/systemd/nova.service
@@ -87,9 +87,62 @@ ProtectKernelTunables=true
 # Disallow loading or unloading kernel modules from this unit.
 ProtectKernelModules=true
 
+# Block read/write access to the kernel log ring buffer (`dmesg` /
+# `/dev/kmsg`). Nova never inspects kernel messages; the buffer can
+# leak fragments of other processes' activity to a misbehaving tool.
+ProtectKernelLogs=true
+
 # Make the cgroup hierarchy read-only, so the unit cannot escape or rewrite
 # its own resource limits.
 ProtectControlGroups=true
+
+# Hide /dev/kmsg, raw block devices and most of /dev. Nova never speaks
+# to a hardware device; only pseudo-terminals and the standard streams
+# remain available.
+PrivateDevices=true
+
+# Restrict the namespace API so the process cannot create new user,
+# mount, ipc, pid, net, uts or cgroup namespaces. Blocks a common
+# container-escape building block and stops misbehaving libraries from
+# sandboxing themselves in ways that hide activity from the host.
+RestrictNamespaces=true
+
+# Drop access to SysV IPC objects (shared memory, semaphores, message
+# queues) on stop. Nova has no IPC peers — leaving stale segments
+# around is a needless attack surface.
+RemoveIPC=true
+
+# Hide other users' processes in /proc and expose only generic
+# directories. The combination prevents Nova (or a tool it spawns)
+# from enumerating PIDs that belong to other users on the host.
+ProtectProc=invisible
+ProcSubset=pid
+
+# Prevent the unit from changing the system clock or scheduling
+# realtime priorities. Both are common targets for denial-of-service
+# style abuse and Nova never needs them.
+ProtectClock=true
+RestrictRealtime=true
+
+# Hostname is read-only for the unit. Some Linux libraries try to
+# rewrite it when probing locale; this lock keeps the host name stable.
+ProtectHostname=true
+
+# UMask 0077 ensures any file Nova writes (nova.db, backups, logs) is
+# owner-only by default. systemd's default UMask is 0022 which would
+# leave the SQLite database world-readable on a shared host.
+UMask=0077
+
+# Syscall allow-list. Anything outside the chosen groups is filtered by
+# the kernel before the process sees it. We start from the standard
+# "service" set (the safe baseline for a userspace HTTP app), keep the
+# few extras Python / uvicorn need, and reject anything the kernel does
+# not understand as a syscall in that group. ``~`` denylist entries
+# remove syscalls a misbehaving binary should never reach for: ptrace
+# debugging, swap, kernel reboot, raw clock writes.
+SystemCallFilter=@system-service
+SystemCallFilter=~@debug @mount @swap @reboot @raw-io @cpu-emulation @obsolete
+SystemCallErrorNumber=EPERM
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -1,0 +1,289 @@
+# Secure local deployment
+
+Nova is a **local-first** assistant. Its safest deployment is the one
+the rest of this repo already documents: one long-lived service, owned
+by an unprivileged user, reachable only over your trusted local
+network. This guide collects the boundaries that hold that promise
+together and the few extra knobs you should turn before running Nova
+on a host that is also reachable from elsewhere.
+
+Treat Nova as a **powerful local service**, not as a trusted
+root-level agent. Everything below is defence in depth on top of the
+application-level controls Nova already ships (per-user auth, JWT
+sessions, rate-limited login, scoped settings).
+
+## Threat model — what this guide does and does not cover
+
+In scope:
+
+- A misbehaving, compromised or malicious dependency running inside the
+  Nova process (Python, FastAPI, a model adapter, etc.).
+- An attacker who reaches the HTTP listener and looks for ways to pivot
+  beyond the Nova checkout — escape the user account, read files in
+  other users' home directories, load a kernel module, change firewall
+  rules, fiddle with the system clock.
+- A tool / plugin that Nova spawns and that itself misbehaves.
+
+Out of scope:
+
+- A determined attacker who already has code execution **as the
+  Nova user** with full read/write access to the checkout. The
+  hardening reduces blast radius, it does not erase it.
+- Patching Nova, Python, Ollama, Piper, your reverse proxy or your
+  kernel. Keep them up to date.
+- Authentication / authorization inside Nova. Those live in
+  `core/auth.py` and the admin surface — they are unrelated to the
+  systemd unit.
+
+If you need stronger isolation than this guide provides, run Nova in
+a container or VM and apply the same hardening to the
+container / VM host.
+
+## Recommended deployment shapes
+
+Pick the option closest to where Nova actually lives on your network.
+**Never expose Nova directly to the public Internet.**
+
+### Local-only (laptop, home server)
+
+This is the default. Nova binds to `0.0.0.0:8080`, but only your local
+machine — or the LAN it sits on — can reach it. No proxy is required.
+
+- Confirm the listener does **not** punch through your home router.
+  Most home routers do not port-forward by default; if yours does,
+  remove the rule.
+- Optional: change the bind address to `127.0.0.1` in the unit's
+  `ExecStart=` line to keep Nova loopback-only on a multi-user host:
+  ```ini
+  ExecStart=/path/to/Nova/.venv/bin/uvicorn web:app --host 127.0.0.1 --port 8080
+  ```
+
+### LAN-only
+
+If Nova should be reachable from other devices on your network (a
+tablet, a second laptop), keep the bind address on the LAN interface
+but stop there. Do not add a public DNS record.
+
+- Treat every device on the LAN as a user. Nova's per-user auth and
+  per-user settings already model that.
+- If your LAN includes guest devices, segregate them onto a guest
+  SSID / VLAN so they cannot reach the Nova port.
+
+### Remote access through a trusted gateway
+
+If you need to reach Nova from outside your LAN, place an
+authenticated gateway in front of it. Nova should still be **only**
+reachable through the gateway — never bind it directly to a public
+interface.
+
+Choose one:
+
+- **VPN.** WireGuard or Tailscale are simple, secure, and keep Nova
+  inside the same trust boundary as the rest of your home network.
+- **Cloudflare Access / Tailscale Funnel / similar Zero Trust
+  gateway.** The gateway terminates TLS and applies its own
+  identity / SSO check before forwarding requests to Nova on
+  `127.0.0.1:8080`.
+- **Reverse proxy on a hardened host (nginx, Caddy) with TLS and
+  client-certificate / SSO authentication enabled.** The proxy is the
+  only thing on a public IP; Nova listens on loopback or a private
+  interface.
+
+In every case:
+
+- Terminate TLS at the gateway, not in Nova. Uvicorn's TLS support is
+  fine but a hardened proxy is easier to keep patched.
+- Require authentication **at the gateway as well**, not only inside
+  Nova. Two layers of identity is the point.
+- Keep an allow-list of source IPs / identities on the gateway. Public
+  exposure with no allow-list is equivalent to "directly on the
+  Internet".
+
+## Systemd hardening
+
+The hardened example unit lives at
+[`deploy/systemd/nova.service`](../deploy/systemd/nova.service) and
+the [`deploy/systemd/README.md`](../deploy/systemd/README.md) explains
+each directive line by line. The unit shipped in this repo already
+enforces:
+
+- `NoNewPrivileges=true`, `CapabilityBoundingSet=` (empty),
+  `AmbientCapabilities=` (empty) — Nova cannot gain new privileges and
+  holds no Linux capabilities.
+- `ProtectSystem=strict` + `ProtectHome=read-only` +
+  `ReadWritePaths=/path/to/Nova` — the filesystem is read-only except
+  for Nova's checkout (where `nova.db` lives). Home directories are
+  read-only; other users' home directories are inaccessible.
+- `PrivateTmp=true` — a private `/tmp`, wiped on stop.
+- `PrivateDevices=true` — raw devices and most of `/dev` are hidden.
+- `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX` — only the
+  socket families Nova actually uses.
+- `RestrictNamespaces=true`, `RestrictRealtime=true`,
+  `RestrictSUIDSGID=true`, `LockPersonality=true`,
+  `MemoryDenyWriteExecute=true`,
+  `SystemCallArchitectures=native` — closes off namespace creation,
+  realtime priority abuse, setuid creation, ABI swaps, and W^X
+  bypasses.
+- `ProtectKernelTunables=true`, `ProtectKernelModules=true`,
+  `ProtectKernelLogs=true`, `ProtectControlGroups=true`,
+  `ProtectClock=true`, `ProtectHostname=true`,
+  `ProtectProc=invisible`, `ProcSubset=pid` — kernel surfaces,
+  dmesg, and `/proc` cross-user visibility are locked down.
+- `SystemCallFilter=@system-service` with a `~@debug @mount @swap
+  @reboot @raw-io @cpu-emulation @obsolete` denylist — a userspace
+  HTTP service does not need ptrace, mount, swap, reboot, raw I/O, or
+  CPU emulation syscalls.
+- `UMask=0077` — files Nova writes (including `nova.db` and its
+  backups) are owner-only.
+- `RemoveIPC=true` — SysV IPC objects are removed when the unit
+  stops.
+
+Verify the profile after installing:
+
+```bash
+systemd-analyze security nova.service
+```
+
+`systemd-analyze` prints a per-directive score and an overall exposure
+number (lower is better). A non-zero score is normal — it does not
+mean the unit is misconfigured.
+
+### What stays writable
+
+`ReadWritePaths=` is intentionally narrow:
+
+- The Nova checkout (so `nova.db`, `nova.db.backup`, and any data
+  Nova writes alongside the code continue to work).
+- Anything you explicitly add, such as a database directory outside
+  the checkout, or a log directory.
+
+If you keep `nova.db` somewhere else, **add only that directory** to
+`ReadWritePaths=`. Avoid giving Nova write access to the whole home
+directory.
+
+### What stays reachable
+
+- **Ollama.** Nova talks to Ollama over HTTP through `OLLAMA_HOST`.
+  `AF_INET` is allowed; if Ollama runs on the same host you can keep
+  it on `127.0.0.1` and rely on the loopback path.
+- **SilentGuard read-only API.** When configured (see
+  [`docs/silentguard-background-service.md`](silentguard-background-service.md)),
+  Nova GETs a fixed read-only path list on `127.0.0.1`. Read-only is
+  the contract — the systemd unit does not need any extra grants
+  beyond `AF_INET`.
+- **Piper / local TTS.** Synthesis runs as a subprocess of Nova, in
+  the same systemd unit. No network is involved.
+- **Outbound calls.** DuckDuckGo search, Open-Meteo weather, the
+  GitHub OAuth flow on the alpha channel, and the RSS learner all use
+  `AF_INET` / `AF_INET6` like any other outbound HTTPS request.
+
+If you want to harden further on a host with no need for outbound
+traffic, you can add an egress allow-list with `IPAddressAllow=` /
+`IPAddressDeny=`. Start permissive and tighten — a too-aggressive
+allow-list will silently break the weather tool, the web search and
+the GitHub OAuth gate.
+
+## Least privilege
+
+Hard rules:
+
+- **Never run Nova as `root`.** The unit ships with `User=` /
+  `Group=` so the process belongs to an unprivileged local account.
+- **Do not give the Nova user `sudo` rights.** No part of Nova calls
+  `sudo`, `pkexec`, `doas`, `su`, or `runuser`, and no part of Nova
+  ever should.
+- **Do not give the Nova user write access to `/etc`, system unit
+  files, or `/usr`.** `ProtectSystem=strict` already enforces this at
+  the kernel level; leave the filesystem permissions matching.
+- **Do not let Nova execute model-generated shell commands.** Nova
+  reads context from narrow local APIs (SilentGuard's read-only
+  endpoint, Piper as a subprocess with a fixed argv, the LLM via
+  Ollama). Anything that would let model output reach `subprocess`
+  is a regression.
+
+A useful exercise on a fresh host:
+
+```bash
+sudo -u nova sudo -l   # should print "Sorry, user nova may not run sudo"
+```
+
+## Secret material
+
+- The `.env` file is the only place secrets live. Keep it
+  mode `0600` and owned by the Nova user. The hardened unit's
+  `ProtectHome=read-only` keeps anything outside `ReadWritePaths=`
+  read-only from inside Nova; combine that with normal POSIX
+  permissions so other local accounts cannot read the file.
+- Rotate `NOVA_SECRET_KEY` if it ever lands in a backup that leaves
+  the host.
+- `GITHUB_CLIENT_SECRET` only matters when `NOVA_CHANNEL=alpha`. If
+  you do not use the alpha channel, leave it empty — the OAuth gate
+  is wired so a missing secret returns `503` rather than silently
+  permitting open access.
+
+## Backups
+
+- `nova.db` and `nova.db.backup` live in the Nova checkout. Back the
+  whole directory up — there are no out-of-band state files.
+- Treat backups as **sensitive**: they contain conversation history,
+  per-user settings, and (if you enabled the natural memory layer)
+  user-authored memories. Encrypt at rest.
+- Test the restore path before you need it. The simplest restore is
+  `sudo systemctl stop nova && cp nova.db.backup nova.db && sudo
+  systemctl start nova`.
+
+## Audit and logs
+
+- `journalctl -u nova` is the canonical log surface for the systemd
+  unit. Rotate the system journal per your distribution's
+  defaults — the hardened unit does not write a separate log file.
+- Nova logs at INFO level by default. Avoid raising verbosity in
+  production — DEBUG can include parsed memory blocks.
+- The SilentGuard provider is intentionally **read-only** and never
+  emits "Nova blocked X" / "Nova unblocked X" log lines, because Nova
+  is not the enforcement layer. If you see such a line, treat it as
+  a regression and file an issue.
+
+## What Nova will NOT do
+
+These are firm boundaries, not future work:
+
+- Nova does not change firewall rules. Ever.
+- Nova does not call `sudo`, `pkexec`, `doas`, `su`, or `runuser`.
+- Nova does not execute model-generated shell commands.
+- Nova does not run anything as root.
+- Nova does not auto-download Piper, voice models, or any other
+  binary.
+- Nova does not block / unblock IPs or hostnames. SilentGuard owns
+  enforcement.
+- Nova does not send audio, prompts, or conversation history to a
+  third-party cloud service.
+
+If a future feature would cross any of these lines, it is the wrong
+feature for Nova.
+
+## Emergency stop (future work)
+
+There is no dedicated "panic button" yet. Today the supported way to
+take Nova fully offline on a host is:
+
+```bash
+sudo systemctl stop nova
+```
+
+A future "safe mode" might disable optional integrations and pause
+background work without killing the HTTP listener, so an
+administrator can keep talking to Nova while the rest of the system
+is being investigated. That work is tracked alongside the broader
+SilentGuard integration roadmap; nothing in this guide depends on it.
+
+## Further reading
+
+- [`deploy/systemd/README.md`](../deploy/systemd/README.md) — the
+  per-directive walkthrough for the hardened unit.
+- [`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md)
+  — the architectural rationale for keeping enforcement out of Nova.
+- [`docs/silentguard-background-service.md`](silentguard-background-service.md)
+  — running SilentGuard's loopback API as a user service.
+- `systemd-analyze security nova.service` — your single best source of
+  truth after a unit edit.

--- a/static/index.html
+++ b/static/index.html
@@ -1338,6 +1338,160 @@
 
         .msg-action-status.is-positive { color: var(--cyan); }
 
+        /* ── "Nova is speaking" indicator ──
+           Sits inside the assistant message row, just below the bubble and
+           above the action row, only while audio is playing. Designed to
+           whisper: a soft cyan orb that breathes, three slim waveform bars
+           that drift, a calm label, and an inline stop button. Lives
+           entirely in CSS — no animation library, no canvas.
+
+           Lifecycle is owned by `speakingIndicator.show()` /
+           `speakingIndicator.hide()` in the script section; the indicator
+           is created on demand and removed when playback ends. */
+        .speaking-indicator {
+            display: none;
+            align-items: center;
+            gap: 10px;
+            padding: 6px 12px 6px 10px;
+            margin: 8px 0 0;
+            width: fit-content;
+            max-width: 75%;
+            background: var(--cyan-soft);
+            border: 1px solid var(--cyan-glow);
+            border-radius: var(--r-pill);
+            color: var(--cyan);
+            font-size: 0.75rem;
+            letter-spacing: 0.02em;
+            opacity: 0;
+            transform: translateY(-2px);
+            transition:
+                opacity var(--t-base),
+                transform var(--t-base);
+        }
+        .speaking-indicator.is-visible {
+            display: inline-flex;
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .speaking-visual {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            position: relative;
+        }
+
+        /* The orb: a small filled circle that pulses with a soft glow. The
+           outer halo is a second pseudo-element that breathes out of phase
+           so the motion never feels mechanical. */
+        .speaking-orb {
+            position: relative;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: var(--cyan);
+            box-shadow: 0 0 8px var(--cyan-glow);
+            animation: speakingOrbBreath 2.4s var(--ease) infinite;
+        }
+        .speaking-orb::after {
+            content: '';
+            position: absolute;
+            inset: -5px;
+            border-radius: 50%;
+            border: 1px solid var(--cyan-glow);
+            opacity: 0.55;
+            animation: speakingOrbHalo 2.4s var(--ease) infinite;
+        }
+
+        @keyframes speakingOrbBreath {
+            0%, 100% { transform: scale(1); opacity: 1; }
+            50%      { transform: scale(1.12); opacity: 0.85; }
+        }
+        @keyframes speakingOrbHalo {
+            0%       { transform: scale(0.85); opacity: 0.6; }
+            70%      { transform: scale(1.55); opacity: 0; }
+            100%     { transform: scale(1.55); opacity: 0; }
+        }
+
+        /* Three slim vertical bars rising / falling out of phase. Pure
+           CSS keyframes — lightweight, GPU-friendly. */
+        .speaking-wave {
+            display: inline-flex;
+            align-items: flex-end;
+            gap: 2px;
+            height: 14px;
+        }
+        .speaking-wave span {
+            display: inline-block;
+            width: 2px;
+            background: var(--cyan);
+            border-radius: 1px;
+            opacity: 0.85;
+            animation: speakingWave 1.1s var(--ease) infinite;
+        }
+        .speaking-wave span:nth-child(1) { height: 6px;  animation-delay: 0.00s; }
+        .speaking-wave span:nth-child(2) { height: 10px; animation-delay: 0.18s; }
+        .speaking-wave span:nth-child(3) { height: 6px;  animation-delay: 0.36s; }
+
+        @keyframes speakingWave {
+            0%, 100% { transform: scaleY(0.45); }
+            50%      { transform: scaleY(1.00); }
+        }
+
+        .speaking-label {
+            white-space: nowrap;
+            color: var(--cyan);
+        }
+
+        /* Stop button is a small icon-only chip — same visual language as
+           the action row, just inside the indicator so users do not need
+           to hunt for the speaker button to silence Nova. */
+        .speaking-stop {
+            appearance: none;
+            -webkit-appearance: none;
+            background: transparent;
+            border: 1px solid transparent;
+            border-radius: var(--r-pill);
+            color: var(--cyan);
+            cursor: pointer;
+            padding: 0;
+            width: 22px;
+            height: 22px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition:
+                color var(--t-base),
+                background var(--t-base),
+                border-color var(--t-base),
+                transform var(--t-fast);
+        }
+        .speaking-stop svg { width: 12px; height: 12px; stroke: currentColor; }
+        .speaking-stop:hover {
+            background: var(--cyan-glow);
+            border-color: var(--cyan-glow);
+            color: var(--text);
+        }
+        .speaking-stop:focus { outline: none; }
+        .speaking-stop:focus-visible {
+            color: var(--text);
+            box-shadow: 0 0 0 2px var(--cyan-glow);
+        }
+        .speaking-stop:active { transform: scale(0.92); }
+
+        /* Respect reduced-motion: keep the visual presence (so users know
+           Nova is speaking) but freeze the animation loops. */
+        @media (prefers-reduced-motion: reduce) {
+            .speaking-orb,
+            .speaking-orb::after,
+            .speaking-wave span {
+                animation: none;
+            }
+            .speaking-indicator {
+                transition: opacity var(--t-base);
+            }
+        }
+
         /* ── SETTINGS PANEL ── */
         #settings-overlay {
             display: none;
@@ -1584,6 +1738,73 @@
         }
         .voice-status.is-visible { opacity: 1; }
         .voice-status.is-warn { color: var(--text-mid); }
+
+        /* Title row that lets the active-engine chip sit beside the
+           "Voice engine" label without entering its text node — which
+           lets _setText() keep updating the title on a language flip. */
+        .settings-row-title-row {
+            display: inline-flex;
+            align-items: center;
+            gap: 0;
+            flex-wrap: wrap;
+        }
+
+        /* "Active engine" chip in Settings → Voice. Compact, read-only,
+           explains which TTS pipeline the next read-aloud will actually
+           use. Distinct from the engine select (the user's preference)
+           because Piper can be selected but unavailable on this host. */
+        .voice-active-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.72rem;
+            color: var(--text-dim);
+            padding: 2px 10px;
+            border: 1px solid var(--border);
+            border-radius: var(--r-pill);
+            background: var(--bg-elev);
+            margin-left: 6px;
+            letter-spacing: 0.02em;
+        }
+        .voice-active-chip[data-engine="piper"] {
+            color: var(--cyan);
+            border-color: var(--cyan-glow);
+            background: var(--cyan-soft);
+        }
+        .voice-active-chip[data-engine="unavailable"] { color: var(--text-mid); }
+        .voice-active-chip-dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: currentColor;
+            opacity: 0.75;
+        }
+
+        /* Gentle hint surfaced in Settings → Voice when the host is on
+           Linux, Piper is not configured, and the installed browser voices
+           look like the robotic eSpeak/Speech Dispatcher fallback. The
+           hint is informational only — Nova never auto-installs anything. */
+        .voice-linux-hint {
+            display: none;
+            margin-top: 12px;
+            padding: 10px 12px;
+            font-size: 0.78rem;
+            line-height: 1.45;
+            color: var(--text-mid);
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            border-radius: var(--r-md);
+        }
+        .voice-linux-hint.is-visible { display: block; }
+        .voice-linux-hint strong { color: var(--text); font-weight: 500; }
+        .voice-linux-hint code {
+            font-family: var(--font-mono);
+            font-size: 0.72rem;
+            color: var(--text);
+            background: rgba(255, 255, 255, 0.04);
+            padding: 1px 5px;
+            border-radius: 4px;
+        }
 
         /* SilentGuard status card — calm, read-only.
            Colour shifts with state but never alarms. */
@@ -2675,7 +2896,13 @@
                     <div class="settings-row" id="voice-engine-row" style="display:none;">
                         <div class="settings-row-head">
                             <div class="settings-row-label">
-                                <span class="settings-row-title" id="voice-engine-title">Voice engine</span>
+                                <span class="settings-row-title-row">
+                                    <span class="settings-row-title" id="voice-engine-title">Voice engine</span>
+                                    <span class="voice-active-chip" id="voice-active-chip" data-engine="browser" aria-live="polite">
+                                        <span class="voice-active-chip-dot" aria-hidden="true"></span>
+                                        <span id="voice-active-chip-label">Browser</span>
+                                    </span>
+                                </span>
                                 <span class="settings-row-hint" id="voice-engine-hint">Browser is the safe default. Piper renders locally on this host for a calmer neural voice.</span>
                             </div>
                         </div>
@@ -2701,6 +2928,13 @@
                             </button>
                             <span class="voice-status" id="voice-status" aria-live="polite"></span>
                         </div>
+                    </div>
+
+                    <!-- Linux hint: shown only when running on Linux with Piper
+                         unavailable and only robotic-sounding browser voices
+                         installed. Informational; Nova never auto-installs. -->
+                    <div class="voice-linux-hint" id="voice-linux-hint" role="note">
+                        <span id="voice-linux-hint-text"></span>
                     </div>
                 </section>
 
@@ -2922,6 +3156,12 @@
             voice_engine_piper_unavailable: "Piper n'est pas configuré sur cet hôte.",
             voice_engine_piper_active: "Piper est prêt — la voix est rendue localement.",
             voice_engine_fallback: "Piper a échoué — Nova est revenue à la voix du navigateur.",
+            voice_active_browser: "Navigateur",
+            voice_active_piper: "Piper",
+            voice_active_unavailable: "Indisponible",
+            voice_linux_hint: "Sur Linux, les voix du navigateur peuvent sonner robotiques. Pour une voix neuronale plus calme rendue localement, installe Piper et un modèle de voix doux (voir README → « Voice »). Aucun téléchargement automatique, aucun service cloud.",
+            speaking_label: "Lecture en cours",
+            speaking_stop: "Arrêter la lecture",
             novamodel_title: "Utiliser le modèle Nova",
             novamodel_hint: "Remplace tout le routage par un seul modèle.",
             novamodel_help: "Nom du modèle Ollama (ex. nova-assistant, llama3:8b)",
@@ -3084,6 +3324,12 @@
             voice_engine_piper_unavailable: "Piper isn't configured on this host.",
             voice_engine_piper_active: "Piper is ready — voice is rendered locally.",
             voice_engine_fallback: "Piper failed — Nova fell back to the browser voice.",
+            voice_active_browser: "Browser",
+            voice_active_piper: "Piper",
+            voice_active_unavailable: "Unavailable",
+            voice_linux_hint: "On Linux, browser voices may sound robotic. For a calmer neural voice rendered locally, install Piper and a soft voice model (see README → \"Voice\"). No automatic downloads, no cloud service.",
+            speaking_label: "Nova is speaking",
+            speaking_stop: "Stop reading",
             novamodel_title: "Use Nova model",
             novamodel_hint: "Override all routing with a single model.",
             novamodel_help: "Ollama model name (e.g. nova-assistant, llama3:8b)",
@@ -3241,6 +3487,11 @@
         _setText("voice-select-hint", t("voice_select_hint"));
         _setText("voice-engine-title", t("voice_engine_title"));
         _setText("voice-engine-hint", t("voice_engine_hint"));
+        if (typeof updateActiveEngineChip === "function") updateActiveEngineChip();
+        if (typeof updateLinuxVoiceHint === "function") updateLinuxVoiceHint();
+        // The "Nova is speaking" indicator caches its label at mount,
+        // so a mid-flight language flip needs an explicit refresh.
+        if (typeof speakingIndicator !== "undefined") speakingIndicator._updateLabel();
         // The voice catalog labels its option groups via the language map.
         // If Settings is open we re-render the dropdown so optgroup labels
         // flip immediately; otherwise the next openSettings() handles it.
@@ -4168,7 +4419,151 @@
         btn.setAttribute("aria-label", label);
         btn.setAttribute("title", label);
         btn.setAttribute("aria-pressed", playing ? "true" : "false");
+
+        // Keep the calm "Nova is speaking" visual in lockstep with the
+        // speaker button. Doing it here means every entry / exit path —
+        // toggle, conversation switch, logout, error — flows through
+        // the same single source of truth.
+        if (playing) {
+            speakingIndicator.show(btn);
+        } else {
+            speakingIndicator.hide(btn);
+        }
     }
+
+    // Polished "Nova is speaking" indicator. Mounts inside the assistant
+    // message row that owns the active speaker button, breathes a small
+    // cyan orb and waveform, and offers a redundant Stop affordance so
+    // the user does not have to find the speaker button again. Lifecycle
+    // is fully driven by `setSpeakButtonState`; this controller is a
+    // view layer, not a state owner.
+    const SPEAKING_INDICATOR_SVG_STOP =
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="6.5" y="6.5" width="11" height="11" rx="2"/></svg>';
+
+    const speakingIndicator = {
+        // Currently mounted element, when any. The single-instance shape
+        // mirrors the rest of the voice controller: only one message
+        // reads aloud at a time, so only one indicator is on screen.
+        el: null,
+        // The speaker button whose row owns the current indicator. We
+        // remember it so `.hide()` only tears down when called for the
+        // owning button, never for a stale call from a different one.
+        ownerBtn: null,
+
+        show(btn) {
+            if (!btn) return;
+            const row = btn.closest(".message-row.nova")
+                || btn.closest(".message-row");
+            if (!row) return;
+            // Replacing a stale indicator from a previous message keeps
+            // the visual in the right row when the user toggles between
+            // messages quickly.
+            if (this.el && this.ownerBtn !== btn) this.hide(this.ownerBtn);
+            if (this.el) {
+                // Same owner — make sure the visual is current.
+                this.el.classList.add("is-visible");
+                this._updateLabel();
+                return;
+            }
+
+            const el = document.createElement("div");
+            el.className = "speaking-indicator";
+            el.setAttribute("role", "status");
+            el.setAttribute("aria-live", "polite");
+
+            const visual = document.createElement("span");
+            visual.className = "speaking-visual";
+            visual.setAttribute("aria-hidden", "true");
+
+            const orb = document.createElement("span");
+            orb.className = "speaking-orb";
+            visual.appendChild(orb);
+
+            const wave = document.createElement("span");
+            wave.className = "speaking-wave";
+            wave.appendChild(document.createElement("span"));
+            wave.appendChild(document.createElement("span"));
+            wave.appendChild(document.createElement("span"));
+            visual.appendChild(wave);
+
+            const label = document.createElement("span");
+            label.className = "speaking-label";
+            label.textContent = (typeof t === "function" ? t("speaking_label") : "Nova is speaking");
+
+            const stopLabel = (typeof t === "function" ? t("speaking_stop") : "Stop reading");
+            const stop = document.createElement("button");
+            stop.type = "button";
+            stop.className = "speaking-stop";
+            stop.setAttribute("aria-label", stopLabel);
+            stop.setAttribute("title", stopLabel);
+            stop.innerHTML = SPEAKING_INDICATOR_SVG_STOP;
+            // The stop button delegates to the same global cancel path
+            // used by the speaker button, the logout flow, etc. Doing it
+            // through stopVoicePlayback() guarantees the indicator is
+            // torn down too — the chain comes back through setSpeak‐
+            // ButtonState(..., false) → speakingIndicator.hide().
+            stop.onclick = (e) => {
+                e.stopPropagation();
+                stopVoicePlayback();
+            };
+
+            el.appendChild(visual);
+            el.appendChild(label);
+            el.appendChild(stop);
+
+            // Insert above the action row so the indicator visually
+            // follows the bubble and precedes the actions. If the row
+            // does not have an action row yet (rare), append to end.
+            const actions = row.querySelector(".message-actions");
+            if (actions) {
+                row.insertBefore(el, actions);
+            } else {
+                row.appendChild(el);
+            }
+
+            // Force a reflow so the .is-visible transition runs from
+            // the initial opacity-0 state on the very first mount.
+            // eslint-disable-next-line no-unused-expressions
+            el.offsetHeight;
+            el.classList.add("is-visible");
+
+            this.el = el;
+            this.ownerBtn = btn;
+        },
+
+        hide(btn) {
+            // Ignore stale hide calls for a different button so the
+            // indicator does not flicker when stopVoicePlayback() runs
+            // its multi-pass cleanup.
+            if (!this.el) return;
+            if (btn && this.ownerBtn && btn !== this.ownerBtn) return;
+            const el = this.el;
+            this.el = null;
+            this.ownerBtn = null;
+            el.classList.remove("is-visible");
+            // Allow the fade-out transition to complete before removing
+            // the node so a quick stop / restart sequence does not flash.
+            setTimeout(() => {
+                if (el && el.parentNode) {
+                    try { el.parentNode.removeChild(el); } catch {}
+                }
+            }, 220);
+        },
+
+        _updateLabel() {
+            if (!this.el) return;
+            const labelEl = this.el.querySelector(".speaking-label");
+            if (labelEl && typeof t === "function") {
+                labelEl.textContent = t("speaking_label");
+            }
+            const stopBtn = this.el.querySelector(".speaking-stop");
+            if (stopBtn && typeof t === "function") {
+                const stopLabel = t("speaking_stop");
+                stopBtn.setAttribute("aria-label", stopLabel);
+                stopBtn.setAttribute("title", stopLabel);
+            }
+        },
+    };
 
     function stopVoicePlayback() {
         // Browser engine — cancel any speechSynthesis utterance.
@@ -4632,6 +5027,10 @@
             if (getSelectedEngine() === VOICE_ENGINE_PIPER) {
                 setSelectedEngine(VOICE_ENGINE_BROWSER);
             }
+            // The hint is the only voice-engine surface left when the
+            // host offers nothing but the browser engine; refresh it
+            // before bailing so the Linux fallback path still helps.
+            updateLinuxVoiceHint();
             return;
         }
         row.style.display = "";
@@ -4668,6 +5067,73 @@
             status.textContent = "";
             status.classList.remove("is-visible", "is-warn");
         }
+        updateActiveEngineChip();
+        updateLinuxVoiceHint();
+    }
+
+    // Updates the small "active engine" chip next to the Voice engine
+    // label. Reports the engine that will actually be used for the next
+    // read-aloud — distinct from the user's stored preference, which
+    // can point at an engine that is no longer available on this host.
+    function updateActiveEngineChip() {
+        const chip = document.getElementById("voice-active-chip");
+        const label = document.getElementById("voice-active-chip-label");
+        if (!chip || !label) return;
+        const config = voice.config || {};
+        const engine = effectiveEngine(config);
+        if (engine === VOICE_ENGINE_PIPER) {
+            chip.dataset.engine = "piper";
+            label.textContent = t("voice_active_piper");
+        } else if (!voiceSupported()) {
+            chip.dataset.engine = "unavailable";
+            label.textContent = t("voice_active_unavailable");
+        } else {
+            chip.dataset.engine = "browser";
+            label.textContent = t("voice_active_browser");
+        }
+    }
+
+    // Heuristic: are we on Linux with only the robotic eSpeak / Speech
+    // Dispatcher voices installed? When that is true we show a calm
+    // hint pointing at Piper. Anything ambiguous (no voices yet, a
+    // neural voice present, non-Linux platform) keeps the hint hidden.
+    function shouldShowLinuxVoiceHint() {
+        if (!voiceSupported()) return false;
+        const ua = (navigator.userAgent || "").toLowerCase();
+        const platform = (navigator.platform || "").toLowerCase();
+        const isLinux = (platform.indexOf("linux") !== -1
+            || ua.indexOf("linux") !== -1)
+            && ua.indexOf("android") === -1;
+        if (!isLinux) return false;
+        // Piper available host-side → the user already has a better
+        // option in the engine select; no hint needed.
+        const config = voice.config || {};
+        if (piperAvailable(config)) return false;
+        const voices = window.speechSynthesis.getVoices() || [];
+        if (!voices.length) return false;
+        // "Looks robotic" → only eSpeak / Speech Dispatcher / generic
+        // entries are installed. Anything that looks like a neural
+        // voice (Microsoft Online (Natural), Google, Apple Samantha,
+        // etc.) suppresses the hint. We're deliberately conservative —
+        // the hint stays hidden when in doubt.
+        const neuralMarkers = [
+            "natural", "online", "google", "samantha", "ava", "allison",
+            "karen", "moira", "aria", "jenny", "sonia", "hazel", "denise",
+            "audrey", "amelie",
+        ];
+        const hasNeural = voices.some(v => {
+            const name = (v.name || "").toLowerCase();
+            return neuralMarkers.some(marker => name.indexOf(marker) !== -1);
+        });
+        return !hasNeural;
+    }
+
+    function updateLinuxVoiceHint() {
+        const hint = document.getElementById("voice-linux-hint");
+        const text = document.getElementById("voice-linux-hint-text");
+        if (!hint || !text) return;
+        text.textContent = t("voice_linux_hint");
+        hint.classList.toggle("is-visible", shouldShowLinuxVoiceHint());
     }
 
     function onVoiceEngineChange(value) {
@@ -4848,6 +5314,11 @@
             window.speechSynthesis.addEventListener?.("voiceschanged", () => {
                 if (document.getElementById("voice-select")) {
                     renderVoiceSelect();
+                }
+                // The Linux hint depends on the installed voice list,
+                // which can populate asynchronously on first load.
+                if (document.getElementById("voice-linux-hint")) {
+                    updateLinuxVoiceHint();
                 }
             });
         } catch {}

--- a/tests/test_systemd_unit.py
+++ b/tests/test_systemd_unit.py
@@ -15,7 +15,6 @@ brackets, ``#`` comments), so we parse it inline.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/test_systemd_unit.py
+++ b/tests/test_systemd_unit.py
@@ -1,0 +1,279 @@
+"""
+Tests for the hardened systemd unit shipped at ``deploy/systemd/nova.service``.
+
+The unit file is text, not Python, but the safety story relies on a
+specific set of directives staying present. A regression here — a
+silent edit that drops ``NoNewPrivileges`` or relaxes the syscall
+filter — would not show up in any application test, so this file
+parses the unit and asserts the hardening contract.
+
+We do not run ``systemd-analyze``; that requires systemd on the host
+and would fail on macOS / minimal CI workers. The format the unit
+file uses is simple (``Key=Value`` lines, section headers in
+brackets, ``#`` comments), so we parse it inline.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+# Two units ship in this directory: the system-level Nova service and
+# the optional user-level SilentGuard read-only API. Both are covered.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOVA_UNIT = REPO_ROOT / "deploy" / "systemd" / "nova.service"
+SILENTGUARD_UNIT = REPO_ROOT / "deploy" / "systemd" / "silentguard-api.service"
+
+
+def _parse_unit(path: Path) -> dict[str, list[str]]:
+    """Return a ``{key: [values...]}`` map of unit-file directives.
+
+    Many systemd directives are *additive* — declaring the same key
+    twice does not overwrite, it appends (e.g. ``SystemCallFilter``
+    allow-list + denylist on two separate lines). We therefore preserve
+    every occurrence in declaration order so a test can assert that
+    both the allow group and the denylist are present.
+    """
+    out: dict[str, list[str]] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("["):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        out.setdefault(key.strip(), []).append(value.strip())
+    return out
+
+
+@pytest.fixture(scope="module")
+def nova_unit() -> dict[str, list[str]]:
+    assert NOVA_UNIT.is_file(), f"missing unit file: {NOVA_UNIT}"
+    return _parse_unit(NOVA_UNIT)
+
+
+@pytest.fixture(scope="module")
+def silentguard_unit() -> dict[str, list[str]]:
+    assert SILENTGUARD_UNIT.is_file(), f"missing unit file: {SILENTGUARD_UNIT}"
+    return _parse_unit(SILENTGUARD_UNIT)
+
+
+# ── nova.service — system-level hardening ──────────────────────────
+
+
+class TestNovaServiceHardening:
+    """Each test pins one of the hardening directives.
+
+    The directive set mirrors the documented contract in
+    ``deploy/systemd/README.md`` and ``docs/secure-deployment.md``.
+    Adding a new directive is fine; removing one needs a deliberate
+    edit here and a justification in the PR.
+    """
+
+    def test_no_new_privileges(self, nova_unit):
+        assert nova_unit.get("NoNewPrivileges") == ["true"]
+
+    def test_private_tmp(self, nova_unit):
+        assert nova_unit.get("PrivateTmp") == ["true"]
+
+    def test_protect_system_strict(self, nova_unit):
+        assert nova_unit.get("ProtectSystem") == ["strict"]
+
+    def test_protect_home_read_only(self, nova_unit):
+        # Nova reads its checkout but should not write into anyone's
+        # home outside ReadWritePaths=.
+        assert nova_unit.get("ProtectHome") == ["read-only"]
+
+    def test_capabilities_dropped(self, nova_unit):
+        # Empty strings — both must be present so systemd actively
+        # drops capabilities instead of inheriting defaults.
+        assert nova_unit.get("CapabilityBoundingSet") == [""]
+        assert nova_unit.get("AmbientCapabilities") == [""]
+
+    def test_restrict_address_families_lan_only(self, nova_unit):
+        families = nova_unit.get("RestrictAddressFamilies", [])
+        assert len(families) == 1
+        chosen = families[0].split()
+        # Nova needs IPv4, IPv6 (for outbound HTTPS) and AF_UNIX (Python
+        # internals). Anything else — raw sockets, netlink, packet —
+        # should remain blocked.
+        assert set(chosen) == {"AF_INET", "AF_INET6", "AF_UNIX"}
+
+    def test_lock_personality(self, nova_unit):
+        assert nova_unit.get("LockPersonality") == ["true"]
+
+    def test_memory_deny_write_execute(self, nova_unit):
+        assert nova_unit.get("MemoryDenyWriteExecute") == ["true"]
+
+    def test_system_call_architectures_native(self, nova_unit):
+        assert nova_unit.get("SystemCallArchitectures") == ["native"]
+
+    def test_restrict_suid_sgid(self, nova_unit):
+        assert nova_unit.get("RestrictSUIDSGID") == ["true"]
+
+    def test_protect_kernel_tunables(self, nova_unit):
+        assert nova_unit.get("ProtectKernelTunables") == ["true"]
+
+    def test_protect_kernel_modules(self, nova_unit):
+        assert nova_unit.get("ProtectKernelModules") == ["true"]
+
+    def test_protect_kernel_logs(self, nova_unit):
+        # Locks dmesg / /dev/kmsg — Nova never reads kernel messages.
+        assert nova_unit.get("ProtectKernelLogs") == ["true"]
+
+    def test_protect_control_groups(self, nova_unit):
+        assert nova_unit.get("ProtectControlGroups") == ["true"]
+
+    # ── New directives added by the hardening PR ────────────────────
+
+    def test_private_devices(self, nova_unit):
+        assert nova_unit.get("PrivateDevices") == ["true"]
+
+    def test_restrict_namespaces(self, nova_unit):
+        assert nova_unit.get("RestrictNamespaces") == ["true"]
+
+    def test_remove_ipc(self, nova_unit):
+        assert nova_unit.get("RemoveIPC") == ["true"]
+
+    def test_protect_proc_invisible(self, nova_unit):
+        assert nova_unit.get("ProtectProc") == ["invisible"]
+
+    def test_proc_subset_pid(self, nova_unit):
+        assert nova_unit.get("ProcSubset") == ["pid"]
+
+    def test_protect_clock(self, nova_unit):
+        assert nova_unit.get("ProtectClock") == ["true"]
+
+    def test_restrict_realtime(self, nova_unit):
+        assert nova_unit.get("RestrictRealtime") == ["true"]
+
+    def test_protect_hostname(self, nova_unit):
+        assert nova_unit.get("ProtectHostname") == ["true"]
+
+    def test_umask_owner_only(self, nova_unit):
+        # 0077 — group and world bits stripped so nova.db and its
+        # backups are owner-readable only.
+        assert nova_unit.get("UMask") == ["0077"]
+
+    def test_system_call_filter_allows_baseline_and_denies_risk_groups(
+        self, nova_unit,
+    ):
+        filters = nova_unit.get("SystemCallFilter", [])
+        # Expect at least one allow line and one denylist line.
+        assert filters, "SystemCallFilter must be configured"
+        joined = " ".join(filters)
+        # Baseline allow group.
+        assert "@system-service" in joined
+        # Each denylist marker we care about.
+        for forbidden in (
+            "@debug",
+            "@mount",
+            "@swap",
+            "@reboot",
+            "@raw-io",
+            "@cpu-emulation",
+            "@obsolete",
+        ):
+            assert forbidden in joined, (
+                f"SystemCallFilter must deny {forbidden!r}; "
+                f"current value: {filters!r}"
+            )
+        # The denylist must use the '~' inversion prefix on at least
+        # one of the filter lines — otherwise the entries would expand
+        # the allow-list instead of restricting it.
+        assert any(entry.startswith("~") for entry in filters), (
+            "Expected at least one SystemCallFilter= line to start with "
+            "'~' so it acts as a denylist on top of the allow set."
+        )
+
+    def test_system_call_error_number_is_eperm(self, nova_unit):
+        # Returning EPERM keeps a filtered syscall an application
+        # error rather than killing the process — the read-aloud
+        # flow stays alive even if a dependency tries something weird.
+        assert nova_unit.get("SystemCallErrorNumber") == ["EPERM"]
+
+    def test_runs_as_unprivileged_user(self, nova_unit):
+        user = (nova_unit.get("User") or [None])[0]
+        group = (nova_unit.get("Group") or [None])[0]
+        assert user, "User= must be set"
+        assert group, "Group= must be set"
+        # The example unit ships with the literal placeholder
+        # USERNAME — anything else (e.g. someone copied the unit
+        # without editing) is also acceptable, but root is not.
+        assert user.lower() != "root"
+        assert group.lower() != "root"
+
+    def test_does_not_grant_privilege_escalation(self, nova_unit):
+        # A handful of directives that, if ever flipped on, would
+        # silently break the safety contract. The test states the
+        # contract: each one MUST stay absent or false.
+        forbidden_keys = (
+            "PermissionsStartOnly",
+            "SupplementaryGroups",
+        )
+        for key in forbidden_keys:
+            # Either absent entirely, or explicitly empty.
+            values = nova_unit.get(key, [])
+            assert not values or all(v == "" for v in values), (
+                f"Directive {key} should not be set in the hardened unit"
+            )
+
+    def test_no_shell_in_exec_start(self, nova_unit):
+        # ExecStart= must be a plain argv (no shell pipeline), so
+        # there's no shell to coerce. systemd does not interpret a
+        # shell unless `/bin/sh -c` is explicit.
+        exec_start = nova_unit.get("ExecStart", [])
+        assert exec_start, "ExecStart= must be set"
+        for line in exec_start:
+            assert "/bin/sh" not in line
+            assert "|" not in line
+            assert ";" not in line
+            assert "$(" not in line
+
+
+# ── silentguard-api.service — optional user-level unit ─────────────
+
+
+class TestSilentGuardUserUnit:
+    """The companion read-only SilentGuard API unit must stay safe.
+
+    Nova does not own SilentGuard, but it ships the example unit, so a
+    minimum safety bar applies here too. None of these directives
+    require root; they are all valid for ``systemctl --user``.
+    """
+
+    def test_loopback_only_address_families(self, silentguard_unit):
+        families = silentguard_unit.get("RestrictAddressFamilies", [])
+        assert families and families[0]
+        assert set(families[0].split()) == {"AF_INET", "AF_INET6", "AF_UNIX"}
+
+    def test_no_new_privileges(self, silentguard_unit):
+        assert silentguard_unit.get("NoNewPrivileges") == ["true"]
+
+    def test_exec_start_binds_loopback(self, silentguard_unit):
+        exec_start = silentguard_unit.get("ExecStart") or []
+        assert exec_start, "ExecStart= must be set"
+        # The example argv must keep ``--host 127.0.0.1`` so a
+        # casual copy-paste does not expose the read-only API on a
+        # non-loopback interface.
+        assert "127.0.0.1" in exec_start[0], (
+            "Example SilentGuard unit must bind --host 127.0.0.1; "
+            f"got: {exec_start!r}"
+        )
+
+    def test_read_only_flag_present(self, silentguard_unit):
+        exec_start = silentguard_unit.get("ExecStart") or []
+        assert exec_start
+        assert "--read-only" in exec_start[0], (
+            "Example SilentGuard unit must include --read-only so the "
+            "integration contract (read-only only) holds."
+        )
+
+    def test_runs_under_default_target(self, silentguard_unit):
+        # User units belong under default.target; using
+        # multi-user.target would imply a system-level install path
+        # that the docs explicitly forbid.
+        assert silentguard_unit.get("WantedBy") == ["default.target"]

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -644,3 +644,67 @@ class TestVoiceSynthesizeWithPiper:
             headers=_h(token),
         )
         assert resp.status_code == 400
+
+
+# ── Voice config payload contract ───────────────────────────────────
+
+
+class TestVoiceConfigPayloadContract:
+    """Pins the keys the Settings UI relies on.
+
+    The Settings panel reads ``available_engines`` to decide whether to
+    show the engine selector and the active-engine chip, and
+    ``piper.detail`` to surface a calm hint when Piper is misconfigured.
+    Renaming or dropping either field would silently break the UX even
+    if the rest of the read-aloud flow still works, so we lock the
+    shape here.
+    """
+
+    def test_browser_only_payload_carries_available_engines(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        body = web_client.get("/voice/config", headers=_h(token)).json()
+        assert "available_engines" in body
+        assert isinstance(body["available_engines"], list)
+        assert voice_providers.ENGINE_BROWSER in body["available_engines"]
+
+    def test_piper_block_exposes_detail_for_ui_hint(
+        self, tmp_path, db_path, web_client, monkeypatch,
+    ):
+        # Half-configured Piper (binary present, model missing) is the
+        # case where the UI most wants a hint. The payload must include
+        # a ``piper`` block with ``available=False`` and a human-readable
+        # ``detail`` string.
+        binary, _model, _config = _make_piper_files(tmp_path, with_config=False)
+        monkeypatch.setattr("config.NOVA_PIPER_BINARY", binary)
+        monkeypatch.setattr("config.NOVA_PIPER_VOICE_MODEL", "")
+        monkeypatch.setattr("config.NOVA_PIPER_VOICE_CONFIG", "")
+
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        body = web_client.get("/voice/config", headers=_h(token)).json()
+
+        piper = body.get("piper")
+        assert isinstance(piper, dict)
+        assert piper["available"] is False
+        assert isinstance(piper["detail"], str)
+        assert piper["detail"].strip(), "detail string must not be empty"
+
+    def test_payload_never_leaks_filesystem_paths(
+        self, tmp_path, db_path, web_client, monkeypatch,
+    ):
+        # The Piper provider holds absolute paths internally. Those
+        # paths must never appear in the public payload — a static
+        # check today, but the kind of regression worth pinning.
+        binary, model, config = _make_piper_files(tmp_path)
+        monkeypatch.setattr("config.NOVA_PIPER_BINARY", binary)
+        monkeypatch.setattr("config.NOVA_PIPER_VOICE_MODEL", model)
+        monkeypatch.setattr("config.NOVA_PIPER_VOICE_CONFIG", config)
+
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        body = web_client.get("/voice/config", headers=_h(token)).json()
+        raw = repr(body)
+        assert binary not in raw
+        assert model not in raw
+        assert config not in raw


### PR DESCRIPTION
## Summary

Two focused, additive improvements that keep Nova local-first, safe by default, and pleasant for long sessions. They share a single PR because each half is modest and they don't touch each other's surface — but they can be reviewed independently.

### Part 1 — systemd / deployment hardening

- `deploy/systemd/nova.service` gains a tighter sandbox profile:
  - Syscall allow-list (`@system-service`) plus a denylist (`~@debug @mount @swap @reboot @raw-io @cpu-emulation @obsolete`). Filtered calls return `EPERM` rather than killing the process.
  - `PrivateDevices`, `RestrictNamespaces`, `RemoveIPC`, `ProtectClock`, `RestrictRealtime`, `ProtectHostname`, `ProtectKernelLogs`, `ProtectProc=invisible`, `ProcSubset=pid`, `UMask=0077`.
  - `systemd-analyze --offline=true security` now scores the example unit **`1.9 OK`** (down from baseline; lower is better).
- New `docs/secure-deployment.md` collects the broader story: recommended local-only deployment shapes (LAN, VPN/Tailscale, Zero Trust gateways), least-privilege rules, secret/backup notes, audit logs, and the explicit "what Nova will NOT do" list (no firewall changes, no `sudo`/`pkexec`/`doas`, no cloud TTS, no model-generated shell commands, no auto-downloads).
- `deploy/systemd/README.md` documents every new directive and explains the score expectation.
- New `tests/test_systemd_unit.py` parses both shipped units and pins every hardening directive so a silent regression fails at test time.

Nothing privileged is introduced. Compatibility with Ollama, SQLite, Piper, and SilentGuard's read-only API is preserved (verified via `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX` and the existing test suite).

### Part 2 — Linux voice experience and "Nova is speaking" visual

- **Active engine chip** in Settings → Voice: a small calm pill next to the engine selector showing which TTS pipeline (`Browser` / `Piper` / `Unavailable`) the next read-aloud will actually use, distinct from the stored preference (Piper can be selected but unavailable on this host).
- **Linux Piper hint**: when the host is on Linux, Piper isn't configured, and only robotic-looking voices (eSpeak / Speech Dispatcher) are installed, Settings shows a gentle informational hint pointing at the existing Piper setup docs. Nova never auto-installs anything. The detection is conservative — any neural marker (Online (Natural), Google, Samantha, Aria, Jenny, …) suppresses the hint.
- **"Nova is speaking" visual**: a small polished indicator with a soft cyan orb that breathes, three slim waveform bars, a localized label (`Nova is speaking` / `Lecture en cours`), and an inline Stop button.
  - Mounted inside the speaking message's `.message-row.nova`, just above the action row.
  - Lifetime is driven entirely by `setSpeakButtonState(btn, playing)` so every existing cancel path (Stop button, logout, conversation switch, new conversation, error fallback) already tears it down — no duplicated playback state.
  - Pure CSS animation, no external library. Respects `@media (prefers-reduced-motion: reduce)`.
- Voice config payload contract tests pin `available_engines`, the `piper` status block (`available` + `detail`), and verify no filesystem paths leak to the client.

No microphone, no autoplay, no notifications, no cloud TTS, no remote services. Existing TTS fallback / voice selection / engine switching all preserved.

## Test plan

- [x] `pytest tests/` — **1281 passed (+36 vs 1245 baseline, 0 regressions)**.
- [x] `pytest tests/test_systemd_unit.py` — 33 new tests cover every hardening directive in both unit files.
- [x] `pytest tests/test_voice.py` — existing 48 + 3 new payload contract tests pass.
- [x] `pytest tests/test_auth.py tests/test_admin_users.py tests/test_alpha_auth.py tests/test_chat_stream.py tests/test_silentguard_*` — auth, admin, alpha gating, chat streaming, and SilentGuard surfaces all unchanged.
- [x] `systemd-analyze --offline=true security` against the hardened unit returns `Overall exposure level for nova.service: 1.9 OK :-)`.
- [x] `node --check` against the extracted `<script>` confirms the new JS is syntactically valid.
- [ ] Manual UI verification once the branch lands in a browser session: speaking indicator appears/disappears cleanly on play/stop/finish/error, conversation switch cancels it, `prefers-reduced-motion` freezes the animation, Linux hint and Active engine chip render correctly.

## Out of scope (kept as future work)

- Egress allow-list (`IPAddressAllow=` / `IPAddressDeny=`) — mentioned in `docs/secure-deployment.md` as an advanced opt-in.
- "Safe mode" / emergency-stop endpoint — noted in `docs/secure-deployment.md` as future work tracked alongside the SilentGuard roadmap.
- Auto-discovery of locally installed Piper voice models — Nova still expects explicit `NOVA_PIPER_*` env vars, on purpose.


---
_Generated by [Claude Code](https://claude.ai/code/session_017YjzL5rjnJ5wwFAdofp3Em)_