### PR TITLE
fix(chat): never leave an empty assistant bubble on streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
   credential are refused at write time. Ratings can be listed and
   deleted via `GET /feedback` and `DELETE /feedback/{id}`.
 
+### Fixed
+- Streaming chat: empty model output no longer leaves a stray empty
+  Nova bubble in the transcript or persists a blank assistant row.
+  The `/chat/stream` endpoint now surfaces an `error` event when the
+  reply is empty or whitespace-only, and the frontend renders a calm
+  fallback message instead of an unanswered bubble. Reloading a
+  conversation no longer shows duplicate or empty assistant rows.
+
 ## v0.4.0 - 2026-04-24
 ### Added
 - Manual web search button in interface

--- a/static/index.html
+++ b/static/index.html
@@ -5704,6 +5704,15 @@
                 bubble.dataset.rawText = "";
             },
             finalise(model, messageId) {
+                if (!buffer) {
+                    // Nothing was streamed — drop the bubble entirely
+                    // so we never leave a stray Nova label with no
+                    // content. The caller is responsible for surfacing
+                    // an error message if appropriate.
+                    if (row.parentNode) row.parentNode.removeChild(row);
+                    return;
+                }
+
                 bubble.classList.remove("streaming");
                 if (caret.parentNode) caret.parentNode.removeChild(caret);
 
@@ -5715,8 +5724,6 @@
                         badge.dataset.model = model;
                     }
                 }
-
-                if (!buffer) return;
 
                 // Swap raw text for rendered markdown in a single pass
                 // so the final layout matches a non-streamed reply.
@@ -5907,14 +5914,22 @@
                         result.assistantMessageId = event.assistant_message_id;
                     }
                     if (userCancelledChat) break;
-                    if (!activeStreamBubble) {
-                        // No deltas reached us (e.g. short-circuit reply
-                        // delivered as a single payload, or empty
-                        // response). Promote the thinking row into a
-                        // bubble now so finalise() can settle layout.
+                    // No deltas + empty buffer means the model produced
+                    // nothing usable; surface a calm error instead of
+                    // leaving an empty Nova bubble in the transcript.
+                    // The backend is expected to send `error` for this
+                    // case but the guard keeps the UI robust against
+                    // any future regression.
+                    if (!activeStreamBubble || !activeStreamBubble.getBuffer()) {
+                        if (activeStreamBubble && activeStreamBubble.row.isConnected) {
+                            activeStreamBubble.row.remove();
+                        }
                         if (thinkingRow.isConnected) thinkingRow.remove();
                         activeThinkingRow = null;
-                        activeStreamBubble = createStreamingAssistantBubble();
+                        result.errored = true;
+                        result.errorDetail = result.errorDetail
+                            || "Nova didn't produce a reply. Please try again.";
+                        break;
                     }
                     activeStreamBubble.finalise(
                         result.model,
@@ -5929,6 +5944,8 @@
                         && !activeStreamBubble.getBuffer()) {
                         activeStreamBubble.row.remove();
                     }
+                    if (thinkingRow.isConnected) thinkingRow.remove();
+                    activeThinkingRow = null;
                     break;
                 }
                 default:
@@ -5966,13 +5983,22 @@
         }
 
         // If the stream ended without a `done` event and without an
-        // explicit error, treat what we have as the final reply so the
-        // bubble still settles into its final layout (no caret, with
-        // actions). The server would also have persisted nothing in
-        // that case — matches existing /chat behaviour on connection
-        // drop mid-reply.
-        if (!result.completed && !result.errored && activeStreamBubble && !userCancelledChat) {
-            activeStreamBubble.finalise(result.model);
+        // explicit error, do not leave the user staring at a half-baked
+        // bubble: finalise whatever text we have, or — if nothing
+        // arrived — mark the result as errored so sendMessage() can
+        // surface a calm fallback message. The server would also have
+        // persisted nothing on a mid-stream drop.
+        if (!result.completed && !result.errored && !userCancelledChat) {
+            if (activeStreamBubble && activeStreamBubble.getBuffer()) {
+                activeStreamBubble.finalise(result.model);
+            } else {
+                if (activeStreamBubble && activeStreamBubble.row.isConnected) {
+                    activeStreamBubble.row.remove();
+                }
+                result.errored = true;
+                result.errorDetail = result.errorDetail
+                    || "Nova didn't produce a reply. Please try again.";
+            }
         }
         if (thinkingRow.isConnected) thinkingRow.remove();
         activeThinkingRow = null;

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -294,6 +294,161 @@ class TestChatStreamEndpoint:
         assert len(assistant) == 1
         assert assistant[0]["content"] == "full reply"
 
+    def test_empty_model_output_surfaces_error_and_persists_nothing(
+        self, db_path, web_client
+    ):
+        # When Ollama yields no content tokens at all, the endpoint must
+        # NOT save an empty assistant row (it would render as a stray
+        # Nova bubble on reload). Instead it surfaces an `error` event
+        # so the frontend can render a calm fallback message.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime([]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        types = [e["type"] for e in events]
+        assert "error" in types
+        assert "done" not in types
+        # No deltas — nothing reached the bubble.
+        assert not any(e["type"] == "delta" for e in events)
+
+        # No conversation should hold any messages: empty reply means
+        # the turn is dropped on the floor, identical to a mid-stream
+        # error. The frontend re-asks; we don't pollute history.
+        with sqlite3.connect(db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert count == 0
+
+    def test_whitespace_only_reply_is_treated_as_error(
+        self, db_path, web_client
+    ):
+        # Models occasionally emit whitespace-only deltas (e.g. just
+        # newlines). Those carry no information so the endpoint should
+        # treat them the same as an empty reply.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime(["   ", "\n"]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        types = [e["type"] for e in events]
+        assert "error" in types
+        assert "done" not in types
+        with sqlite3.connect(db_path) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE role = 'assistant'"
+            ).fetchone()[0]
+        assert count == 0
+
+    def test_reload_after_empty_reply_has_no_assistant_rows(
+        self, db_path, web_client
+    ):
+        # Bug guard: previously an empty model output left an empty
+        # assistant message in the DB, so reloading the conversation
+        # would render a stray empty bubble alongside the user message.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        cid = web_client.post(
+            "/conversations", json={"title": "alice"}, headers=_h(token)
+        ).json()["id"]
+
+        with stub_chat_stream_runtime([]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "hi", "conversation_id": cid, "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+
+        msgs = web_client.get(
+            f"/conversations/{cid}/messages", headers=_h(token)
+        ).json()
+        assistant = [m for m in msgs if m["role"] == "assistant"]
+        assert assistant == []
+
+    def test_error_event_during_stream_does_not_persist(
+        self, db_path, web_client
+    ):
+        # Mid-stream backend failure (Ollama unreachable) → endpoint
+        # forwards an `error` event and persists nothing.
+        import ollama as _ollama
+
+        class _FakeResponseError(Exception):
+            pass
+
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with patch.object(_ollama, "ResponseError", _FakeResponseError), \
+                patch.object(
+                    chat_module.client, "chat",
+                    side_effect=_FakeResponseError("nope"),
+                ), \
+                patch.object(chat_module, "route", lambda _msg: "default"), \
+                patch.object(chat_module, "should_search", lambda _msg: False), \
+                patch.object(chat_module, "is_security_query", lambda _msg: False), \
+                patch.object(chat_module, "detect_weather_city", lambda _msg: None), \
+                patch.object(chat_module, "get_relevant_memories", lambda *_a, **_k: []):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        types = [e["type"] for e in events]
+        assert "error" in types
+        assert "done" not in types
+        with sqlite3.connect(db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert count == 0
+
+    def test_assistant_message_id_only_emitted_when_persisted(
+        self, db_path, web_client
+    ):
+        # Feedback wiring requires the assistant_message_id surfaced on
+        # `done` to match a real saved row. Make sure the empty-reply
+        # path never emits a stale or fabricated id.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime([]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "hi", "mode": "chat"},
+                headers=_h(token),
+            )
+        for ev in _decode_ndjson(resp.content):
+            assert "assistant_message_id" not in ev or ev.get("type") == "done"
+
+        # And the happy path *does* emit one tied to the saved row.
+        with stub_chat_stream_runtime(["yo"]):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "ping", "mode": "chat"},
+                headers=_h(token),
+            )
+        done = next(e for e in _decode_ndjson(resp.content) if e["type"] == "done")
+        assert isinstance(done.get("assistant_message_id"), int)
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT role, content FROM messages WHERE id = ?",
+                (done["assistant_message_id"],),
+            ).fetchone()
+        assert row == ("assistant", "yo")
+
 
 # ── /chat fallback still works ──────────────────────────────────────────────
 

--- a/web.py
+++ b/web.py
@@ -649,6 +649,15 @@ def _stream_event(payload: dict) -> bytes:
     return (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
 
 
+# Surfaced when the model returned no usable text (empty or whitespace
+# only). The streaming endpoint converts that case to an `error` event
+# and persists nothing — an empty bubble in the chat UI would otherwise
+# look like Nova silently failing to answer.
+EMPTY_REPLY_DETAIL = (
+    "Nova didn't produce a reply. Please try again."
+)
+
+
 @app.post("/chat/stream")
 def chat_stream_endpoint(
     request: ChatRequest,
@@ -728,6 +737,16 @@ def chat_stream_endpoint(
                 elif etype == "done":
                     final_reply = event.get("reply", "") or ""
                     final_model = event.get("model") or final_model
+                    if not final_reply.strip():
+                        # Empty model output: surface a calm error
+                        # instead of a silent empty bubble, and persist
+                        # nothing so reloading the conversation does
+                        # not show a stray empty assistant row.
+                        yield _stream_event({
+                            "type": "error",
+                            "detail": EMPTY_REPLY_DETAIL,
+                        })
+                        return
                     # Persist only once we know the full reply landed
                     # cleanly. A client disconnect at this point is
                     # acceptable: the response is already saved.
@@ -750,6 +769,7 @@ def chat_stream_endpoint(
                         "conversation_id": conversation_id,
                         "assistant_message_id": assistant_message_id,
                     })
+                    return
                 elif etype == "error":
                     yield _stream_event({
                         "type": "error",
@@ -763,14 +783,13 @@ def chat_stream_endpoint(
             return
 
         # Defensive fallthrough — chat_stream should always end with
-        # either `done` or `error`, but if it doesn't, signal completion
-        # so the frontend won't hang forever.
-        if not final_reply:
-            yield _stream_event({
-                "type": "done",
-                "model": final_model,
-                "conversation_id": conversation_id,
-            })
+        # either `done` or `error`. If it does not (e.g. generator
+        # exhausted without a terminal event), surface an error so the
+        # frontend renders a clear message instead of waiting forever.
+        yield _stream_event({
+            "type": "error",
+            "detail": EMPTY_REPLY_DETAIL,
+        })
 
     headers = {
         # Disable any reverse-proxy buffering that would batch our chunks


### PR DESCRIPTION
## Summary

When the model produced no usable text, the `/chat/stream` endpoint emitted a `done` event with an empty reply, persisted an empty assistant row, and the frontend then rendered a stray Nova bubble with no content (and no error). Reloading the conversation showed the empty row again because it was saved to the DB.

Make the streaming layer fail loudly and cleanly instead.

### Backend (`web.chat_stream_endpoint._generate`)
- On `done` with empty / whitespace-only reply, yield an `error` event carrying a calm fallback message and persist nothing. The user message and the (empty) assistant message are no longer saved, so reload no longer shows a half-baked turn.
- Tighten the defensive fallthrough so a generator that ends without a terminal event surfaces an error rather than a stub `done`.

### Frontend (`static/index.html`)
- `createStreamingAssistantBubble().finalise()` now removes the row outright when the buffer is empty rather than leaving a stripped bubble in the DOM.
- The `consumeChatStream` `done` and end-of-stream paths treat an empty buffer as an error so `sendMessage()` surfaces the existing calm fallback message via `appendMessage`.
- The `error` handler also removes the lingering thinking row so the fallback message is the only Nova entry the user sees.

## Tests

Added to `tests/test_chat_stream.py`:
- Empty model output → `/chat/stream` emits `error`, no `done`, zero messages persisted.
- Whitespace-only stream is treated identically.
- Reload after an empty reply yields no assistant rows.
- Mid-stream backend error persists nothing.
- `assistant_message_id` is only surfaced when a real saved row exists, so feedback wiring keeps pointing at a real message.

Full suite: `1424 passed, 3 warnings in 477.32s`.

## Scope

Streaming only — `/chat`, SilentGuard, and feedback storage are untouched beyond the new persistence guard on empty replies. No UI redesign.

## Test plan

- [x] `pytest tests/` — all 1424 tests pass.
- [x] `flake8 .` — clean.
- [ ] Manual: successful streaming response still renders text and a working action row (feedback, copy, read-aloud).
- [ ] Manual: simulate empty model output → calm fallback message instead of empty bubble.
- [ ] Manual: simulate Ollama unreachable mid-stream → calm error message, nothing persisted.
- [ ] Manual: reload a conversation that hit the empty-reply path → no orphan empty bubbles.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nTpMbkH7Fp22odTQjzGCt)_