### PR TITLE
feat(memory): harden import safety taxonomy and add commit step (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ core/
   chat.py             Conversation logic, streaming, system prompt
   memory.py           SQLite memory: facts, conversations, settings
   memory_command.py   Manual memory command parser
-  memory_importer.py  Bulk memory import helper
+  memory_importer.py  Local-only Markdown memory pack importer
   nova_contract.py    Nova identity + personalization prompt blocks
   identity.py         Identity contract constant
   auth.py             JWT creation and verification
@@ -307,6 +307,12 @@ feature exists.
 
 - **Natural-language memory pipeline.** Hardening the `memory/`
   package for production use.
+- **Memory pack import (v1 backend).** A local-only Markdown memory
+  pack parser, safety scanner, and confirmation-gated commit step
+  lives in [`core/memory_importer.py`](core/memory_importer.py).
+  Format and safety rules are documented in
+  [docs/memory-pack-import.md](docs/memory-pack-import.md). UI / API
+  wiring is intentionally a follow-up.
 - **Multi-user UX polish.** The data model and admin endpoints exist;
   the design document
   [docs/multi-user-architecture.md](docs/multi-user-architecture.md)

--- a/core/memory_importer.py
+++ b/core/memory_importer.py
@@ -1,27 +1,72 @@
+"""Local-only memory pack importer (issue #84).
+
+The importer converts a Markdown memory pack into a list of reviewable
+candidates and exposes an explicit commit step. It never writes to the
+database on its own; persistence is delegated to a caller-supplied
+``save_fn``. This keeps parsing, safety scanning, and persistence in
+clearly separated layers.
+
+Design contracts:
+
+* Parser logic lives in :func:`parse_markdown_memory_pack`.
+* Safety scanning lives in :func:`scan_content_for_flags` and the helpers
+  it composes — none of them touch storage or do Markdown parsing.
+* Preview generation in :func:`build_memory_import_preview` composes the
+  parser, deduper, and scanner but writes nothing.
+* Saving requires :func:`commit_memory_import` to be called with
+  ``confirm=True``; without that, nothing is persisted.
+
+Safety rules are deterministic regexes/keywords — no ML, no network.
+"""
+
 from dataclasses import dataclass, field
-from typing import List
+import re
+from typing import Callable, List
 
 MIN_CONTENT_LENGTH = 10
 
-_SENSITIVE_KEYWORDS = (
-    "password",
-    "passwd",
-    "token",
-    "secret",
+# A single whitespace-free alphanumeric token this long looks like a secret
+# (API keys, OAuth tokens, hex digests, etc.).
+_RANDOM_STRING_MIN_LEN = 20
+
+# Keyword tables used by the scanner. They are intentionally small and
+# explicit so a contributor can audit them at a glance.
+_PASSWORD_KEYWORDS = ("password", "passwd", "passphrase")
+_TOKEN_KEYWORDS = (
     "api key",
     "api_key",
+    "access token",
+    "auth_token",
+    "auth token",
+    "bearer token",
+    "token",
+)
+_PRIVATE_KEY_KEYWORDS = (
     "private key",
     "private_key",
-    "credential",
-    "auth_token",
+    "-----begin",
+    "begin rsa",
+    "begin openssh",
+    "ssh-rsa ",
+    "ssh-ed25519 ",
 )
+_GENERIC_SECRET_KEYWORDS = ("secret", "credential")
 
-# A single whitespace-free alphanumeric token this long looks like a secret.
-_RANDOM_STRING_MIN_LEN = 20
+# Patterns used to spot personal data without an LLM. They are tuned to
+# be conservative: false negatives are preferable to false positives in
+# a "review-before-save" workflow.
+_EMAIL_PATTERN = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_SSN_PATTERN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+_CREDIT_CARD_PATTERN = re.compile(r"\b(?:\d[ -]?){13,19}\b")
+_PHONE_PATTERN = re.compile(
+    r"(?:\+?\d[\s.\-]?){2,}\(?\d{2,4}\)?[\s.\-]?\d{2,4}[\s.\-]?\d{2,4}"
+)
 
 
 @dataclass
 class MemoryImportCandidate:
+    """A single reviewable memory entry parsed from a memory pack."""
+
     category: str
     content: str
     source: str = field(default="import")
@@ -32,6 +77,8 @@ class MemoryImportCandidate:
 
 @dataclass
 class MemoryImportPreview:
+    """Result of running the parser + safety + dedup pipeline."""
+
     candidates: List[MemoryImportCandidate]
     total: int
     categories: List[str]
@@ -41,35 +88,143 @@ class MemoryImportPreview:
     flagged_count: int = 0
 
 
-def _normalize(text: str) -> str:
-    """Lowercase and collapse whitespace for comparison."""
-    return " ".join(text.lower().split())
+@dataclass
+class MemoryImportCommitResult:
+    """Summary of an explicit, confirmed import commit."""
+
+    saved_count: int = 0
+    skipped_flagged: int = 0
+    skipped_duplicate: int = 0
+    skipped_unconfirmed: int = 0
 
 
-def _flag_sensitive(content: str) -> tuple:
-    """Return flag strings when content looks like it might contain secrets."""
-    flags = []
+# ---------------------------------------------------------------------------
+# Markdown parser — pure, no DB, no safety scanning.
+# ---------------------------------------------------------------------------
+
+def parse_markdown_memory_pack(text: str) -> List[MemoryImportCandidate]:
+    """Parse a Markdown memory pack into structured memory candidates.
+
+    Headings (``##``) become categories; bullet points beneath them become
+    entries. Content before the first ``##`` heading and empty/too-short
+    bullets are ignored. A top-level ``#`` title resets the active
+    category so its bullets are not attached to it.
+    """
+    candidates: List[MemoryImportCandidate] = []
+    current_category: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+
+        if line.startswith("## "):
+            current_category = line[3:].strip()
+            continue
+
+        if line.startswith("# "):
+            current_category = None
+            continue
+
+        if current_category is None:
+            continue
+
+        if line.startswith("- "):
+            content = line[2:].strip()
+            if len(content) >= MIN_CONTENT_LENGTH:
+                candidates.append(
+                    MemoryImportCandidate(category=current_category, content=content)
+                )
+
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Safety scanning — pure, no DB, no Markdown parsing.
+# ---------------------------------------------------------------------------
+
+def scan_content_for_flags(content: str) -> tuple[str, ...]:
+    """Return a tuple of safety flag strings for ``content``.
+
+    Multiple flags can fire for the same entry. The umbrella flag
+    ``possible_secret`` is added whenever a more specific
+    password/token/private-key flag fires, so callers that only check
+    for the umbrella flag still see all credential-like entries.
+    """
+    flags: list[str] = []
     lower = content.lower()
 
-    for keyword in _SENSITIVE_KEYWORDS:
-        if keyword in lower:
-            flags.append("possible_secret")
-            break
+    matched_specific_secret = False
 
-    # Long alphanumeric token with no spaces is suspicious (e.g. an API key value).
+    if any(k in lower for k in _PASSWORD_KEYWORDS):
+        flags.append("possible_password")
+        matched_specific_secret = True
+
+    if any(k in lower for k in _TOKEN_KEYWORDS):
+        flags.append("possible_token")
+        matched_specific_secret = True
+
+    if any(k in lower for k in _PRIVATE_KEY_KEYWORDS):
+        flags.append("possible_private_key")
+        matched_specific_secret = True
+
+    if matched_specific_secret or any(k in lower for k in _GENERIC_SECRET_KEYWORDS):
+        if "possible_secret" not in flags:
+            flags.append("possible_secret")
+
     for word in content.split():
         if len(word) >= _RANDOM_STRING_MIN_LEN and word.isalnum():
             flags.append("suspicious_string")
+            if "possible_token" not in flags:
+                flags.append("possible_token")
+            if "possible_secret" not in flags:
+                flags.append("possible_secret")
             break
+
+    if _looks_like_sensitive_personal_data(content):
+        flags.append("possible_sensitive_personal_data")
 
     return tuple(flags)
 
+
+def _looks_like_sensitive_personal_data(content: str) -> bool:
+    """Conservative regex check for emails, SSN, phones, or credit cards."""
+    if _EMAIL_PATTERN.search(content):
+        return True
+    if _SSN_PATTERN.search(content):
+        return True
+    if _looks_like_credit_card(content):
+        return True
+    if _looks_like_phone(content):
+        return True
+    return False
+
+
+def _looks_like_credit_card(content: str) -> bool:
+    """Detect a 13–19 digit sequence after stripping separators."""
+    for match in _CREDIT_CARD_PATTERN.finditer(content):
+        digits = re.sub(r"[ -]", "", match.group(0))
+        if 13 <= len(digits) <= 19 and digits.isdigit():
+            return True
+    return False
+
+
+def _looks_like_phone(content: str) -> bool:
+    """Heuristic phone-number detection (>= 10 digits, with separators)."""
+    for match in _PHONE_PATTERN.finditer(content):
+        digits = re.sub(r"\D", "", match.group(0))
+        if 10 <= len(digits) <= 15:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Preview pipeline — composes parser + dedup + scanner.
+# ---------------------------------------------------------------------------
 
 def build_memory_import_preview(
     text: str,
     existing_contents: list[str] | None = None,
 ) -> MemoryImportPreview:
-    """Return a preview of what would be imported without writing to the database."""
+    """Return a preview of what would be imported, without writing anything."""
     warnings: List[str] = []
 
     if not text or not text.strip():
@@ -95,7 +250,6 @@ def build_memory_import_preview(
             f"{rejected} entr{'y' if rejected == 1 else 'ies'} rejected for being too short"
         )
 
-    # Mark duplicates against caller-supplied existing content.
     normalized_existing: set[str] = set()
     if existing_contents:
         for entry in existing_contents:
@@ -112,19 +266,17 @@ def build_memory_import_preview(
             f"{duplicate_count} duplicate{'s' if duplicate_count != 1 else ''} found"
         )
 
-    # Flag candidates that look like they contain sensitive data.
     flagged_count = 0
     for candidate in candidates:
-        flags = _flag_sensitive(candidate.content)
+        flags = list(scan_content_for_flags(candidate.content))
+        if candidate.duplicate and "duplicate" not in flags:
+            flags.append("duplicate")
         if flags:
-            candidate.flags = flags
-            flagged_count += 1
+            candidate.flags = tuple(flags)
+            if any(f != "duplicate" for f in flags):
+                flagged_count += 1
 
-    seen: dict[str, int] = {}
-    for c in candidates:
-        seen.setdefault(c.category, 0)
-        seen[c.category] += 1
-    categories = list(seen.keys())
+    categories = list(dict.fromkeys(c.category for c in candidates))
 
     return MemoryImportPreview(
         candidates=candidates,
@@ -135,6 +287,60 @@ def build_memory_import_preview(
         duplicate_count=duplicate_count,
         flagged_count=flagged_count,
     )
+
+
+# ---------------------------------------------------------------------------
+# Explicit confirmation step — persistence is delegated to ``save_fn``.
+# ---------------------------------------------------------------------------
+
+def commit_memory_import(
+    preview: MemoryImportPreview,
+    user_id: int,
+    save_fn: Callable[[str, str, int], None],
+    confirm: bool = False,
+    allow_flagged: bool = False,
+    allow_duplicates: bool = False,
+) -> MemoryImportCommitResult:
+    """Persist approved candidates from ``preview`` via ``save_fn``.
+
+    Nothing is saved unless ``confirm=True``. Flagged and duplicate
+    candidates are skipped by default and only included when the caller
+    explicitly opts in via ``allow_flagged`` / ``allow_duplicates``.
+    ``save_fn`` is invoked as ``save_fn(category, content, user_id)``.
+    The function is injected so this module stays free of database
+    coupling — see :mod:`core.memory` for the standard implementation.
+    """
+    result = MemoryImportCommitResult()
+
+    if not confirm:
+        result.skipped_unconfirmed = preview.total
+        return result
+
+    for candidate in preview.candidates:
+        if candidate.duplicate and not allow_duplicates:
+            result.skipped_duplicate += 1
+            continue
+        if _is_flagged(candidate) and not allow_flagged:
+            result.skipped_flagged += 1
+            continue
+        save_fn(candidate.category, candidate.content, user_id)
+        result.saved_count += 1
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers.
+# ---------------------------------------------------------------------------
+
+def _is_flagged(candidate: MemoryImportCandidate) -> bool:
+    """True when a candidate has at least one non-``duplicate`` safety flag."""
+    return any(f != "duplicate" for f in candidate.flags)
+
+
+def _normalize(text: str) -> str:
+    """Lowercase and collapse whitespace for comparison."""
+    return " ".join(text.lower().split())
 
 
 def _count_short_entries(text: str) -> int:
@@ -154,37 +360,3 @@ def _count_short_entries(text: str) -> int:
             if content and len(content) < MIN_CONTENT_LENGTH:
                 count += 1
     return count
-
-
-def parse_markdown_memory_pack(text: str) -> List[MemoryImportCandidate]:
-    """Parse a Markdown memory pack into structured memory candidates.
-
-    Headings (##) become categories; bullet points beneath them become entries.
-    Content before the first heading and empty/too-short bullets are ignored.
-    """
-    candidates: List[MemoryImportCandidate] = []
-    current_category: str | None = None
-
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-
-        if line.startswith("## "):
-            current_category = line[3:].strip()
-            continue
-
-        if line.startswith("# "):
-            # Top-level title — not a category; ignore content until next ##.
-            current_category = None
-            continue
-
-        if current_category is None:
-            continue
-
-        if line.startswith("- "):
-            content = line[2:].strip()
-            if len(content) >= MIN_CONTENT_LENGTH:
-                candidates.append(
-                    MemoryImportCandidate(category=current_category, content=content)
-                )
-
-    return candidates

--- a/docs/memory-pack-import.md
+++ b/docs/memory-pack-import.md
@@ -1,0 +1,162 @@
+# Memory pack import (v1)
+
+Nova can ingest a curated **Markdown memory pack** so a user can bring
+useful long-term context with them from another assistant without
+re-teaching everything by hand. The import flow is **local-only**,
+**preview-first**, and **never saves anything without explicit user
+confirmation**.
+
+This document describes the v1 backend contract implemented in
+[`core/memory_importer.py`](../core/memory_importer.py). UI / API
+wiring is intentionally out of scope for v1; the helpers below can be
+exercised programmatically or from a future Settings panel.
+
+## What a memory pack is
+
+A memory pack is a small, human-readable Markdown file. The top-level
+heading (`#`) is a title; each second-level heading (`##`) is a memory
+**category**; bullet points beneath a category become individual
+**memory entries**.
+
+```markdown
+# Nova Memory Pack
+
+## Git workflow
+- The user wants main to stay stable.
+- The user uses feature/*, fix/*, and hotfix/* branches for PRs.
+
+## Response style
+- The user prefers clear, direct, step-by-step answers.
+- The user wants warnings before risky Git actions.
+
+## Projects
+- The user works on Nova, Auryn, SilentGuard, and NexaNote.
+```
+
+Parsing rules:
+
+- `## Heading` opens a category. The text after `## ` is used verbatim.
+- `# Title` resets the current category — bullets immediately after a
+  top-level heading are ignored until the next `## Heading`.
+- Bullets must start with `- ` (dash, space). Anything else is ignored.
+- Entries shorter than 10 characters are rejected as too short.
+- Empty bullets, content before the first `##`, and free prose are
+  ignored.
+
+## Local-only behaviour
+
+The importer never reaches the network. It accepts Markdown text in
+memory and returns Python data structures. There is **no** cloud
+connector, **no** OAuth, **no** ChatGPT/Claude account integration,
+**no** background import, and **no** raw conversation ingest in v1.
+
+The parser, safety scanner, and preview pipeline are pure functions
+with no dependency on SQLite or the file system. Persistence is
+delegated to a caller-supplied `save_fn`, so callers control where —
+and whether — data lands.
+
+## Preview before save
+
+`build_memory_import_preview(text, existing_contents=None)` returns a
+`MemoryImportPreview` containing:
+
+- `candidates: list[MemoryImportCandidate]` — every reviewable entry,
+  with `category`, `content`, `source="import"`, `priority="normal"`,
+  a `flags` tuple, and a `duplicate` boolean.
+- `total`, `categories`, and counts for rejected / duplicate / flagged
+  entries.
+- `warnings` — short, human-readable strings describing the rejected
+  count, duplicate count, empty input, or "no valid candidates found".
+
+The preview is deterministic: the same input produces the same output.
+**Nothing is written to the database at this stage.** A caller can
+display the preview, let the user toggle entries, and only then call
+the commit helper below.
+
+## Safety flags
+
+Each candidate carries a `flags: tuple[str, ...]` produced by the
+deterministic scanner in `scan_content_for_flags()`. Multiple flags
+can fire on the same entry. Possible values:
+
+| Flag | Meaning |
+|---|---|
+| `possible_password` | Content mentions `password`, `passwd`, or `passphrase`. |
+| `possible_token` | Content mentions an API key, access token, bearer token, or contains a long alphanumeric run. |
+| `possible_private_key` | Content mentions `private key`, `private_key`, or a PEM/OpenSSH header. |
+| `possible_secret` | Umbrella flag — set whenever any of the three above fires, or when `secret` / `credential` appear. |
+| `possible_sensitive_personal_data` | Content matches an email, phone number, SSN, or credit-card-shaped pattern. |
+| `suspicious_string` | A whitespace-free alphanumeric run of 20+ characters was found. |
+| `duplicate` | Content matches a memory already in `existing_contents` (case- and whitespace-insensitive). |
+
+The detection is intentionally keyword- and regex-based — **no ML or
+LLM is involved**. False negatives are preferred over false positives
+in a review-before-save workflow; users still see the entry and
+decide.
+
+The importer never imports passwords, tokens, API keys, private keys,
+or credentials automatically. Any candidate with a non-`duplicate`
+safety flag is skipped at commit time unless the caller explicitly
+opts in via `allow_flagged=True`.
+
+## Explicit confirmation step
+
+`commit_memory_import(preview, user_id, save_fn, confirm=False,
+allow_flagged=False, allow_duplicates=False)` is the only function in
+this module that can cause data to be written. It returns a
+`MemoryImportCommitResult` summarising:
+
+- `saved_count` — entries actually persisted via `save_fn`.
+- `skipped_flagged` — flagged entries skipped because
+  `allow_flagged=False`.
+- `skipped_duplicate` — duplicates skipped because
+  `allow_duplicates=False`.
+- `skipped_unconfirmed` — set to `preview.total` when `confirm=False`,
+  signalling that no save was attempted.
+
+Rules:
+
+1. With `confirm=False` the function is a no-op. `allow_flagged` /
+   `allow_duplicates` have no effect on their own — confirmation is
+   always required.
+2. With `confirm=True`, clean candidates are passed to `save_fn` as
+   `save_fn(category, content, user_id)`.
+3. Flagged and duplicate candidates are skipped by default. The caller
+   must enable each opt-in explicitly to import them.
+
+A typical wiring looks like this:
+
+```python
+from core.memory import save_memory, list_memories
+from core.memory_importer import build_memory_import_preview, commit_memory_import
+
+existing = [m["content"] for m in list_memories(user_id)]
+preview = build_memory_import_preview(markdown_text, existing_contents=existing)
+
+# Show preview.candidates / preview.warnings to the user, let them confirm.
+
+result = commit_memory_import(
+    preview,
+    user_id=user_id,
+    save_fn=save_memory,
+    confirm=True,                # set only after a real user confirms
+    allow_flagged=False,         # never silently save sensitive entries
+    allow_duplicates=False,
+)
+```
+
+## Non-goals for v1
+
+The following are **explicitly out of scope** for this iteration and
+should not be added to the importer module:
+
+- Direct connection to ChatGPT, Claude, or any cloud account.
+- Importing whole raw conversation transcripts.
+- Background / scheduled imports.
+- Automatic saving of any entry without a confirmation step.
+- Storing passwords, tokens, API keys, or private keys.
+- ML- or LLM-based safety classification.
+
+Future work — a Settings UI, a paste-text endpoint, multi-pack import
+history — should build **on top of** the contract above, not replace
+it.

--- a/tests/test_memory_importer.py
+++ b/tests/test_memory_importer.py
@@ -1,8 +1,11 @@
 from core.memory_importer import (
     MemoryImportCandidate,
+    MemoryImportCommitResult,
     MemoryImportPreview,
     build_memory_import_preview,
+    commit_memory_import,
     parse_markdown_memory_pack,
+    scan_content_for_flags,
 )
 
 
@@ -348,3 +351,254 @@ def test_no_sqlite_usage_in_importer():
         source = f.read()
     assert "sqlite3" not in source
     assert "save_memory" not in source
+
+
+# ---------------------------------------------------------------------------
+# Granular safety flags
+# ---------------------------------------------------------------------------
+
+def test_scan_returns_empty_tuple_for_clean_content():
+    assert scan_content_for_flags("The user prefers dark mode.") == ()
+
+
+def test_password_emits_possible_password_flag():
+    flags = scan_content_for_flags("My password is hunter2 for the work account.")
+    assert "possible_password" in flags
+    # Umbrella flag still present for callers that only check the generic one.
+    assert "possible_secret" in flags
+
+
+def test_passphrase_emits_possible_password_flag():
+    flags = scan_content_for_flags("The passphrase for the disk is on a sticky note.")
+    assert "possible_password" in flags
+
+
+def test_api_key_emits_possible_token_flag():
+    flags = scan_content_for_flags("The api key is stored in the config file.")
+    assert "possible_token" in flags
+    assert "possible_secret" in flags
+
+
+def test_bearer_token_emits_possible_token_flag():
+    flags = scan_content_for_flags("Send the bearer token in the Authorization header.")
+    assert "possible_token" in flags
+
+
+def test_private_key_emits_possible_private_key_flag():
+    flags = scan_content_for_flags("The private key lives at ~/.ssh/id_rsa.")
+    assert "possible_private_key" in flags
+    assert "possible_secret" in flags
+
+
+def test_pem_header_emits_possible_private_key_flag():
+    flags = scan_content_for_flags("-----BEGIN OPENSSH PRIVATE KEY----- pasted here")
+    assert "possible_private_key" in flags
+
+
+def test_email_emits_possible_sensitive_personal_data_flag():
+    flags = scan_content_for_flags("Contact me at jane.doe@example.com for questions.")
+    assert "possible_sensitive_personal_data" in flags
+
+
+def test_phone_number_emits_possible_sensitive_personal_data_flag():
+    flags = scan_content_for_flags("Reach me at +1 555-123-4567 anytime.")
+    assert "possible_sensitive_personal_data" in flags
+
+
+def test_ssn_emits_possible_sensitive_personal_data_flag():
+    flags = scan_content_for_flags("My SSN is 123-45-6789, do not share.")
+    assert "possible_sensitive_personal_data" in flags
+
+
+def test_credit_card_emits_possible_sensitive_personal_data_flag():
+    flags = scan_content_for_flags("Card number 4111 1111 1111 1111 expires soon.")
+    assert "possible_sensitive_personal_data" in flags
+
+
+def test_long_alphanumeric_emits_possible_token_flag():
+    token = "a" * 25
+    flags = scan_content_for_flags(f"The pasted value is {token} here.")
+    assert "possible_token" in flags
+    # Existing umbrella flag is also kept.
+    assert "possible_secret" in flags
+    assert "suspicious_string" in flags
+
+
+def test_preview_personal_data_increments_flagged_count():
+    text = "## Contacts\n- Email me at jane.doe@example.com please.\n"
+    preview = build_memory_import_preview(text)
+    assert preview.flagged_count == 1
+    assert "possible_sensitive_personal_data" in preview.candidates[0].flags
+
+
+def test_preview_emits_specific_password_flag():
+    text = "## Creds\n- My password is hunter2 for the work account.\n"
+    preview = build_memory_import_preview(text)
+    flags = preview.candidates[0].flags
+    assert "possible_password" in flags
+    assert "possible_secret" in flags
+
+
+def test_preview_emits_specific_private_key_flag():
+    text = "## Security\n- The private key is saved in the secrets folder.\n"
+    preview = build_memory_import_preview(text)
+    flags = preview.candidates[0].flags
+    assert "possible_private_key" in flags
+
+
+def test_duplicate_flag_appears_on_candidate_flags():
+    text = "## Info\n- The user wants main to stay stable.\n"
+    existing = ["The user wants main to stay stable."]
+    preview = build_memory_import_preview(text, existing_contents=existing)
+    assert "duplicate" in preview.candidates[0].flags
+    assert preview.candidates[0].duplicate is True
+
+
+def test_duplicate_only_flag_does_not_count_as_sensitive_flagged():
+    # A plain duplicate should not bump flagged_count — only sensitive flags do.
+    text = "## Info\n- The user wants main to stay stable.\n"
+    existing = ["The user wants main to stay stable."]
+    preview = build_memory_import_preview(text, existing_contents=existing)
+    assert preview.flagged_count == 0
+    assert preview.duplicate_count == 1
+
+
+def test_clean_entry_has_no_flags():
+    flags = scan_content_for_flags("The user prefers concise, direct answers.")
+    assert flags == ()
+
+
+# ---------------------------------------------------------------------------
+# commit_memory_import — explicit confirmation
+# ---------------------------------------------------------------------------
+
+class _RecorderSave:
+    """Stand-in for ``core.memory.save_memory(category, content, user_id)``."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, int]] = []
+
+    def __call__(self, category: str, content: str, user_id: int) -> None:
+        self.calls.append((category, content, user_id))
+
+
+def test_commit_without_confirmation_saves_nothing():
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    saver = _RecorderSave()
+    result = commit_memory_import(preview, user_id=1, save_fn=saver)
+    assert isinstance(result, MemoryImportCommitResult)
+    assert result.saved_count == 0
+    assert result.skipped_unconfirmed == preview.total
+    assert saver.calls == []
+
+
+def test_commit_with_confirmation_saves_clean_candidates():
+    preview = build_memory_import_preview(SAMPLE_PACK)
+    saver = _RecorderSave()
+    result = commit_memory_import(preview, user_id=7, save_fn=saver, confirm=True)
+    assert result.saved_count == preview.total
+    assert len(saver.calls) == preview.total
+    assert all(call[2] == 7 for call in saver.calls)
+    categories = {call[0] for call in saver.calls}
+    assert "Git workflow" in categories
+    assert "Response style" in categories
+
+
+def test_commit_skips_flagged_by_default():
+    text = (
+        "## Notes\n"
+        "- The user prefers concise answers always.\n"
+        "## Creds\n"
+        "- My password is hunter2 for the work account.\n"
+    )
+    preview = build_memory_import_preview(text)
+    saver = _RecorderSave()
+    result = commit_memory_import(preview, user_id=1, save_fn=saver, confirm=True)
+    assert result.saved_count == 1
+    assert result.skipped_flagged == 1
+    saved_contents = [c[1] for c in saver.calls]
+    assert "My password is hunter2 for the work account." not in saved_contents
+
+
+def test_commit_skips_duplicates_by_default():
+    text = "## Info\n- The user wants main to stay stable.\n"
+    existing = ["The user wants main to stay stable."]
+    preview = build_memory_import_preview(text, existing_contents=existing)
+    saver = _RecorderSave()
+    result = commit_memory_import(preview, user_id=1, save_fn=saver, confirm=True)
+    assert result.saved_count == 0
+    assert result.skipped_duplicate == 1
+    assert saver.calls == []
+
+
+def test_commit_allow_flagged_persists_flagged_entries():
+    text = "## Creds\n- My password is hunter2 for the work account.\n"
+    preview = build_memory_import_preview(text)
+    saver = _RecorderSave()
+    result = commit_memory_import(
+        preview, user_id=1, save_fn=saver, confirm=True, allow_flagged=True,
+    )
+    assert result.saved_count == 1
+    assert result.skipped_flagged == 0
+    assert len(saver.calls) == 1
+
+
+def test_commit_allow_duplicates_persists_duplicate_entries():
+    text = "## Info\n- The user wants main to stay stable.\n"
+    existing = ["The user wants main to stay stable."]
+    preview = build_memory_import_preview(text, existing_contents=existing)
+    saver = _RecorderSave()
+    result = commit_memory_import(
+        preview, user_id=1, save_fn=saver, confirm=True, allow_duplicates=True,
+    )
+    assert result.saved_count == 1
+    assert result.skipped_duplicate == 0
+
+
+def test_commit_returns_zero_counts_on_empty_preview():
+    preview = build_memory_import_preview("")
+    saver = _RecorderSave()
+    result = commit_memory_import(preview, user_id=1, save_fn=saver, confirm=True)
+    assert result.saved_count == 0
+    assert result.skipped_flagged == 0
+    assert result.skipped_duplicate == 0
+    assert saver.calls == []
+
+
+def test_commit_passes_category_and_content_to_save_fn():
+    text = "## Workflow\n- The user wants warnings before risky Git actions.\n"
+    preview = build_memory_import_preview(text)
+    saver = _RecorderSave()
+    commit_memory_import(preview, user_id=42, save_fn=saver, confirm=True)
+    assert saver.calls == [
+        ("Workflow", "The user wants warnings before risky Git actions.", 42),
+    ]
+
+
+def test_commit_does_not_save_on_confirm_false_even_with_allow_flags():
+    text = "## Creds\n- My password is hunter2 for the work account.\n"
+    preview = build_memory_import_preview(text)
+    saver = _RecorderSave()
+    result = commit_memory_import(
+        preview,
+        user_id=1,
+        save_fn=saver,
+        confirm=False,
+        allow_flagged=True,
+        allow_duplicates=True,
+    )
+    assert result.saved_count == 0
+    assert saver.calls == []
+
+
+def test_commit_skipped_flagged_counts_each_flagged_candidate():
+    text = (
+        "## A\n- My password is hunter2 for the work account.\n"
+        "## B\n- The api key is stored in config_file_here.\n"
+        "## C\n- The user prefers concise replies always.\n"
+    )
+    preview = build_memory_import_preview(text)
+    saver = _RecorderSave()
+    result = commit_memory_import(preview, user_id=1, save_fn=saver, confirm=True)
+    assert result.saved_count == 1
+    assert result.skipped_flagged == 2


### PR DESCRIPTION
## Summary

Builds on the existing parser/preview foundation in `core/memory_importer.py` to deliver the rest of the v1 backend contract called out in issue #84: a richer safety-flag taxonomy, an explicit confirmation-gated commit step, clean separation of parser / scanner / preview / persistence, and the documentation that describes the format and guarantees.

- `core/memory_importer.py` is refactored into four small layers:
  - `parse_markdown_memory_pack(text)` — pure parser; no scanning, no DB.
  - `scan_content_for_flags(content)` — pure deterministic scanner that returns `possible_password`, `possible_token`, `possible_private_key`, `possible_secret` (umbrella), `possible_sensitive_personal_data`, and `suspicious_string` as needed.
  - `build_memory_import_preview(text, existing_contents)` — composes parser + dedup + scanner, surfaces `flagged_count` / `duplicate_count` / `rejected_count`, also adds `"duplicate"` to the candidate `flags` tuple alongside the existing `.duplicate` field. Writes nothing.
  - `commit_memory_import(preview, user_id, save_fn, confirm=False, allow_flagged=False, allow_duplicates=False)` — the only place that can persist, and only when `confirm=True`. Flagged and duplicate entries are skipped by default. Persistence is delegated to `save_fn` so the module stays free of any database coupling and the existing `test_no_sqlite_usage_in_importer` continues to hold.
- Sensitive-personal-data detection covers emails, SSN-shaped digits, credit-card-shaped digit runs (13–19 digits with optional separators), and conservative phone-number patterns. No ML, no LLM, no network.
- 28 new unit tests cover the granular flag taxonomy, personal-data detection, the duplicate flag surface, and every branch of the commit helper (confirm gate, default skips, `allow_flagged` / `allow_duplicates` opt-ins, multiple flagged entries).
- `docs/memory-pack-import.md` documents the format, the local-only contract, the preview-before-save flow, the safety flag taxonomy, the explicit non-goals (no cloud import, no full conversation import, no automatic saving), and shows a typical wiring against `core.memory.save_memory`.
- The README's `core/` map entry for `memory_importer.py` is rewritten, and a short Development status bullet points at the new doc.

This PR intentionally **does not** add UI, an HTTP endpoint, a cloud connector, a ChatGPT/Claude account import, background imports, or full-conversation ingest — those are explicit non-goals for v1.

## Test plan

- [x] `pytest tests/test_memory_importer.py` — 72 passed (44 pre-existing + 28 new).
- [x] `pytest tests/test_memory.py tests/test_memory_command.py tests/test_memory_parsing.py tests/test_memory_importer.py tests/test_natural_memory.py` — 165 passed.
- [x] Full `pytest tests/` — `996 passed, 3 failed`; the 3 failures (`test_default_admin_sees_migrated_history`, `test_default_admin_sees_migrated_memories`, `test_legacy_admin_single_user_flow_preserved`) reproduce on `main` and are unrelated to this change; the 238 collection errors are sandbox-only (missing `_cffi_backend`, etc.).
- [x] `flake8 core/memory_importer.py tests/test_memory_importer.py` — clean.

https://claude.ai/code/session_019E8RdqpfS287JCw5RBkjFf

---
_Generated by [Claude Code](https://claude.ai/code/session_019E8RdqpfS287JCw5RBkjFf)_