### PR TITLE
feat(integrations): add optional read-only GitHub maintainer connector (#119)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,44 @@ NOVA_SILENTGUARD_SYSTEMD_UNIT=silentguard-api.service
 NEXANOTE_API_URL=
 NEXANOTE_API_TOKEN=
 NEXANOTE_TIMEOUT_SECONDS=3.0
+#
+# Optional GitHub maintainer connector (issue #119). Lets an admin
+# inspect a repo's issues / pull requests via the GitHub REST API.
+#
+# This is NOT the alpha-channel GitHub OAuth login (see GITHUB_CLIENT_ID
+# / GITHUB_CLIENT_SECRET above). The OAuth gate signs users into Nova;
+# this connector reads repository state on behalf of a configured
+# maintainer token. They are independent — different config keys,
+# different code paths, different code modules.
+#
+# Defaults are off / read-only and the token must never be:
+#   * returned to the frontend or chat,
+#   * written to any log line or error message,
+#   * stored in the database.
+#
+#   NOVA_GITHUB_ENABLED        — host-wide switch. False → connector
+#                                disabled for everyone; admin-only
+#                                endpoints still resolve but report
+#                                state="disabled".
+#   NOVA_GITHUB_TOKEN          — personal-access / fine-grained token
+#                                with read scopes only (`repo:read` is
+#                                enough for v1). No write scopes are
+#                                ever required by Nova.
+#   NOVA_GITHUB_DEFAULT_REPO   — optional ``owner/name`` fallback used
+#                                when an endpoint is called without an
+#                                explicit ``?repo=…``. Empty disables
+#                                the fallback.
+#   NOVA_GITHUB_READ_ONLY      — belt-and-braces flag, default true.
+#                                v1 never performs writes; this is
+#                                kept for future write helpers, which
+#                                will require explicit confirmation
+#                                and audit logging when introduced.
+#   NOVA_GITHUB_TIMEOUT_SECONDS — per-request HTTP timeout (default 5).
+NOVA_GITHUB_ENABLED=false
+NOVA_GITHUB_TOKEN=
+NOVA_GITHUB_DEFAULT_REPO=
+NOVA_GITHUB_READ_ONLY=true
+NOVA_GITHUB_TIMEOUT_SECONDS=5.0
 
 # ── Time / calendar context ───────────────────────────────────────────
 # Override the timezone Nova uses when resolving "today", "yesterday", etc.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,84 @@ read-only API as a user service, see
 an example unit lives at
 [`deploy/systemd/silentguard-api.service`](deploy/systemd/silentguard-api.service).
 
+## Optional GitHub maintainer connector
+
+Nova ships an **optional**, **admin-only**, **read-only** GitHub
+connector (issue #119). The connector lets a maintainer ask Nova
+calm questions about a repository — open issues, open pull
+requests, basic metadata — without turning Nova into an autonomous
+bot.
+
+Important: this is **not** the alpha-channel GitHub OAuth login
+gate (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` /
+`/auth/github`). The OAuth flow is about *signing users into Nova*
+on the alpha channel. The connector below is about *reading a
+repo's state on the maintainer's behalf*. They share neither code
+paths nor config keys.
+
+The connector is disabled by default. To enable it on a local
+Nova install, add the following to your `.env`:
+
+```ini
+NOVA_GITHUB_ENABLED=true
+NOVA_GITHUB_TOKEN=ghp_your_local_token
+NOVA_GITHUB_DEFAULT_REPO=owner/name      # optional fallback
+NOVA_GITHUB_READ_ONLY=true               # default; v1 has no writes
+NOVA_GITHUB_TIMEOUT_SECONDS=5.0
+```
+
+The token only needs **read** scopes (`repo:read` is enough for v1)
+because Nova never performs write operations against GitHub in this
+phase. Use a fine-grained personal access token scoped to the
+repositories you want Nova to read; do not give the token write,
+admin, or organisation-management scopes.
+
+Once configured, Nova exposes five admin-only endpoints:
+
+- `GET /integrations/github/status` — calm snapshot of the
+  connector. The `state` field is one of `disabled`,
+  `not_configured`, `unavailable`, or `connected_read_only`.
+- `GET /integrations/github/issues` — list open issues for
+  `?repo=owner/name` (or the default repo).
+- `GET /integrations/github/pulls` — list open pull requests.
+- `GET /integrations/github/issues/{number}` — single issue.
+- `GET /integrations/github/pulls/{number}` — single pull request.
+
+All endpoints are auth-gated and admin-only. Non-admin and
+restricted users receive a 403; the aggregate
+`/integrations/status` response surfaces `state: "disabled"` for
+the GitHub entry to non-admin callers so the UI can hide the card
+without leaking the configured state.
+
+Token safety contract:
+
+- The token is read from `NOVA_GITHUB_TOKEN` and **never** returned
+  in any HTTP response body, chat context, log line, or error
+  message.
+- The token only ever appears inside the connector's private
+  request `Authorization` header — never in URLs, query params, or
+  JSON bodies.
+- The connector stores the token in environment-local config only.
+  This PR does not persist it to the database; future revisions
+  may add encrypted storage, but the v1 contract is local-first.
+- Sanitised error responses (e.g. invalid token, unreachable API)
+  surface a short, hard-coded summary like *"GitHub rejected the
+  configured token."* — never the raw exception, never the
+  response body.
+
+What this connector is **not** allowed to do (now or via this PR):
+
+- create, close, or comment on issues,
+- comment on, approve, reject, or merge pull requests,
+- change repository settings, labels, or permissions,
+- push, force-push, or run any git command,
+- run any background polling or scheduled maintenance.
+
+Any future write actions will be introduced behind their own
+opt-in switch, will require explicit user confirmation in the
+UI, and will carry audit logging. There is no autonomous
+maintainer behaviour planned.
+
 ## Voice and TTS
 
 Every assistant message has a "Read aloud" button. By default Nova uses

--- a/config.py
+++ b/config.py
@@ -30,6 +30,55 @@ NEXANOTE_API_URL = os.getenv("NEXANOTE_API_URL", "").strip().rstrip("/")
 NEXANOTE_API_TOKEN = os.getenv("NEXANOTE_API_TOKEN", "").strip()
 NEXANOTE_TIMEOUT_SECONDS = float(os.getenv("NEXANOTE_TIMEOUT_SECONDS", "3.0"))
 
+# ── Optional GitHub connector (read-only by default) ───────────────
+# A small, opt-in bridge that lets Nova help maintainers *read* the
+# state of a repository (issues, pull requests, basic metadata) from
+# the GitHub REST API. Nova is a local maintainer assistant, not an
+# autonomous bot: this v1 ships read-only methods only. Writes,
+# auto-merge, comments, and any background polling are out of scope.
+#
+# Every switch defaults to OFF so an unconfigured Nova install never
+# contacts GitHub. When ``NOVA_GITHUB_ENABLED`` is on but
+# ``NOVA_GITHUB_TOKEN`` is missing the status endpoint reports
+# ``not_configured`` — Nova does not fall back to anonymous access,
+# both to avoid the strict unauthenticated rate limit and to make the
+# "no token configured" state visible to the admin.
+#
+# ``NOVA_GITHUB_TOKEN`` must never be:
+#   * returned in any HTTP response body,
+#   * embedded in any log line,
+#   * included in any error message surfaced to the frontend / chat,
+#   * persisted to the database in this PR.
+#
+#   NOVA_GITHUB_ENABLED       — host-wide opt-in. False → connector
+#                               disabled for everyone.
+#   NOVA_GITHUB_TOKEN         — personal-access / fine-grained token
+#                               with read-only scopes (``repo:read`` /
+#                               ``read:org`` is enough for v1).
+#   NOVA_GITHUB_DEFAULT_REPO  — optional ``owner/name`` used when an
+#                               endpoint is called without an explicit
+#                               repo. Empty disables the fallback.
+#   NOVA_GITHUB_READ_ONLY     — belt-and-braces switch. Defaults to
+#                               True; v1 never performs writes so the
+#                               flag is purely informational today.
+#                               Future write helpers will refuse when
+#                               this is True.
+#   NOVA_GITHUB_TIMEOUT_SECONDS — per-request HTTP timeout (default 5).
+NOVA_GITHUB_ENABLED = (
+    os.getenv("NOVA_GITHUB_ENABLED", "false").strip().lower() == "true"
+)
+NOVA_GITHUB_TOKEN = os.getenv("NOVA_GITHUB_TOKEN", "").strip()
+NOVA_GITHUB_DEFAULT_REPO = os.getenv("NOVA_GITHUB_DEFAULT_REPO", "").strip()
+NOVA_GITHUB_READ_ONLY = (
+    os.getenv("NOVA_GITHUB_READ_ONLY", "true").strip().lower() != "false"
+)
+try:
+    NOVA_GITHUB_TIMEOUT_SECONDS = float(
+        os.getenv("NOVA_GITHUB_TIMEOUT_SECONDS", "5.0")
+    )
+except ValueError:
+    NOVA_GITHUB_TIMEOUT_SECONDS = 5.0
+
 # SilentGuard local read-only HTTP API (optional; off by default).
 # An empty value keeps the file-based probe in place. Setting a URL
 # (typically loopback, e.g. http://127.0.0.1:8767) enables the HTTP

--- a/core/integrations/__init__.py
+++ b/core/integrations/__init__.py
@@ -4,9 +4,12 @@ Optional integrations Nova can talk to without absorbing their codebases.
 Each module in this package is a passive bridge to an external tool:
   * silentguard — read-only file-based feed of network observations.
   * nexanote   — HTTP API for notes (read by default; writes opt-in).
+  * github     — read-only HTTP bridge to the GitHub REST API for
+                 admin-only issue / PR visibility (no writes in v1).
 
-Every integration is gated behind a per-user setting and is safe to
-import even when the underlying tool is missing or unreachable. Public
-helpers must never raise on the happy "tool absent" path; they return
-empty results or a `{"state": "..."}` status dict instead.
+Every integration is gated behind a per-user or host-level switch and
+is safe to import even when the underlying tool is missing or
+unreachable. Public helpers must never raise on the happy "tool
+absent" path; they return empty results or a `{"state": "..."}`
+status dict instead.
 """

--- a/core/integrations/github.py
+++ b/core/integrations/github.py
@@ -1,0 +1,527 @@
+"""
+Optional read-only GitHub connector (issue #119).
+
+Nova is a *local maintainer assistant*, not an autonomous GitHub bot.
+This v1 module is intentionally narrow:
+
+  * read-only HTTP calls against the GitHub REST API,
+  * admin-gated at the endpoint layer (this module is a pure library
+    and is never invoked from chat),
+  * a single status snapshot the UI / chat can show calmly,
+  * helpers to list / fetch issues and pull requests for a repo.
+
+What this module deliberately does NOT do:
+
+  * create / close issues or PRs,
+  * comment, approve, merge, or auto-merge,
+  * change repository settings, labels, or permissions,
+  * push, force-push, or run any git command,
+  * background polling or scheduled maintenance.
+
+Token safety contract (enforced):
+
+  * the token is read from ``config.NOVA_GITHUB_TOKEN`` and never
+    returned by any public function;
+  * the token is sent only as a request ``Authorization`` header — it
+    never appears in URLs, query params, or JSON request bodies;
+  * exceptions are logged at debug level by *type* only, never with the
+    raw message, so a misbehaving stack trace cannot leak the header;
+  * detail strings surfaced to the frontend are short, hard-coded
+    summaries — they never include the token, the response body, or the
+    exception's repr.
+
+Configuration (env vars, see ``config.py``):
+
+  * ``NOVA_GITHUB_ENABLED``        — host-wide on/off switch.
+  * ``NOVA_GITHUB_TOKEN``          — personal access token. Read-only
+                                     scopes are enough; v1 never writes.
+  * ``NOVA_GITHUB_DEFAULT_REPO``   — optional ``owner/name`` fallback.
+  * ``NOVA_GITHUB_READ_ONLY``      — belt-and-braces; defaults True.
+  * ``NOVA_GITHUB_TIMEOUT_SECONDS`` — per-request timeout (default 5s).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+import httpx
+
+from config import (
+    NOVA_GITHUB_DEFAULT_REPO,
+    NOVA_GITHUB_ENABLED,
+    NOVA_GITHUB_READ_ONLY,
+    NOVA_GITHUB_TIMEOUT_SECONDS,
+    NOVA_GITHUB_TOKEN,
+)
+
+logger = logging.getLogger(__name__)
+
+NAME = "github"
+
+API_BASE_URL = "https://api.github.com"
+USER_AGENT = "Nova-GitHub-Connector/1.0"
+
+STATE_DISABLED = "disabled"
+STATE_NOT_CONFIGURED = "not_configured"
+STATE_UNAVAILABLE = "unavailable"
+STATE_CONNECTED = "connected_read_only"
+
+# Caps so a single response can never balloon Nova's memory or chat
+# context. GitHub already pages at 30 by default; we enforce a hard
+# upper bound of 100 (the GitHub API's own per_page cap).
+_MAX_LIMIT = 100
+_DEFAULT_LIMIT = 30
+# Single-issue / single-PR bodies can be large markdown; truncating
+# protects callers that splice the value into a chat prompt. The cap
+# is generous (~16 KB) and never silently rewrites — callers see an
+# explicit ``"body_truncated": True`` marker when it fires.
+_BODY_MAX_CHARS = 16_000
+
+# GitHub permits these characters in owner / repo path segments. The
+# regex is anchored on both ends so any rejected slug aborts before
+# the HTTP call is built — defence in depth against path injection.
+_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
+_REPO_SPEC_RE = re.compile(
+    r"^([A-Za-z0-9][A-Za-z0-9._-]{0,99})/([A-Za-z0-9][A-Za-z0-9._-]{0,99})$"
+)
+
+
+# ── Status type ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GitHubStatus:
+    """Calm, frontend-safe snapshot of the connector's availability.
+
+    Never includes the token, never includes raw exception text. The
+    ``state`` field is one of the four module-level ``STATE_*`` values
+    so the UI can branch on a stable enum.
+    """
+
+    name: str
+    enabled: bool
+    state: str
+    detail: str = ""
+    default_repo: str = ""
+    read_only: bool = True
+    authenticated_login: Optional[str] = None
+    scopes: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "enabled": self.enabled,
+            "state": self.state,
+            "detail": self.detail,
+            "default_repo": self.default_repo,
+            "read_only": self.read_only,
+            "authenticated_login": self.authenticated_login,
+            "scopes": list(self.scopes),
+        }
+
+
+# ── Switch helpers ──────────────────────────────────────────────────
+
+
+def is_enabled() -> bool:
+    """True when the host operator has flipped the env switch on."""
+    return bool(NOVA_GITHUB_ENABLED)
+
+
+def is_read_only() -> bool:
+    """Always True in v1; reflects ``NOVA_GITHUB_READ_ONLY``."""
+    return bool(NOVA_GITHUB_READ_ONLY)
+
+
+def _has_token() -> bool:
+    return bool(NOVA_GITHUB_TOKEN)
+
+
+def _headers() -> dict:
+    """Build the request headers. Never returned to callers."""
+    return {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": USER_AGENT,
+        "Authorization": f"Bearer {NOVA_GITHUB_TOKEN}",
+    }
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(
+        base_url=API_BASE_URL,
+        timeout=NOVA_GITHUB_TIMEOUT_SECONDS,
+        headers=_headers(),
+    )
+
+
+def _log_error(where: str, exc: BaseException) -> None:
+    """Log an exception by type only so the token cannot leak via repr."""
+    logger.debug("github %s failed: %s", where, type(exc).__name__)
+
+
+# ── Repo helpers ────────────────────────────────────────────────────
+
+
+def parse_repo_spec(spec: Optional[str]) -> Optional[tuple[str, str]]:
+    """Validate ``owner/name`` and return the pair, or ``None`` if invalid.
+
+    Used by the endpoint layer so a caller cannot smuggle a path
+    fragment via the ``repo`` query param.
+    """
+    if not spec or not isinstance(spec, str):
+        return None
+    match = _REPO_SPEC_RE.match(spec.strip())
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+def resolve_repo(spec: Optional[str]) -> Optional[tuple[str, str]]:
+    """Return the validated ``(owner, name)`` for the requested spec.
+
+    Falls back to ``NOVA_GITHUB_DEFAULT_REPO`` when ``spec`` is empty.
+    ``None`` means neither the request nor the host config provided a
+    usable repo — the caller surfaces that as a 400.
+    """
+    if spec:
+        return parse_repo_spec(spec)
+    return parse_repo_spec(NOVA_GITHUB_DEFAULT_REPO)
+
+
+def _valid_slug(slug: str) -> bool:
+    return isinstance(slug, str) and _SLUG_RE.match(slug) is not None
+
+
+def _valid_number(number) -> bool:
+    try:
+        return int(number) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _clamp_limit(limit: int) -> int:
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return _DEFAULT_LIMIT
+    if n <= 0:
+        return _DEFAULT_LIMIT
+    return min(n, _MAX_LIMIT)
+
+
+def _valid_state(state: str) -> str:
+    """Coerce the optional GitHub ``state`` filter to a known value."""
+    if isinstance(state, str) and state.lower() in ("open", "closed", "all"):
+        return state.lower()
+    return "open"
+
+
+# ── Status ──────────────────────────────────────────────────────────
+
+
+def status() -> GitHubStatus:
+    """Report whether the connector is on and reachable. Never raises.
+
+    Off                                  → ``disabled``.
+    On + no token                        → ``not_configured``.
+    On + token + ``GET /user`` 2xx       → ``connected_read_only``.
+    On + token + any HTTP / network err  → ``unavailable`` with a
+                                           short, sanitised detail.
+    """
+    if not is_enabled():
+        return GitHubStatus(
+            name=NAME, enabled=False, state=STATE_DISABLED,
+            detail="Set NOVA_GITHUB_ENABLED=true to turn the connector on.",
+            default_repo=NOVA_GITHUB_DEFAULT_REPO,
+            read_only=is_read_only(),
+        )
+    if not _has_token():
+        return GitHubStatus(
+            name=NAME, enabled=True, state=STATE_NOT_CONFIGURED,
+            detail="NOVA_GITHUB_TOKEN is not set on this Nova host.",
+            default_repo=NOVA_GITHUB_DEFAULT_REPO,
+            read_only=is_read_only(),
+        )
+    try:
+        with _client() as client:
+            resp = client.get("/user")
+    except (httpx.HTTPError, OSError) as exc:
+        _log_error("status", exc)
+        return GitHubStatus(
+            name=NAME, enabled=True, state=STATE_UNAVAILABLE,
+            detail="GitHub API is not reachable.",
+            default_repo=NOVA_GITHUB_DEFAULT_REPO,
+            read_only=is_read_only(),
+        )
+    if resp.status_code == 401:
+        return GitHubStatus(
+            name=NAME, enabled=True, state=STATE_UNAVAILABLE,
+            detail="GitHub rejected the configured token.",
+            default_repo=NOVA_GITHUB_DEFAULT_REPO,
+            read_only=is_read_only(),
+        )
+    if not (200 <= resp.status_code < 300):
+        return GitHubStatus(
+            name=NAME, enabled=True, state=STATE_UNAVAILABLE,
+            detail=f"GitHub returned HTTP {resp.status_code}.",
+            default_repo=NOVA_GITHUB_DEFAULT_REPO,
+            read_only=is_read_only(),
+        )
+    login: Optional[str] = None
+    try:
+        body = resp.json()
+        if isinstance(body, dict):
+            raw_login = body.get("login")
+            if isinstance(raw_login, str):
+                login = raw_login
+    except ValueError as exc:
+        _log_error("status decode", exc)
+    scopes = _parse_scopes(resp.headers.get("X-OAuth-Scopes"))
+    return GitHubStatus(
+        name=NAME, enabled=True, state=STATE_CONNECTED,
+        detail=(
+            f"Authenticated as {login}." if login
+            else "Authenticated read-only access."
+        ),
+        default_repo=NOVA_GITHUB_DEFAULT_REPO,
+        read_only=is_read_only(),
+        authenticated_login=login,
+        scopes=scopes,
+    )
+
+
+def _parse_scopes(header: Optional[str]) -> tuple[str, ...]:
+    if not isinstance(header, str) or not header.strip():
+        return ()
+    return tuple(s.strip() for s in header.split(",") if s.strip())
+
+
+# ── Read API ────────────────────────────────────────────────────────
+
+
+def list_issues(
+    owner: str,
+    repo: str,
+    state: str = "open",
+    limit: int = _DEFAULT_LIMIT,
+) -> list[dict]:
+    """Return sanitised issues for ``owner/repo``.
+
+    Empty list when the connector is off / not configured / unreachable,
+    when the slugs fail validation, or when GitHub returns a non-2xx
+    response. ``state`` accepts ``open`` / ``closed`` / ``all``.
+
+    Note: GitHub's ``/issues`` endpoint also returns pull requests; we
+    drop those from this list and let callers use :func:`list_pull_requests`
+    for PR data instead.
+    """
+    if not is_enabled() or not _has_token():
+        return []
+    if not (_valid_slug(owner) and _valid_slug(repo)):
+        return []
+    params = {
+        "state": _valid_state(state),
+        "per_page": _clamp_limit(limit),
+    }
+    try:
+        with _client() as client:
+            resp = client.get(f"/repos/{owner}/{repo}/issues", params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_issues", exc)
+        return []
+    if not isinstance(data, list):
+        return []
+    issues = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        # GitHub flags PRs by including a ``pull_request`` key; skip them.
+        if "pull_request" in item:
+            continue
+        issues.append(_sanitize_issue(item))
+    return issues
+
+
+def get_issue(owner: str, repo: str, number) -> Optional[dict]:
+    """Return one sanitised issue, or ``None`` on any failure path."""
+    if not is_enabled() or not _has_token():
+        return None
+    if not (_valid_slug(owner) and _valid_slug(repo) and _valid_number(number)):
+        return None
+    try:
+        with _client() as client:
+            resp = client.get(f"/repos/{owner}/{repo}/issues/{int(number)}")
+        if not (200 <= resp.status_code < 300):
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("get_issue", exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    # If GitHub hands back a PR via the issues endpoint, surface it as
+    # such; the caller can decide whether to redirect.
+    if "pull_request" in data:
+        return None
+    return _sanitize_issue(data, include_body=True)
+
+
+def list_pull_requests(
+    owner: str,
+    repo: str,
+    state: str = "open",
+    limit: int = _DEFAULT_LIMIT,
+) -> list[dict]:
+    """Return sanitised pull requests for ``owner/repo``. Empty on failure."""
+    if not is_enabled() or not _has_token():
+        return []
+    if not (_valid_slug(owner) and _valid_slug(repo)):
+        return []
+    params = {
+        "state": _valid_state(state),
+        "per_page": _clamp_limit(limit),
+    }
+    try:
+        with _client() as client:
+            resp = client.get(f"/repos/{owner}/{repo}/pulls", params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_pull_requests", exc)
+        return []
+    if not isinstance(data, list):
+        return []
+    return [_sanitize_pr(item) for item in data if isinstance(item, dict)]
+
+
+def get_pull_request(owner: str, repo: str, number) -> Optional[dict]:
+    """Return one sanitised pull request, or ``None`` on any failure."""
+    if not is_enabled() or not _has_token():
+        return None
+    if not (_valid_slug(owner) and _valid_slug(repo) and _valid_number(number)):
+        return None
+    try:
+        with _client() as client:
+            resp = client.get(f"/repos/{owner}/{repo}/pulls/{int(number)}")
+        if not (200 <= resp.status_code < 300):
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("get_pull_request", exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _sanitize_pr(data, include_body=True)
+
+
+# ── Summary helper ──────────────────────────────────────────────────
+
+
+def summarize_repo_activity(
+    owner: str, repo: str, limit: int = _DEFAULT_LIMIT
+) -> dict:
+    """Read-only roll-up of open issues + PRs for ``owner/repo``.
+
+    Returns a plain dict the chat layer or UI can surface without
+    further processing. Never raises; failure paths yield zeroed
+    counts and empty lists so the caller can render a calm summary.
+    """
+    issues = list_issues(owner, repo, state="open", limit=limit)
+    pulls = list_pull_requests(owner, repo, state="open", limit=limit)
+    return {
+        "repo": f"{owner}/{repo}",
+        "open_issues": len(issues),
+        "open_pull_requests": len(pulls),
+        "issues": issues,
+        "pull_requests": pulls,
+        "read_only": True,
+    }
+
+
+# ── Sanitisers ──────────────────────────────────────────────────────
+
+
+def _truncate_body(body) -> tuple[Optional[str], bool]:
+    if not isinstance(body, str):
+        return None, False
+    if len(body) <= _BODY_MAX_CHARS:
+        return body, False
+    return body[:_BODY_MAX_CHARS], True
+
+
+def _labels(item: dict) -> list[str]:
+    labels = item.get("labels") or []
+    if not isinstance(labels, list):
+        return []
+    out = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                out.append(name)
+        elif isinstance(label, str):
+            out.append(label)
+    return out
+
+
+def _login(item: dict, key: str = "user") -> Optional[str]:
+    sub = item.get(key)
+    if isinstance(sub, dict):
+        login = sub.get("login")
+        if isinstance(login, str):
+            return login
+    return None
+
+
+def _sanitize_issue(item: dict, include_body: bool = False) -> dict:
+    out: dict = {
+        "number": item.get("number"),
+        "title": item.get("title"),
+        "state": item.get("state"),
+        "user": _login(item),
+        "labels": _labels(item),
+        "comments": item.get("comments"),
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+        "closed_at": item.get("closed_at"),
+        "html_url": item.get("html_url"),
+    }
+    if include_body:
+        body, truncated = _truncate_body(item.get("body"))
+        out["body"] = body
+        out["body_truncated"] = truncated
+    return out
+
+
+def _sanitize_pr(item: dict, include_body: bool = False) -> dict:
+    head = item.get("head") if isinstance(item.get("head"), dict) else {}
+    base = item.get("base") if isinstance(item.get("base"), dict) else {}
+    out: dict = {
+        "number": item.get("number"),
+        "title": item.get("title"),
+        "state": item.get("state"),
+        "draft": item.get("draft"),
+        "merged": item.get("merged"),
+        "user": _login(item),
+        "labels": _labels(item),
+        "head": head.get("ref"),
+        "base": base.get("ref"),
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+        "closed_at": item.get("closed_at"),
+        "merged_at": item.get("merged_at"),
+        "html_url": item.get("html_url"),
+    }
+    if include_body:
+        body, truncated = _truncate_body(item.get("body"))
+        out["body"] = body
+        out["body_truncated"] = truncated
+    return out

--- a/tests/test_integrations_github.py
+++ b/tests/test_integrations_github.py
@@ -1,0 +1,818 @@
+"""
+Tests for the optional read-only GitHub connector (issue #119).
+
+Scope of the suite mirrors the issue's testing requirements:
+
+  * disabled connector reports ``disabled`` and never reaches the wire,
+  * missing token reports ``not_configured`` without leaking secrets,
+  * invalid token / HTTP errors are sanitised and surface as
+    ``unavailable`` with no token bleed,
+  * read-only issue and pull request listing works against a mocked
+    GitHub response,
+  * the connector module exposes no write helpers and contains no
+    POST / PUT / PATCH / DELETE calls,
+  * the FastAPI endpoints are admin-only — non-admin and restricted
+    users get a 403,
+  * the configured token never appears in any returned JSON body or
+    error message.
+
+The HTTP transport is stubbed via the same ``httpx.Client`` factory
+swap pattern used by the NexaNote integration tests, so no real
+network call is ever issued.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import sqlite3
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, users
+from core.integrations import github as gh
+from memory import store as natural_store
+
+
+SECRET_TOKEN = "ghp_TESTTOKEN_must_never_leak_1234567890"
+SECRET_FRAGMENT = "TESTTOKEN_must_never_leak"
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+# ── Fake httpx client ───────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any = None,
+                 headers: dict | None = None, raise_decode: bool = False):
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+        self._raise_decode = raise_decode
+
+    def json(self):
+        if self._raise_decode:
+            raise ValueError("decode error")
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, scripted: dict, calls: list,
+                 raise_on: set | None = None, headers: dict | None = None):
+        self._scripted = scripted
+        self._calls = calls
+        self._raise_on = raise_on or set()
+        self._headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def _record(self, method: str, path: str, **kwargs):
+        self._calls.append(
+            {"method": method, "path": path, "kwargs": kwargs,
+             "headers": dict(self._headers)},
+        )
+        if path in self._raise_on:
+            raise httpx.ConnectError("boom")
+        return self._scripted.get((method, path), _FakeResponse(404))
+
+    def get(self, path: str, **kwargs):
+        return self._record("GET", path, **kwargs)
+
+
+@pytest.fixture
+def github_stub(monkeypatch):
+    """Replace ``httpx.Client`` in the connector and enable the integration.
+
+    Returns ``(install, calls)``; ``install(scripted, raise_on=...)``
+    sets the scripted responses, and ``calls`` accumulates every
+    outbound request (method, path, kwargs, captured headers).
+    """
+    calls: list = []
+    state: dict = {"scripted": {}, "raise_on": set()}
+
+    monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", True)
+    monkeypatch.setattr(gh, "NOVA_GITHUB_TOKEN", SECRET_TOKEN)
+    monkeypatch.setattr(gh, "NOVA_GITHUB_DEFAULT_REPO", "octocat/Hello-World")
+    monkeypatch.setattr(gh, "NOVA_GITHUB_READ_ONLY", True)
+
+    def factory(*args, **kwargs):
+        return _FakeClient(
+            state["scripted"], calls, state["raise_on"],
+            headers=kwargs.get("headers", {}),
+        )
+
+    monkeypatch.setattr(gh.httpx, "Client", factory)
+
+    def install(scripted: dict, raise_on: set | None = None):
+        state["scripted"] = scripted
+        state["raise_on"] = raise_on or set()
+
+    return install, calls
+
+
+# ── Switches ────────────────────────────────────────────────────────
+
+
+class TestSwitches:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", False)
+        assert gh.is_enabled() is False
+
+    def test_enabled_when_env_true(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", True)
+        assert gh.is_enabled() is True
+
+    def test_read_only_is_true_by_default(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_READ_ONLY", True)
+        assert gh.is_read_only() is True
+
+
+# ── Status states ───────────────────────────────────────────────────
+
+
+class TestStatus:
+    def test_disabled_when_switch_off(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", False)
+        monkeypatch.setattr(gh, "NOVA_GITHUB_TOKEN", SECRET_TOKEN)
+        s = gh.status()
+        assert s.state == gh.STATE_DISABLED
+        assert s.enabled is False
+
+    def test_not_configured_when_token_missing(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", True)
+        monkeypatch.setattr(gh, "NOVA_GITHUB_TOKEN", "")
+        s = gh.status()
+        assert s.state == gh.STATE_NOT_CONFIGURED
+        assert s.enabled is True
+
+    def test_connected_on_2xx(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/user"): _FakeResponse(
+                200, {"login": "octocat"},
+                headers={"X-OAuth-Scopes": "repo, read:org"},
+            ),
+        })
+        s = gh.status()
+        assert s.state == gh.STATE_CONNECTED
+        assert s.authenticated_login == "octocat"
+        assert s.scopes == ("repo", "read:org")
+
+    def test_unavailable_on_401(self, github_stub):
+        install, _ = github_stub
+        install({("GET", "/user"): _FakeResponse(401, {"message": "Bad credentials"})})
+        s = gh.status()
+        assert s.state == gh.STATE_UNAVAILABLE
+
+    def test_unavailable_on_5xx(self, github_stub):
+        install, _ = github_stub
+        install({("GET", "/user"): _FakeResponse(503)})
+        s = gh.status()
+        assert s.state == gh.STATE_UNAVAILABLE
+
+    def test_unavailable_on_network_error(self, github_stub):
+        install, _ = github_stub
+        install({}, raise_on={"/user"})
+        s = gh.status()
+        assert s.state == gh.STATE_UNAVAILABLE
+
+    def test_no_http_when_disabled(self, monkeypatch, github_stub):
+        install, calls = github_stub
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", False)
+        install({("GET", "/user"): _FakeResponse(200, {"login": "octocat"})})
+        gh.status()
+        assert calls == []
+
+    def test_no_http_when_token_missing(self, monkeypatch, github_stub):
+        install, calls = github_stub
+        monkeypatch.setattr(gh, "NOVA_GITHUB_TOKEN", "")
+        install({("GET", "/user"): _FakeResponse(200, {"login": "octocat"})})
+        gh.status()
+        assert calls == []
+
+
+# ── Read API ────────────────────────────────────────────────────────
+
+
+_ISSUE_PAYLOAD = {
+    "number": 42,
+    "title": "Add tests",
+    "state": "open",
+    "user": {"login": "alice"},
+    "labels": [{"name": "bug"}, {"name": "good first issue"}],
+    "comments": 3,
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-02T00:00:00Z",
+    "closed_at": None,
+    "html_url": "https://github.com/octocat/Hello-World/issues/42",
+    "body": "Body of the issue",
+}
+
+_PR_PAYLOAD = {
+    "number": 7,
+    "title": "Add feature",
+    "state": "open",
+    "draft": False,
+    "merged": False,
+    "user": {"login": "bob"},
+    "labels": [{"name": "enhancement"}],
+    "head": {"ref": "feature-branch"},
+    "base": {"ref": "main"},
+    "created_at": "2024-01-03T00:00:00Z",
+    "updated_at": "2024-01-04T00:00:00Z",
+    "closed_at": None,
+    "merged_at": None,
+    "html_url": "https://github.com/octocat/Hello-World/pull/7",
+    "body": "Body of the PR",
+}
+
+
+class TestListIssues:
+    def test_returns_sanitised_issues(self, github_stub):
+        install, calls = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+        })
+        result = gh.list_issues("octocat", "Hello-World")
+        assert result == [{
+            "number": 42,
+            "title": "Add tests",
+            "state": "open",
+            "user": "alice",
+            "labels": ["bug", "good first issue"],
+            "comments": 3,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "closed_at": None,
+            "html_url": "https://github.com/octocat/Hello-World/issues/42",
+        }]
+        # The list view never includes the body — it stays small and chat-safe.
+        assert "body" not in result[0]
+        assert calls[-1]["kwargs"]["params"]["state"] == "open"
+
+    def test_skips_pull_requests_in_issue_listing(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues"): _FakeResponse(
+                200,
+                [
+                    _ISSUE_PAYLOAD,
+                    {**_ISSUE_PAYLOAD, "number": 99, "pull_request": {"url": "..."}},
+                ],
+            ),
+        })
+        result = gh.list_issues("octocat", "Hello-World")
+        assert [i["number"] for i in result] == [42]
+
+    def test_empty_when_disabled(self, monkeypatch, github_stub):
+        install, calls = github_stub
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", False)
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+        })
+        assert gh.list_issues("octocat", "Hello-World") == []
+        assert calls == []
+
+    def test_empty_on_network_error(self, github_stub):
+        install, _ = github_stub
+        install({}, raise_on={"/repos/octocat/Hello-World/issues"})
+        assert gh.list_issues("octocat", "Hello-World") == []
+
+    def test_empty_on_invalid_slug(self, github_stub):
+        install, calls = github_stub
+        install({})
+        assert gh.list_issues("../etc", "passwd") == []
+        assert gh.list_issues("octocat", "../etc") == []
+        assert calls == []
+
+    def test_state_filter_coerced(self, github_stub):
+        install, calls = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+        })
+        gh.list_issues("octocat", "Hello-World", state="banana")
+        assert calls[-1]["kwargs"]["params"]["state"] == "open"
+
+    def test_limit_clamped(self, github_stub):
+        install, calls = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+        })
+        gh.list_issues("octocat", "Hello-World", limit=10_000)
+        assert calls[-1]["kwargs"]["params"]["per_page"] == 100
+
+
+class TestGetIssue:
+    def test_returns_issue_with_body(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues/42"):
+                _FakeResponse(200, _ISSUE_PAYLOAD),
+        })
+        out = gh.get_issue("octocat", "Hello-World", 42)
+        assert out["number"] == 42
+        assert out["body"] == "Body of the issue"
+        assert out["body_truncated"] is False
+
+    def test_returns_none_for_pull_request(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues/77"): _FakeResponse(
+                200, {**_ISSUE_PAYLOAD, "number": 77, "pull_request": {"url": "..."}},
+            ),
+        })
+        assert gh.get_issue("octocat", "Hello-World", 77) is None
+
+    def test_returns_none_on_404(self, github_stub):
+        install, _ = github_stub
+        install({("GET", "/repos/octocat/Hello-World/issues/99"): _FakeResponse(404)})
+        assert gh.get_issue("octocat", "Hello-World", 99) is None
+
+    def test_invalid_number_returns_none(self, github_stub):
+        install, calls = github_stub
+        install({})
+        assert gh.get_issue("octocat", "Hello-World", 0) is None
+        assert gh.get_issue("octocat", "Hello-World", "../etc") is None
+        assert calls == []
+
+    def test_body_truncation(self, github_stub):
+        install, _ = github_stub
+        big = "x" * 20_000
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues/42"): _FakeResponse(
+                200, {**_ISSUE_PAYLOAD, "body": big},
+            ),
+        })
+        out = gh.get_issue("octocat", "Hello-World", 42)
+        assert len(out["body"]) == 16_000
+        assert out["body_truncated"] is True
+
+
+class TestListPulls:
+    def test_returns_sanitised_pulls(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/pulls"):
+                _FakeResponse(200, [_PR_PAYLOAD]),
+        })
+        result = gh.list_pull_requests("octocat", "Hello-World")
+        assert result == [{
+            "number": 7,
+            "title": "Add feature",
+            "state": "open",
+            "draft": False,
+            "merged": False,
+            "user": "bob",
+            "labels": ["enhancement"],
+            "head": "feature-branch",
+            "base": "main",
+            "created_at": "2024-01-03T00:00:00Z",
+            "updated_at": "2024-01-04T00:00:00Z",
+            "closed_at": None,
+            "merged_at": None,
+            "html_url": "https://github.com/octocat/Hello-World/pull/7",
+        }]
+
+    def test_empty_on_network_error(self, github_stub):
+        install, _ = github_stub
+        install({}, raise_on={"/repos/octocat/Hello-World/pulls"})
+        assert gh.list_pull_requests("octocat", "Hello-World") == []
+
+    def test_empty_when_token_missing(self, monkeypatch, github_stub):
+        install, calls = github_stub
+        monkeypatch.setattr(gh, "NOVA_GITHUB_TOKEN", "")
+        install({
+            ("GET", "/repos/octocat/Hello-World/pulls"):
+                _FakeResponse(200, [_PR_PAYLOAD]),
+        })
+        assert gh.list_pull_requests("octocat", "Hello-World") == []
+        assert calls == []
+
+
+class TestGetPull:
+    def test_returns_pr_with_body(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/pulls/7"):
+                _FakeResponse(200, _PR_PAYLOAD),
+        })
+        out = gh.get_pull_request("octocat", "Hello-World", 7)
+        assert out["number"] == 7
+        assert out["body"] == "Body of the PR"
+
+    def test_returns_none_on_404(self, github_stub):
+        install, _ = github_stub
+        install({("GET", "/repos/octocat/Hello-World/pulls/99"): _FakeResponse(404)})
+        assert gh.get_pull_request("octocat", "Hello-World", 99) is None
+
+
+class TestRepoResolution:
+    def test_parses_default_repo(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_DEFAULT_REPO", "octocat/Hello-World")
+        assert gh.resolve_repo(None) == ("octocat", "Hello-World")
+
+    def test_explicit_repo_wins(self, monkeypatch):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_DEFAULT_REPO", "octocat/Hello-World")
+        assert gh.resolve_repo("foo/bar") == ("foo", "bar")
+
+    def test_invalid_spec_rejected(self):
+        for bad in ("", "no-slash", "two/slashes/here", "../etc/passwd",
+                    "owner/", "/repo", "owner/repo;rm -rf /"):
+            assert gh.parse_repo_spec(bad) is None
+
+
+# ── Token safety ────────────────────────────────────────────────────
+
+
+class TestTokenSafety:
+    def test_token_not_in_status_payload(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/user"): _FakeResponse(200, {"login": "octocat"}),
+        })
+        serialised = repr(gh.status().as_dict())
+        assert SECRET_FRAGMENT not in serialised
+
+    def test_token_not_in_issue_payload(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/repos/octocat/Hello-World/issues/42"):
+                _FakeResponse(200, _ISSUE_PAYLOAD),
+        })
+        out = gh.get_issue("octocat", "Hello-World", 42)
+        assert SECRET_FRAGMENT not in repr(out)
+
+    def test_token_only_in_auth_header(self, github_stub):
+        install, calls = github_stub
+        install({("GET", "/user"): _FakeResponse(200, {"login": "octocat"})})
+        gh.status()
+        assert calls, "expected at least one outbound request"
+        captured = calls[-1]["headers"]
+        # Token must be present in the Authorization header...
+        assert captured.get("Authorization") == f"Bearer {SECRET_TOKEN}"
+        # ...and nowhere in the URL / params / query.
+        assert SECRET_FRAGMENT not in captured["path"] if "path" in captured else True
+        assert SECRET_FRAGMENT not in repr(calls[-1]["kwargs"])
+
+    def test_logger_messages_omit_token(self, monkeypatch, github_stub, caplog):
+        install, _ = github_stub
+        install({}, raise_on={"/user"})
+        with caplog.at_level("DEBUG", logger=gh.logger.name):
+            gh.status()
+        for record in caplog.records:
+            assert SECRET_FRAGMENT not in record.getMessage()
+            assert SECRET_FRAGMENT not in str(record.args or "")
+
+
+# ── Module-level "no write code" enforcement ────────────────────────
+
+
+class TestNoWriteCode:
+    """The Phase-1 module must not call any write verb against GitHub.
+
+    A future PR can add write helpers, but they must come with their
+    own gating + audit + confirmation logic. This test fails fast if
+    POST / PUT / PATCH / DELETE ever leak into the read-only module by
+    accident.
+    """
+
+    def test_module_has_no_write_helpers(self):
+        for name in (
+            "create_issue", "close_issue", "comment_on_issue",
+            "merge_pull_request", "approve_pull_request",
+            "comment_on_pull_request", "create_pull_request",
+        ):
+            assert not hasattr(gh, name), (
+                f"{name!r} should not exist in the Phase-1 connector"
+            )
+
+    def test_module_never_calls_write_verbs(self):
+        with open(gh.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        forbidden = {"post", "put", "patch", "delete"}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            attr = getattr(func, "attr", None)
+            if isinstance(attr, str) and attr.lower() in forbidden:
+                raise AssertionError(
+                    f"forbidden write verb {attr!r} called at line {node.lineno}"
+                )
+
+    def test_module_does_not_import_oauth_flow(self):
+        """The maintainer connector must stay independent of the OAuth gate."""
+        with open(gh.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                assert "github_oauth" not in module, (
+                    f"connector must not import from {module!r}"
+                )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert "github_oauth" not in alias.name, (
+                        f"connector must not import {alias.name!r}"
+                    )
+
+
+# ── Endpoint: admin-only enforcement ────────────────────────────────
+
+
+class TestEndpointsAdminOnly:
+    @pytest.fixture(autouse=True)
+    def _stub(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/user"): _FakeResponse(200, {"login": "octocat"}),
+            ("GET", "/repos/octocat/Hello-World/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+            ("GET", "/repos/octocat/Hello-World/issues/42"):
+                _FakeResponse(200, _ISSUE_PAYLOAD),
+            ("GET", "/repos/octocat/Hello-World/pulls"):
+                _FakeResponse(200, [_PR_PAYLOAD]),
+            ("GET", "/repos/octocat/Hello-World/pulls/7"):
+                _FakeResponse(200, _PR_PAYLOAD),
+        })
+
+    @pytest.mark.parametrize("path", [
+        "/integrations/github/status",
+        "/integrations/github/issues",
+        "/integrations/github/pulls",
+        "/integrations/github/issues/42",
+        "/integrations/github/pulls/7",
+    ])
+    def test_non_admin_user_forbidden(self, web_client, user_token, path):
+        resp = web_client.get(path, headers=_h(user_token))
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("path", [
+        "/integrations/github/status",
+        "/integrations/github/issues",
+        "/integrations/github/pulls",
+        "/integrations/github/issues/42",
+        "/integrations/github/pulls/7",
+    ])
+    def test_restricted_user_forbidden(self, web_client, restricted_token, path):
+        resp = web_client.get(path, headers=_h(restricted_token))
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("path", [
+        "/integrations/github/status",
+        "/integrations/github/issues",
+        "/integrations/github/pulls",
+        "/integrations/github/issues/42",
+        "/integrations/github/pulls/7",
+    ])
+    def test_unauthenticated_blocked(self, web_client, path):
+        resp = web_client.get(path)
+        assert resp.status_code in (401, 403)
+
+
+# ── Endpoint: admin happy path ──────────────────────────────────────
+
+
+class TestEndpointsAdmin:
+    @pytest.fixture(autouse=True)
+    def _stub(self, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/user"): _FakeResponse(200, {"login": "octocat"}),
+            ("GET", "/repos/octocat/Hello-World/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+            ("GET", "/repos/octocat/Hello-World/issues/42"):
+                _FakeResponse(200, _ISSUE_PAYLOAD),
+            ("GET", "/repos/octocat/Hello-World/pulls"):
+                _FakeResponse(200, [_PR_PAYLOAD]),
+            ("GET", "/repos/octocat/Hello-World/pulls/7"):
+                _FakeResponse(200, _PR_PAYLOAD),
+        })
+
+    def test_status_endpoint(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/github/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == gh.STATE_CONNECTED
+        assert body["read_only"] is True
+        assert "token" not in body
+        assert SECRET_FRAGMENT not in resp.text
+
+    def test_status_disabled_when_switch_off(
+        self, monkeypatch, web_client, admin_token,
+    ):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_ENABLED", False)
+        resp = web_client.get(
+            "/integrations/github/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == gh.STATE_DISABLED
+
+    def test_list_issues_default_repo(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/github/issues", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["repo"] == "octocat/Hello-World"
+        assert body["read_only"] is True
+        assert body["issues"][0]["number"] == 42
+        assert SECRET_FRAGMENT not in resp.text
+
+    def test_list_issues_explicit_repo(self, web_client, admin_token, github_stub):
+        install, _ = github_stub
+        install({
+            ("GET", "/user"): _FakeResponse(200, {"login": "octocat"}),
+            ("GET", "/repos/foo/bar/issues"):
+                _FakeResponse(200, [_ISSUE_PAYLOAD]),
+        })
+        resp = web_client.get(
+            "/integrations/github/issues?repo=foo/bar",
+            headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["repo"] == "foo/bar"
+
+    def test_list_issues_400_without_repo(
+        self, monkeypatch, web_client, admin_token,
+    ):
+        monkeypatch.setattr(gh, "NOVA_GITHUB_DEFAULT_REPO", "")
+        resp = web_client.get(
+            "/integrations/github/issues", headers=_h(admin_token),
+        )
+        assert resp.status_code == 400
+
+    def test_get_issue(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/github/issues/42", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["issue"]["title"] == "Add tests"
+        assert SECRET_FRAGMENT not in resp.text
+
+    def test_get_issue_404_when_missing(
+        self, web_client, admin_token, github_stub,
+    ):
+        install, _ = github_stub
+        install({
+            ("GET", "/user"): _FakeResponse(200, {"login": "octocat"}),
+            ("GET", "/repos/octocat/Hello-World/issues/99"): _FakeResponse(404),
+        })
+        resp = web_client.get(
+            "/integrations/github/issues/99", headers=_h(admin_token),
+        )
+        assert resp.status_code == 404
+
+    def test_list_pulls(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/github/pulls", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["pull_requests"][0]["number"] == 7
+        assert body["read_only"] is True
+
+    def test_get_pull(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/github/pulls/7", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["pull_request"]["title"] == "Add feature"
+
+    def test_endpoints_503_when_unconfigured(
+        self, monkeypatch, web_client, admin_token, github_stub,
+    ):
+        install, _ = github_stub
+        monkeypatch.setattr(gh, "NOVA_GITHUB_TOKEN", "")
+        install({})
+        # status itself stays 200 with state="not_configured"
+        resp = web_client.get(
+            "/integrations/github/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == gh.STATE_NOT_CONFIGURED
+        # listing endpoints translate that into 503 so the caller does
+        # not have to peek at the status body to know when to retry.
+        for path in (
+            "/integrations/github/issues",
+            "/integrations/github/pulls",
+            "/integrations/github/issues/42",
+            "/integrations/github/pulls/7",
+        ):
+            resp = web_client.get(path, headers=_h(admin_token))
+            assert resp.status_code == 503, path
+
+    def test_endpoint_errors_do_not_leak_token(
+        self, monkeypatch, web_client, admin_token, github_stub,
+    ):
+        install, _ = github_stub
+        install({}, raise_on={"/user", "/repos/octocat/Hello-World/issues"})
+        for path in (
+            "/integrations/github/status",
+            "/integrations/github/issues",
+        ):
+            resp = web_client.get(path, headers=_h(admin_token))
+            assert SECRET_FRAGMENT not in resp.text, path
+
+
+# ── Aggregate /integrations/status surface ──────────────────────────
+
+
+class TestAggregateStatus:
+    def test_admin_sees_github_state(self, web_client, admin_token, github_stub):
+        install, _ = github_stub
+        install({("GET", "/user"): _FakeResponse(200, {"login": "octocat"})})
+        resp = web_client.get("/integrations/status", headers=_h(admin_token))
+        assert resp.status_code == 200
+        github = resp.json()["github"]
+        assert github["state"] == gh.STATE_CONNECTED
+
+    def test_non_admin_sees_disabled_github(
+        self, web_client, user_token, github_stub,
+    ):
+        install, _ = github_stub
+        install({("GET", "/user"): _FakeResponse(200, {"login": "octocat"})})
+        resp = web_client.get("/integrations/status", headers=_h(user_token))
+        assert resp.status_code == 200
+        github = resp.json()["github"]
+        assert github["state"] == gh.STATE_DISABLED
+        assert github["enabled"] is False

--- a/web.py
+++ b/web.py
@@ -57,6 +57,7 @@ from core import local_models as _local_models
 from core.ollama_client import OllamaUnavailable
 from core.integrations import silentguard as _silentguard_integration
 from core.integrations import nexanote as _nexanote_integration
+from core.integrations import github as _github_integration
 from core.security import ensure_silentguard_running as _ensure_silentguard_running
 from core.security import lifecycle as _silentguard_lifecycle
 from core.security import SilentGuardProvider as _SilentGuardProvider
@@ -891,14 +892,33 @@ def update_settings(
 
 @app.get("/integrations/status")
 def integrations_status(user: CurrentUser = Depends(get_current_user)):
-    """Per-integration availability snapshot for the caller."""
-    return {
+    """Per-integration availability snapshot for the caller.
+
+    The GitHub connector is host-level and admin-only; non-admin
+    callers see only that it is ``disabled`` so the UI can hide the
+    card without leaking the configured state.
+    """
+    payload: dict = {
         "silentguard": _silentguard_integration.status(user.id).as_dict(),
         "nexanote": {
             **_nexanote_integration.status(user.id).as_dict(),
             "write_enabled": _nexanote_integration.is_write_enabled(user.id),
         },
     }
+    if user.role == "admin":
+        payload["github"] = _github_integration.status().as_dict()
+    else:
+        payload["github"] = {
+            "name": _github_integration.NAME,
+            "enabled": False,
+            "state": _github_integration.STATE_DISABLED,
+            "detail": "GitHub connector is admin-only.",
+            "default_repo": "",
+            "read_only": True,
+            "authenticated_login": None,
+            "scopes": [],
+        }
+    return payload
 
 
 @app.get("/integrations/silentguard/lifecycle")
@@ -1783,6 +1803,156 @@ def admin_get_pull(
     if job is None:
         raise HTTPException(status_code=404, detail="Pull job not found.")
     return job
+
+
+# ── ADMIN: OPTIONAL GITHUB CONNECTOR (read-only, #119) ─────────────
+# Phase-1 admin-only window into a GitHub repository. Every endpoint is
+# wrapped with ``require_admin`` so non-admin / restricted users get a
+# 403 — never a leak of the configured repo or the connector state. The
+# underlying ``core.integrations.github`` module is strictly read-only:
+# no helper in this PR creates, comments on, merges, approves, or
+# otherwise mutates anything on GitHub. The token configured in
+# ``NOVA_GITHUB_TOKEN`` is never serialised into any response, header,
+# or log line surfaced here — it lives only inside the connector's
+# private ``Authorization`` header.
+#
+# This connector is intentionally *separate* from the alpha-channel
+# GitHub OAuth gate (``GITHUB_CLIENT_ID`` / ``GITHUB_CLIENT_SECRET`` /
+# ``/auth/github`` flow). The OAuth flow is about *logging into Nova*;
+# this connector is about reading a maintainer's repo state via the
+# GitHub REST API. They share neither config keys nor code paths.
+
+def _resolve_repo_or_400(repo: str | None) -> tuple[str, str]:
+    """Validate ``owner/name`` or fall back to ``NOVA_GITHUB_DEFAULT_REPO``.
+
+    Raises a 400 when neither source produces a valid slug pair, so a
+    misconfigured admin sees a clear error rather than a silent empty
+    response.
+    """
+    resolved = _github_integration.resolve_repo(repo)
+    if resolved is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No GitHub repository specified. Provide ?repo=owner/name "
+                "or set NOVA_GITHUB_DEFAULT_REPO."
+            ),
+        )
+    return resolved
+
+
+def _require_github_ready(status: _github_integration.GitHubStatus) -> None:
+    """Translate a non-connected connector status into a clean 503/404.
+
+    Keeps the response shape consistent so the UI never has to peek at
+    ``status.state`` to know whether to retry.
+    """
+    if status.state == _github_integration.STATE_DISABLED:
+        raise HTTPException(
+            status_code=404,
+            detail="GitHub connector is disabled on this Nova host.",
+        )
+    if status.state == _github_integration.STATE_NOT_CONFIGURED:
+        raise HTTPException(
+            status_code=503,
+            detail="GitHub connector is not configured (no token).",
+        )
+    if status.state == _github_integration.STATE_UNAVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail="GitHub connector is unavailable.",
+        )
+
+
+@app.get("/integrations/github/status")
+def github_status(_: CurrentUser = Depends(require_admin)):
+    """Calm read-only snapshot of the GitHub connector.
+
+    Returns one of the four documented states — ``disabled``,
+    ``not_configured``, ``unavailable``, ``connected_read_only`` —
+    plus the configured default repo and the ``read_only`` flag. The
+    token is intentionally absent from the payload.
+    """
+    return _github_integration.status().as_dict()
+
+
+@app.get("/integrations/github/issues")
+def github_list_issues(
+    repo: str | None = None,
+    state: str = "open",
+    limit: int = 30,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised issues for ``repo`` (or the default repo).
+
+    Read-only. Pull requests are filtered out — use ``/pulls`` for
+    those. ``state`` accepts ``open`` / ``closed`` / ``all``. ``limit``
+    is clamped to the GitHub per_page cap of 100.
+    """
+    owner, name = _resolve_repo_or_400(repo)
+    _require_github_ready(_github_integration.status())
+    return {
+        "repo": f"{owner}/{name}",
+        "state": state,
+        "issues": _github_integration.list_issues(
+            owner, name, state=state, limit=limit
+        ),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/github/issues/{number}")
+def github_get_issue(
+    number: int,
+    repo: str | None = None,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Fetch one sanitised issue. 404 when the issue cannot be read."""
+    if number <= 0:
+        raise HTTPException(status_code=400, detail="Issue number must be positive.")
+    owner, name = _resolve_repo_or_400(repo)
+    _require_github_ready(_github_integration.status())
+    issue = _github_integration.get_issue(owner, name, number)
+    if issue is None:
+        raise HTTPException(status_code=404, detail="Issue not found.")
+    return {"repo": f"{owner}/{name}", "issue": issue, "read_only": True}
+
+
+@app.get("/integrations/github/pulls")
+def github_list_pulls(
+    repo: str | None = None,
+    state: str = "open",
+    limit: int = 30,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised pull requests for ``repo`` (or the default repo)."""
+    owner, name = _resolve_repo_or_400(repo)
+    _require_github_ready(_github_integration.status())
+    return {
+        "repo": f"{owner}/{name}",
+        "state": state,
+        "pull_requests": _github_integration.list_pull_requests(
+            owner, name, state=state, limit=limit
+        ),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/github/pulls/{number}")
+def github_get_pull(
+    number: int,
+    repo: str | None = None,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Fetch one sanitised pull request. 404 when it cannot be read."""
+    if number <= 0:
+        raise HTTPException(status_code=400, detail="PR number must be positive.")
+    owner, name = _resolve_repo_or_400(repo)
+    _require_github_ready(_github_integration.status())
+    pull = _github_integration.get_pull_request(owner, name, number)
+    if pull is None:
+        raise HTTPException(status_code=404, detail="Pull request not found.")
+    return {"repo": f"{owner}/{name}", "pull_request": pull, "read_only": True}
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

Phase-1 foundation for an optional, admin-only, read-only GitHub
maintainer connector (issue #119). Nova can now help a maintainer
*read* the state of a configured repository — open issues, open pull
requests, basic metadata — without becoming an autonomous GitHub bot.

The connector is intentionally separate from the existing alpha-channel
GitHub OAuth login gate. Different config keys, different code paths,
different modules:

- **OAuth gate** (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` /
  `/auth/github` flow) — signs users into Nova.
- **Maintainer connector** (`NOVA_GITHUB_*`, this PR) — reads repo
  state on the maintainer's behalf.

## Scope

What this PR adds:

- `core/integrations/github.py` — read-only connector with status /
  list / get helpers and sanitised dataclass responses.
- 5 admin-only endpoints in `web.py`:
  - `GET /integrations/github/status`
  - `GET /integrations/github/issues`
  - `GET /integrations/github/pulls`
  - `GET /integrations/github/issues/{number}`
  - `GET /integrations/github/pulls/{number}`
- Aggregate `/integrations/status` surfaces the connector state to
  admins only; non-admins see `state: "disabled"` so the UI can hide
  the card without leaking host config.
- Five new config switches in `config.py` (defaults are all OFF /
  read-only), plus `.env.example` documentation.
- 66 new tests in `tests/test_integrations_github.py`.
- README section covering local configuration, security contract, and
  explicit non-goals.

What this PR deliberately does NOT do:

- create / close issues, comment on issues or PRs, approve, reject, or
  merge pull requests,
- change repository settings, labels, or permissions,
- push, force-push, or run any git command,
- run any background polling or scheduled maintenance,
- store the token in the database.

## Security contract

- Disabled by default. `NOVA_GITHUB_ENABLED=true` is required even
  before the token is read.
- Admin-only at every endpoint (`require_admin`). Non-admin and
  restricted users get a 403.
- The token lives only in env config; it is never returned in any
  response, log line, error message, or chat context.
- Exceptions are logged by type only — the raw message (which could
  in theory carry header echoes) never enters the log.
- HTTP errors from GitHub are translated into one of four calm,
  hard-coded detail strings.
- A static AST test asserts the module never calls
  `post` / `put` / `patch` / `delete` and never imports the OAuth
  module, so any future drift breaks the build.

## Test plan

- [x] Disabled connector reports `disabled` and never reaches the
      network (`TestStatus::test_no_http_when_disabled`).
- [x] Missing token reports `not_configured` without leaking secrets
      (`TestStatus::test_not_configured_when_token_missing`).
- [x] Invalid token + transport errors surface as `unavailable` with
      sanitised detail (`TestStatus::test_unavailable_on_401`,
      `test_unavailable_on_network_error`).
- [x] Read-only issue listing works against a mocked GitHub response
      (`TestListIssues`), pull-request listing too (`TestListPulls`).
- [x] Token never appears in any returned JSON payload or error body
      (`TestTokenSafety`, endpoint-level
      `test_endpoint_errors_do_not_leak_token`).
- [x] Non-admin and restricted users blocked on every endpoint
      (`TestEndpointsAdminOnly`).
- [x] Connector module exposes no write helpers and never calls
      `POST` / `PUT` / `PATCH` / `DELETE`
      (`TestNoWriteCode::test_module_never_calls_write_verbs`).
- [x] Connector does not import from `core/github_oauth.py`
      (`TestNoWriteCode::test_module_does_not_import_oauth_flow`).
- [x] Full existing suite still passes: **1375 tests, 0 failures**.

https://claude.ai/code/session_01HKG4GdhinoZ2XJwTHyY41R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKG4GdhinoZ2XJwTHyY41R)_