### PR TITLE
docs: restructure README around local-first, modular, user-controlled posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,195 +1,258 @@
 # Nova
 
-A self-hosted, local AI assistant built on FastAPI and Ollama.
+A local-first, self-hostable AI assistant built on FastAPI and Ollama.
 
 ## What Nova is
 
-Nova is a personal AI assistant that runs entirely on your own machine. It routes each conversation to the most appropriate local model based on complexity, maintains a persistent memory database across sessions, and serves a web interface reachable from any browser on your network.
+Nova is a personal AI assistant designed to run entirely on hardware you
+control. It routes each conversation to the most appropriate local model,
+maintains a persistent SQLite memory across sessions, and serves a calm
+web interface reachable from any browser on your network. There is no
+cloud account, no telemetry, and no required external service.
 
-Nova is under active development. Core features are functional. Some subsystems — the natural language memory retriever and the embedding pipeline — are present in the codebase but are not yet fully validated for production use.
+Nova is built around four ideas:
 
-## What works today
+- **Local-first.** Inference, memory, and audio synthesis all run on
+  your machine. Outbound calls are limited to clearly-scoped optional
+  tools (weather, web search) and only when the user triggers them.
+- **User control.** Optional integrations are off by default and
+  per-user. Nova never auto-installs binaries, never escalates
+  privilege, and never performs sensitive actions without a visible,
+  explicit confirmation.
+- **Modular.** Memory, voice, security context, and remote integrations
+  sit behind small abstractions. None of them is required for Nova to
+  work; each can be replaced or left disabled.
+- **Privacy-focused.** Conversation history and user-authored memories
+  stay in a local SQLite file under your account. No cloud sync, no
+  third-party analytics.
 
-- Multi-model routing: a lightweight classifier (`gemma3:1b`) decides which model handles each request
-- Persistent memory stored in SQLite with automatic extraction from conversations
-- Manual memory commands for explicit fact storage (`Retiens ça:`, `Souviens-toi:`, `Souviens-toi de ça:`)
-- JWT-secured web interface accessible from desktop and mobile browsers on your network
-- Conversation history with a sidebar for navigation
-- Mode selector: Auto / Chat / Code / Deep
-- Real-time weather via Open-Meteo (no API key required)
-- Web search via DuckDuckGo (manual trigger)
-- Settings panel: view, add, edit, and delete stored memories; RAM budget control
-- Login rate limiting (5 attempts per 60-second window, configurable via environment variables)
-- Nova identity contract: Nova presents itself as a named assistant rather than exposing the underlying model name
-- Background RSS/web learning (disabled by default, opt-in via `NOVA_AUTO_WEB_LEARNING=true`)
-- AMD GPU acceleration via ROCm; falls back to CPU automatically
-- systemd service configuration for unattended startup
+Nova is under active development. Most of what is described in this
+README ships today; the **Development status** section calls out what
+is still design work or experimental.
 
-## Privacy and local-first principles
+## Key features
 
-- Model inference runs locally through Ollama. Optional tools such as web search and weather can contact external services only when explicitly triggered.
-- The memory database is a local SQLite file under your control.
-- Credentials live in `.env` and are never committed to the repository.
-- No telemetry, no cloud sync, no third-party analytics.
+Shipped today:
+
+- **Multi-model routing.** A lightweight classifier (`gemma3:1b`)
+  decides which local model handles each request: general chat,
+  code-focused, or advanced reasoning. The router falls back cleanly
+  when a model is missing.
+- **Streaming replies.** Assistant messages stream into the UI as they
+  are generated, with a calm typing indicator while Nova is thinking.
+- **Persistent memory.** A local SQLite database stores conversations,
+  user-authored memories, and per-user settings. Manual commands
+  (`Retiens ça:`, `Souviens-toi:`) let users save explicit facts;
+  automatic extraction adds short, low-confidence facts from chat.
+- **Session continuity.** A small, deterministic "continue where we
+  left off" summary surfaces recent conversation topics on return.
+  Derived from data already in the sidebar, dismissable, never
+  emotional or inferential.
+- **Web interface.** A futuristic but quiet web UI with conversation
+  sidebar, mode selector (Auto / Chat / Code / Deep), copy buttons,
+  read-aloud, and a settings panel for memories, model preferences,
+  personalization, and optional integrations.
+- **Per-user accounts and family controls.** JWT-secured login,
+  admin-managed user list, per-user settings, and an optional
+  family-controls layer for restricted roles.
+- **Personalization preferences.** Response length, warmth,
+  enthusiasm, emoji density, and free-text custom instructions are
+  stored per user and shape Nova's tone without leaking into other
+  accounts.
+- **Voice / read-aloud.** Every assistant message has a "Read aloud"
+  button. The default engine is the browser's local
+  `speechSynthesis` API; an optional local [Piper](https://github.com/rhasspy/piper)
+  neural voice is available for users who want richer audio.
+- **Optional weather and web search.** Open-Meteo (no API key) and
+  DuckDuckGo, both opt-in and triggered explicitly by the user.
+- **Optional SilentGuard read-only integration.** See the
+  [SilentGuard integration](#silentguard-integration) section.
+- **Optional background RSS learning.** Off by default; opt in via
+  `NOVA_AUTO_WEB_LEARNING=true`.
+- **Login rate limiting.** Per-IP sliding-window limiter on the login
+  endpoint, configurable via environment variables.
+- **Identity contract.** Nova presents itself as a named assistant and
+  does not reveal the underlying model name unless asked a technical
+  implementation question.
+- **AMD GPU acceleration via ROCm.** Falls back to CPU automatically.
+- **Systemd and Docker deployment.** A hardened systemd unit and a
+  `docker-compose.yml` ship with the repo.
+
+Experimental / partial:
+
+- Natural-language memory store and retriever (`memory/`). The pipeline
+  is present and used in some paths, but not yet validated for
+  production use.
 
 ## Architecture overview
 
 ```
-web.py              FastAPI application and REST endpoints
-main.py             Terminal interface (no web server required)
-config.py           Central configuration loaded from .env
+web.py                FastAPI application, REST and SSE endpoints
+main.py               Terminal interface (no web server)
+config.py             Central configuration loaded from .env
 
 core/
-  router.py         Model selection via gemma3:1b classifier
-  chat.py           Conversation logic and message assembly
-  memory.py         SQLite memory: facts, conversations, settings
-  memory_command.py Manual memory command parser
-  identity.py       Nova identity contract injected into the system prompt
-  auth.py           JWT creation and verification
-  rate_limiter.py   Per-IP sliding-window rate limiter for the login endpoint
-  learner.py        Background RSS feed ingestion (opt-in)
-  weather.py        Open-Meteo integration
-  search.py         DuckDuckGo integration
-  updater.py        Model version management
+  router.py           Model selection via gemma3:1b classifier
+  chat.py             Conversation logic, streaming, system prompt
+  memory.py           SQLite memory: facts, conversations, settings
+  memory_command.py   Manual memory command parser
+  memory_importer.py  Bulk memory import helper
+  nova_contract.py    Nova identity + personalization prompt blocks
+  identity.py         Identity contract constant
+  auth.py             JWT creation and verification
+  github_oauth.py     Optional GitHub OAuth gate (alpha channel)
+  rate_limiter.py     Per-IP sliding-window login rate limiter
+  users.py            Users table, default-admin migration
+  policies.py         Role-based family controls
+  settings.py         System and per-user settings storage
+  session_continuity.py  Deterministic "continue where we left off"
+  learner.py          Background RSS ingestion (opt-in)
+  weather.py          Open-Meteo integration
+  search.py           DuckDuckGo integration
+  time_context.py     Calendar/timezone context for prompts
+  updater.py          Model version management
+  ollama_client.py    Thin Ollama HTTP client
+  local_models.py     Local model discovery / readiness
+  model_registry.py   Allow-list of installable models
+  model_access.py     Per-user model access checks
+  model_pulls.py      Background model pull progress
+  security_feed.py    Read-only SilentGuard JSON parser
+  security/           Read-only security provider package
+  integrations/       Per-user gates for optional integrations
+  voice/              TTS provider abstraction (browser + Piper)
 
 memory/
-  store.py          Natural language memory store
-  retriever.py      Semantic memory retrieval
-  extractor.py      Memory extraction pipeline
-  schema.py         Memory data schema
-  policy.py         Retention and cleanup policy
+  store.py            Natural-language memory store
+  retriever.py        Semantic memory retrieval
+  extractor.py        Memory extraction pipeline
+  schema.py           Memory data schema
+  policy.py           Retention and cleanup policy
+  embeddings.py       Embedding helper
 
 static/
-  index.html        Web interface
+  index.html          Web interface
 
-tests/              Pytest test suite
+deploy/systemd/       Hardened nova.service + walkthrough
+docker/               Docker entrypoint
+docs/                 Roadmaps and deployment guides
+tests/                Pytest test suite
 ```
 
-## Getting started
+## Security and local-first philosophy
 
-### Requirements
+Nova is a **powerful local service**, not a trusted root-level agent.
+The deployment guide in [docs/secure-deployment.md](docs/secure-deployment.md)
+covers recommended setups, VPN / Zero-Trust gateways, least privilege,
+backups, and the systemd hardening that ships in
+[deploy/systemd/nova.service](deploy/systemd/nova.service).
 
-- Linux (tested on Fedora)
-- Python 3.11+
-- [Ollama](https://ollama.com) installed and running
-- AMD GPU with ROCm (optional — falls back to CPU)
+The boundaries below are firm. They are commitments, not future work:
 
-### 1. Clone the repository
+- Nova does **not** run as root.
+- Nova does **not** call `sudo`, `pkexec`, `doas`, `su`, or `runuser`.
+- Nova does **not** execute model-generated shell commands.
+- Nova does **not** modify firewall rules or block / unblock IPs by
+  itself. SilentGuard owns enforcement.
+- Nova does **not** act as a firewall.
+- Nova does **not** perform autonomous security actions. Anything
+  sensitive requires an explicit user confirmation in the UI.
+- Nova does **not** auto-install Piper, voice models, or any other
+  binary.
+- Nova does **not** send prompts, audio, or conversation history to a
+  third-party cloud service.
+- Nova does **not** require SilentGuard to function. SilentGuard is an
+  optional, off-by-default integration.
 
-```bash
-git clone https://github.com/TheZupZup/Nova.git
-cd Nova
-```
+The hardened systemd unit drops capabilities, enables
+`ProtectSystem=strict`, restricts namespaces, applies a syscall
+denylist, and confines writes to the Nova checkout. See
+[deploy/systemd/README.md](deploy/systemd/README.md) for the
+per-directive walkthrough.
 
-### 2. Create a virtual environment and install dependencies
+## SilentGuard integration
 
-```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-```
+SilentGuard is a **separate project** and remains the security and
+network monitoring engine. Nova does not re-implement it.
 
-### 3. Pull the required Ollama models
+SilentGuard's role:
 
-```bash
-ollama pull gemma3:1b
-ollama pull gemma4
-ollama pull deepseek-coder-v2
-ollama pull qwen2.5:32b
-```
+- Observing local connections.
+- Classifying trust (known / trusted / blocked).
+- Persisting rules and emitting alerts / events.
+- Mitigation and enforcement when the operator explicitly enables it.
+- Exposing an optional, loopback-only read API.
 
-`qwen2.5:32b` requires significant disk space and RAM. If your hardware is constrained, you can skip it; the router falls back to `gemma4` for advanced requests.
+Nova's role:
 
-### 4. Configure credentials
+- Reading SilentGuard's status and recent context, when configured.
+- Explaining network and security activity in plain language.
+- Summarising alerts, connections, blocked items, and trusted items.
+- Asking for an explicit user confirmation before forwarding any
+  sensitive request (for example, enabling a temporary mitigation
+  window) to SilentGuard.
 
-```bash
-cp .env.example .env
-```
+The integration is **optional and off by default**:
 
-Edit `.env` and set at minimum:
+- A per-user toggle in Settings opts each account in. Without it,
+  SilentGuard data is never surfaced to that user.
+- The default transport is a read-only file probe of
+  `~/.silentguard_memory.json`. If `NOVA_SILENTGUARD_API_URL` is set
+  (typically `http://127.0.0.1:<port>`), Nova switches to SilentGuard's
+  loopback read-only HTTP API. Both transports are GET-only against a
+  fixed path list.
+- A small lifecycle helper can optionally start SilentGuard's user-level
+  service (`systemctl --user start <unit>`) after a failed probe. Every
+  gate defaults off; the helper never uses `sudo`, never spawns a
+  shell, never touches firewall config, and never polls.
+- Mitigation actions (enable / disable temporary mitigation) are
+  confirmation-gated. Nova only POSTs to SilentGuard after an explicit
+  acknowledgement from the user in the UI; SilentGuard itself requires
+  the same acknowledgement payload.
 
-```
-NOVA_USERNAME=your_username
-NOVA_PASSWORD=your_password
-NOVA_SECRET_KEY=a-long-random-string
-```
+When SilentGuard is reachable and the user has opted in, Nova's chat
+layer appends a short read-only "Security context:" block to the
+system prompt: it states the connection state and, when available,
+summarises four counts (alerts, blocked items, trusted items, active
+connections). Every variant of the block reminds the model that Nova
+may **explain and summarise only** — it must not perform firewall or
+rule actions.
 
-The defaults in `.env.example` are intentionally weak placeholders. Change them before any deployment, especially if Nova is exposed beyond localhost.
+For the broader design — connector abstraction, JSON contract, and
+phased scope — see
+[docs/silentguard-integration-roadmap.md](docs/silentguard-integration-roadmap.md).
+For the operator-facing walkthrough of running SilentGuard's
+read-only API as a user service, see
+[docs/silentguard-background-service.md](docs/silentguard-background-service.md);
+an example unit lives at
+[`deploy/systemd/silentguard-api.service`](deploy/systemd/silentguard-api.service).
 
-### 5. Start Nova
+## Voice and TTS
 
-```bash
-python web.py
-```
-
-Nova is available at `http://localhost:8080`.
-
-## Running as a systemd service
-
-Create `/etc/systemd/system/nova.service`:
-
-```ini
-[Unit]
-Description=Nova AI Assistant
-After=network.target ollama.service
-
-[Service]
-Type=simple
-User=yourusername
-WorkingDirectory=/path/to/Nova
-ExecStart=/path/to/Nova/.venv/bin/uvicorn web:app --host 0.0.0.0 --port 8080
-Restart=always
-RestartSec=5
-Environment="PATH=/path/to/Nova/.venv/bin:/usr/bin:/usr/local/bin"
-
-[Install]
-WantedBy=multi-user.target
-```
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable nova
-sudo systemctl start nova
-```
-
-For an optional hardened unit file with systemd sandbox restrictions
-(`NoNewPrivileges`, `ProtectSystem=strict`, capability drop, syscall
-filter, etc.), see [deploy/systemd/README.md](deploy/systemd/README.md).
-It is a drop-in replacement for the minimal unit above and does not
-change Nova's behavior.
-
-For the broader deployment story — recommended local-only setups,
-VPN / Zero Trust gateways, least privilege, backups, and the explicit
-list of things Nova will never do (no firewall changes, no `sudo`, no
-cloud TTS, …) — see [docs/secure-deployment.md](docs/secure-deployment.md).
-
-## Voice / read-aloud
-
-Every assistant message has a "Read aloud" button. By default, Nova uses
+Every assistant message has a "Read aloud" button. By default Nova uses
 the browser's built-in `speechSynthesis` API — zero install, fully
 local, and pleasant on most platforms (Apple Samantha, Microsoft Aria,
 Google Female, …).
 
-While Nova is reading, a small calm indicator with a soft cyan orb and
-waveform appears beside the message ("Nova is speaking" / "Lecture en
-cours") with an inline Stop control. The animation is lightweight CSS
-and respects `prefers-reduced-motion`; it disappears the moment
-playback stops, the user switches conversations, or they log out.
+While Nova is reading, a soft cyan orb and waveform appears beside the
+message with an inline Stop control. The animation respects
+`prefers-reduced-motion` and disappears the moment playback stops or
+the user switches conversations.
 
 On Fedora and other Linux desktops the platform voices sometimes fall
-back to a robotic engine. Nova detects that and surfaces a gentle
-hint under Settings → Voice recommending the optional local Piper
-path; it never auto-installs anything. The hint is informational only.
+back to a robotic engine. Nova detects this and surfaces a gentle hint
+in Settings → Voice recommending the optional local Piper path. It
+never auto-installs anything. Settings → Voice also shows an **Active
+engine** chip next to the engine selector and a **Test voice** button
+for side-by-side comparisons.
 
-In that case Nova can drive a local
-[Piper](https://github.com/rhasspy/piper) neural voice instead. Piper
-is opt-in, runs entirely on this host, and is never downloaded
-automatically.
+Privacy notes:
 
-Settings → Voice also shows an **Active engine** chip next to the
-engine selector so the active TTS pipeline (Browser or Piper) is
-unambiguous, plus a **Test voice** button to compare voices
-side-by-side without leaving the panel.
+- Piper, when installed, runs offline. No audio bytes leave the host.
+- Nova never auto-downloads a Piper binary or voice model.
+- Nova does not use any cloud TTS service — neither for the
+  "Read aloud" button nor for the Settings preview.
+- No microphone capture, no always-on listening. Read-aloud is the only
+  voice surface today.
 
 ### Optional: enable Piper
 
@@ -227,47 +290,157 @@ side-by-side without leaving the panel.
    `piper` is already on the system `PATH`. `NOVA_PIPER_VOICE_CONFIG`
    is optional — Piper auto-discovers the sibling `.onnx.json`.
 
-4. Restart Nova. Open Settings → Voice. A new "Voice engine" row will
-   appear with `Browser` and `Piper (local neural)` options. Select
-   Piper and click "Test voice" to confirm it works.
+4. Restart Nova. Open Settings → Voice and select Piper. Click
+   "Test voice" to confirm it works.
 
 If Piper is missing, the model is unreadable, the subprocess fails, or
 synthesis times out, Nova silently falls back to the browser engine —
 the read-aloud experience is never lost.
 
-### Privacy
+## Development status and roadmap
 
-- Piper runs offline. No audio bytes leave this host.
-- Nova never auto-installs a Piper binary or voice model.
-- Nova does not use any cloud TTS service — neither for the
-  "Read aloud" button nor for the Settings preview.
-- No telemetry, no microphone capture, no always-on listening — the
-  read-aloud button is the only voice surface in Nova today.
+Nova is under active development. The features in **Key features**
+above are shipped and exercised by the test suite. The items below are
+the directions of active interest — they are not commitments and
+nothing in the linked documents should be cited as evidence that a
+feature exists.
 
-## Configuration
+- **Natural-language memory pipeline.** Hardening the `memory/`
+  package for production use.
+- **Multi-user UX polish.** The data model and admin endpoints exist;
+  the design document
+  [docs/multi-user-architecture.md](docs/multi-user-architecture.md)
+  tracks the broader plan.
+- **Cognitive copilot direction.** A longer-term design for semantic
+  memory, temporal awareness, and Git-aware workflows lives in
+  [docs/cognitive-copilot-roadmap.md](docs/cognitive-copilot-roadmap.md).
+  Design only — nothing in it is implemented yet.
+- **SilentGuard integration phases.** The current Phase 1 scope and
+  the explicit non-goals (no autonomous blocking, no firewall
+  mutations, no background polling) are tracked in
+  [docs/silentguard-integration-roadmap.md](docs/silentguard-integration-roadmap.md).
+- **Broader test coverage and improved model-fallback UX.**
+
+## Running locally
+
+### Requirements
+
+- Linux (tested on Fedora).
+- Python 3.11+.
+- [Ollama](https://ollama.com) installed and running.
+- AMD GPU with ROCm (optional — falls back to CPU).
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/TheZupZup/Nova.git
+cd Nova
+```
+
+### 2. Create a virtual environment and install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 3. Pull the required Ollama models
+
+```bash
+ollama pull gemma3:1b
+ollama pull gemma4
+ollama pull deepseek-coder-v2
+ollama pull qwen2.5:32b
+```
+
+`qwen2.5:32b` requires significant disk space and RAM. If your hardware
+is constrained, skip it; the router falls back to `gemma4` for advanced
+requests.
+
+### 4. Configure credentials
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```
+NOVA_USERNAME=your_username
+NOVA_PASSWORD=your_password
+NOVA_SECRET_KEY=a-long-random-string
+```
+
+The defaults in `.env.example` are intentionally weak placeholders.
+Change them before any deployment, especially if Nova is exposed
+beyond localhost.
+
+### 5. Start Nova
+
+```bash
+python web.py
+```
+
+Nova is available at `http://localhost:8080`.
+
+### Running as a systemd service
+
+A hardened example unit lives at
+[`deploy/systemd/nova.service`](deploy/systemd/nova.service); the
+per-directive walkthrough is in
+[`deploy/systemd/README.md`](deploy/systemd/README.md). The unit
+enforces `NoNewPrivileges`, an empty capability bounding set,
+`ProtectSystem=strict`, `ProtectHome=read-only`, restricted address
+families, a syscall denylist, and `UMask=0077` — it does not change
+Nova's behaviour, only its blast radius if something goes wrong.
+
+For the broader deployment story (LAN-only, VPN / Zero-Trust gateway,
+backups, and the explicit list of things Nova will never do) see
+[docs/secure-deployment.md](docs/secure-deployment.md).
+
+### Docker
+
+A `Dockerfile` and `docker-compose.yml` are included. The compose
+stack persists `nova.db` in a Docker volume, keeps Ollama external
+(reachable via `OLLAMA_HOST`), and supports clean updates via
+`docker compose pull`. See [docs/docker.md](docs/docker.md) for the
+full guide.
+
+### Configuration
 
 All configuration is read from `.env` at startup. Key variables:
 
 | Variable | Default | Description |
 |---|---|---|
-| `NOVA_USERNAME` | — | Login username |
-| `NOVA_PASSWORD` | — | Login password |
+| `NOVA_USERNAME` | — | Login username for the seeded admin |
+| `NOVA_PASSWORD` | — | Login password for the seeded admin |
 | `NOVA_SECRET_KEY` | — | JWT signing secret |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
 | `NOVA_AUTO_WEB_LEARNING` | `false` | Enable background RSS/web learning |
 | `LOGIN_RATE_LIMIT_MAX` | `5` | Max login attempts per window |
 | `LOGIN_RATE_LIMIT_WINDOW` | `60` | Rate limit window in seconds (sliding) |
 | `LOGIN_RATE_LIMIT_TRUSTED_PROXIES` | — | Comma-separated proxy IPs to trust for `X-Forwarded-For` |
+| `NOVA_SILENTGUARD_API_URL` | — | Loopback URL of SilentGuard's read-only API (blank = file probe) |
+| `NOVA_SILENTGUARD_API_TIMEOUT_SECONDS` | `2.0` | Timeout for SilentGuard probes |
+| `NOVA_SILENTGUARD_ENABLED` | `false` | Host-level switch for the lifecycle helper |
+| `NOVA_SILENTGUARD_AUTO_START` | `false` | Allow one-shot `systemctl --user start` after a failed probe |
+| `NOVA_SILENTGUARD_START_MODE` | `disabled` | `systemd-user` is the only enabled value |
+| `NOVA_SILENTGUARD_SYSTEMD_UNIT` | `silentguard-api.service` | User-level unit name to start |
 | `NOVA_PIPER_BINARY` | — | Path to the optional Piper TTS binary (blank = auto-detect on `PATH`) |
 | `NOVA_PIPER_VOICE_MODEL` | — | Path to a Piper `.onnx` voice model. Blank disables Piper. |
 | `NOVA_PIPER_VOICE_CONFIG` | — | Path to the `.onnx.json` config (blank = auto-discover sibling) |
-| `NOVA_PIPER_TIMEOUT_SECONDS` | `20` | Synthesis timeout, in seconds |
+| `NOVA_PIPER_TIMEOUT_SECONDS` | `20` | Piper synthesis timeout, in seconds |
 
-Model assignments are defined in `config.py` in the `MODELS` dictionary. To swap a model, update that dictionary and restart Nova.
+Model assignments are defined in `config.py` in the `MODELS`
+dictionary. To swap a model, update that dictionary and restart Nova.
 
-A note on language: the default system prompt and Nova's persona are written in French. Nova auto-detects the language of each message and replies in kind, so English conversations work without any configuration change.
+A note on language: the default system prompt and Nova's persona are
+written in French. Nova auto-detects the language of each message and
+replies in kind, so English conversations work without any
+configuration change.
 
-## Development workflow
+### Development workflow
 
 ```bash
 # Run the full test suite
@@ -277,51 +450,27 @@ pytest
 pytest tests/test_router.py -v
 ```
 
-The test suite covers model routing, memory storage and parsing, manual memory commands, rate limiting, the identity contract, and weather integration.
-
-## Docker deployment
-
-A `Dockerfile` and `docker-compose.yml` are included for self-hosted container deployments. The compose stack persists `nova.db` in a Docker volume, keeps Ollama external (reachable via `OLLAMA_HOST`), and supports clean updates via `docker compose pull`.
-
-See [docs/docker.md](docs/docker.md) for the full guide: first run, updates, where data is stored, how to point Nova at an Ollama on the host or another machine, and backup notes.
+The test suite covers model routing, memory storage and parsing,
+manual memory commands, rate limiting, the identity contract,
+personalization, session continuity, SilentGuard provider behaviour
+(including the read-only and mitigation paths), voice providers, and
+the systemd unit shape.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branch and pull request rules.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch and pull request
+rules.
 
 Short version:
 
-- Branch from `main` with a descriptive name (`feature/…`, `fix/…`, `refactor/…`)
-- One change per PR
-- Avoid modifying unrelated files
-- Keep changes small and readable
+- Branch from `main` with a descriptive name (`feature/…`, `fix/…`,
+  `refactor/…`).
+- One change per PR.
+- Avoid modifying unrelated files.
+- Keep changes small and readable.
 
-## Good first issues
-
-Check the [open issues](https://github.com/TheZupZup/Nova/issues) on GitHub, particularly those labelled `good first issue`. Current tracked issues suitable for new contributors:
-
-- [#23](https://github.com/TheZupZup/Nova/issues/23) Persist the selected model mode across sessions
-- [#49](https://github.com/TheZupZup/Nova/issues/49) Add `max_length` constraints to relevant input fields
-- [#66](https://github.com/TheZupZup/Nova/issues/66) Replace deprecated `datetime.utcnow()` calls
-
-## Roadmap
-
-The following are areas of active interest, not commitments:
-
-- Hardening the natural language memory pipeline for production use
-- Multi-user support (currently single-user via one set of credentials) — see the design plan in [docs/multi-user-architecture.md](docs/multi-user-architecture.md)
-- Improved model fallback and error reporting in the web UI
-- Broader test coverage
-
-For the longer-term direction — turning Nova into a local-first cognitive copilot with semantic memory, temporal awareness, and Git-aware workflows — see the design document in [docs/cognitive-copilot-roadmap.md](docs/cognitive-copilot-roadmap.md). Like the multi-user plan, it is a design document only; nothing in it is implemented yet.
-
-For the read-only, opt-in integration with SilentGuard (the dedicated network monitoring tool) — including the connector abstraction, JSON contract, and Phase 1 scope — see [docs/silentguard-integration-roadmap.md](docs/silentguard-integration-roadmap.md). Nova reads SilentGuard's local state and explains it; SilentGuard remains the security/enforcement layer.
-
-The integration is **optional** and **off by default**. Nova works normally whether SilentGuard is installed or not. The security provider in `core/security/` probes SilentGuard's on-disk memory file; if `NOVA_SILENTGUARD_API_URL` is set, it instead probes SilentGuard's optional **read-only loopback API** (`GET /status` and a small fixed endpoint list — no writes, no firewall actions, no shell calls). Either way, a missing, unreachable, or malformed response maps to a calm `available=False` snapshot.
-
-Nova's chat layer surfaces the provider's state as a small **read-only "Security context:" block** appended to the system prompt (`core/security/context.py`). The block tells the model whether SilentGuard is *not configured*, *unavailable*, or *connected in read-only mode* — and, when the optional HTTP transport is responsive, summarises four counts (`alerts`, `blocked items`, `trusted items`, `active connections`). Every variant restates that Nova may **explain and summarize only**; it must not perform firewall or rule actions. There is no notification surface, no background polling, and no autonomous alerting attached to this — the block is built on demand from the same provider as the existing settings status.
-
-For the operator-facing walkthrough — running SilentGuard's loopback, read-only API as a `systemctl --user` background service so Nova can probe it — see [docs/silentguard-background-service.md](docs/silentguard-background-service.md). The example unit lives at [`deploy/systemd/silentguard-api.service`](deploy/systemd/silentguard-api.service); it binds to `127.0.0.1`, runs without sudo, and is disabled by default.
+Check the [open issues](https://github.com/TheZupZup/Nova/issues),
+particularly those labelled `good first issue`, for a way in.
 
 ## License
 


### PR DESCRIPTION
## Summary

Reworks `README.md` so it accurately reflects the current state and
direction of Nova as a local-first, self-hostable AI assistant —
without overselling capabilities.

- Reorders sections to match the requested structure (project title,
  what Nova is, key features, architecture, security philosophy,
  SilentGuard, voice, roadmap, running locally, contributing, license).
- Splits Key features into **Shipped today** vs **Experimental / partial**
  so planned work is never mistaken for shipped behaviour.
- Reflects features that have landed since the previous README:
  streaming replies, session continuity banner, per-user accounts and
  family controls, personalization preferences, the read-only
  SilentGuard provider, the lifecycle helper, and the
  confirmation-gated mitigation flow.
- Gives SilentGuard its own top-level section that cleanly separates
  SilentGuard's role (monitoring, classification, enforcement) from
  Nova's role (reading status, explaining activity, asking for
  confirmation before any sensitive request).
- Promotes the "what Nova will not do" boundaries (no firewall, no
  sudo, no shell execution, no autonomous security actions, no cloud
  TTS, never requires SilentGuard) to the Security philosophy section
  so they are visible at a glance.
- Refreshes the architecture map to match the current `core/` layout
  and the configuration table with the SilentGuard transport,
  lifecycle, and Piper variables.
- Preserves the Piper install walkthrough, deployment links, and
  roadmap references unchanged.

## Test plan

- [ ] Render the README on GitHub and confirm sections, links, and code
  blocks display correctly.
- [ ] Confirm every relative link resolves on the branch
  (`docs/secure-deployment.md`, `docs/silentguard-integration-roadmap.md`,
  `docs/silentguard-background-service.md`,
  `docs/multi-user-architecture.md`,
  `docs/cognitive-copilot-roadmap.md`, `docs/docker.md`,
  `deploy/systemd/nova.service`, `deploy/systemd/README.md`,
  `deploy/systemd/silentguard-api.service`, `CONTRIBUTING.md`, `LICENSE`).
- [ ] Confirm the in-page anchor `#silentguard-integration` jumps to the
  SilentGuard section.
- [ ] Spot-check that no "shipped today" bullet describes a feature
  that does not exist in the codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tg8Jv7K9wshZsSjUqmE7d)_