### PR TITLE
feat(admin): add admin-only Maintenance / Update Center foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,63 @@ NOVA_GITHUB_DEFAULT_REPO=
 NOVA_GITHUB_READ_ONLY=true
 NOVA_GITHUB_TIMEOUT_SECONDS=5.0
 
+# ── Admin-only Maintenance / Update Center (opt-in) ────────────────
+# Disabled by default. When enabled, an admin can see the local
+# checkout's branch / commit / upstream / clean-state from the web
+# UI and — after an explicit confirmation, and only when the
+# corresponding switches are on — fast-forward the checkout and ask
+# systemd-user to restart Nova. Every switch defaults to off so an
+# unconfigured Nova install never executes any maintenance command.
+#
+# Safety boundaries (enforced in core/maintenance.py):
+#   * No shell interpretation — shell=False on every subprocess.
+#   * No sudo / pkexec / doas / su / runuser.
+#   * Only an allowlist of git subcommands ever runs (fetch,
+#     status --porcelain, rev-parse, log --oneline, diff --stat,
+#     pull --ff-only). No model output or chat input reaches argv.
+#   * Only fast-forward pulls. Dirty trees / diverged branches /
+#     missing upstream are refused with a structured outcome
+#     (dirty_working_tree / diverged / no_upstream) — never a
+#     destructive reset or merge.
+#   * Restart, when enabled, is restricted to
+#     systemctl --user restart <validated-unit>. No system-level
+#     systemctl, no arbitrary restart command, no sudo fallback.
+#   * The admin role is still required at the endpoint layer.
+#
+# See docs/maintenance-center.md for the full walkthrough and the
+# explicit non-goals (no web terminal, no GitHub writes, no
+# auto-update scheduling, no rollback in v1).
+#
+#   NOVA_MAINTENANCE_ENABLED       — host-wide opt-in. False → every
+#                                     maintenance endpoint resolves
+#                                     but reports state="disabled".
+#   NOVA_MAINTENANCE_ALLOW_PULL    — gates POST /admin/maintenance/pull.
+#                                     Independent of ENABLED: a host
+#                                     that wants the status card but
+#                                     no destructive actions keeps
+#                                     this off.
+#   NOVA_MAINTENANCE_ALLOW_RESTART — gates POST /admin/maintenance/restart.
+#                                     Independent of ALLOW_PULL.
+#   NOVA_MAINTENANCE_REPO_PATH     — absolute path to the Nova
+#                                     checkout. Empty falls back to
+#                                     the directory containing
+#                                     config.py (the install itself).
+#   NOVA_MAINTENANCE_RESTART_MODE  — systemd-user enables the
+#                                     systemctl --user restart path.
+#                                     Anything else (including a
+#                                     typo or "sudo-systemctl")
+#                                     normalises to "disabled".
+#   NOVA_MAINTENANCE_SYSTEMD_UNIT  — user-level unit name to restart.
+#                                     Validated against
+#                                     ^[a-z0-9][a-z0-9._-]*\.service$
+#                                     before any spawn.
+NOVA_MAINTENANCE_ENABLED=false
+NOVA_MAINTENANCE_ALLOW_PULL=false
+NOVA_MAINTENANCE_ALLOW_RESTART=false
+NOVA_MAINTENANCE_REPO_PATH=
+NOVA_MAINTENANCE_RESTART_MODE=disabled
+NOVA_MAINTENANCE_SYSTEMD_UNIT=nova.service
+
 # ── Time / calendar context ───────────────────────────────────────────
 # Override the timezone Nova uses when resolving "today", "yesterday", etc.
 # Must be a valid IANA timezone name (e.g. America/Montreal, Europe/Paris).

--- a/README.md
+++ b/README.md
@@ -372,6 +372,69 @@ opt-in switch, will require explicit user confirmation in the
 UI, and will carry audit logging. There is no autonomous
 maintainer behaviour planned.
 
+## Optional admin Maintenance / Update Center
+
+Nova ships an **optional**, **admin-only**, **opt-in** Maintenance
+surface that lets an administrator inspect the local checkout's git
+state, fast-forward to upstream after an explicit confirmation, and
+(when explicitly configured) ask systemd-user to restart Nova — all
+from the web UI. Every switch defaults to off so an unconfigured
+Nova install never executes any maintenance command.
+
+The full walkthrough lives in
+[`docs/maintenance-center.md`](docs/maintenance-center.md). Setup is
+deliberately granular:
+
+```ini
+NOVA_MAINTENANCE_ENABLED=false          # default; flip to true to opt in
+NOVA_MAINTENANCE_ALLOW_PULL=false       # gates POST /admin/maintenance/pull
+NOVA_MAINTENANCE_ALLOW_RESTART=false    # gates POST /admin/maintenance/restart
+NOVA_MAINTENANCE_REPO_PATH=             # empty → use the install directory
+NOVA_MAINTENANCE_RESTART_MODE=disabled  # or systemd-user
+NOVA_MAINTENANCE_SYSTEMD_UNIT=nova.service
+```
+
+When enabled, the **Settings → Admin → Maintenance & Updates** card
+shows the configured branch, current commit, upstream tracking
+branch, working-tree cleanliness, incoming commits, and a diff-stat
+summary. Pull and restart actions each require a separate switch
+and a visible `confirm()` before the request is sent. The server
+re-checks every condition on the actual call — the UI is a
+convenience layer, not a security boundary.
+
+Safety boundaries (enforced in
+[`core/maintenance.py`](core/maintenance.py) and pinned by
+[`tests/test_maintenance.py`](tests/test_maintenance.py)):
+
+- **No web terminal.** Only a fixed allowlist of `git` subcommands
+  ever runs: `fetch`, `status --porcelain`, `rev-parse`,
+  `log --oneline`, `diff --stat`, and `pull --ff-only`.
+- **No arbitrary shell.** Every subprocess call uses an argv list
+  with `shell=False`. No string commands, no `os.system`.
+- **No `sudo` / `pkexec` / `doas` / `su` / `runuser`.** Nova never
+  asks for elevation.
+- **No system-level `systemctl`.** Restart, when enabled, is locked
+  to `systemctl --user restart <validated-unit>` with a strict
+  unit-name regex.
+- **Fast-forward only.** A dirty working tree or a diverged branch
+  blocks the pull with a calm "manual intervention required"
+  message — Nova never improvises a merge or reset.
+- **Admin-only.** Non-admin and restricted users receive a `403`.
+- **Confirmation-gated.** Pull and restart endpoints reject requests
+  that do not carry `{"confirm": true}`.
+- **No GitHub writes.** This feature reads the upstream tip via
+  `git fetch` and the local working tree. It never pushes, merges
+  PRs, or interacts with GitHub beyond `git fetch`.
+- **No auto-update.** Nothing happens until an admin clicks
+  through the confirmation. There is no background polling, no
+  scheduled update.
+
+`docs/maintenance-center.md` documents the recommended starting
+point (status-only, no pull, no restart) and explains how to
+optionally set up a user-level Nova unit if you want the restart
+button to work without leaving the secure-deployment guide's
+boundaries.
+
 ## Voice and TTS
 
 Every assistant message has a "Read aloud" button. By default Nova uses

--- a/config.py
+++ b/config.py
@@ -135,6 +135,70 @@ NOVA_SILENTGUARD_SYSTEMD_UNIT = (
     os.getenv("NOVA_SILENTGUARD_SYSTEMD_UNIT", "silentguard-api.service").strip()
 )
 
+# ── Admin-only Maintenance / Update Center (opt-in) ────────────────
+# Optional admin surface that lets a maintainer ask the local Nova
+# install whether new code is available on the configured upstream
+# branch, pull a fast-forward update, and (when configured) ask
+# systemd-user to restart Nova. Every switch defaults to OFF so an
+# unconfigured Nova install never executes any maintenance command,
+# even for an admin.
+#
+# Safety rules (enforced in ``core/maintenance.py``):
+#   * No shell interpretation — ``shell=False`` on every subprocess.
+#   * No ``sudo`` / ``pkexec`` / ``doas`` / ``su`` / ``runuser``.
+#   * No model-generated or chat-sourced command strings.
+#   * Only a small fixed allowlist of ``git`` subcommands runs:
+#       fetch, status --porcelain, rev-parse, log --oneline,
+#       diff --stat, pull --ff-only.
+#   * Only fast-forward pulls. A dirty working tree or a diverged
+#     branch surfaces a sanitised refusal — never a destructive reset
+#     or merge.
+#   * Restart is gated by its own switch and is restricted to
+#     ``systemctl --user restart <validated-unit>``. There is no
+#     system-level systemctl, no arbitrary restart command, no
+#     fallback to ``sudo``.
+#   * The admin role is still required at the endpoint layer.
+#
+#   NOVA_MAINTENANCE_ENABLED       — host-wide opt-in. False → every
+#                                     maintenance endpoint reports
+#                                     ``state="disabled"``.
+#   NOVA_MAINTENANCE_ALLOW_PULL    — gates ``POST /admin/maintenance/pull``.
+#                                     False → the endpoint refuses with
+#                                     ``pull_not_allowed`` even when the
+#                                     repo is clean and fast-forwardable.
+#   NOVA_MAINTENANCE_ALLOW_RESTART — gates ``POST /admin/maintenance/restart``.
+#                                     False → the endpoint refuses with
+#                                     ``restart_not_allowed``.
+#   NOVA_MAINTENANCE_REPO_PATH     — absolute path to the Nova checkout
+#                                     to operate on. Empty falls back to
+#                                     the directory containing this
+#                                     ``config.py`` (the install
+#                                     itself).
+#   NOVA_MAINTENANCE_RESTART_MODE  — ``systemd-user`` enables the
+#                                     ``systemctl --user restart`` path.
+#                                     Anything else normalises to
+#                                     ``disabled``.
+#   NOVA_MAINTENANCE_SYSTEMD_UNIT  — user-level unit name to restart.
+#                                     Validated against
+#                                     ``^[a-z0-9][a-z0-9._-]*\.service$``
+#                                     before any spawn.
+NOVA_MAINTENANCE_ENABLED = (
+    os.getenv("NOVA_MAINTENANCE_ENABLED", "false").strip().lower() == "true"
+)
+NOVA_MAINTENANCE_ALLOW_PULL = (
+    os.getenv("NOVA_MAINTENANCE_ALLOW_PULL", "false").strip().lower() == "true"
+)
+NOVA_MAINTENANCE_ALLOW_RESTART = (
+    os.getenv("NOVA_MAINTENANCE_ALLOW_RESTART", "false").strip().lower() == "true"
+)
+NOVA_MAINTENANCE_REPO_PATH = os.getenv("NOVA_MAINTENANCE_REPO_PATH", "").strip()
+NOVA_MAINTENANCE_RESTART_MODE = (
+    os.getenv("NOVA_MAINTENANCE_RESTART_MODE", "disabled").strip().lower()
+)
+NOVA_MAINTENANCE_SYSTEMD_UNIT = (
+    os.getenv("NOVA_MAINTENANCE_SYSTEMD_UNIT", "nova.service").strip()
+)
+
 # ── Optional local TTS: Piper ─────────────────────────────────────────
 # Browser speechSynthesis remains the safe default. Piper is an opt-in
 # local neural voice for hosts where the platform default sounds robotic

--- a/core/maintenance.py
+++ b/core/maintenance.py
@@ -1,0 +1,913 @@
+"""
+Admin-only maintenance / update helper.
+
+Nova is a local-first, self-hostable assistant. This module gives an
+admin a *narrow*, *opt-in* way to ask the local install three things:
+
+  1. What is the state of the checkout (branch, commit, upstream,
+     clean / dirty, fast-forward-able)?
+  2. After an explicit confirmation, run ``git pull --ff-only`` once
+     so the working tree advances to the upstream tip — but only when
+     the working tree is clean and the branch is strictly behind
+     upstream.
+  3. After an explicit confirmation, ask systemd-user to restart the
+     configured Nova unit — when (and only when) the operator has
+     enabled the systemd-user restart mode and configured a valid
+     unit name.
+
+What this module is *not*:
+
+  * a web terminal,
+  * a generic command runner,
+  * a chat-driven action,
+  * an auto-updater,
+  * a privilege-escalation helper.
+
+Safety contract (enforced):
+
+  * **Allowlisted git commands only.** Every subprocess call is
+    constructed from a hard-coded argv list — the only varying parts
+    are the resolved git binary path and ``HEAD..@{u}`` for the
+    upstream comparisons. No user / model / chat input is ever
+    concatenated into a command.
+  * **``shell=False`` everywhere.** No string commands, no shell
+    interpretation by Python or by the OS.
+  * **No ``sudo`` / ``pkexec`` / ``doas`` / ``su`` / ``runuser``.** No
+    privilege escalation, ever.
+  * **Timeouts on every subprocess call.** A hung git or systemctl
+    maps to a calm "command_failed" snapshot, never to a wedged
+    request.
+  * **Fast-forward pulls only.** ``git pull --ff-only`` refuses to
+    merge or rebase. A dirty working tree or a diverged branch
+    surfaces a refusal *before* the pull is attempted.
+  * **Restart is its own switch.** The pull switch does not unlock
+    restart, and vice versa. Restart, when enabled, uses
+    ``systemctl --user restart <validated-unit>`` exclusively.
+  * **Sanitised errors.** The structured response never embeds
+    secrets, environment variables, raw stderr, or stack traces.
+    Detail strings are short, fixed, frontend-safe summaries.
+
+The helper is the single module in ``core`` allowed to import
+``subprocess`` for git operations. The web layer must call only the
+public functions in this module and gate them with ``require_admin``.
+
+See ``docs/maintenance-center.md`` for the operator-facing setup
+walkthrough and the non-goals.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public state constants ──────────────────────────────────────────
+
+STATE_DISABLED = "disabled"            # NOVA_MAINTENANCE_ENABLED is off
+STATE_READY = "ready"                  # repo probed, snapshot is valid
+STATE_UNAVAILABLE = "unavailable"      # git missing, repo not a checkout
+
+# Update-availability sub-states returned in ``update_available``.
+UPDATE_UP_TO_DATE = "up_to_date"
+UPDATE_AVAILABLE = "available"
+UPDATE_DIVERGED = "diverged"
+UPDATE_NO_UPSTREAM = "no_upstream"
+UPDATE_UNKNOWN = "unknown"
+
+# Pull outcomes.
+PULL_DISABLED = "disabled"
+PULL_NOT_ALLOWED = "pull_not_allowed"
+PULL_REPO_UNAVAILABLE = "repo_unavailable"
+PULL_DIRTY_WORKING_TREE = "dirty_working_tree"
+PULL_DIVERGED = "diverged"
+PULL_NO_UPSTREAM = "no_upstream"
+PULL_NOT_FAST_FORWARD = "not_fast_forward"
+PULL_SUCCESS = "success"
+PULL_FAILED = "failed"
+
+# Restart outcomes.
+RESTART_DISABLED = "disabled"
+RESTART_NOT_ALLOWED = "restart_not_allowed"
+RESTART_MODE_DISABLED = "restart_mode_disabled"
+RESTART_INVALID_UNIT = "invalid_unit"
+RESTART_SYSTEMCTL_MISSING = "systemctl_missing"
+RESTART_FAILED = "failed"
+RESTART_ACCEPTED = "accepted"
+
+# Restart modes.
+RESTART_MODE_SYSTEMD_USER = "systemd-user"
+RESTART_MODE_OFF = "disabled"
+_ALLOWED_RESTART_MODES = frozenset({RESTART_MODE_SYSTEMD_USER, RESTART_MODE_OFF})
+
+
+# ── Internal limits ─────────────────────────────────────────────────
+
+# Per-call timeouts. Network-touching calls (``fetch``, ``pull``) get
+# a larger budget; local-only calls (``status``, ``rev-parse``) stay
+# small so a misbehaving repo cannot wedge a request.
+_GIT_LOCAL_TIMEOUT_SECONDS = 5.0
+_GIT_FETCH_TIMEOUT_SECONDS = 30.0
+_GIT_PULL_TIMEOUT_SECONDS = 60.0
+_SYSTEMCTL_TIMEOUT_SECONDS = 5.0
+
+# Caps so a single response cannot balloon the JSON payload. The
+# changed-files summary is the only stretchy field — keep it small.
+_MAX_LOG_LINES = 50
+_MAX_DIFF_LINES = 50
+_MAX_LINE_CHARS = 300
+
+# Strict unit-name regex (mirrors the SilentGuard lifecycle helper).
+_UNIT_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*\.service$")
+_UNIT_FORBIDDEN_SUBSTRINGS = (
+    "..", "/", "\\", "\n", "\r", "\t", " ",
+    ";", "&", "|", "$", "`", "<", ">", "(", ")", "{", "}",
+)
+
+
+# ── Snapshot dataclasses ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MaintenanceStatus:
+    """Calm, frontend-safe snapshot of the maintenance surface.
+
+    ``state`` is one of the module-level ``STATE_*`` values. When the
+    feature is disabled, every other field is left at its default so
+    the response shape stays stable. The structure deliberately does
+    not include env vars, raw stderr, or absolute paths — the only
+    paths surfaced are the configured ``repo_path`` (when non-empty)
+    and the ``unit`` field.
+    """
+
+    state: str
+    enabled: bool = False
+    allow_pull: bool = False
+    allow_restart: bool = False
+    restart_mode: str = RESTART_MODE_OFF
+    unit: str = ""
+    repo_path: str = ""
+
+    # Repo facts (filled when state == STATE_READY).
+    branch: str = ""
+    commit: str = ""
+    upstream: str = ""
+    has_upstream: bool = False
+    working_tree_clean: bool = True
+    update_available: str = UPDATE_UNKNOWN
+    behind_count: int = 0
+    ahead_count: int = 0
+    incoming_commits: tuple[str, ...] = field(default_factory=tuple)
+    changed_files: tuple[str, ...] = field(default_factory=tuple)
+
+    # ``detail`` is a short, fixed sentence the UI can render verbatim.
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "enabled": self.enabled,
+            "allow_pull": self.allow_pull,
+            "allow_restart": self.allow_restart,
+            "restart_mode": self.restart_mode,
+            "unit": self.unit,
+            "repo_path": self.repo_path,
+            "branch": self.branch,
+            "commit": self.commit,
+            "upstream": self.upstream,
+            "has_upstream": self.has_upstream,
+            "working_tree_clean": self.working_tree_clean,
+            "update_available": self.update_available,
+            "behind_count": self.behind_count,
+            "ahead_count": self.ahead_count,
+            "incoming_commits": list(self.incoming_commits),
+            "changed_files": list(self.changed_files),
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class PullResult:
+    """Outcome of a single ``git pull --ff-only`` attempt."""
+
+    outcome: str
+    detail: str = ""
+    previous_commit: str = ""
+    new_commit: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "outcome": self.outcome,
+            "detail": self.detail,
+            "previous_commit": self.previous_commit,
+            "new_commit": self.new_commit,
+        }
+
+
+@dataclass(frozen=True)
+class RestartResult:
+    """Outcome of a single restart attempt."""
+
+    outcome: str
+    detail: str = ""
+    mode: str = RESTART_MODE_OFF
+    unit: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "outcome": self.outcome,
+            "detail": self.detail,
+            "mode": self.mode,
+            "unit": self.unit,
+        }
+
+
+# ── Config resolution ───────────────────────────────────────────────
+
+
+def _resolve_enabled() -> bool:
+    raw = os.environ.get("NOVA_MAINTENANCE_ENABLED")
+    if raw is not None:
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from config import NOVA_MAINTENANCE_ENABLED
+    except Exception:  # pragma: no cover — config import is best-effort
+        return False
+    return bool(NOVA_MAINTENANCE_ENABLED)
+
+
+def _resolve_allow_pull() -> bool:
+    raw = os.environ.get("NOVA_MAINTENANCE_ALLOW_PULL")
+    if raw is not None:
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from config import NOVA_MAINTENANCE_ALLOW_PULL
+    except Exception:  # pragma: no cover
+        return False
+    return bool(NOVA_MAINTENANCE_ALLOW_PULL)
+
+
+def _resolve_allow_restart() -> bool:
+    raw = os.environ.get("NOVA_MAINTENANCE_ALLOW_RESTART")
+    if raw is not None:
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from config import NOVA_MAINTENANCE_ALLOW_RESTART
+    except Exception:  # pragma: no cover
+        return False
+    return bool(NOVA_MAINTENANCE_ALLOW_RESTART)
+
+
+def _resolve_restart_mode() -> str:
+    raw = os.environ.get("NOVA_MAINTENANCE_RESTART_MODE")
+    if raw is None:
+        try:
+            from config import NOVA_MAINTENANCE_RESTART_MODE
+        except Exception:  # pragma: no cover
+            return RESTART_MODE_OFF
+        raw = NOVA_MAINTENANCE_RESTART_MODE
+    value = (raw or "").strip().lower()
+    return value if value in _ALLOWED_RESTART_MODES else RESTART_MODE_OFF
+
+
+def _resolve_unit() -> str:
+    raw = os.environ.get("NOVA_MAINTENANCE_SYSTEMD_UNIT")
+    if raw is None:
+        try:
+            from config import NOVA_MAINTENANCE_SYSTEMD_UNIT
+        except Exception:  # pragma: no cover
+            return "nova.service"
+        raw = NOVA_MAINTENANCE_SYSTEMD_UNIT
+    return (raw or "").strip()
+
+
+def _resolve_repo_path() -> str:
+    raw = os.environ.get("NOVA_MAINTENANCE_REPO_PATH")
+    if raw is None:
+        try:
+            from config import NOVA_MAINTENANCE_REPO_PATH
+        except Exception:  # pragma: no cover
+            raw = ""
+        else:
+            raw = NOVA_MAINTENANCE_REPO_PATH
+    value = (raw or "").strip()
+    if value:
+        return value
+    # Fall back to the directory that contains this module's package —
+    # i.e. the Nova checkout itself. We never invent a path; we only
+    # use the install's own directory when the operator did not pin
+    # one explicitly.
+    return str(Path(__file__).resolve().parent.parent)
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+
+def validate_unit_name(unit: str) -> bool:
+    """Return True only when ``unit`` is a safe systemd user unit name.
+
+    Same defensive rules as ``core/security/lifecycle.py``: the input
+    must be a non-empty string under 128 characters, equal to its
+    ``.strip()`` form, free of forbidden substrings (``..``, path
+    separators, shell metacharacters, whitespace, control characters),
+    and matching ``^[a-z0-9][a-z0-9._-]*\\.service$``.
+    """
+    if not isinstance(unit, str):
+        return False
+    if not unit or len(unit) > 128:
+        return False
+    if unit != unit.strip():
+        return False
+    if any(bad in unit for bad in _UNIT_FORBIDDEN_SUBSTRINGS):
+        return False
+    return bool(_UNIT_RE.match(unit))
+
+
+def _git_path() -> Optional[str]:
+    """Return the absolute path to git, or ``None`` if missing."""
+    return shutil.which("git")
+
+
+def _systemctl_path() -> Optional[str]:
+    return shutil.which("systemctl")
+
+
+def _is_git_checkout(repo_path: str) -> bool:
+    """Cheap structural check: ``repo_path/.git`` must exist.
+
+    The directory form is the common case; a worktree gitfile lands as
+    a regular file pointing to the real ``.git`` dir, so we accept
+    either. We deliberately do *not* fall back to walking parents —
+    the maintenance surface operates on the configured checkout, not
+    on an ancestor.
+    """
+    try:
+        p = Path(repo_path)
+        if not p.is_dir():
+            return False
+        gitdir = p / ".git"
+        return gitdir.exists()
+    except OSError:
+        return False
+
+
+# ── Subprocess primitives ───────────────────────────────────────────
+
+
+def _run_git(
+    argv_tail: Sequence[str],
+    *,
+    repo_path: str,
+    timeout: float,
+) -> tuple[int, str, str]:
+    """Run ``git <argv_tail>`` in ``repo_path`` with strict argv.
+
+    Never raises. Returns ``(returncode, stdout, stderr)``. A missing
+    git binary maps to ``(-1, "", "")`` so callers can branch on the
+    rc cleanly. stdout / stderr are decoded as UTF-8 with replacement,
+    *not* surfaced to the frontend — they exist for the helper's own
+    parsing only.
+
+    The first argv element is always the *resolved* git path; the
+    rest is the literal argv_tail. The CWD is the configured repo
+    path, ``shell=False`` is mandatory, stdin is closed, env is left
+    untouched (we never set HOME or GIT_DIR from user input).
+    """
+    binary = _git_path()
+    if binary is None:
+        return -1, "", ""
+    argv = [binary, *argv_tail]
+    try:
+        result = subprocess.run(
+            argv,
+            cwd=repo_path,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("git %s timed out in %s", argv_tail, repo_path)
+        return -1, "", ""
+    except (OSError, ValueError) as exc:
+        logger.debug("git %s failed to spawn: %s", argv_tail, exc)
+        return -1, "", ""
+    stdout = (result.stdout or b"").decode("utf-8", errors="replace")
+    stderr = (result.stderr or b"").decode("utf-8", errors="replace")
+    return result.returncode, stdout, stderr
+
+
+def _git_branch(repo_path: str) -> str:
+    rc, out, _ = _run_git(
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    return out.strip() if rc == 0 else ""
+
+
+def _git_head(repo_path: str) -> str:
+    rc, out, _ = _run_git(
+        ["rev-parse", "HEAD"],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    return out.strip() if rc == 0 else ""
+
+
+def _git_upstream(repo_path: str) -> str:
+    rc, out, _ = _run_git(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    return out.strip() if rc == 0 else ""
+
+
+def _git_status_clean(repo_path: str) -> bool:
+    """True when the working tree is clean (porcelain output empty)."""
+    rc, out, _ = _run_git(
+        ["status", "--porcelain"],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    if rc != 0:
+        # An unreadable status is not "clean" — surface it as dirty so
+        # we never pull on top of a state we couldn't inspect.
+        return False
+    return out.strip() == ""
+
+
+def _git_revlist_count(repo_path: str, spec: str) -> int:
+    """Count commits on one side of a symmetric difference.
+
+    ``spec`` is one of ``HEAD..@{u}`` (commits Nova is behind) or
+    ``@{u}..HEAD`` (commits Nova is ahead by). The function is
+    defensive: a non-zero rc or an unparseable count returns 0.
+    """
+    rc, out, _ = _run_git(
+        ["rev-list", "--count", spec],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    if rc != 0:
+        return 0
+    try:
+        return max(0, int(out.strip()))
+    except ValueError:
+        return 0
+
+
+def _truncate(line: str) -> str:
+    """Clip a single log / diff line so it cannot bloat the response."""
+    if len(line) <= _MAX_LINE_CHARS:
+        return line
+    return line[:_MAX_LINE_CHARS] + "…"
+
+
+def _git_incoming_log(repo_path: str) -> tuple[str, ...]:
+    rc, out, _ = _run_git(
+        ["log", "--oneline", "HEAD..@{u}"],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    if rc != 0:
+        return ()
+    lines = [_truncate(s) for s in out.splitlines() if s.strip()]
+    return tuple(lines[:_MAX_LOG_LINES])
+
+
+def _git_incoming_diffstat(repo_path: str) -> tuple[str, ...]:
+    rc, out, _ = _run_git(
+        ["diff", "--stat", "HEAD..@{u}"],
+        repo_path=repo_path, timeout=_GIT_LOCAL_TIMEOUT_SECONDS,
+    )
+    if rc != 0:
+        return ()
+    lines = [_truncate(s) for s in out.splitlines() if s.strip()]
+    return tuple(lines[:_MAX_DIFF_LINES])
+
+
+# ── Public helpers ──────────────────────────────────────────────────
+
+
+def is_enabled() -> bool:
+    """Public read of ``NOVA_MAINTENANCE_ENABLED``.
+
+    Re-evaluated on every call so a tests-time ``monkeypatch.setenv``
+    and a systemd-provided env both resolve correctly.
+    """
+    return _resolve_enabled()
+
+
+def disabled_status(message: str = "Maintenance disabled.") -> MaintenanceStatus:
+    """Return a calm ``state="disabled"`` snapshot.
+
+    The web layer calls this when the host operator has not opted in,
+    so the response shape is stable even with the feature off.
+    """
+    return MaintenanceStatus(
+        state=STATE_DISABLED,
+        enabled=False,
+        allow_pull=False,
+        allow_restart=False,
+        restart_mode=_resolve_restart_mode(),
+        unit=_resolve_unit(),
+        repo_path=_resolve_repo_path(),
+        detail=message,
+    )
+
+
+def get_status(*, do_fetch: bool = False) -> MaintenanceStatus:
+    """Read-only snapshot of the maintenance surface.
+
+    When ``do_fetch`` is True, the helper runs ``git fetch`` once
+    before reading branch / status / ahead-behind state so the
+    response reflects the freshest upstream. ``fetch`` is the only
+    network-touching call here, and it never modifies the working
+    tree.
+
+    Never raises. A missing git binary, a non-checkout path, or a
+    transient failure each map to a calm ``state="unavailable"``
+    snapshot with a fixed message.
+    """
+    enabled = _resolve_enabled()
+    allow_pull = _resolve_allow_pull()
+    allow_restart = _resolve_allow_restart()
+    restart_mode = _resolve_restart_mode()
+    unit = _resolve_unit()
+    repo_path = _resolve_repo_path()
+
+    if not enabled:
+        return MaintenanceStatus(
+            state=STATE_DISABLED,
+            enabled=False,
+            allow_pull=allow_pull,
+            allow_restart=allow_restart,
+            restart_mode=restart_mode,
+            unit=unit,
+            repo_path=repo_path,
+            detail="Maintenance disabled.",
+        )
+
+    if _git_path() is None:
+        return MaintenanceStatus(
+            state=STATE_UNAVAILABLE,
+            enabled=True,
+            allow_pull=allow_pull,
+            allow_restart=allow_restart,
+            restart_mode=restart_mode,
+            unit=unit,
+            repo_path=repo_path,
+            detail="git is not available on this host.",
+        )
+
+    if not _is_git_checkout(repo_path):
+        return MaintenanceStatus(
+            state=STATE_UNAVAILABLE,
+            enabled=True,
+            allow_pull=allow_pull,
+            allow_restart=allow_restart,
+            restart_mode=restart_mode,
+            unit=unit,
+            repo_path=repo_path,
+            detail="Configured path is not a git checkout.",
+        )
+
+    if do_fetch:
+        # ``git fetch`` is read-only against the working tree. It can
+        # be slow on a misconfigured remote — the timeout above is
+        # already short. We tolerate a non-zero rc (offline host, no
+        # remote, auth refused) by continuing with the existing
+        # remote-tracking refs.
+        _run_git(
+            ["fetch"],
+            repo_path=repo_path, timeout=_GIT_FETCH_TIMEOUT_SECONDS,
+        )
+
+    branch = _git_branch(repo_path)
+    commit = _git_head(repo_path)
+    upstream = _git_upstream(repo_path)
+    has_upstream = bool(upstream)
+    clean = _git_status_clean(repo_path)
+
+    if not has_upstream:
+        return MaintenanceStatus(
+            state=STATE_READY,
+            enabled=True,
+            allow_pull=allow_pull,
+            allow_restart=allow_restart,
+            restart_mode=restart_mode,
+            unit=unit,
+            repo_path=repo_path,
+            branch=branch,
+            commit=commit,
+            upstream="",
+            has_upstream=False,
+            working_tree_clean=clean,
+            update_available=UPDATE_NO_UPSTREAM,
+            detail="No upstream branch configured.",
+        )
+
+    behind = _git_revlist_count(repo_path, "HEAD..@{u}")
+    ahead = _git_revlist_count(repo_path, "@{u}..HEAD")
+
+    if behind == 0 and ahead == 0:
+        availability = UPDATE_UP_TO_DATE
+        detail = "Already up to date."
+        incoming = ()
+        changed = ()
+    elif behind > 0 and ahead == 0:
+        availability = UPDATE_AVAILABLE
+        detail = f"{behind} new commit{'s' if behind != 1 else ''} available."
+        incoming = _git_incoming_log(repo_path)
+        changed = _git_incoming_diffstat(repo_path)
+    elif behind == 0 and ahead > 0:
+        # Local branch is ahead of upstream. From the update-center
+        # perspective there is nothing to pull, but we surface
+        # ``up_to_date`` with the ahead count exposed so the UI can
+        # show a soft note if it likes.
+        availability = UPDATE_UP_TO_DATE
+        detail = "Already up to date."
+        incoming = ()
+        changed = ()
+    else:
+        availability = UPDATE_DIVERGED
+        detail = "Branch diverged from upstream. Manual intervention required."
+        # We still surface the incoming commits / diffstat so the
+        # admin can see what's on the other side without us touching
+        # the working tree.
+        incoming = _git_incoming_log(repo_path)
+        changed = _git_incoming_diffstat(repo_path)
+
+    return MaintenanceStatus(
+        state=STATE_READY,
+        enabled=True,
+        allow_pull=allow_pull,
+        allow_restart=allow_restart,
+        restart_mode=restart_mode,
+        unit=unit,
+        repo_path=repo_path,
+        branch=branch,
+        commit=commit,
+        upstream=upstream,
+        has_upstream=True,
+        working_tree_clean=clean,
+        update_available=availability,
+        behind_count=behind,
+        ahead_count=ahead,
+        incoming_commits=incoming,
+        changed_files=changed,
+        detail=detail,
+    )
+
+
+def fetch() -> MaintenanceStatus:
+    """Run ``git fetch`` and return a refreshed status snapshot.
+
+    Convenience wrapper for the ``POST /admin/maintenance/fetch``
+    endpoint. Disabled maintenance short-circuits to the calm
+    disabled snapshot — no network call is issued.
+    """
+    if not _resolve_enabled():
+        return disabled_status()
+    return get_status(do_fetch=True)
+
+
+def pull() -> PullResult:
+    """Run ``git pull --ff-only`` after the strict safety checks.
+
+    Returns a :class:`PullResult` describing the outcome. The function
+    never raises and never falls back to a non-fast-forward pull,
+    even when the underlying git call would accept one.
+
+    Refusal reasons (no spawn happens for any of these):
+      * maintenance is disabled  → ``disabled``
+      * pull is not allowed      → ``pull_not_allowed``
+      * git is missing / no repo → ``repo_unavailable``
+      * no upstream configured   → ``no_upstream``
+      * working tree is dirty    → ``dirty_working_tree``
+      * branch is diverged       → ``diverged``
+      * branch is ahead-only or already up-to-date → ``not_fast_forward``
+    """
+    if not _resolve_enabled():
+        return PullResult(
+            outcome=PULL_DISABLED, detail="Maintenance disabled.",
+        )
+    if not _resolve_allow_pull():
+        return PullResult(
+            outcome=PULL_NOT_ALLOWED,
+            detail="Pull is disabled in the host configuration.",
+        )
+
+    repo_path = _resolve_repo_path()
+    if _git_path() is None or not _is_git_checkout(repo_path):
+        return PullResult(
+            outcome=PULL_REPO_UNAVAILABLE,
+            detail="Configured repository is not available.",
+        )
+
+    upstream = _git_upstream(repo_path)
+    if not upstream:
+        return PullResult(
+            outcome=PULL_NO_UPSTREAM,
+            detail="No upstream branch configured.",
+        )
+
+    if not _git_status_clean(repo_path):
+        return PullResult(
+            outcome=PULL_DIRTY_WORKING_TREE,
+            detail=(
+                "Local changes detected. Manual intervention required."
+            ),
+        )
+
+    behind = _git_revlist_count(repo_path, "HEAD..@{u}")
+    ahead = _git_revlist_count(repo_path, "@{u}..HEAD")
+    if behind > 0 and ahead > 0:
+        return PullResult(
+            outcome=PULL_DIVERGED,
+            detail="Branch diverged. Manual intervention required.",
+        )
+    if behind == 0:
+        # Already up to date (or local-only ahead): there is nothing
+        # to fast-forward. Surface this as a structured refusal rather
+        # than spawning a no-op pull.
+        return PullResult(
+            outcome=PULL_NOT_FAST_FORWARD,
+            detail="No fast-forward update available.",
+        )
+
+    previous_commit = _git_head(repo_path)
+    rc, _out, _err = _run_git(
+        ["pull", "--ff-only"],
+        repo_path=repo_path, timeout=_GIT_PULL_TIMEOUT_SECONDS,
+    )
+    new_commit = _git_head(repo_path) if rc == 0 else previous_commit
+    if rc != 0:
+        return PullResult(
+            outcome=PULL_FAILED,
+            detail="git pull --ff-only failed.",
+            previous_commit=previous_commit,
+            new_commit=previous_commit,
+        )
+    return PullResult(
+        outcome=PULL_SUCCESS,
+        detail="Updated.",
+        previous_commit=previous_commit,
+        new_commit=new_commit,
+    )
+
+
+def _start_systemctl_user_restart(unit: str) -> tuple[bool, str]:
+    """Run ``systemctl --user restart <unit>`` with strict argv.
+
+    Never raises. Returns ``(success, sanitized_detail)``. The detail
+    is a short fixed string, never raw stderr.
+
+    Safety properties:
+      * argv list, ``shell=False`` — no shell interpretation.
+      * absolute systemctl path resolved via ``shutil.which``; we
+        never spawn when it is missing.
+      * literal ``--user`` flag — no system-level systemctl path.
+      * literal ``restart`` verb — no ``stop`` / ``start`` /
+        ``daemon-reload`` reachable from this code path.
+      * stdin closed; stdout / stderr captured into bounded buffers.
+      * short timeout — a hung systemctl maps to failure, not to a
+        wedged request.
+    """
+    binary = _systemctl_path()
+    if binary is None:
+        return False, "systemctl_not_found"
+    if not validate_unit_name(unit):
+        return False, "unit_validation_failed"
+
+    argv = [binary, "--user", "restart", unit]
+    try:
+        result = subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=_SYSTEMCTL_TIMEOUT_SECONDS,
+            check=False,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("systemctl --user restart %s timed out", unit)
+        return False, "spawn_timeout"
+    except (OSError, ValueError) as exc:
+        logger.debug("systemctl --user restart %s failed to spawn: %s", unit, exc)
+        return False, "spawn_error"
+
+    if result.returncode != 0:
+        logger.debug(
+            "systemctl --user restart %s exited with code %s",
+            unit, result.returncode,
+        )
+        return False, "non_zero_exit"
+    return True, "spawn_accepted"
+
+
+def restart() -> RestartResult:
+    """Ask systemd-user to restart the configured Nova unit.
+
+    Refusal reasons (no spawn happens for any of these):
+      * maintenance is disabled    → ``disabled``
+      * restart is not allowed     → ``restart_not_allowed``
+      * restart mode is not systemd-user → ``restart_mode_disabled``
+      * unit name fails validation → ``invalid_unit``
+      * systemctl is not on PATH   → ``systemctl_missing``
+
+    On a successful spawn the result is ``accepted`` — Nova will be
+    restarted by systemd-user a moment later. The caller should warn
+    the user that the connection will drop while the unit cycles.
+    """
+    mode = _resolve_restart_mode()
+    unit = _resolve_unit()
+
+    if not _resolve_enabled():
+        return RestartResult(
+            outcome=RESTART_DISABLED, detail="Maintenance disabled.",
+            mode=mode, unit=unit,
+        )
+    if not _resolve_allow_restart():
+        return RestartResult(
+            outcome=RESTART_NOT_ALLOWED,
+            detail="Restart is disabled in the host configuration.",
+            mode=mode, unit=unit,
+        )
+    if mode != RESTART_MODE_SYSTEMD_USER:
+        return RestartResult(
+            outcome=RESTART_MODE_DISABLED,
+            detail="Restart mode is disabled.",
+            mode=mode, unit=unit,
+        )
+    if not validate_unit_name(unit):
+        return RestartResult(
+            outcome=RESTART_INVALID_UNIT,
+            detail="Configured systemd unit name is invalid.",
+            mode=mode, unit=unit,
+        )
+    if _systemctl_path() is None:
+        return RestartResult(
+            outcome=RESTART_SYSTEMCTL_MISSING,
+            detail="systemctl is not available on this host.",
+            mode=mode, unit=unit,
+        )
+
+    accepted, _detail = _start_systemctl_user_restart(unit)
+    if not accepted:
+        return RestartResult(
+            outcome=RESTART_FAILED,
+            detail="Restart could not be started.",
+            mode=mode, unit=unit,
+        )
+    return RestartResult(
+        outcome=RESTART_ACCEPTED,
+        detail="Restart accepted by systemd.",
+        mode=mode, unit=unit,
+    )
+
+
+__all__ = [
+    "MaintenanceStatus",
+    "PullResult",
+    "RestartResult",
+    "PULL_DIRTY_WORKING_TREE",
+    "PULL_DISABLED",
+    "PULL_DIVERGED",
+    "PULL_FAILED",
+    "PULL_NOT_ALLOWED",
+    "PULL_NOT_FAST_FORWARD",
+    "PULL_NO_UPSTREAM",
+    "PULL_REPO_UNAVAILABLE",
+    "PULL_SUCCESS",
+    "RESTART_ACCEPTED",
+    "RESTART_DISABLED",
+    "RESTART_FAILED",
+    "RESTART_INVALID_UNIT",
+    "RESTART_MODE_DISABLED",
+    "RESTART_MODE_OFF",
+    "RESTART_MODE_SYSTEMD_USER",
+    "RESTART_NOT_ALLOWED",
+    "RESTART_SYSTEMCTL_MISSING",
+    "STATE_DISABLED",
+    "STATE_READY",
+    "STATE_UNAVAILABLE",
+    "UPDATE_AVAILABLE",
+    "UPDATE_DIVERGED",
+    "UPDATE_NO_UPSTREAM",
+    "UPDATE_UNKNOWN",
+    "UPDATE_UP_TO_DATE",
+    "disabled_status",
+    "fetch",
+    "get_status",
+    "is_enabled",
+    "pull",
+    "restart",
+    "validate_unit_name",
+]

--- a/docs/maintenance-center.md
+++ b/docs/maintenance-center.md
@@ -1,0 +1,355 @@
+# Admin-only Maintenance / Update Center
+
+> **Status: optional, disabled by default.** Nova ships an admin-only
+> Maintenance surface that lets a maintainer check for upstream
+> changes, fast-forward the local checkout, and (when explicitly
+> configured) ask systemd-user to restart Nova — all from the web UI.
+> Every switch defaults to off. An unconfigured Nova install never
+> executes any maintenance command, even for an admin.
+
+This document describes the safety boundaries the feature commits to
+and the setup steps required before any of it does anything. It
+sits alongside [`secure-deployment.md`](secure-deployment.md) and
+[`nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md);
+nothing in this guide weakens those documents.
+
+---
+
+## TL;DR
+
+- **Remote updates are optional, opt-in, and admin-only.**
+- **No arbitrary shell.** Only a fixed allowlist of `git` commands
+  runs, plus a single `systemctl --user restart <validated-unit>`
+  when the restart switch is on.
+- **No `sudo`, no `pkexec`, no system-level `systemctl`.** Nova never
+  asks for elevation, ever.
+- **Fast-forward only.** A dirty working tree or a diverged branch
+  blocks the pull and prints a clear "manual intervention required"
+  message — Nova does not improvise.
+- **Confirmation-gated.** Pull and restart each require an explicit
+  `{"confirm": true}` body. The UI shows a `confirm()` prompt before
+  posting.
+- **Back up first.** `nova.db` and any other state in the checkout
+  should be backed up before enabling the pull switch.
+
+---
+
+## What this feature does (and does not)
+
+What the Maintenance surface **does** when fully enabled:
+
+- Tells the admin which branch the checkout is on, which commit it
+  points at, and which upstream branch is configured.
+- Reports whether the working tree is clean.
+- Reports whether the local branch is up-to-date, strictly behind
+  upstream (fast-forward-able), or diverged.
+- Lists the incoming commits (`git log --oneline HEAD..@{u}`) and
+  the changed-files summary (`git diff --stat HEAD..@{u}`) when an
+  update is available.
+- After an explicit confirmation, runs `git pull --ff-only`.
+- After an explicit confirmation, asks systemd-user to restart the
+  configured Nova unit.
+
+What the Maintenance surface **does not** do:
+
+- It is **not** a web terminal. No free-text commands are accepted.
+- It does **not** execute arbitrary shell. Every subprocess call is
+  built from a hard-coded argv list with `shell=False`.
+- It does **not** accept commands from chat input. The chat surface
+  is unchanged; this is a separate admin endpoint with its own
+  confirmation.
+- It does **not** run as root. It does **not** call `sudo`,
+  `pkexec`, `doas`, `su`, or `runuser`.
+- It does **not** bypass systemd. The only restart path is
+  `systemctl --user restart <validated-unit>`.
+- It does **not** auto-update. Nothing happens until an admin clicks
+  through the confirmation.
+- It does **not** restart without confirmation.
+- It is **not** reachable by a non-admin or a restricted user. Every
+  endpoint is wrapped in `require_admin`.
+- It does **not** modify the GitHub repository. There are no pushes,
+  no force-pushes, no branch creation, no comments, and no PR
+  actions.
+- It does **not** merge or rebase on a diverged branch. The only
+  pull verb wired in is `pull --ff-only`.
+- It does **not** disable any other Nova safety check. SilentGuard,
+  the GitHub read-only connector, the family controls, and the
+  identity contract are untouched.
+
+These are firm boundaries. A future change that crosses any of them
+is a contract change that must be discussed in its own PR.
+
+---
+
+## Configuration
+
+Every switch is read from the environment and defaults to off / safe.
+You can set them in `.env` or in the systemd unit's `Environment=`
+lines (the README walks through both).
+
+```ini
+# Host-wide opt-in. When false, every maintenance endpoint resolves
+# but reports state="disabled" and never touches git or systemctl.
+NOVA_MAINTENANCE_ENABLED=false
+
+# Independent switches. Enabling NOVA_MAINTENANCE_ENABLED does not
+# auto-enable pull or restart — the admin has to opt into each
+# action explicitly so an admin who only wants to *see* the status
+# card can do that without unlocking the destructive paths.
+NOVA_MAINTENANCE_ALLOW_PULL=false
+NOVA_MAINTENANCE_ALLOW_RESTART=false
+
+# Absolute path to the Nova checkout. Empty falls back to the
+# directory containing config.py (the install itself), which is
+# usually what you want.
+NOVA_MAINTENANCE_REPO_PATH=
+
+# Restart backend. `systemd-user` is the only allowed non-disabled
+# value, on purpose: it pins Nova to `systemctl --user restart <unit>`,
+# which never escalates privilege and never touches firewall config.
+# Anything else (typos, "sudo-systemctl", etc.) normalises to
+# `disabled`.
+NOVA_MAINTENANCE_RESTART_MODE=disabled
+
+# User-level systemd unit name to restart. Validated against
+# ^[a-z0-9][a-z0-9._-]*\.service$ before any spawn — path
+# traversal, shell metacharacters, whitespace, control characters,
+# and system-level targets are all rejected before exec.
+NOVA_MAINTENANCE_SYSTEMD_UNIT=nova.service
+```
+
+### Recommended starting point
+
+For an admin who wants to *try* the surface without unlocking the
+destructive actions yet:
+
+```ini
+NOVA_MAINTENANCE_ENABLED=true
+NOVA_MAINTENANCE_ALLOW_PULL=false
+NOVA_MAINTENANCE_ALLOW_RESTART=false
+```
+
+The card will now appear in **Settings → Admin** for admin users.
+It shows the branch, commit, upstream, clean / dirty state, and
+update availability — but the **Pull update** and **Restart Nova**
+buttons stay hidden because the corresponding switches are off.
+
+Once you are comfortable with the surface, flip `ALLOW_PULL=true`
+to enable fast-forward updates. Flip `ALLOW_RESTART=true` (and pick
+a `RESTART_MODE` / `SYSTEMD_UNIT`) to enable the restart path.
+
+---
+
+## HTTP endpoints
+
+All four endpoints are auth-gated, admin-only, and disabled unless
+configured. Non-admin and restricted users receive a `403`.
+
+- `GET  /admin/maintenance/status`
+
+  Read-only snapshot. Never reaches the network. Returns the
+  disabled snapshot when the feature is off so the admin UI can
+  render a stable shape either way. Fields include `state` (`disabled`
+  / `ready` / `unavailable`), `branch`, `commit`, `upstream`,
+  `has_upstream`, `working_tree_clean`, `update_available`
+  (`up_to_date` / `available` / `diverged` / `no_upstream` /
+  `unknown`), `behind_count`, `ahead_count`, `incoming_commits`,
+  `changed_files`, `allow_pull`, `allow_restart`, `restart_mode`,
+  and `unit`.
+
+- `POST /admin/maintenance/fetch`
+
+  Runs `git fetch` once and returns a refreshed status snapshot.
+  The only network-touching maintenance endpoint that does not
+  require a confirmation: fetching never modifies the working tree.
+
+- `POST /admin/maintenance/pull` (requires `{"confirm": true}`)
+
+  Refusal outcomes (no spawn happens for any of these):
+  - `disabled` — maintenance is off.
+  - `pull_not_allowed` — `NOVA_MAINTENANCE_ALLOW_PULL` is false.
+  - `repo_unavailable` — git missing or path is not a checkout.
+  - `no_upstream` — no upstream is configured for the current branch.
+  - `dirty_working_tree` — `git status --porcelain` had output.
+  - `diverged` — both `behind` and `ahead` are non-zero.
+  - `not_fast_forward` — already up-to-date, nothing to pull.
+
+  Success outcome: `success`, with `previous_commit` and `new_commit`
+  exposed so the admin can confirm the advance.
+
+- `POST /admin/maintenance/restart` (requires `{"confirm": true}`)
+
+  Refusal outcomes (no spawn happens for any of these):
+  - `disabled` — maintenance is off.
+  - `restart_not_allowed` — `NOVA_MAINTENANCE_ALLOW_RESTART` is false.
+  - `restart_mode_disabled` — `NOVA_MAINTENANCE_RESTART_MODE` is not
+    `systemd-user`.
+  - `invalid_unit` — the configured unit name fails validation.
+  - `systemctl_missing` — `systemctl` is not on PATH.
+  - `failed` — the spawn returned non-zero or timed out.
+
+  Success outcome: `accepted`. systemd will restart the unit
+  asynchronously; the admin should refresh the page after a moment.
+
+Pull and restart bodies that omit `confirm`, send `confirm: false`,
+or send any other value, are rejected with `400` before any helper
+code runs.
+
+---
+
+## Behaviour by state
+
+| Repo state | Status response | Pull behaviour |
+|---|---|---|
+| Maintenance disabled | `state="disabled"` | `outcome="disabled"` |
+| Pull switch off | `state="ready"` (pull button hidden in UI) | `outcome="pull_not_allowed"` |
+| No upstream configured | `update_available="no_upstream"` | `outcome="no_upstream"` |
+| Clean + behind | `update_available="available"` with `incoming_commits` / `changed_files` | `outcome="success"` (runs `git pull --ff-only`) |
+| Clean + up-to-date | `update_available="up_to_date"` | `outcome="not_fast_forward"` |
+| Dirty working tree | `working_tree_clean=false` | `outcome="dirty_working_tree"` |
+| Diverged | `update_available="diverged"` | `outcome="diverged"` |
+
+The UI hides the **Pull update** button unless the helper reports
+`allow_pull=true`, `has_upstream=true`, `working_tree_clean=true`,
+and `update_available="available"`. The server still re-checks each
+condition on the actual pull call — the UI is a convenience layer,
+not a security boundary.
+
+---
+
+## Restart safety
+
+The restart path is firmly opt-in and locked down to one verb:
+
+```text
+systemctl --user restart <validated-unit>
+```
+
+Everything about that call is fixed:
+
+- **Argv list, `shell=False`.** Python builds the argv array
+  manually; nothing is concatenated as a shell string.
+- **Absolute `systemctl` path.** Resolved with `shutil.which`. If
+  systemctl is missing, the call is refused with
+  `outcome="systemctl_missing"` — Nova never invents a path.
+- **`--user` is non-negotiable.** There is no system-level
+  `systemctl` code path in the maintenance module.
+- **`restart` is the only verb.** `start` / `stop` / `enable` /
+  `daemon-reload` are not reachable through this surface.
+- **Unit name is validated.** A strict
+  `^[a-z0-9][a-z0-9._-]*\.service$` regex plus a forbidden-substring
+  list (`..`, path separators, shell metacharacters, whitespace,
+  control characters) reject anything that could escape the argv.
+- **Bounded timeout.** A hung `systemctl` returns `outcome="failed"`,
+  never a wedged request.
+
+If your install does not have a systemd-user unit, leave
+`NOVA_MAINTENANCE_RESTART_MODE=disabled` and use the documented
+`sudo systemctl restart nova` from
+[`docs/secure-deployment.md`](secure-deployment.md). The UI will
+hide the Restart button when the restart mode is disabled — it
+will not pretend a restart succeeded when no path is configured.
+
+### Setting up a user-level Nova unit (optional)
+
+If you run Nova as a system unit (the default in
+[`deploy/systemd/nova.service`](../deploy/systemd/nova.service))
+and want the in-app restart to work, you have two options:
+
+1. **Keep Nova as a system unit and leave the restart switch off.**
+   This is the recommended default. Use `sudo systemctl restart nova`
+   from a shell when you want to restart, exactly as the security
+   guide documents. The Maintenance card still shows status / pull
+   actions; only the Restart button is hidden.
+
+2. **Run Nova under `systemctl --user`** in a user-level unit
+   (place a copy of `nova.service` under `~/.config/systemd/user/`,
+   adapted for your account). Then set
+   `NOVA_MAINTENANCE_RESTART_MODE=systemd-user` and point
+   `NOVA_MAINTENANCE_SYSTEMD_UNIT` at that unit name. Nova runs in
+   the same unprivileged account in both cases; this option just
+   changes where the unit lives so that `systemctl --user` can
+   manage it without elevation.
+
+Either option is consistent with the rest of the secure-deployment
+guide. The Maintenance surface does not require option 2.
+
+---
+
+## Audit logging
+
+Today, sensitive maintenance actions are visible through:
+
+- The systemd journal for the Nova process (`journalctl -u nova`).
+- The Maintenance response payloads themselves, which echo the
+  resolved branch / commit / outcome so the action is reviewable in
+  the admin's browser history.
+
+A dedicated audit log table (write actions to a `maintenance_audit`
+table with `who / when / outcome / previous_commit / new_commit`) is
+deliberately deferred so this PR stays small. Adding it later does
+not require changing the safety contract — it is a strict extension
+of the existing surface.
+
+---
+
+## Backups (strongly recommended)
+
+Before enabling `NOVA_MAINTENANCE_ALLOW_PULL=true`:
+
+```bash
+# Back up nova.db and the rest of the checkout. The whole checkout
+# is the simplest unit because nova.db, nova.db.backup, and any
+# user-authored memories all live alongside the code.
+tar czf nova-backup-$(date +%F).tar.gz /path/to/Nova
+```
+
+Even though `git pull --ff-only` is a strict advance, the database
+file is the part of the install that holds your data. Backing it up
+before a code update is cheap insurance.
+
+---
+
+## Non-goals
+
+These are explicitly **out of scope** for this PR and will not be
+added without their own review:
+
+- **No auto-update scheduling.** Nova does not poll for updates,
+  does not check on a timer, and does not run a background updater.
+- **No GitHub write actions.** The Maintenance surface is local-only:
+  it reads the upstream tip via `git fetch` and reads the working
+  tree. It never pushes, force-pushes, or interacts with GitHub
+  beyond `git fetch`'s normal behaviour.
+- **No rollback.** A future "roll back to the previous commit"
+  button is plausible but is deliberately not part of this PR.
+- **No remote terminal.** Period.
+- **No SilentGuard behaviour change.** The SilentGuard read-only
+  surface and the mitigation flow are unaffected by this feature.
+
+---
+
+## Tests
+
+The contract is pinned by [`tests/test_maintenance.py`](../tests/test_maintenance.py):
+
+- Disabled feature short-circuits every endpoint.
+- Pull / restart switches default to off and gate independently.
+- Pull refuses on dirty / diverged / no-upstream / not-fast-forward
+  states *before* any git command runs.
+- Pull uses the exact argv `["git", "pull", "--ff-only"]`.
+- Restart uses the exact argv
+  `[<systemctl>, "--user", "restart", <unit>]`.
+- Unit-name validation rejects path traversal, shell metacharacters,
+  system-level targets, and any non-`.service` suffix.
+- `subprocess.run` is always called with `shell=False`, a bounded
+  timeout, `stdin=DEVNULL`, and a list argv.
+- The maintenance module contains no `shell=True` and no string
+  reference to `sudo` / `pkexec` / `doas` / `runuser`.
+- The web endpoints are admin-only — non-admin and restricted users
+  receive `403`; missing bearer returns `401` / `403`.
+- Pull and restart require `{"confirm": true}` and return `400`
+  otherwise.
+
+The existing auth / admin / SilentGuard / GitHub-connector test
+suites continue to pass — this feature is additive.

--- a/static/index.html
+++ b/static/index.html
@@ -3053,6 +3053,52 @@
                             <button class="memory-btn" id="settings-open-admin-btn" onclick="openAdminFromSettings()">Open</button>
                         </div>
                     </div>
+                    <!--
+                      Maintenance / Updates card. Disabled by default and
+                      opt-in via NOVA_MAINTENANCE_ENABLED. When the host
+                      operator has not enabled the feature, the card stays
+                      visible with a calm "off" state so admins can see
+                      that the surface exists; pull and restart buttons
+                      stay hidden until the corresponding switches are on.
+                      Pull and restart always go through an explicit
+                      confirm() prompt so a stray click cannot trigger
+                      either action.
+                    -->
+                    <div class="settings-row" id="maintenance-row" data-state="loading">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-maintenance-title">Maintenance &amp; Updates</span>
+                                <span class="settings-row-hint" id="settings-maintenance-headline">Checking maintenance status…</span>
+                            </div>
+                            <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;justify-content:flex-end;">
+                                <button type="button" class="memory-btn" id="maintenance-check-btn" onclick="maintenanceCheck()" style="white-space:nowrap;display:none;">
+                                    <span id="maintenance-check-label">Check for updates</span>
+                                </button>
+                                <button type="button" class="memory-btn" id="maintenance-pull-btn" onclick="maintenancePull()" style="white-space:nowrap;display:none;">
+                                    <span id="maintenance-pull-label">Pull update</span>
+                                </button>
+                                <button type="button" class="memory-btn" id="maintenance-restart-btn" onclick="maintenanceRestart()" style="white-space:nowrap;display:none;">
+                                    <span id="maintenance-restart-label">Restart Nova</span>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="settings-row-foot" id="maintenance-details" style="margin-top:10px;font-size:0.78rem;color:var(--text-dim);line-height:1.55;display:none;">
+                            <div id="maintenance-detail-branch"></div>
+                            <div id="maintenance-detail-commit"></div>
+                            <div id="maintenance-detail-upstream"></div>
+                            <div id="maintenance-detail-clean"></div>
+                            <div id="maintenance-detail-availability"></div>
+                            <div id="maintenance-detail-incoming" style="margin-top:6px;display:none;">
+                                <div style="font-weight:500;color:var(--text);margin-bottom:4px;" id="maintenance-incoming-title">Incoming commits</div>
+                                <pre id="maintenance-incoming-commits" style="margin:0;padding:6px 8px;background:var(--bg-elev);border:1px solid var(--border);border-radius:6px;white-space:pre-wrap;word-break:break-word;font-size:0.72rem;max-height:180px;overflow:auto;"></pre>
+                            </div>
+                            <div id="maintenance-detail-changed" style="margin-top:6px;display:none;">
+                                <div style="font-weight:500;color:var(--text);margin-bottom:4px;" id="maintenance-changed-title">Changed files</div>
+                                <pre id="maintenance-changed-files" style="margin:0;padding:6px 8px;background:var(--bg-elev);border:1px solid var(--border);border-radius:6px;white-space:pre-wrap;word-break:break-word;font-size:0.72rem;max-height:180px;overflow:auto;"></pre>
+                            </div>
+                            <div id="maintenance-detail-status" style="margin-top:8px;color:var(--text);"></div>
+                        </div>
+                    </div>
                 </section>
 
                 <!-- ACCOUNT -->
@@ -6845,6 +6891,12 @@
         // background polling — the card stays fresh because every open
         // re-pulls and the Refresh button is the only other trigger.
         refreshSilentGuardStatus().catch(() => {});
+        // Maintenance card: admin-only and opt-in. The endpoint is
+        // admin-gated, so refresh only when the current user is an
+        // admin — otherwise the call would 403 noisily.
+        if (currentUser && currentUser.role === "admin") {
+            refreshMaintenanceStatus().catch(() => {});
+        }
         await loadSystemSettings();
         await loadMemories();
     }
@@ -6904,6 +6956,333 @@
         if (!currentUser || currentUser.role !== "admin") return;
         closeSettings();
         openAdmin();
+    }
+
+    // ── Maintenance / Update Center (admin-only, opt-in) ──────────
+    //
+    // The maintenance surface is admin-only on the server side too —
+    // every fetch carries the bearer token and a 403 response means
+    // the user lost their admin role between the open and the click.
+    // We never poll the endpoints in the background; the card is
+    // refreshed on Settings open and on each explicit user action.
+    let _maintenanceInFlight = false;
+
+    function _maintenanceSetMessage(text) {
+        const el = document.getElementById("settings-maintenance-headline");
+        if (el) el.textContent = text || "";
+    }
+
+    function _maintenanceSetStatusLine(text) {
+        const el = document.getElementById("maintenance-detail-status");
+        if (el) el.textContent = text || "";
+    }
+
+    function _maintenanceClearDetails() {
+        const ids = [
+            "maintenance-detail-branch",
+            "maintenance-detail-commit",
+            "maintenance-detail-upstream",
+            "maintenance-detail-clean",
+            "maintenance-detail-availability",
+        ];
+        ids.forEach((id) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = "";
+        });
+        const inc = document.getElementById("maintenance-detail-incoming");
+        if (inc) inc.style.display = "none";
+        const chg = document.getElementById("maintenance-detail-changed");
+        if (chg) chg.style.display = "none";
+        const wrap = document.getElementById("maintenance-details");
+        if (wrap) wrap.style.display = "none";
+    }
+
+    function _maintenanceRenderDetails(data) {
+        const wrap = document.getElementById("maintenance-details");
+        if (!wrap) return;
+        wrap.style.display = "";
+        const set = (id, text) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = text || "";
+        };
+        const shortSha = (sha) => (sha && sha.length >= 7 ? sha.slice(0, 7) : sha || "");
+        set("maintenance-detail-branch", "Branch: " + (data.branch || "—"));
+        set("maintenance-detail-commit", "Commit: " + shortSha(data.commit));
+        set(
+            "maintenance-detail-upstream",
+            "Upstream: " + (data.has_upstream ? (data.upstream || "—") : "(none)"),
+        );
+        set(
+            "maintenance-detail-clean",
+            data.working_tree_clean
+                ? "Working tree: clean"
+                : "Working tree: local changes detected",
+        );
+        let avail = "Update: unknown";
+        if (data.update_available === "up_to_date") {
+            avail = "Update: up to date";
+        } else if (data.update_available === "available") {
+            avail =
+                "Update: " + (data.behind_count || 0) +
+                " new commit" + ((data.behind_count || 0) === 1 ? "" : "s") +
+                " available";
+        } else if (data.update_available === "diverged") {
+            avail = "Update: branch diverged — manual intervention required";
+        } else if (data.update_available === "no_upstream") {
+            avail = "Update: no upstream branch configured";
+        }
+        set("maintenance-detail-availability", avail);
+
+        const incomingList = Array.isArray(data.incoming_commits)
+            ? data.incoming_commits : [];
+        const incomingWrap = document.getElementById("maintenance-detail-incoming");
+        const incomingPre = document.getElementById("maintenance-incoming-commits");
+        if (incomingWrap && incomingPre) {
+            if (incomingList.length > 0) {
+                incomingPre.textContent = incomingList.join("\n");
+                incomingWrap.style.display = "";
+            } else {
+                incomingPre.textContent = "";
+                incomingWrap.style.display = "none";
+            }
+        }
+        const changedList = Array.isArray(data.changed_files)
+            ? data.changed_files : [];
+        const changedWrap = document.getElementById("maintenance-detail-changed");
+        const changedPre = document.getElementById("maintenance-changed-files");
+        if (changedWrap && changedPre) {
+            if (changedList.length > 0) {
+                changedPre.textContent = changedList.join("\n");
+                changedWrap.style.display = "";
+            } else {
+                changedPre.textContent = "";
+                changedWrap.style.display = "none";
+            }
+        }
+    }
+
+    function _maintenanceApplyState(data) {
+        const row = document.getElementById("maintenance-row");
+        if (row) row.dataset.state = data.state || "unknown";
+
+        const checkBtn = document.getElementById("maintenance-check-btn");
+        const pullBtn = document.getElementById("maintenance-pull-btn");
+        const restartBtn = document.getElementById("maintenance-restart-btn");
+
+        // Hide all action buttons by default and re-show only the ones
+        // the server's structured response says are actually allowed.
+        // No client-side "guessing" — the server is the source of truth.
+        if (checkBtn) checkBtn.style.display = "none";
+        if (pullBtn) pullBtn.style.display = "none";
+        if (restartBtn) restartBtn.style.display = "none";
+
+        if (data.state === "disabled") {
+            _maintenanceSetMessage(
+                "Maintenance is disabled on this host."
+                + " Set NOVA_MAINTENANCE_ENABLED=true to opt in.",
+            );
+            _maintenanceClearDetails();
+            return;
+        }
+
+        if (data.state === "unavailable") {
+            _maintenanceSetMessage(data.detail || "Maintenance unavailable.");
+            _maintenanceClearDetails();
+            // Still allow re-checking so a transient miss can be retried.
+            if (checkBtn) checkBtn.style.display = "";
+            return;
+        }
+
+        // state === "ready"
+        _maintenanceSetMessage(data.detail || "Ready.");
+        _maintenanceRenderDetails(data);
+        _maintenanceSetStatusLine("");
+
+        if (checkBtn) checkBtn.style.display = "";
+
+        // Pull is only offered when:
+        //   * the host operator allowed it,
+        //   * the working tree is clean,
+        //   * an upstream is configured,
+        //   * the branch is strictly behind upstream.
+        const pullEligible =
+            data.allow_pull === true
+            && data.has_upstream === true
+            && data.working_tree_clean === true
+            && data.update_available === "available";
+        if (pullBtn) pullBtn.style.display = pullEligible ? "" : "none";
+
+        // Restart is only offered when:
+        //   * the host operator allowed it,
+        //   * a systemd-user mode is configured.
+        const restartEligible =
+            data.allow_restart === true
+            && data.restart_mode === "systemd-user";
+        if (restartBtn) restartBtn.style.display = restartEligible ? "" : "none";
+    }
+
+    async function refreshMaintenanceStatus() {
+        if (_maintenanceInFlight) return;
+        _maintenanceInFlight = true;
+        try {
+            const res = await fetch("/admin/maintenance/status", {
+                credentials: "include",
+                headers: { "Authorization": `Bearer ${token}` },
+            });
+            if (res.status === 403 || res.status === 401) {
+                _maintenanceSetMessage("Admin access required.");
+                _maintenanceClearDetails();
+                return;
+            }
+            if (!res.ok) {
+                _maintenanceSetMessage("Could not load maintenance status.");
+                _maintenanceClearDetails();
+                return;
+            }
+            const data = await res.json();
+            _maintenanceApplyState(data);
+        } catch (e) {
+            _maintenanceSetMessage("Could not load maintenance status.");
+            _maintenanceClearDetails();
+        } finally {
+            _maintenanceInFlight = false;
+        }
+    }
+
+    async function maintenanceCheck() {
+        if (_maintenanceInFlight) return;
+        _maintenanceInFlight = true;
+        _maintenanceSetStatusLine("Checking for updates…");
+        try {
+            const res = await fetch("/admin/maintenance/fetch", {
+                method: "POST",
+                credentials: "include",
+                headers: { "Authorization": `Bearer ${token}` },
+            });
+            if (!res.ok) {
+                _maintenanceSetStatusLine("Check failed.");
+                return;
+            }
+            const data = await res.json();
+            _maintenanceApplyState(data);
+        } catch (e) {
+            _maintenanceSetStatusLine("Check failed.");
+        } finally {
+            _maintenanceInFlight = false;
+        }
+    }
+
+    async function maintenancePull() {
+        // Explicit confirm() — a stray click never triggers a pull.
+        const ok = window.confirm(
+            "Apply available update with git pull --ff-only?\n\n"
+            + "Nova will only fast-forward; local changes or a diverged "
+            + "branch will block the update."
+        );
+        if (!ok) return;
+        if (_maintenanceInFlight) return;
+        _maintenanceInFlight = true;
+        _maintenanceSetStatusLine("Applying update…");
+        try {
+            const res = await fetch("/admin/maintenance/pull", {
+                method: "POST",
+                credentials: "include",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ confirm: true }),
+            });
+            if (!res.ok) {
+                _maintenanceSetStatusLine("Update failed.");
+                return;
+            }
+            const data = await res.json();
+            const detail = data.detail || "";
+            if (data.outcome === "success") {
+                _maintenanceSetStatusLine(
+                    "Update applied. Restart Nova to load the new code."
+                );
+            } else if (data.outcome === "dirty_working_tree") {
+                _maintenanceSetStatusLine(
+                    "Local changes detected. Manual intervention required."
+                );
+            } else if (data.outcome === "diverged") {
+                _maintenanceSetStatusLine(
+                    "Branch diverged. Manual intervention required."
+                );
+            } else if (data.outcome === "no_upstream") {
+                _maintenanceSetStatusLine("No upstream branch configured.");
+            } else if (data.outcome === "pull_not_allowed") {
+                _maintenanceSetStatusLine(
+                    "Pull is disabled in the host configuration."
+                );
+            } else {
+                _maintenanceSetStatusLine(detail || "Update did not apply.");
+            }
+            // Refresh the snapshot so the UI reflects the new state.
+            refreshMaintenanceStatus().catch(() => {});
+        } catch (e) {
+            _maintenanceSetStatusLine("Update failed.");
+        } finally {
+            _maintenanceInFlight = false;
+        }
+    }
+
+    async function maintenanceRestart() {
+        // Explicit confirm() — restart drops the connection.
+        const ok = window.confirm(
+            "Restart Nova now?\n\n"
+            + "Your session will drop while the unit cycles. "
+            + "Refresh the page after a few seconds to reconnect."
+        );
+        if (!ok) return;
+        if (_maintenanceInFlight) return;
+        _maintenanceInFlight = true;
+        _maintenanceSetStatusLine("Restart requested…");
+        try {
+            const res = await fetch("/admin/maintenance/restart", {
+                method: "POST",
+                credentials: "include",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ confirm: true }),
+            });
+            if (!res.ok) {
+                _maintenanceSetStatusLine("Restart failed.");
+                return;
+            }
+            const data = await res.json();
+            if (data.outcome === "accepted") {
+                _maintenanceSetStatusLine(
+                    "Restart accepted. Nova is restarting — refresh in a moment."
+                );
+            } else if (data.outcome === "restart_not_allowed") {
+                _maintenanceSetStatusLine(
+                    "Restart is disabled in the host configuration."
+                );
+            } else if (data.outcome === "restart_mode_disabled") {
+                _maintenanceSetStatusLine(
+                    "Restart mode is not configured."
+                );
+            } else if (data.outcome === "invalid_unit") {
+                _maintenanceSetStatusLine(
+                    "Configured systemd unit name is invalid."
+                );
+            } else if (data.outcome === "systemctl_missing") {
+                _maintenanceSetStatusLine(
+                    "systemctl is not available on this host."
+                );
+            } else {
+                _maintenanceSetStatusLine(data.detail || "Restart did not apply.");
+            }
+        } catch (e) {
+            _maintenanceSetStatusLine("Restart failed.");
+        } finally {
+            _maintenanceInFlight = false;
+        }
     }
 
     function filterMemories(query) {

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,966 @@
+"""
+Tests for the admin-only maintenance / update center.
+
+The suite pins the safety contract documented in ``core/maintenance.py``:
+
+  * disabled feature is silent — no probe, no spawn, every endpoint
+    reports ``state="disabled"``;
+  * pull / restart switches are independent and default to off;
+  * pull refuses on a dirty working tree, a diverged branch, a
+    missing upstream, or an already-up-to-date state — *before* any
+    git command runs;
+  * pull uses the exact argv ``["git", "pull", "--ff-only"]``;
+  * restart uses the exact argv ``[*, "--user", "restart", <unit>]``
+    and ``--user`` is non-negotiable;
+  * no subprocess invocation ever uses ``shell=True``;
+  * no spawn contains ``sudo`` / ``pkexec`` / ``doas`` / ``su`` /
+    ``runuser``;
+  * the helper never raises into the web layer;
+  * the FastAPI endpoints are admin-only and confirmation-gated for
+    pull / restart;
+  * the module itself contains no string-mode ``subprocess`` usage
+    and no ``shell=True`` literal.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import sqlite3
+import subprocess
+import sys
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Heavy / optional deps that ``web.py`` pulls in at module load. Stub
+# them before any test imports ``web`` so a missing wheel cannot block
+# this file. Only the minimal attribute surface the importers actually
+# touch is provided; everything else degrades to a MagicMock.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core import maintenance as maint  # noqa: E402
+from core import memory as core_memory, users  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_maintenance_env(monkeypatch):
+    """Strip every host-level env var so each test starts fresh."""
+    for var in (
+        "NOVA_MAINTENANCE_ENABLED",
+        "NOVA_MAINTENANCE_ALLOW_PULL",
+        "NOVA_MAINTENANCE_ALLOW_RESTART",
+        "NOVA_MAINTENANCE_REPO_PATH",
+        "NOVA_MAINTENANCE_RESTART_MODE",
+        "NOVA_MAINTENANCE_SYSTEMD_UNIT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def fake_repo(tmp_path):
+    """Materialise a directory that looks like a git checkout to the helper."""
+    (tmp_path / ".git").mkdir()
+    return str(tmp_path)
+
+
+@pytest.fixture
+def enable_maintenance(monkeypatch, fake_repo):
+    """Turn the maintenance surface on with a configured repo path."""
+    monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "true")
+    monkeypatch.setenv("NOVA_MAINTENANCE_REPO_PATH", fake_repo)
+    return fake_repo
+
+
+class _FakeGit:
+    """Scriptable replacement for ``maintenance._run_git``.
+
+    Records every argv tail so tests can assert the allowlist is
+    obeyed. Returns ``(returncode, stdout, stderr)`` from a dict
+    keyed by the argv tail tuple, with a configurable fallback.
+    """
+
+    def __init__(self, scripted: Optional[dict] = None, default: tuple = (0, "", "")):
+        self.scripted: dict = dict(scripted or {})
+        self.default = default
+        self.calls: list[tuple] = []
+        self.repo_paths: list[str] = []
+        self.timeouts: list[float] = []
+
+    def __call__(self, argv_tail, *, repo_path, timeout):
+        key = tuple(argv_tail)
+        self.calls.append(key)
+        self.repo_paths.append(repo_path)
+        self.timeouts.append(timeout)
+        return self.scripted.get(key, self.default)
+
+
+@pytest.fixture
+def fake_git(monkeypatch):
+    fake = _FakeGit()
+    monkeypatch.setattr(maint, "_run_git", fake)
+    # Pretend git is on PATH so the helper does not short-circuit.
+    monkeypatch.setattr(
+        maint.shutil, "which",
+        lambda name: "/usr/bin/git" if name == "git" else None,
+    )
+    return fake
+
+
+@pytest.fixture
+def fake_git_and_systemctl(monkeypatch):
+    fake = _FakeGit()
+    monkeypatch.setattr(maint, "_run_git", fake)
+
+    def _which(name):
+        if name == "git":
+            return "/usr/bin/git"
+        if name == "systemctl":
+            return "/usr/bin/systemctl"
+        return None
+
+    monkeypatch.setattr(maint.shutil, "which", _which)
+    return fake
+
+
+# ── Module-level safety contract ────────────────────────────────────
+
+
+class TestModuleSafetyContract:
+    def test_no_shell_true_anywhere(self):
+        """The maintenance module must never call subprocess with shell=True."""
+        with open(maint.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                for kw in node.keywords or []:
+                    if kw.arg == "shell":
+                        # Only ``shell=False`` is acceptable.
+                        assert isinstance(kw.value, ast.Constant), (
+                            "shell kwarg must be a constant"
+                        )
+                        assert kw.value.value is False, (
+                            "shell=True is forbidden in maintenance helper"
+                        )
+
+    def test_no_privilege_escalation_strings(self):
+        """The module must not mention sudo / pkexec / doas / su / runuser."""
+        with open(maint.__file__, "r", encoding="utf-8") as f:
+            source = f.read()
+        # Word-boundary-ish guard: bare strings would catch ``su`` in
+        # words like ``status``. Only literal command names with
+        # spaces / quotes around them.
+        forbidden = (
+            '"sudo"', "'sudo'", " sudo ",
+            '"pkexec"', "'pkexec'",
+            '"doas"', "'doas'",
+            '"runuser"', "'runuser'",
+        )
+        for needle in forbidden:
+            assert needle not in source, (
+                f"maintenance helper must not reference {needle!r}"
+            )
+
+    def test_subprocess_imports_are_module_form(self):
+        """Module imports subprocess once, at module scope; no ``os.system``."""
+        with open(maint.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        bad_attrs = {"system", "popen", "spawnl", "spawnv"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                if node.value.id == "os" and node.attr in bad_attrs:
+                    pytest.fail(f"maintenance helper must not call os.{node.attr}")
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+
+class TestValidateUnitName:
+    @pytest.mark.parametrize("unit", [
+        "nova.service",
+        "nova-api.service",
+        "nova_backend.service",
+        "n.service",
+        "nova.test.service",
+    ])
+    def test_accepts_safe_names(self, unit):
+        assert maint.validate_unit_name(unit) is True
+
+    @pytest.mark.parametrize("unit", [
+        "",
+        " nova.service",
+        "nova.service ",
+        "Nova.service",
+        "/usr/nova.service",
+        "../nova.service",
+        "nova\n.service",
+        "nova\t.service",
+        "nova .service",
+        "nova.service;rm",
+        "nova.service && reboot",
+        "nova.service|sh",
+        "nova.service$",
+        "nova.service`x`",
+        "nova.target",
+        ".service",
+        "-.service",
+    ])
+    def test_rejects_unsafe_names(self, unit):
+        assert maint.validate_unit_name(unit) is False
+
+
+# ── Disabled state ──────────────────────────────────────────────────
+
+
+class TestDisabled:
+    def test_disabled_by_default(self):
+        assert maint.is_enabled() is False
+
+    def test_status_disabled_when_env_unset(self):
+        s = maint.get_status()
+        assert s.state == maint.STATE_DISABLED
+        assert s.enabled is False
+        assert s.allow_pull is False
+        assert s.allow_restart is False
+
+    def test_status_disabled_when_env_explicit_false(self, monkeypatch):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "false")
+        s = maint.get_status()
+        assert s.state == maint.STATE_DISABLED
+
+    def test_fetch_disabled_does_not_call_git(self, fake_git):
+        result = maint.fetch()
+        assert result.state == maint.STATE_DISABLED
+        assert fake_git.calls == []
+
+    def test_pull_disabled_short_circuits(self, fake_git):
+        result = maint.pull()
+        assert result.outcome == maint.PULL_DISABLED
+        assert fake_git.calls == []
+
+    def test_restart_disabled_short_circuits(self, fake_git_and_systemctl, monkeypatch):
+        # Spy on subprocess.run so we can confirm no spawn happens.
+        recorded = []
+        monkeypatch.setattr(
+            maint.subprocess, "run",
+            lambda *a, **kw: recorded.append((a, kw)) or MagicMock(returncode=0),
+        )
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_DISABLED
+        assert recorded == []
+
+
+# ── Status snapshot ─────────────────────────────────────────────────
+
+
+class TestStatusSnapshot:
+    def test_unavailable_when_path_is_not_a_checkout(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_REPO_PATH", str(tmp_path))
+        # Pretend git is on PATH so the "not a checkout" branch is hit.
+        monkeypatch.setattr(
+            maint.shutil, "which",
+            lambda name: "/usr/bin/git" if name == "git" else None,
+        )
+        s = maint.get_status()
+        assert s.state == maint.STATE_UNAVAILABLE
+        assert "not a git checkout" in s.detail
+
+    def test_unavailable_when_git_missing(self, monkeypatch, fake_repo):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_REPO_PATH", fake_repo)
+        monkeypatch.setattr(maint.shutil, "which", lambda _name: None)
+        s = maint.get_status()
+        assert s.state == maint.STATE_UNAVAILABLE
+        assert "git is not available" in s.detail
+
+    def test_ready_up_to_date(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc123\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "0\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+        }
+        s = maint.get_status()
+        assert s.state == maint.STATE_READY
+        assert s.branch == "main"
+        assert s.commit == "abc123"
+        assert s.upstream == "origin/main"
+        assert s.has_upstream is True
+        assert s.working_tree_clean is True
+        assert s.update_available == maint.UPDATE_UP_TO_DATE
+        assert s.behind_count == 0
+        assert s.ahead_count == 0
+
+    def test_ready_no_upstream(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature\n", ""),
+            ("rev-parse", "HEAD"): (0, "deadbeef\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (128, "", "fatal: no upstream\n"),
+            ("status", "--porcelain"): (0, "", ""),
+        }
+        s = maint.get_status()
+        assert s.state == maint.STATE_READY
+        assert s.has_upstream is False
+        assert s.update_available == maint.UPDATE_NO_UPSTREAM
+        assert "No upstream" in s.detail
+
+    def test_ready_update_available(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc123\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "3\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+            ("log", "--oneline", "HEAD..@{u}"):
+                (0, "aaaaaaa first\nbbbbbbb second\nccccccc third\n", ""),
+            ("diff", "--stat", "HEAD..@{u}"):
+                (0, " core/maintenance.py | 10 +++++++\n 1 file changed\n", ""),
+        }
+        s = maint.get_status()
+        assert s.update_available == maint.UPDATE_AVAILABLE
+        assert s.behind_count == 3
+        assert s.incoming_commits == (
+            "aaaaaaa first", "bbbbbbb second", "ccccccc third",
+        )
+        assert len(s.changed_files) == 2
+
+    def test_ready_diverged(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc123\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "2\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "1\n", ""),
+            ("log", "--oneline", "HEAD..@{u}"): (0, "aaa A\nbbb B\n", ""),
+            ("diff", "--stat", "HEAD..@{u}"): (0, " a.py | 2\n", ""),
+        }
+        s = maint.get_status()
+        assert s.update_available == maint.UPDATE_DIVERGED
+        assert s.behind_count == 2
+        assert s.ahead_count == 1
+        assert "diverged" in s.detail.lower()
+
+    def test_dirty_working_tree_surfaces_in_status(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, " M core/maintenance.py\n", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "0\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+        }
+        s = maint.get_status()
+        assert s.working_tree_clean is False
+
+    def test_fetch_runs_fetch_before_reading_state(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("fetch",): (0, "", ""),
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "0\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+        }
+        s = maint.fetch()
+        assert ("fetch",) in fake_git.calls
+        # Fetch must come first.
+        assert fake_git.calls[0] == ("fetch",)
+        assert s.state == maint.STATE_READY
+
+    def test_status_does_not_fetch_by_default(self, enable_maintenance, fake_git):
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc\n", ""),
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "0\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+        }
+        maint.get_status()
+        assert ("fetch",) not in fake_git.calls
+
+
+# ── Pull refusals ───────────────────────────────────────────────────
+
+
+class TestPullRefusals:
+    def test_pull_not_allowed_blocks_even_when_clean(
+        self, enable_maintenance, fake_git,
+    ):
+        # Allow-pull off → no git command runs.
+        fake_git.scripted = {}  # would crash if any call landed
+        result = maint.pull()
+        assert result.outcome == maint.PULL_NOT_ALLOWED
+        # No subprocess primitives executed at all.
+        assert fake_git.calls == []
+
+    def test_pull_repo_unavailable_when_path_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_REPO_PATH", str(tmp_path))  # no .git
+        monkeypatch.setattr(
+            maint.shutil, "which",
+            lambda name: "/usr/bin/git" if name == "git" else None,
+        )
+        result = maint.pull()
+        assert result.outcome == maint.PULL_REPO_UNAVAILABLE
+
+    def test_pull_no_upstream_blocks(
+        self, monkeypatch, enable_maintenance, fake_git,
+    ):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (128, "", "fatal: no upstream\n"),
+        }
+        result = maint.pull()
+        assert result.outcome == maint.PULL_NO_UPSTREAM
+        # No pull command was issued.
+        assert ("pull", "--ff-only") not in fake_git.calls
+
+    def test_pull_dirty_working_tree_blocks(
+        self, monkeypatch, enable_maintenance, fake_git,
+    ):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, " M file.py\n", ""),
+        }
+        result = maint.pull()
+        assert result.outcome == maint.PULL_DIRTY_WORKING_TREE
+        assert "Local changes" in result.detail
+        assert ("pull", "--ff-only") not in fake_git.calls
+
+    def test_pull_diverged_blocks(
+        self, monkeypatch, enable_maintenance, fake_git,
+    ):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "2\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "1\n", ""),
+        }
+        result = maint.pull()
+        assert result.outcome == maint.PULL_DIVERGED
+        assert "diverged" in result.detail.lower()
+        assert ("pull", "--ff-only") not in fake_git.calls
+
+    def test_pull_not_fast_forward_when_already_up_to_date(
+        self, monkeypatch, enable_maintenance, fake_git,
+    ):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "0\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+        }
+        result = maint.pull()
+        assert result.outcome == maint.PULL_NOT_FAST_FORWARD
+        assert ("pull", "--ff-only") not in fake_git.calls
+
+
+# ── Pull happy path ─────────────────────────────────────────────────
+
+
+class TestPullHappyPath:
+    def test_pull_runs_ff_only_with_exact_argv(
+        self, monkeypatch, enable_maintenance, fake_git,
+    ):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "1\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+            ("rev-parse", "HEAD"): (0, "newcommit\n", ""),
+            ("pull", "--ff-only"): (0, "Updating abc..def\n", ""),
+        }
+        result = maint.pull()
+        assert result.outcome == maint.PULL_SUCCESS
+        # Exact argv — never ``merge``, never ``rebase``, never plain
+        # ``pull``. The ``--ff-only`` flag is non-negotiable.
+        assert ("pull", "--ff-only") in fake_git.calls
+
+    def test_pull_failed_surface_when_git_exits_nonzero(
+        self, monkeypatch, enable_maintenance, fake_git,
+    ):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+        fake_git.scripted = {
+            ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+                (0, "origin/main\n", ""),
+            ("status", "--porcelain"): (0, "", ""),
+            ("rev-list", "--count", "HEAD..@{u}"): (0, "1\n", ""),
+            ("rev-list", "--count", "@{u}..HEAD"): (0, "0\n", ""),
+            ("rev-parse", "HEAD"): (0, "abc\n", ""),
+            ("pull", "--ff-only"): (1, "", "fatal: non-ff\n"),
+        }
+        result = maint.pull()
+        assert result.outcome == maint.PULL_FAILED
+        # Detail must be sanitised — never the raw stderr.
+        assert "fatal" not in result.detail.lower()
+
+
+# ── Restart safety ──────────────────────────────────────────────────
+
+
+class TestRestartRefusals:
+    def test_restart_not_allowed_by_default(
+        self, monkeypatch, enable_maintenance, fake_git_and_systemctl,
+    ):
+        recorded = []
+        monkeypatch.setattr(
+            maint.subprocess, "run",
+            lambda *a, **kw: recorded.append((a, kw)) or MagicMock(returncode=0),
+        )
+        # Restart switch off; even with enabled=true and mode set, refused.
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "systemd-user")
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_NOT_ALLOWED
+        assert recorded == []
+
+    def test_restart_mode_disabled_blocks_even_when_allowed(
+        self, monkeypatch, enable_maintenance, fake_git_and_systemctl,
+    ):
+        recorded = []
+        monkeypatch.setattr(
+            maint.subprocess, "run",
+            lambda *a, **kw: recorded.append((a, kw)) or MagicMock(returncode=0),
+        )
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        # Mode unset → resolves to "disabled".
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_MODE_DISABLED
+        assert recorded == []
+
+    def test_restart_mode_unknown_normalises_to_disabled(
+        self, monkeypatch, enable_maintenance, fake_git_and_systemctl,
+    ):
+        recorded = []
+        monkeypatch.setattr(
+            maint.subprocess, "run",
+            lambda *a, **kw: recorded.append((a, kw)) or MagicMock(returncode=0),
+        )
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        # A typo / dangerous backend name must never spawn.
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "sudo-systemctl")
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_MODE_DISABLED
+        assert recorded == []
+
+    def test_restart_invalid_unit_blocks(
+        self, monkeypatch, enable_maintenance, fake_git_and_systemctl,
+    ):
+        recorded = []
+        monkeypatch.setattr(
+            maint.subprocess, "run",
+            lambda *a, **kw: recorded.append((a, kw)) or MagicMock(returncode=0),
+        )
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "systemd-user")
+        monkeypatch.setenv("NOVA_MAINTENANCE_SYSTEMD_UNIT", "nova.service; rm -rf /")
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_INVALID_UNIT
+        assert recorded == []
+
+
+class TestRestartHappyPath:
+    def test_restart_spawns_systemctl_user_restart(self, monkeypatch, enable_maintenance):
+        # Configure restart switch + mode + unit.
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "systemd-user")
+        monkeypatch.setenv("NOVA_MAINTENANCE_SYSTEMD_UNIT", "nova.service")
+        monkeypatch.setattr(
+            maint.shutil, "which",
+            lambda name: f"/usr/bin/{name}" if name in ("systemctl", "git") else None,
+        )
+        recorded = []
+
+        class _FakeCompleted:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+
+        def _fake_run(argv, **kwargs):
+            recorded.append({"argv": list(argv), "kwargs": dict(kwargs)})
+            return _FakeCompleted()
+
+        monkeypatch.setattr(maint.subprocess, "run", _fake_run)
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_ACCEPTED
+        assert len(recorded) == 1
+        call = recorded[0]
+        # Exact argv. No sudo, no system-level systemctl, no extra flags.
+        assert call["argv"] == [
+            "/usr/bin/systemctl", "--user", "restart", "nova.service",
+        ]
+        # shell=False on every spawn.
+        assert call["kwargs"].get("shell") is False
+        # Timeout must be bounded.
+        assert isinstance(call["kwargs"].get("timeout"), (int, float))
+        # No privilege-escalation argv elements anywhere.
+        for token_arg in call["argv"]:
+            assert "sudo" not in token_arg
+            assert "pkexec" not in token_arg
+            assert "doas" not in token_arg
+
+    def test_restart_systemctl_missing(self, monkeypatch, enable_maintenance):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "systemd-user")
+        monkeypatch.setattr(maint.shutil, "which", lambda _name: None)
+        recorded = []
+        monkeypatch.setattr(
+            maint.subprocess, "run",
+            lambda *a, **kw: recorded.append((a, kw)) or MagicMock(returncode=0),
+        )
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_SYSTEMCTL_MISSING
+        assert recorded == []
+
+    def test_restart_failure_surfaces_calmly(self, monkeypatch, enable_maintenance):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "systemd-user")
+        monkeypatch.setenv("NOVA_MAINTENANCE_SYSTEMD_UNIT", "nova.service")
+        monkeypatch.setattr(
+            maint.shutil, "which",
+            lambda name: f"/usr/bin/{name}" if name in ("systemctl", "git") else None,
+        )
+
+        class _FakeCompleted:
+            returncode = 1
+            stdout = b""
+            stderr = b"Failed to restart nova.service\n"
+
+        monkeypatch.setattr(maint.subprocess, "run", lambda *a, **kw: _FakeCompleted())
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_FAILED
+        assert "Failed" not in result.detail  # sanitised
+        # The unit / mode are still surfaced for the UI.
+        assert result.unit == "nova.service"
+        assert result.mode == maint.RESTART_MODE_SYSTEMD_USER
+
+    def test_restart_handles_timeout_calmly(self, monkeypatch, enable_maintenance):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_RESTART", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_RESTART_MODE", "systemd-user")
+        monkeypatch.setenv("NOVA_MAINTENANCE_SYSTEMD_UNIT", "nova.service")
+        monkeypatch.setattr(
+            maint.shutil, "which",
+            lambda name: f"/usr/bin/{name}" if name in ("systemctl", "git") else None,
+        )
+
+        def _raise_timeout(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=a[0], timeout=kw.get("timeout", 5))
+
+        monkeypatch.setattr(maint.subprocess, "run", _raise_timeout)
+        result = maint.restart()
+        assert result.outcome == maint.RESTART_FAILED
+
+
+# ── Subprocess kwargs contract ──────────────────────────────────────
+
+
+class TestSubprocessKwargs:
+    """Pin the exact subprocess.run kwargs used by the git path.
+
+    The maintenance helper must never set ``shell=True``, must use an
+    argv list (not a string), must close stdin, and must always pass
+    a finite timeout.
+    """
+
+    def test_run_git_uses_argv_list_and_shell_false(
+        self, monkeypatch, fake_repo,
+    ):
+        recorded = []
+
+        class _FakeCompleted:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+
+        def _fake_run(argv, **kwargs):
+            recorded.append({"argv": list(argv), "kwargs": dict(kwargs)})
+            return _FakeCompleted()
+
+        monkeypatch.setattr(
+            maint.shutil, "which",
+            lambda name: "/usr/bin/git" if name == "git" else None,
+        )
+        monkeypatch.setattr(maint.subprocess, "run", _fake_run)
+        # Use the actual helper — not the test-only `fake_git` injection.
+        rc, out, err = maint._run_git(
+            ["status", "--porcelain"],
+            repo_path=fake_repo, timeout=5.0,
+        )
+        assert rc == 0
+        assert len(recorded) == 1
+        call = recorded[0]
+        # argv is a list whose first element is the resolved git path.
+        assert isinstance(call["argv"], list)
+        assert call["argv"][0] == "/usr/bin/git"
+        assert call["argv"][1:] == ["status", "--porcelain"]
+        # shell=False on every git call.
+        assert call["kwargs"].get("shell") is False
+        # Bounded timeout.
+        assert call["kwargs"].get("timeout") == 5.0
+        # CWD pinned to the configured repo path.
+        assert call["kwargs"].get("cwd") == fake_repo
+        # Stdin is closed.
+        assert call["kwargs"].get("stdin") is subprocess.DEVNULL
+
+
+# ── Web endpoint integration ────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+class TestMaintenanceEndpointsAuth:
+    @pytest.mark.parametrize("method,path", [
+        ("GET", "/admin/maintenance/status"),
+        ("POST", "/admin/maintenance/fetch"),
+        ("POST", "/admin/maintenance/pull"),
+        ("POST", "/admin/maintenance/restart"),
+    ])
+    def test_non_admin_user_forbidden(self, web_client, user_token, method, path):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(user_token))
+        else:
+            resp = web_client.post(path, headers=_h(user_token), json={"confirm": True})
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path", [
+        ("GET", "/admin/maintenance/status"),
+        ("POST", "/admin/maintenance/fetch"),
+        ("POST", "/admin/maintenance/pull"),
+        ("POST", "/admin/maintenance/restart"),
+    ])
+    def test_restricted_user_forbidden(self, web_client, restricted_token, method, path):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(restricted_token))
+        else:
+            resp = web_client.post(
+                path, headers=_h(restricted_token), json={"confirm": True},
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path", [
+        ("GET", "/admin/maintenance/status"),
+        ("POST", "/admin/maintenance/fetch"),
+        ("POST", "/admin/maintenance/pull"),
+        ("POST", "/admin/maintenance/restart"),
+    ])
+    def test_unauthenticated_blocked(self, web_client, method, path):
+        if method == "GET":
+            resp = web_client.get(path)
+        else:
+            resp = web_client.post(path, json={"confirm": True})
+        # FastAPI maps a missing bearer to 403 (HTTPBearer's default).
+        assert resp.status_code in (401, 403)
+
+
+class TestMaintenanceEndpointsDisabled:
+    """When the feature is disabled, every admin endpoint reports
+    ``state="disabled"`` (or ``outcome="disabled"``) without touching
+    git or systemctl."""
+
+    def test_status_disabled(self, web_client, admin_token):
+        resp = web_client.get(
+            "/admin/maintenance/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "disabled"
+        assert body["enabled"] is False
+
+    def test_fetch_disabled(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/maintenance/fetch", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "disabled"
+
+    def test_pull_disabled_requires_confirm_first(self, web_client, admin_token):
+        # Missing confirm → 400 regardless of feature switch state.
+        resp = web_client.post(
+            "/admin/maintenance/pull", headers=_h(admin_token), json={},
+        )
+        assert resp.status_code == 400
+
+    def test_pull_disabled_with_confirm_returns_disabled(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/maintenance/pull",
+            headers=_h(admin_token), json={"confirm": True},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["outcome"] == "disabled"
+
+    def test_restart_disabled_with_confirm_returns_disabled(
+        self, web_client, admin_token,
+    ):
+        resp = web_client.post(
+            "/admin/maintenance/restart",
+            headers=_h(admin_token), json={"confirm": True},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["outcome"] == "disabled"
+
+
+class TestMaintenanceEndpointsConfirmation:
+    """Confirmation is mandatory for pull / restart even when enabled."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_pull(self, monkeypatch):
+        monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_ALLOW_PULL", "true")
+
+    def test_pull_requires_confirm_true(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/maintenance/pull",
+            headers=_h(admin_token), json={"confirm": False},
+        )
+        assert resp.status_code == 400
+
+    def test_restart_requires_confirm_true(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/maintenance/restart",
+            headers=_h(admin_token), json={"confirm": False},
+        )
+        assert resp.status_code == 400
+
+
+class TestMaintenanceEndpointsResponses:
+    """When enabled, the admin endpoints surface the helper's snapshot."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_with_repo(self, monkeypatch, tmp_path):
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("NOVA_MAINTENANCE_ENABLED", "true")
+        monkeypatch.setenv("NOVA_MAINTENANCE_REPO_PATH", str(tmp_path))
+        # Stub the helper layer so we don't depend on a real repo.
+        from core import maintenance as _maint
+
+        def _fake_status(do_fetch=False):
+            return _maint.MaintenanceStatus(
+                state=_maint.STATE_READY,
+                enabled=True,
+                allow_pull=False,
+                allow_restart=False,
+                restart_mode=_maint.RESTART_MODE_OFF,
+                unit="nova.service",
+                repo_path=str(tmp_path),
+                branch="main",
+                commit="abc123",
+                upstream="origin/main",
+                has_upstream=True,
+                working_tree_clean=True,
+                update_available=_maint.UPDATE_UP_TO_DATE,
+                detail="Already up to date.",
+            )
+
+        monkeypatch.setattr(_maint, "get_status", _fake_status)
+
+    def test_status_shape(self, web_client, admin_token):
+        resp = web_client.get(
+            "/admin/maintenance/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "ready"
+        assert body["branch"] == "main"
+        assert body["commit"] == "abc123"
+        assert body["upstream"] == "origin/main"
+        assert body["update_available"] == "up_to_date"
+        # The response must never leak the configured token / secret
+        # values. We have no token field here on purpose.
+        assert "token" not in body

--- a/web.py
+++ b/web.py
@@ -63,6 +63,7 @@ from core.integrations import github_triage as _github_triage
 from core.security import ensure_silentguard_running as _ensure_silentguard_running
 from core.security import lifecycle as _silentguard_lifecycle
 from core.security import SilentGuardProvider as _SilentGuardProvider
+from core import maintenance as _maintenance
 from core import voice as _voice
 import sqlite3 as _sqlite3
 from core import users as _users_mod
@@ -2108,6 +2109,102 @@ def github_recommendations(
         "recommendations": recommendations,
         "read_only": True,
     }
+
+
+# ── ADMIN: OPTIONAL MAINTENANCE / UPDATE CENTER ────────────────────
+# Tiny admin surface that lets a maintainer see (and after a visible
+# confirmation, apply) a fast-forward update to the local Nova
+# checkout. Every endpoint is wrapped with ``require_admin`` and the
+# underlying ``core.maintenance`` module enforces:
+#
+#   * NOVA_MAINTENANCE_ENABLED gates the whole surface,
+#   * NOVA_MAINTENANCE_ALLOW_PULL gates the pull action,
+#   * NOVA_MAINTENANCE_ALLOW_RESTART + NOVA_MAINTENANCE_RESTART_MODE
+#     gate the restart action,
+#   * git commands run from a fixed allowlist with ``shell=False``,
+#   * restart uses ``systemctl --user restart <validated-unit>`` only
+#     — never ``sudo``, never system-level systemctl.
+#
+# When the feature is disabled, every endpoint still resolves and
+# returns ``state="disabled"`` so the admin UI can render a calm
+# "off" card without guessing at the configured state. The pull and
+# restart endpoints additionally require an explicit ``{"confirm":
+# true}`` body so a stray click cannot trigger them.
+
+
+class MaintenanceConfirmRequest(BaseModel):
+    """Explicit confirmation payload for pull / restart endpoints.
+
+    The frontend is responsible for showing a visible confirmation
+    surface before posting ``{"confirm": true}``. The server rejects
+    any other shape (default ``False`` → 400) so a misbehaving client
+    cannot trigger a pull or restart by sending an empty body.
+    """
+
+    confirm: bool = False
+
+
+def _require_confirm(req: MaintenanceConfirmRequest) -> None:
+    if not req.confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Action requires explicit confirmation.",
+        )
+
+
+@app.get("/admin/maintenance/status")
+def maintenance_status(_: CurrentUser = Depends(require_admin)):
+    """Calm read-only snapshot of the maintenance surface.
+
+    Never reaches the network — equivalent to ``git fetch``-less
+    state. Returns the disabled snapshot when the feature is off so
+    the admin UI can render a stable shape either way.
+    """
+    return _maintenance.get_status().as_dict()
+
+
+@app.post("/admin/maintenance/fetch")
+def maintenance_fetch(_: CurrentUser = Depends(require_admin)):
+    """Run ``git fetch`` once and return a refreshed snapshot.
+
+    The only network-touching maintenance endpoint that does not need
+    a confirmation: fetching never modifies the working tree. The
+    response shape mirrors ``/admin/maintenance/status``.
+    """
+    return _maintenance.fetch().as_dict()
+
+
+@app.post("/admin/maintenance/pull")
+def maintenance_pull(
+    req: MaintenanceConfirmRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Apply a fast-forward update after an explicit confirmation.
+
+    Returns 400 when ``confirm`` is not True. The underlying helper
+    refuses on a dirty working tree, a diverged branch, or a missing
+    upstream — surfaced as ``outcome="dirty_working_tree" /
+    "diverged" / "no_upstream"`` rather than 500.
+    """
+    _require_confirm(req)
+    return _maintenance.pull().as_dict()
+
+
+@app.post("/admin/maintenance/restart")
+def maintenance_restart(
+    req: MaintenanceConfirmRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Restart the configured systemd-user unit after a confirmation.
+
+    Returns 400 when ``confirm`` is not True. The underlying helper
+    refuses unless the restart switch *and* the systemd-user mode
+    are both enabled with a valid unit name — surfaced as
+    ``outcome="restart_not_allowed" / "restart_mode_disabled" /
+    "invalid_unit"`` rather than 500.
+    """
+    _require_confirm(req)
+    return _maintenance.restart().as_dict()
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

Adds an **opt-in, admin-only** Settings card that lets a maintainer:

- see the local checkout's branch / commit / upstream / clean state,
- fast-forward to upstream after an explicit confirmation,
- ask systemd-user to restart Nova after an explicit confirmation
  (when the restart switch is enabled).

Every switch defaults to off so an unconfigured Nova install never
executes any maintenance command, even for an admin.

This is **not** a web terminal, **not** a generic command runner,
**not** chat-driven, **not** an auto-updater, and **not** a
privilege-escalation helper. It is a narrow, allowlisted surface
for remote maintainability.

## Safety boundaries (enforced + pinned by tests)

- **Fixed allowlist of git subcommands only**: `fetch`, `status --porcelain`,
  `rev-parse`, `log --oneline HEAD..@{u}`, `diff --stat HEAD..@{u}`,
  and `pull --ff-only`. No chat input or model output reaches argv.
- **`shell=False` everywhere.** No string commands, no `os.system`,
  no shell interpretation.
- **No `sudo` / `pkexec` / `doas` / `su` / `runuser`.** Nova never
  asks for elevation.
- **Fast-forward only.** Dirty working tree / diverged branch /
  missing upstream are refused with structured outcomes
  (`dirty_working_tree` / `diverged` / `no_upstream`) **before** any
  git command runs. Nova does not improvise a merge, reset, or rebase.
- **Restart restricted to `systemctl --user restart <validated-unit>`**
  with a strict `^[a-z0-9][a-z0-9._-]*\.service$` regex plus a
  forbidden-substring list. No system-level `systemctl`, no
  arbitrary restart command.
- **Admin-only at the endpoint layer**, with confirmation-gated POST
  for pull / restart (rejected with `400` when `{"confirm": true}`
  is missing).
- **Sanitised errors.** No raw stderr / secrets / paths leak to the
  response.

## What changed

- `core/maintenance.py` — new helper with `MaintenanceStatus`,
  `PullResult`, `RestartResult` dataclasses and `get_status` /
  `fetch` / `pull` / `restart` public functions. Single subprocess
  call site per command, all argv lists.
- `web.py` — four admin-only endpoints: `GET /admin/maintenance/status`,
  `POST /admin/maintenance/fetch`, `POST /admin/maintenance/pull`,
  `POST /admin/maintenance/restart`. Wrapped with `require_admin`.
- `config.py` + `.env.example` — six `NOVA_MAINTENANCE_*` switches,
  all defaulting to safe values.
- `static/index.html` — Settings → Admin → "Maintenance & Updates"
  card, hidden for non-admin users by the existing admin-only pane
  gating. Pull / restart buttons each go through a `window.confirm()`
  before posting.
- `tests/test_maintenance.py` — 77 tests covering the safety
  contract (no `shell=True`, no privilege-escalation strings, exact
  pull argv, exact restart argv, unit-name validation, every refusal
  path, admin gating, confirmation gating).
- `docs/maintenance-center.md` — operator-facing walkthrough,
  recommended starting points, non-goals, audit notes.

## Configuration

```ini
NOVA_MAINTENANCE_ENABLED=false          # default
NOVA_MAINTENANCE_ALLOW_PULL=false       # independent of ENABLED
NOVA_MAINTENANCE_ALLOW_RESTART=false    # independent of ALLOW_PULL
NOVA_MAINTENANCE_REPO_PATH=             # empty → install directory
NOVA_MAINTENANCE_RESTART_MODE=disabled  # or systemd-user
NOVA_MAINTENANCE_SYSTEMD_UNIT=nova.service
```

## Non-goals (deliberately out of scope)

- No auto-update scheduling, no background polling.
- No GitHub write actions.
- No rollback (could land later as a small follow-up).
- No web terminal.
- No SilentGuard behaviour change.

## Test plan

- [x] `python -m pytest tests/test_maintenance.py` — 77 / 77 pass.
- [x] `python -m pytest tests/test_auth.py tests/test_admin_users.py tests/test_users.py tests/test_security_lifecycle.py tests/test_integrations_github.py tests/test_systemd_unit.py` — 225 / 225 pass.
- [x] Pre-existing failures in `test_natural_memory` / `test_router` /
  `test_model_*` reproduce on `main` without these changes — unrelated.
- [ ] Manual smoke: open Settings → Admin as admin, with
  `NOVA_MAINTENANCE_ENABLED=true` and a clean checkout; confirm the
  card renders branch/commit/upstream and the **Pull update** /
  **Restart Nova** buttons stay hidden until the corresponding
  switches are flipped on.
- [ ] Manual: as a non-admin, confirm `/admin/maintenance/*` returns
  `403`.
- [ ] Manual: POST `/admin/maintenance/pull` with `{}` returns `400`.



---
_Generated by [Claude Code](https://claude.ai/code/session_018SB4SEvzQUPcRsB6BAqXeg)_