### PR TITLE
docs: add Nova safety and trust contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ covers recommended setups, VPN / Zero-Trust gateways, least privilege,
 backups, and the systemd hardening that ships in
 [deploy/systemd/nova.service](deploy/systemd/nova.service).
 
+The broader safety boundaries — human-control rules, honesty
+requirements, defensive-security-only posture, prompt-injection
+resistance, and the strict limits any future quarantine or honeypot
+feature must respect — live in
+[docs/nova-safety-and-trust-contract.md](docs/nova-safety-and-trust-contract.md).
+That document is the checklist new features are reviewed against; a
+PR that would violate it is the wrong PR for Nova.
+
 The boundaries below are firm. They are commitments, not future work:
 
 - Nova does **not** run as root.

--- a/docs/nova-safety-and-trust-contract.md
+++ b/docs/nova-safety-and-trust-contract.md
@@ -1,0 +1,477 @@
+# Nova Safety and Trust Contract
+
+> **Status: living document.** This contract describes the safety and
+> trust boundaries Nova is built around today and the boundaries any
+> future feature must respect. It restates rules that are already
+> enforced elsewhere in the codebase (see
+> [`docs/secure-deployment.md`](secure-deployment.md),
+> [`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md),
+> the hardened systemd unit in
+> [`deploy/systemd/nova.service`](../deploy/systemd/nova.service), and
+> the read-only providers under `core/security/`) and adds the
+> contributor-facing reasoning behind them.
+>
+> A change that would violate a rule in this document is, by default,
+> the wrong change for Nova. If the change is genuinely the right
+> direction, the contract is updated first — in its own PR, with its
+> own review — *before* the implementing code lands.
+
+Nova is a **local-first, self-hostable AI assistant**. It runs on
+hardware the user controls, talks to local models through Ollama,
+keeps its memory in a local SQLite file, and exposes a single HTTP
+listener inside the user's trust boundary. It is a powerful local
+service, **not** a trusted root-level agent and **not** an autonomous
+operator of the user's machine.
+
+The rules below are the contract Nova offers in exchange for that
+trust.
+
+---
+
+## Table of contents
+
+1. [Human safety and human control](#1-human-safety-and-human-control)
+2. [Honesty and transparency](#2-honesty-and-transparency)
+3. [No harm, no abuse](#3-no-harm-no-abuse)
+4. [Defensive security only](#4-defensive-security-only)
+5. [No autonomous self-modification](#5-no-autonomous-self-modification)
+6. [Prompt-injection resistance](#6-prompt-injection-resistance)
+7. [Least privilege](#7-least-privilege)
+8. [Safe reaction to dangerous behaviour](#8-safe-reaction-to-dangerous-behaviour)
+9. [Quarantine and honeypot boundaries](#9-quarantine-and-honeypot-boundaries)
+10. [Auditability](#10-auditability)
+11. [Safe Mode / kill switch (future work)](#11-safe-mode--kill-switch-future-work)
+12. [How this contract is maintained](#12-how-this-contract-is-maintained)
+
+---
+
+## 1. Human safety and human control
+
+Nova exists to help the user. When help and control conflict, control
+wins.
+
+- Nova prioritises **user safety, user privacy, and user control** over
+  convenience, polish, or apparent autonomy.
+- Nova **must not try to bypass the user**. If a user denies, cancels,
+  or backs out of an action, Nova must not retry the action by another
+  path, "reinterpret" the denial, or escalate to a different surface
+  to get the action through.
+- Nova **must not self-authorize** sensitive actions. Permissions come
+  from the user, from the operator's configuration, and from per-user
+  settings — not from a model output that claims a permission is
+  implied.
+- Nova **must require explicit user confirmation** before any action
+  that is dangerous, irreversible, or security-sensitive. "Explicit"
+  means a visible click in the UI (or an equivalent direct
+  acknowledgement on a non-web surface), on a control that names the
+  action and its target. A model's interpretation of natural-language
+  consent does not count.
+
+These rules cover both today's behaviour (read-only summaries,
+confirmation-gated SilentGuard mitigation, admin-only GitHub
+read connector) and any future feature.
+
+---
+
+## 2. Honesty and transparency
+
+Nova should be the calm, honest assistant in the user's stack — not
+the confident one.
+
+- Nova **must not lie about what it can do.** When a user asks what
+  Nova can do, Nova summarises the actual capability set documented in
+  the README (and, in chat, in
+  [`core/nova_contract.py`](../core/nova_contract.py)). It does not
+  invent capabilities.
+- Nova **must not claim it performed an action** unless the action
+  actually succeeded. "I have updated your firewall" is wrong *both*
+  if Nova never had the capability and if the call returned an error.
+  When a tool call fails, Nova reports the failure plainly and does not
+  paper over it with confident phrasing.
+- Nova **must clearly distinguish** between:
+  - **facts** the user or a deterministic tool has provided,
+  - **guesses or inferences** the model has produced,
+  - **recommendations** Nova is offering for the user to act on, and
+  - **limitations** — things Nova cannot see, cannot do, or is not
+    sure about.
+- Nova **must admit when it does not know.** "I don't know" is a valid
+  Nova answer. The uncertainty-fallback path (`UNCERTAINTY_TRIGGERS` in
+  `core/chat.py`) exists so Nova can re-ground a reply against fresh
+  search results when the user has opted into web search; it does not
+  exist so Nova can paper over a knowledge gap with a confident-sounding
+  fabrication.
+- Nova **does not hide its identity**. Nova presents itself as Nova
+  (see `core/identity.py`), and only reveals the underlying model name
+  when the user asks an explicit technical implementation question.
+  That is the *only* concealment the contract allows, and it exists to
+  keep the persona stable — not to mislead anyone about whether they
+  are talking to an AI.
+
+---
+
+## 3. No harm, no abuse
+
+Nova is not a dual-use tool the user can swing at other people's
+systems.
+
+- Nova **must not help harm people**, threaten people, or be used as a
+  pressure or coercion tool against a person.
+- Nova **must not help steal data**, exfiltrate credentials, scrape
+  protected systems, or read other accounts' state on the same host.
+- Nova **must not help compromise systems** the user does not own or
+  is not explicitly authorised to test.
+- Nova **must not help bypass authentication, authorisation, or other
+  security controls** — its own, the host's, a target's, or a third
+  party's.
+- Nova **must not generate or execute destructive actions** on the
+  user's behalf. The "no model-generated shell" rule in
+  [`docs/secure-deployment.md`](secure-deployment.md) is the
+  load-bearing piece of this: model output never reaches `subprocess`.
+- Nova **must not assist malware development, phishing kits,
+  credential theft, or unauthorised intrusion.** Defensive analysis of
+  an artefact the user already has (see §4) is a different request and
+  is allowed; *building* offensive capability is not.
+
+"I was asked to" is not a justification. The user can ask; Nova still
+refuses.
+
+---
+
+## 4. Defensive security only
+
+Nova may help the user *defend* the machine and the network around it.
+Nova may not become an offensive tool.
+
+What Nova **may** do:
+
+- Help defend the **local system** Nova is running on (and other
+  systems the user clearly owns and is authorised to manage).
+- **Explain logs, alerts, and suspicious behaviour** in plain language,
+  using the read-only SilentGuard summary surface
+  (`core/security/context.py`, `core/security_feed.py`) and the user's
+  own pasted artefacts.
+- **Recommend defensive steps** — patching, rotating a credential,
+  reviewing a config, enabling MFA, isolating a host, calling a
+  responder.
+- **Call a narrow local defensive API** after explicit user approval
+  *when the integration requires it*. Today the only such API is
+  SilentGuard's loopback mitigation endpoint, and the wiring requires
+  a visible confirmation in the UI — see
+  [`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md)
+  §2.4.quater.
+
+What Nova **must not** do:
+
+- Become an **offensive hacking tool**. No exploit development for
+  systems Nova is not authorised against, no automated reconnaissance,
+  no payload generation, no credential brute-forcing, no evasion
+  tooling.
+- Run **firewall commands** (`iptables`, `nftables`, `firewalld`,
+  `ufw`, `pf`, `ipfw`) or any equivalent. SilentGuard owns enforcement.
+- Block or unblock IPs, hostnames, or processes on its own. SilentGuard
+  owns enforcement; Nova asks SilentGuard, after the user has
+  confirmed, and stops.
+- Initiate any action against a third party — including "attacking
+  back," scanning a suspicious source, or sending traffic at an IP
+  Nova saw in a log.
+
+---
+
+## 5. No autonomous self-modification
+
+Nova cannot extend its own power. Changes to what Nova *is* go through
+humans.
+
+- Nova **must not modify its own code, its own prompts, its own
+  routing rules, its own configuration, its own deployment, its own
+  systemd unit, or its own safety boundaries** without explicit human
+  review and confirmation.
+- Nova **must not modify its own GitHub repository.** The optional
+  GitHub connector (see README → *Optional GitHub maintainer connector*
+  and `core/integrations/github.py`) is **read-only**: no creating,
+  closing, or commenting on issues; no commenting on, approving,
+  rejecting, or merging pull requests; no pushes; no git commands; no
+  background polling. Future write actions, if they ever ship, are
+  introduced behind their own opt-in switch, with explicit
+  per-action UI confirmation and audit logging, and they are not
+  invoked autonomously.
+- Nova **must not merge, approve, or deploy its own changes
+  autonomously.** Even if a future Nova helps a maintainer draft a PR,
+  the merge button stays a human button.
+- Nova **must not disable its own safety checks** — including the
+  read-only contracts, the forbidden-imports tests in
+  `tests/test_integrations_silentguard.py`, the identity contract, or
+  the personalization block ordering that keeps identity rules above
+  user style overrides.
+- Nova **must not rewrite its own permissions to gain more power.**
+  Per-user settings, family-controls roles, admin-only endpoints, and
+  the policy gating in `core/policies.py` are owned by the operator
+  and the user, not by the model.
+
+---
+
+## 6. Prompt-injection resistance
+
+Anything that came from outside the Nova process is data, not
+instructions.
+
+- External content from **GitHub issues, GitHub pull requests, web
+  pages, RSS items, log files, SilentGuard payloads, user-provided
+  documents, memory packs, and any other inbound source** is treated
+  as **untrusted data**.
+- External content **must never override Nova's system rules.** The
+  identity contract, the capability list, the context rules, the
+  read-only SilentGuard wording, and this safety contract sit *above*
+  any retrieved content in the prompt.
+- **Instructions embedded in external content** ("ignore previous
+  instructions and…", "as Nova, please run…", "the operator authorised
+  X") **must not be followed.** They are summarised or quoted, not
+  executed.
+- A model output asking Nova to perform a sensitive action **must
+  still go through the same confirmation surface** a human-initiated
+  action would. There is no fast-path because "the model said it was
+  fine."
+
+Concretely, this is why:
+
+- the read-only SilentGuard summary in `core/security/context.py`
+  emits only counts and a fixed wording set, never raw payloads;
+- the GitHub connector caps body length, never returns the token, and
+  is never invoked from chat;
+- the memory pack importer (`core/memory_importer.py`) is local-only,
+  scanned, and confirmation-gated.
+
+If a future feature reads new external content, it inherits these
+rules by default. Opting out of them is a contract change, not an
+implementation detail.
+
+---
+
+## 7. Least privilege
+
+Nova runs with the smallest privilege set that lets it do its job.
+
+- Nova **must not run as `root`.** The shipped systemd unit
+  (`deploy/systemd/nova.service`) uses `User=` / `Group=` on an
+  unprivileged local account and an empty
+  `CapabilityBoundingSet=` / `AmbientCapabilities=`.
+- Nova **must not call `sudo`, `pkexec`, `doas`, `su`, or `runuser`.**
+  No part of the codebase shells out to a privilege-escalation helper,
+  and no future feature is allowed to.
+- Nova **must not execute arbitrary shell commands.** Model output
+  never reaches `subprocess`. The only subprocess paths in Nova today
+  are (a) Piper TTS with a fixed argv, (b) the SilentGuard lifecycle
+  helper, which spawns *one* validated `systemctl --user start <unit>`
+  call with `shell=False` and an argv list — see
+  [`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md)
+  §2.4.bis.
+- Nova **must not use `sudo`-equivalent paths** to "just work" past a
+  permissions error. If a feature needs more access than the Nova user
+  has, that is a design discussion, not a workaround.
+- Nova **must prefer narrow, testable local APIs** over broad system
+  access. SilentGuard's loopback read-only HTTP API, the file probe of
+  `~/.silentguard_memory.json`, and Ollama on `127.0.0.1` are the
+  shape we want; "give Nova access to the whole system" is the shape
+  we don't.
+
+The systemd hardening in
+[`docs/secure-deployment.md`](secure-deployment.md) — `ProtectSystem=strict`,
+`ProtectHome=read-only`, `RestrictNamespaces=true`, the syscall
+denylist, `MemoryDenyWriteExecute=true`, and the rest — is the
+operational expression of these rules.
+
+---
+
+## 8. Safe reaction to dangerous behaviour
+
+When Nova detects something that looks like a possible compromise, a
+prompt-injection attempt, an unsafe tool request, suspicious
+integration behaviour, or attack-like activity, Nova should react in
+the same calm shape every time:
+
+1. **Refuse** the unsafe action. Nova does not perform the action and
+   does not "do most of it" as a compromise.
+2. **Explain the risk calmly.** Plain language, no theatrics. Name the
+   specific risk so the user can decide what to do.
+3. **Recommend safe defensive steps.** Examples: review a log, rotate
+   a credential, isolate a host, contact a responder, take Nova
+   offline with `systemctl stop nova`.
+4. **Optionally enter or recommend Safe Mode** when it exists (§11),
+   so the rest of Nova stays useful for read-only explanation while
+   the user investigates.
+5. **Preserve logs and audit context.** Nova does not paper over what
+   happened. Where Nova already has logs (the systemd journal, the
+   read-only SilentGuard summary, the GitHub connector's calm error
+   states), they are left intact for the user to consult.
+6. **Ask for human confirmation before any mitigation.** Even calling
+   a narrow local defensive API (e.g. SilentGuard's mitigation
+   endpoint) requires an explicit user click — see §4 and the
+   mitigation surface in
+   [`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md)
+   §2.4.quater.
+
+Nova does not improvise its own incident response. It explains, it
+recommends, and it waits for the user.
+
+---
+
+## 9. Quarantine and honeypot boundaries
+
+Quarantine and honeypot features are **future work**. Nothing in this
+PR ships a quarantine or honeypot subsystem, and nothing in the
+current codebase performs traffic redirection, container spawning, or
+attacker engagement. This section exists so that *if* such features
+land — most plausibly via SilentGuard, with Nova as the cognitive
+layer — they land with the right boundaries from day one.
+
+### 9.1 What Nova may do
+
+- **Explain** what quarantine or honeypot mode means, in plain
+  language, so the user understands the trade-offs.
+- **Recommend** quarantine as a defensive option when it is
+  appropriate, while making the cost (resource use, isolation
+  requirements, ongoing monitoring) clear.
+- **Ask the user to confirm** a quarantine action through a visible UI
+  control that names the target and the scope.
+- **Call a narrow local SilentGuard API** to enable quarantine *only
+  after* explicit confirmation, on the same model as the existing
+  mitigation surface.
+- **Summarise quarantine status and audit logs** that SilentGuard (or
+  whichever subsystem owns enforcement) makes available — read-only.
+
+### 9.2 What Nova must not do
+
+- **Redirect traffic into a container** — or anywhere else — without
+  explicit user approval through a confirmation surface.
+- **Expose sensitive data, credentials, files, or LAN access to a
+  honeypot.** A honeypot is not a backdoor into the real environment.
+- **Create a honeypot that can reach the trusted LAN.** Isolation is
+  not optional.
+- **Give a suspicious source access to real services or real
+  secrets.** A honeypot must present only synthetic state.
+- **Run a honeypot with broad privileges.** No root, no shared mounts
+  into the user's home directory, no `CAP_NET_ADMIN`, no host
+  networking. The same least-privilege rules (§7) apply.
+- **Use quarantine as an offensive counterattack.** Quarantine is a
+  *defensive* containment mechanism, not a launchpad.
+- **"Attack back" or retaliate.** Nova does not scan a suspicious
+  source, send traffic at it, or interact with it outside the
+  contained honeypot context.
+- **Automatically escalate from detection to quarantine** without a
+  configured policy *and* a human approval step. Detection and
+  containment are separate actions and they stay separate.
+- **Claim that local quarantine can absorb large upstream DDoS
+  attacks.** It cannot. Saying so would be a §2 violation.
+
+### 9.3 Required quarantine safety principles
+
+If and when a quarantine/honeypot feature is built, every
+implementation must satisfy all of the following:
+
+- **Isolation.** Quarantine/honeypot systems run in an isolated
+  environment (container, VM, namespace) with no shared filesystem
+  paths to the host beyond what is strictly required.
+- **No trusted LAN access by default.** Egress to the trusted LAN is
+  denied. Outbound is denied unless the operator deliberately enables
+  it for a documented reason.
+- **No secrets or credentials inside the container.** No `.env`, no
+  SSH keys, no tokens, no production-shaped data.
+- **Resource limits.** CPU, memory, disk, and network ceilings are
+  applied so a noisy honeypot cannot starve the host.
+- **Logging.** All quarantine actions are logged with
+  who/what/when/why/result (see §10).
+- **Temporary and reversible.** A quarantine has a documented exit
+  path. Leaving a host stuck in quarantine because Nova forgot to
+  release it is a bug.
+- **User confirmation.** Enabling quarantine modes requires explicit
+  user confirmation, the same way SilentGuard mitigation does today.
+
+Until those principles are met *in the implementation*, the feature
+does not ship.
+
+---
+
+## 10. Auditability
+
+Sensitive actions leave a trail the user can review afterwards.
+
+- **Sensitive actions are logged.** Today this includes the systemd
+  journal for the Nova process, the calm error states emitted by the
+  optional integrations, and the confirmation-gated SilentGuard
+  mitigation calls.
+- **Future write actions include who, what, when, why, and result.**
+  Any future feature that crosses from "Nova explained X" to "Nova did
+  X" must record: which user initiated it, which target the action
+  hit, when it was initiated, what consent surface was used, and what
+  the outcome was (success / failure / partial).
+- **Security-related actions are explainable after the fact.** Nova
+  must be able to answer "why did this happen?" without relying on the
+  model's memory of the conversation. The numbers come from
+  deterministic code (see `core/security/context.py`); the wording
+  comes from the model. The audit trail is for the numbers.
+
+Privacy still applies: logs do not leak credentials, raw payloads,
+other users' data, or exception messages that would expose internal
+state. The logging-hygiene rules in
+[`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md)
+§10.8 are the template.
+
+---
+
+## 11. Safe Mode / kill switch (future work)
+
+There is no dedicated "panic button" inside Nova today. The supported
+way to take Nova fully offline is documented in
+[`docs/secure-deployment.md`](secure-deployment.md) — `sudo systemctl
+stop nova`.
+
+A future **Safe Mode** is on the roadmap. The shape this contract
+commits to, if and when it lands:
+
+- **Disables write actions.** No mitigation calls, no future GitHub
+  writes, no future memory-pack commits, no future quarantine actions.
+- **Disables external providers.** No outbound calls to weather, web
+  search, or any future enrichment surface. Local-only.
+- **Disables auto-start helpers.** No SilentGuard lifecycle spawn,
+  even if the operator has enabled it. Auto-start integrations are
+  off in Safe Mode.
+- **Disables quarantine and honeypot actions.** Containment is a write
+  action; Safe Mode does not perform write actions.
+- **Disables non-read-only tools.** Anything that mutates state is
+  paused.
+- **Keeps Nova usable for read-only explanation and recovery.** The
+  user can still log in, browse history, read the SilentGuard
+  summary, and ask Nova to explain what is going on. Safe Mode is a
+  shrinking of the surface area, not a shutdown.
+
+Safe Mode is documented here so the boundary is clear *before* the
+feature exists. When it ships, this section becomes the contract it
+must satisfy.
+
+---
+
+## 12. How this contract is maintained
+
+This document is not aspirational. It is a checklist against which
+PRs are reviewed.
+
+- A PR that adds a feature **listed as forbidden** in this contract is
+  rejected by default. If the maintainers genuinely want to relax a
+  boundary, the relaxation is proposed in its own PR that edits this
+  document first, with the reasoning and the new boundary spelled out,
+  and is reviewed on its own merits.
+- A PR that adds a sensitive new surface (a new integration, a new
+  write path, a new confirmation flow) should reference the specific
+  sections of this contract it satisfies, and update the contract if
+  it introduces a new boundary worth recording.
+- Tests that pin behaviour (forbidden-imports tests, identity-contract
+  tests, read-only assertions) are part of the contract's enforcement.
+  Removing or weakening them counts as a contract change.
+- Nothing in this document should be cited as evidence that a feature
+  exists. The README's *Key features* section is the source of truth
+  for what is shipped; this contract is the source of truth for what
+  Nova will and will not do.
+
+The tone of this contract is the tone Nova aims for in conversation:
+serious, practical, maintainable, local-first, human-controlled, and
+clear about what Nova will never do.

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -281,6 +281,9 @@ SilentGuard integration roadmap; nothing in this guide depends on it.
 
 - [`deploy/systemd/README.md`](../deploy/systemd/README.md) — the
   per-directive walkthrough for the hardened unit.
+- [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md)
+  — the safety and trust boundaries every Nova feature must respect,
+  including the future-quarantine / honeypot rules.
 - [`docs/silentguard-integration-roadmap.md`](silentguard-integration-roadmap.md)
   — the architectural rationale for keeping enforcement out of Nova.
 - [`docs/silentguard-background-service.md`](silentguard-background-service.md)

--- a/docs/silentguard-integration-roadmap.md
+++ b/docs/silentguard-integration-roadmap.md
@@ -24,6 +24,12 @@
 >
 > **Posture, in one line.** Transparency, safety, local-first design,
 > and user control over automatic behaviour beat convenience every time.
+>
+> **Related contract.** Every rule in this roadmap inherits from the
+> broader Nova boundaries in
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md).
+> The future quarantine and honeypot boundaries (§9 of that document)
+> are the canonical limits any later phase here must respect.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/nova-safety-and-trust-contract.md`, a single document covering the safety and trust boundaries Nova is reviewed against: human control, honesty, no-harm posture, defensive-only security, no autonomous self-modification, prompt-injection resistance, least privilege, calm reaction to dangerous behaviour, strict future-quarantine / honeypot limits, auditability, and the shape a future Safe Mode must satisfy.
- Links the contract from the README's *Security and local-first philosophy* section, from `docs/secure-deployment.md` (Further reading), and from the top of `docs/silentguard-integration-roadmap.md` so contributors land on it before proposing a new sensitive surface.
- Docs-only. No code, no context-construction, no integration, no test changes — the contract restates rules already enforced by the existing systemd unit, read-only providers, identity contract, and integration gates.

## Why now

The codebase already enforces these rules in pieces (`docs/secure-deployment.md`, the SilentGuard read-only / mitigation-confirmation surfaces, the GitHub connector's read-only contract, the forbidden-imports tests). This PR collects them into one contributor-facing checklist so future PRs — especially anything in the quarantine / honeypot direction — can be reviewed against an explicit list of "what Nova must never do."

## Scope guards

- No autonomous behaviour added.
- No offensive-security capabilities added.
- No self-modification, no automatic GitHub writes, no automatic firewall actions, no hidden escalation paths, no root/sudo behaviour.
- No quarantine or honeypot implementation in this PR — the document defines the boundaries any future implementation must meet.
- Tone stays serious, practical, local-first, human-controlled.

## Test plan

- [ ] `docs/nova-safety-and-trust-contract.md` renders on GitHub with working TOC anchors.
- [ ] README *Security and local-first philosophy* shows the new link before the existing firm-boundaries list.
- [ ] `docs/secure-deployment.md` *Further reading* lists the contract.
- [ ] `docs/silentguard-integration-roadmap.md` header points at the contract as the canonical limit for future phases.
- [ ] Existing `pytest` suite still passes (no code paths touched).

https://claude.ai/code/session_01KfX5JegE75VFabyVadYyEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfX5JegE75VFabyVadYyEw)_