### PR TITLE
feat(media): read-only Jellyfin music bridge + local playlist suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,6 +186,57 @@ NOVA_MAINTENANCE_REPO_PATH=
 NOVA_MAINTENANCE_RESTART_MODE=disabled
 NOVA_MAINTENANCE_SYSTEMD_UNIT=nova.service
 
+# ── Optional local media: Jellyfin (read-only Phase 1) ────────────
+# A small, opt-in bridge that lets Nova help you *explore* a local
+# Jellyfin music library and suggest playlists. Nova is a media
+# *assistant*, not an autonomous media manager — Phase 1 is strictly
+# read-only.
+#
+# What this bridge does (Phase 1):
+#   * connection status,
+#   * list artists / albums / tracks / genres / playlists,
+#   * compute deterministic playlist suggestions from library metadata
+#     (chill, focus, gym, night drive, coding, ...).
+#
+# What this bridge does NOT do (now or via this PR):
+#   * create / edit / delete playlists on Jellyfin,
+#   * stream, transcode, or copy any media file,
+#   * send your library data to any cloud music API,
+#   * scan disk outside of Jellyfin,
+#   * poll Jellyfin in the background,
+#   * start playback or autoplay anything.
+#
+# Defaults are off / read-only and the API key must never be:
+#   * returned to the frontend or chat,
+#   * written to any log line or error message,
+#   * stored in the database in this PR.
+#
+#   NOVA_JELLYFIN_ENABLED         — host-wide switch. False → bridge
+#                                   disabled for everyone; admin-only
+#                                   endpoints still resolve but report
+#                                   state="disabled".
+#   NOVA_JELLYFIN_URL             — base URL of the Jellyfin server
+#                                   (e.g. http://127.0.0.1:8096).
+#   NOVA_JELLYFIN_API_KEY         — Jellyfin API key with read scopes.
+#                                   No write scopes are ever required
+#                                   by Nova in Phase 1.
+#   NOVA_JELLYFIN_USER_ID         — optional Jellyfin user GUID. When
+#                                   set, library queries are scoped
+#                                   to this user; empty falls back to
+#                                   server-wide read endpoints.
+#   NOVA_JELLYFIN_READ_ONLY       — belt-and-braces flag, default true.
+#                                   Phase 1 never performs writes;
+#                                   future playlist-creation helpers
+#                                   will require explicit confirmation
+#                                   in the UI.
+#   NOVA_JELLYFIN_TIMEOUT_SECONDS — per-request HTTP timeout (default 5).
+NOVA_JELLYFIN_ENABLED=false
+NOVA_JELLYFIN_URL=http://127.0.0.1:8096
+NOVA_JELLYFIN_API_KEY=
+NOVA_JELLYFIN_USER_ID=
+NOVA_JELLYFIN_READ_ONLY=true
+NOVA_JELLYFIN_TIMEOUT_SECONDS=5.0
+
 # ── Time / calendar context ───────────────────────────────────────────
 # Override the timezone Nova uses when resolving "today", "yesterday", etc.
 # Must be a valid IANA timezone name (e.g. America/Montreal, Europe/Paris).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ core/
   security_feed.py    Read-only SilentGuard JSON parser
   security/           Read-only security provider package
   integrations/       Per-user gates for optional integrations
+    media/            Local-first media bridges (Jellyfin, read-only)
   voice/              TTS provider abstraction (browser + Piper)
 
 memory/
@@ -180,6 +181,9 @@ The boundaries below are firm. They are commitments, not future work:
   third-party cloud service.
 - Nova does **not** require SilentGuard to function. SilentGuard is an
   optional, off-by-default integration.
+- Nova does **not** stream, transcode, or copy media files. The
+  optional Jellyfin bridge reads library metadata only and never
+  contacts a cloud music API.
 
 The hardened systemd unit drops capabilities, enables
 `ProtectSystem=strict`, restricts namespaces, applies a syscall
@@ -371,6 +375,139 @@ Any future write actions will be introduced behind their own
 opt-in switch, will require explicit user confirmation in the
 UI, and will carry audit logging. There is no autonomous
 maintainer behaviour planned.
+
+## Optional local media assistant (Jellyfin, read-only)
+
+Nova ships an **optional**, **admin-only**, **read-only** bridge to a
+local Jellyfin music library, plus a small deterministic helper that
+turns library metadata into playlist suggestions. Nova is a *local
+media assistant*, not an autonomous media manager — Phase 1 is
+strictly read-only and works entirely against your local server.
+
+This is **not** a cloud music client. Nova does **not** send your
+library data to any third-party music service. Nova does **not**
+stream, transcode, or copy media files. Nova **only** reads metadata
+(artists, albums, tracks, genres, playlists) and computes playlist
+*ideas* you can choose to use.
+
+The bridge is disabled by default. To enable it on a local Nova
+install, add the following to your `.env`:
+
+```ini
+NOVA_JELLYFIN_ENABLED=true
+NOVA_JELLYFIN_URL=http://127.0.0.1:8096
+NOVA_JELLYFIN_API_KEY=your_local_jellyfin_api_key
+NOVA_JELLYFIN_USER_ID=                   # optional; scopes reads to one user
+NOVA_JELLYFIN_READ_ONLY=true             # default; Phase 1 has no writes
+NOVA_JELLYFIN_TIMEOUT_SECONDS=5.0
+```
+
+The API key only needs **read** scopes because Nova never performs
+write operations against Jellyfin in this phase. Generate the key
+from Jellyfin's *Dashboard → API Keys* page; do not give the key
+admin or playback-control scopes.
+
+Once configured, Nova exposes six admin-only endpoints:
+
+- `GET /integrations/media/jellyfin/status` — calm snapshot of the
+  bridge. The `state` field is one of `disabled`, `not_configured`,
+  `unavailable`, or `connected_read_only`.
+- `GET /integrations/media/jellyfin/artists` — list music artists.
+- `GET /integrations/media/jellyfin/albums` — list music albums.
+- `GET /integrations/media/jellyfin/tracks` — list music tracks
+  with title, artist, album, year, genres, and whole-second duration.
+- `GET /integrations/media/jellyfin/genres` — list music genres.
+- `GET /integrations/media/jellyfin/playlists` — list playlists
+  (read-only; this endpoint never creates or edits playlists).
+- `GET /integrations/media/recommendations` — deterministic playlist
+  suggestions computed from the local library (see below).
+
+All endpoints are auth-gated and admin-only. Non-admin and
+restricted users receive a 403; the aggregate `/integrations/status`
+response surfaces `state: "disabled"` for the Jellyfin entry to
+non-admin callers so the UI can hide the card without leaking the
+configured state.
+
+### Playlist recommendations
+
+`GET /integrations/media/recommendations` answers questions like
+*"give me some chill playlist ideas"* or *"what could I play for a
+late-night coding session?"* by scoring each track in your local
+library against a small mood catalogue:
+
+- `chill`, `focus`, `gym`, `dark`, `upbeat`, `sad`, `night drive`,
+  `coding`.
+
+Each playlist suggestion carries: `title`, `mood`, `description`,
+`estimated_duration` (when track durations are available), a list
+of `tracks` (each with `title`, `artist`, `album`, `duration`, and
+a short `reason`), and a `confidence` label.
+
+Optional query params:
+
+- `mood=chill,focus` — comma-separated filter; entries not in the
+  catalogue are dropped.
+- `limit=8` — clamp to 1..12 (default 8).
+- `per_playlist=12` — clamp to 3..25 (default 12).
+
+The heuristics are deterministic — identical libraries produce
+identical suggestions. There is **no** LLM call, **no** embedding
+model, and **no** cloud lookup involved. The score is computed from
+genre dictionaries, title-token signals, and track-duration nudges
+so the output is reproducible and explainable.
+
+This endpoint is **read-only**. Nova never:
+
+- creates, edits, or deletes playlists on Jellyfin,
+- streams, transcodes, or copies any media file,
+- starts playback, queues tracks, or autoplays anything,
+- decides for the user what to play — it surfaces ideas; the
+  user picks.
+
+There is no background polling, no autonomous behaviour, no autoplay.
+
+### API-key safety contract
+
+- The API key is read from `NOVA_JELLYFIN_API_KEY` and **never**
+  returned in any HTTP response body, chat context, log line, or
+  error message.
+- The key only ever appears inside the bridge's private request
+  `X-Emby-Token` header — never in URLs, query params, or JSON
+  bodies.
+- The bridge stores the key in environment-local config only.
+  This PR does not persist it to the database; future revisions
+  may add encrypted storage, but the Phase-1 contract is
+  local-first.
+- Sanitised error responses (e.g. invalid key, unreachable server)
+  surface a short, hard-coded summary like *"Jellyfin rejected the
+  configured API key."* — never the raw exception, never the
+  response body.
+
+### What this bridge is **not** allowed to do (now or via this PR)
+
+- create, edit, or delete playlists on Jellyfin,
+- stream, transcode, or copy any media file,
+- start playback or queue tracks for playback,
+- change Jellyfin server settings,
+- talk to any cloud music API (Spotify, Tidal, Deezer, etc.),
+- scan local disk outside of Jellyfin's own metadata,
+- poll Jellyfin in the background or run scheduled work.
+
+### Future direction (NOT in this PR)
+
+- **Plex** support behind the same provider interface. The
+  recommendation module operates on a sanitised-track dict shape,
+  so a future Plex provider can plug in without touching playlist
+  logic.
+- **Playlist creation** behind an explicit per-request confirmation
+  in the UI and a separate write switch. Nova will never create a
+  playlist without an explicit "yes" from the user.
+- **Auryn-led library population** as a separate project. Auryn
+  remains independent; this bridge does not change Auryn's
+  behaviour.
+
+The full walkthrough lives in
+[`docs/jellyfin-integration.md`](docs/jellyfin-integration.md).
 
 ## Optional admin Maintenance / Update Center
 

--- a/config.py
+++ b/config.py
@@ -199,6 +199,57 @@ NOVA_MAINTENANCE_SYSTEMD_UNIT = (
     os.getenv("NOVA_MAINTENANCE_SYSTEMD_UNIT", "nova.service").strip()
 )
 
+# ── Optional local media: Jellyfin (read-only Phase 1) ────────────
+# Nova is a *local media assistant*, not an autonomous media manager.
+# The Phase-1 Jellyfin bridge is intentionally narrow: it can only
+# read library metadata (artists, albums, tracks, genres, playlists)
+# and surface deterministic playlist suggestions computed from that
+# metadata. Nothing in this PR creates, edits, or deletes playlists
+# on Jellyfin; nothing streams or copies media files; nothing talks
+# to cloud music services.
+#
+# Every switch defaults to OFF so an unconfigured Nova install never
+# contacts Jellyfin. When ``NOVA_JELLYFIN_ENABLED`` is on but
+# ``NOVA_JELLYFIN_API_KEY`` is missing the status endpoint reports
+# ``not_configured`` — Nova does not fall back to anonymous access.
+#
+# ``NOVA_JELLYFIN_API_KEY`` must never be:
+#   * returned in any HTTP response body,
+#   * embedded in any log line,
+#   * included in any error message surfaced to the frontend / chat,
+#   * stored in the database in this PR.
+#
+#   NOVA_JELLYFIN_ENABLED         — host-wide opt-in. False → bridge
+#                                   disabled for everyone.
+#   NOVA_JELLYFIN_URL             — base URL of the local Jellyfin
+#                                   server. Typically loopback or LAN.
+#   NOVA_JELLYFIN_API_KEY         — Jellyfin API key with read scopes.
+#                                   No write scopes are ever required.
+#   NOVA_JELLYFIN_USER_ID         — optional Jellyfin user GUID. When
+#                                   set, library queries are scoped to
+#                                   this user; empty falls back to
+#                                   server-wide read endpoints.
+#   NOVA_JELLYFIN_READ_ONLY       — belt-and-braces switch. Defaults to
+#                                   True; Phase 1 never performs
+#                                   writes so the flag is purely
+#                                   informational today.
+#   NOVA_JELLYFIN_TIMEOUT_SECONDS — per-request HTTP timeout (default 5).
+NOVA_JELLYFIN_ENABLED = (
+    os.getenv("NOVA_JELLYFIN_ENABLED", "false").strip().lower() == "true"
+)
+NOVA_JELLYFIN_URL = os.getenv("NOVA_JELLYFIN_URL", "").strip().rstrip("/")
+NOVA_JELLYFIN_API_KEY = os.getenv("NOVA_JELLYFIN_API_KEY", "").strip()
+NOVA_JELLYFIN_USER_ID = os.getenv("NOVA_JELLYFIN_USER_ID", "").strip()
+NOVA_JELLYFIN_READ_ONLY = (
+    os.getenv("NOVA_JELLYFIN_READ_ONLY", "true").strip().lower() != "false"
+)
+try:
+    NOVA_JELLYFIN_TIMEOUT_SECONDS = float(
+        os.getenv("NOVA_JELLYFIN_TIMEOUT_SECONDS", "5.0")
+    )
+except ValueError:
+    NOVA_JELLYFIN_TIMEOUT_SECONDS = 5.0
+
 # ── Optional local TTS: Piper ─────────────────────────────────────────
 # Browser speechSynthesis remains the safe default. Piper is an opt-in
 # local neural voice for hosts where the platform default sounds robotic

--- a/core/integrations/media/__init__.py
+++ b/core/integrations/media/__init__.py
@@ -1,0 +1,45 @@
+"""
+Optional local media-assistant bridges (Phase 1: Jellyfin, read-only).
+
+Nova is a **local media assistant**, not an autonomous media manager.
+This sub-package collects read-only bridges that help a user *explore*
+a locally-hosted media library and surface deterministic suggestions
+from the library's own metadata.
+
+What lives here:
+
+  * :mod:`jellyfin`        — read-only HTTP client for a local
+                             Jellyfin server (status + music metadata).
+  * :mod:`recommendations` — pure-Python heuristics that turn a list
+                             of sanitised tracks into short, calmly
+                             ranked playlist suggestions. Never makes
+                             HTTP calls; never uses ML or embeddings.
+
+Provider / recommendation split (intentional):
+
+  * The provider module knows how to talk to *one* media server and
+    returns small, sanitised dicts the rest of Nova can splice into
+    chat context safely.
+  * The recommendation module never imports a provider directly — it
+    operates on the sanitised track dicts. That keeps the heuristics
+    deterministic and lets a future Plex provider plug in without
+    touching the playlist logic.
+
+Phase 1 boundaries (enforced):
+
+  * Read-only HTTP against the configured local server.
+  * No playlist creation, edit, or deletion.
+  * No streaming, transcoding, or copying of media files.
+  * No cloud music APIs.
+  * No background polling / autoplay.
+  * No on-disk scanning outside of Jellyfin.
+  * API keys live only in env config and the connector's request
+    headers — never in any response body, log line, or chat context.
+
+Future direction (NOT in this PR):
+
+  * Plex support behind the same provider interface.
+  * Playlist creation, gated by an explicit per-request confirmation
+    in the UI and a separate write switch.
+  * Auryn-led library population, as a separate project.
+"""

--- a/core/integrations/media/jellyfin.py
+++ b/core/integrations/media/jellyfin.py
@@ -1,0 +1,596 @@
+"""
+Optional read-only Jellyfin music bridge (Phase 1).
+
+Nova is a *local media assistant*, not an autonomous media manager.
+This Phase-1 module is intentionally narrow:
+
+  * read-only HTTP calls against a locally-hosted Jellyfin server,
+  * admin-gated at the endpoint layer (this module is a pure library
+    and is never invoked from chat),
+  * a single status snapshot the UI / chat can show calmly,
+  * helpers to list music artists, albums, tracks, genres, and
+    playlists for the configured library.
+
+What this module deliberately does NOT do:
+
+  * create / edit / delete playlists on Jellyfin,
+  * stream, transcode, or copy any media file,
+  * start playback or queue tracks for playback,
+  * change Jellyfin server settings,
+  * talk to any cloud music API,
+  * poll Jellyfin in the background or run any scheduled work,
+  * scan the local disk outside of Jellyfin's own metadata.
+
+API-key safety contract (enforced):
+
+  * the key is read from ``config.NOVA_JELLYFIN_API_KEY`` and is
+    never returned by any public function;
+  * the key is sent only as the ``X-Emby-Token`` request header — it
+    never appears in URLs, query params, or JSON request bodies;
+  * exceptions are logged at debug level by *type* only, never with
+    the raw message, so a misbehaving stack trace cannot leak the
+    header;
+  * detail strings surfaced to the frontend are short, hard-coded
+    summaries — they never include the key, the response body, or
+    the exception's repr.
+
+Configuration (env vars, see ``config.py``):
+
+  * ``NOVA_JELLYFIN_ENABLED``         — host-wide on/off switch.
+  * ``NOVA_JELLYFIN_URL``             — base URL of the Jellyfin server.
+  * ``NOVA_JELLYFIN_API_KEY``         — Jellyfin API key (read scopes).
+  * ``NOVA_JELLYFIN_USER_ID``         — optional Jellyfin user GUID.
+  * ``NOVA_JELLYFIN_READ_ONLY``       — belt-and-braces; defaults True.
+  * ``NOVA_JELLYFIN_TIMEOUT_SECONDS`` — per-request timeout (default 5s).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+import httpx
+
+from config import (
+    NOVA_JELLYFIN_API_KEY,
+    NOVA_JELLYFIN_ENABLED,
+    NOVA_JELLYFIN_READ_ONLY,
+    NOVA_JELLYFIN_TIMEOUT_SECONDS,
+    NOVA_JELLYFIN_URL,
+    NOVA_JELLYFIN_USER_ID,
+)
+
+logger = logging.getLogger(__name__)
+
+NAME = "jellyfin"
+
+USER_AGENT = "Nova-Jellyfin-Bridge/1.0"
+API_KEY_HEADER = "X-Emby-Token"
+
+STATE_DISABLED = "disabled"
+STATE_NOT_CONFIGURED = "not_configured"
+STATE_UNAVAILABLE = "unavailable"
+STATE_CONNECTED = "connected_read_only"
+
+# Caps so a single response can never balloon Nova's chat context.
+# Jellyfin's ``Limit`` query param accepts large values; we clamp
+# to a sane upper bound and a smaller default. Callers asking for
+# more get exactly the cap — never an unbounded list.
+_MAX_LIMIT = 200
+_DEFAULT_LIMIT = 50
+
+# Jellyfin returns ``RunTimeTicks`` in 100-nanosecond units. Dividing
+# by 10_000_000 yields whole seconds.
+_TICKS_PER_SECOND = 10_000_000
+
+# The Jellyfin GUID format is hex characters and hyphens. Anything
+# else is rejected before any HTTP call so a caller cannot smuggle a
+# path fragment via the ``id`` field.
+_GUID_RE = re.compile(r"^[A-Fa-f0-9-]{1,64}$")
+
+
+# ── Status type ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class JellyfinStatus:
+    """Calm, frontend-safe snapshot of the bridge's availability.
+
+    Never includes the API key, never includes raw exception text.
+    The ``state`` field is one of the four module-level ``STATE_*``
+    values so the UI can branch on a stable enum.
+    """
+
+    name: str
+    enabled: bool
+    state: str
+    detail: str = ""
+    server_name: Optional[str] = None
+    server_version: Optional[str] = None
+    read_only: bool = True
+    user_id_configured: bool = False
+    base_url_configured: bool = False
+    library_kinds: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "enabled": self.enabled,
+            "state": self.state,
+            "detail": self.detail,
+            "server_name": self.server_name,
+            "server_version": self.server_version,
+            "read_only": self.read_only,
+            "user_id_configured": self.user_id_configured,
+            "base_url_configured": self.base_url_configured,
+            "library_kinds": list(self.library_kinds),
+        }
+
+
+# ── Switch helpers ──────────────────────────────────────────────────
+
+
+def is_enabled() -> bool:
+    """True when the host operator has flipped the env switch on."""
+    return bool(NOVA_JELLYFIN_ENABLED)
+
+
+def is_read_only() -> bool:
+    """Always True in Phase 1; reflects ``NOVA_JELLYFIN_READ_ONLY``."""
+    return bool(NOVA_JELLYFIN_READ_ONLY)
+
+
+def _has_api_key() -> bool:
+    return bool(NOVA_JELLYFIN_API_KEY)
+
+
+def _has_base_url() -> bool:
+    return bool(NOVA_JELLYFIN_URL)
+
+
+def _has_user_id() -> bool:
+    return bool(NOVA_JELLYFIN_USER_ID)
+
+
+def _valid_user_id(user_id: str) -> bool:
+    return isinstance(user_id, str) and _GUID_RE.match(user_id) is not None
+
+
+def _headers() -> dict:
+    """Build the request headers. Never returned to callers."""
+    return {
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+        API_KEY_HEADER: NOVA_JELLYFIN_API_KEY,
+    }
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(
+        base_url=NOVA_JELLYFIN_URL,
+        timeout=NOVA_JELLYFIN_TIMEOUT_SECONDS,
+        headers=_headers(),
+    )
+
+
+def _log_error(where: str, exc: BaseException) -> None:
+    """Log an exception by type only so the API key cannot leak via repr."""
+    logger.debug("jellyfin %s failed: %s", where, type(exc).__name__)
+
+
+def _clamp_limit(limit) -> int:
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return _DEFAULT_LIMIT
+    if n <= 0:
+        return _DEFAULT_LIMIT
+    return min(n, _MAX_LIMIT)
+
+
+def _ticks_to_seconds(ticks) -> Optional[int]:
+    """Convert Jellyfin RunTimeTicks (100-ns units) to whole seconds."""
+    try:
+        n = int(ticks)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return n // _TICKS_PER_SECOND
+
+
+# ── Status ──────────────────────────────────────────────────────────
+
+
+def status() -> JellyfinStatus:
+    """Report whether the bridge is on and reachable. Never raises.
+
+    Off                                     → ``disabled``.
+    On + no URL or API key                  → ``not_configured``.
+    On + URL + key + ``GET /System/Info``   → ``connected_read_only``.
+    On + URL + key + HTTP / network failure → ``unavailable`` with a
+                                              short, sanitised detail.
+    """
+    if not is_enabled():
+        return JellyfinStatus(
+            name=NAME, enabled=False, state=STATE_DISABLED,
+            detail="Set NOVA_JELLYFIN_ENABLED=true to turn the bridge on.",
+            read_only=is_read_only(),
+            user_id_configured=_has_user_id(),
+            base_url_configured=_has_base_url(),
+        )
+    if not _has_base_url() or not _has_api_key():
+        missing = []
+        if not _has_base_url():
+            missing.append("NOVA_JELLYFIN_URL")
+        if not _has_api_key():
+            missing.append("NOVA_JELLYFIN_API_KEY")
+        return JellyfinStatus(
+            name=NAME, enabled=True, state=STATE_NOT_CONFIGURED,
+            detail=(
+                f"Jellyfin bridge is missing config: {', '.join(missing)}."
+            ),
+            read_only=is_read_only(),
+            user_id_configured=_has_user_id(),
+            base_url_configured=_has_base_url(),
+        )
+    try:
+        with _client() as client:
+            resp = client.get("/System/Info/Public")
+    except (httpx.HTTPError, OSError) as exc:
+        _log_error("status", exc)
+        return JellyfinStatus(
+            name=NAME, enabled=True, state=STATE_UNAVAILABLE,
+            detail="Jellyfin server is not reachable.",
+            read_only=is_read_only(),
+            user_id_configured=_has_user_id(),
+            base_url_configured=_has_base_url(),
+        )
+    if resp.status_code == 401 or resp.status_code == 403:
+        return JellyfinStatus(
+            name=NAME, enabled=True, state=STATE_UNAVAILABLE,
+            detail="Jellyfin rejected the configured API key.",
+            read_only=is_read_only(),
+            user_id_configured=_has_user_id(),
+            base_url_configured=_has_base_url(),
+        )
+    if not (200 <= resp.status_code < 300):
+        return JellyfinStatus(
+            name=NAME, enabled=True, state=STATE_UNAVAILABLE,
+            detail=f"Jellyfin returned HTTP {resp.status_code}.",
+            read_only=is_read_only(),
+            user_id_configured=_has_user_id(),
+            base_url_configured=_has_base_url(),
+        )
+    server_name: Optional[str] = None
+    server_version: Optional[str] = None
+    try:
+        body = resp.json()
+        if isinstance(body, dict):
+            raw_name = body.get("ServerName")
+            if isinstance(raw_name, str):
+                server_name = raw_name
+            raw_version = body.get("Version")
+            if isinstance(raw_version, str):
+                server_version = raw_version
+    except ValueError as exc:
+        _log_error("status decode", exc)
+    library_kinds = _probe_library_kinds()
+    return JellyfinStatus(
+        name=NAME, enabled=True, state=STATE_CONNECTED,
+        detail=(
+            f"Connected to {server_name}." if server_name
+            else "Authenticated read-only access."
+        ),
+        server_name=server_name,
+        server_version=server_version,
+        read_only=is_read_only(),
+        user_id_configured=_has_user_id(),
+        base_url_configured=_has_base_url(),
+        library_kinds=library_kinds,
+    )
+
+
+def _probe_library_kinds() -> tuple[str, ...]:
+    """Best-effort library-kind probe. Never raises; returns ``()`` on failure.
+
+    Surfaces a small set of strings (e.g. ``("music",)``) so the UI
+    can tell users "your library has music" without sending Nova back
+    to the server for full metadata on every status load.
+    """
+    if not _has_user_id() or not _valid_user_id(NOVA_JELLYFIN_USER_ID):
+        return ()
+    try:
+        with _client() as client:
+            resp = client.get(f"/Users/{NOVA_JELLYFIN_USER_ID}/Views")
+        if not (200 <= resp.status_code < 300):
+            return ()
+        body = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("library kinds probe", exc)
+        return ()
+    if not isinstance(body, dict):
+        return ()
+    items = body.get("Items") or []
+    if not isinstance(items, list):
+        return ()
+    kinds: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("CollectionType")
+        if isinstance(kind, str) and kind.strip():
+            kinds.add(kind.strip().lower())
+    return tuple(sorted(kinds))
+
+
+# ── Read API ────────────────────────────────────────────────────────
+
+
+def _user_scoped_path(suffix: str) -> str:
+    """Return a path scoped to the configured user when one is set.
+
+    Jellyfin exposes both ``/Items`` (server-wide) and
+    ``/Users/<id>/Items`` (per-user) endpoints. Phase 1 prefers the
+    per-user variant when a valid GUID is configured because it lets
+    Jellyfin enforce per-user library visibility.
+    """
+    if _has_user_id() and _valid_user_id(NOVA_JELLYFIN_USER_ID):
+        return f"/Users/{NOVA_JELLYFIN_USER_ID}/{suffix.lstrip('/')}"
+    return f"/{suffix.lstrip('/')}"
+
+
+def _is_ready() -> bool:
+    return is_enabled() and _has_base_url() and _has_api_key()
+
+
+def list_artists(limit: int = _DEFAULT_LIMIT) -> list[dict]:
+    """Return sanitised music artists from the configured Jellyfin library.
+
+    Empty list when the bridge is off / not configured / unreachable.
+    """
+    if not _is_ready():
+        return []
+    params = {
+        "IncludeItemTypes": "MusicArtist",
+        "Recursive": "true",
+        "SortBy": "SortName",
+        "SortOrder": "Ascending",
+        "Limit": _clamp_limit(limit),
+    }
+    try:
+        with _client() as client:
+            resp = client.get("/Artists", params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_artists", exc)
+        return []
+    if not isinstance(data, dict):
+        return []
+    items = data.get("Items") or []
+    if not isinstance(items, list):
+        return []
+    return [
+        _sanitize_artist(item) for item in items
+        if isinstance(item, dict)
+    ]
+
+
+def list_albums(limit: int = _DEFAULT_LIMIT) -> list[dict]:
+    """Return sanitised music albums from the configured Jellyfin library."""
+    if not _is_ready():
+        return []
+    params = {
+        "IncludeItemTypes": "MusicAlbum",
+        "Recursive": "true",
+        "SortBy": "SortName",
+        "SortOrder": "Ascending",
+        "Limit": _clamp_limit(limit),
+        "Fields": "Genres,ProductionYear,AlbumArtist",
+    }
+    try:
+        with _client() as client:
+            resp = client.get(_user_scoped_path("Items"), params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_albums", exc)
+        return []
+    return _extract_items(data, _sanitize_album)
+
+
+def list_tracks(limit: int = _DEFAULT_LIMIT) -> list[dict]:
+    """Return sanitised music tracks (Audio items) from the library.
+
+    Each track carries title, artist(s), album, genres, year, and a
+    whole-second ``duration`` derived from Jellyfin's ``RunTimeTicks``
+    (or ``None`` when the server did not provide one).
+    """
+    if not _is_ready():
+        return []
+    params = {
+        "IncludeItemTypes": "Audio",
+        "Recursive": "true",
+        "SortBy": "SortName",
+        "SortOrder": "Ascending",
+        "Limit": _clamp_limit(limit),
+        "Fields": "Genres,ProductionYear,AlbumArtist,RunTimeTicks",
+    }
+    try:
+        with _client() as client:
+            resp = client.get(_user_scoped_path("Items"), params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_tracks", exc)
+        return []
+    return _extract_items(data, _sanitize_track)
+
+
+def list_genres(limit: int = _DEFAULT_LIMIT) -> list[dict]:
+    """Return sanitised music genres available in the library."""
+    if not _is_ready():
+        return []
+    params = {
+        "SortBy": "SortName",
+        "SortOrder": "Ascending",
+        "Limit": _clamp_limit(limit),
+    }
+    try:
+        with _client() as client:
+            resp = client.get("/MusicGenres", params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_genres", exc)
+        return []
+    return _extract_items(data, _sanitize_genre)
+
+
+def list_playlists(limit: int = _DEFAULT_LIMIT) -> list[dict]:
+    """Return sanitised playlists from the library. Empty on failure.
+
+    Phase 1 *reads* playlists only — it never creates, edits, or
+    deletes them. The returned dicts carry id, name, track count
+    (when reported), and a media-kind hint so the caller can filter
+    to music-only playlists.
+    """
+    if not _is_ready():
+        return []
+    params = {
+        "IncludeItemTypes": "Playlist",
+        "Recursive": "true",
+        "SortBy": "SortName",
+        "SortOrder": "Ascending",
+        "Limit": _clamp_limit(limit),
+        "Fields": "ChildCount,RunTimeTicks",
+    }
+    try:
+        with _client() as client:
+            resp = client.get(_user_scoped_path("Items"), params=params)
+        if not (200 <= resp.status_code < 300):
+            return []
+        data = resp.json()
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        _log_error("list_playlists", exc)
+        return []
+    return _extract_items(data, _sanitize_playlist)
+
+
+# ── Sanitisers ──────────────────────────────────────────────────────
+
+
+def _extract_items(data, sanitiser) -> list[dict]:
+    if not isinstance(data, dict):
+        return []
+    items = data.get("Items") or []
+    if not isinstance(items, list):
+        return []
+    return [sanitiser(item) for item in items if isinstance(item, dict)]
+
+
+def _safe_str(value) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
+
+
+def _safe_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _genres(item: dict) -> list[str]:
+    genres = item.get("Genres") or []
+    if not isinstance(genres, list):
+        return []
+    return [g for g in genres if isinstance(g, str) and g]
+
+
+def _artists(item: dict) -> list[str]:
+    raw = item.get("Artists") or []
+    if isinstance(raw, list):
+        out = [a for a in raw if isinstance(a, str) and a]
+        if out:
+            return out
+    album_artist = item.get("AlbumArtist")
+    if isinstance(album_artist, str) and album_artist:
+        return [album_artist]
+    return []
+
+
+def _sanitize_artist(item: dict) -> dict:
+    return {
+        "id": _safe_str(item.get("Id")),
+        "name": _safe_str(item.get("Name")),
+        "genres": _genres(item),
+    }
+
+
+def _sanitize_album(item: dict) -> dict:
+    return {
+        "id": _safe_str(item.get("Id")),
+        "name": _safe_str(item.get("Name")),
+        "artist": _safe_str(item.get("AlbumArtist")),
+        "year": _safe_int(item.get("ProductionYear")),
+        "genres": _genres(item),
+    }
+
+
+def _sanitize_track(item: dict) -> dict:
+    return {
+        "id": _safe_str(item.get("Id")),
+        "title": _safe_str(item.get("Name")),
+        "artist": (_artists(item)[0] if _artists(item) else None),
+        "artists": _artists(item),
+        "album": _safe_str(item.get("Album")),
+        "year": _safe_int(item.get("ProductionYear")),
+        "genres": _genres(item),
+        "duration": _ticks_to_seconds(item.get("RunTimeTicks")),
+    }
+
+
+def _sanitize_genre(item: dict) -> dict:
+    return {
+        "id": _safe_str(item.get("Id")),
+        "name": _safe_str(item.get("Name")),
+    }
+
+
+def _sanitize_playlist(item: dict) -> dict:
+    kind = item.get("MediaType")
+    return {
+        "id": _safe_str(item.get("Id")),
+        "name": _safe_str(item.get("Name")),
+        "track_count": _safe_int(item.get("ChildCount")),
+        "duration": _ticks_to_seconds(item.get("RunTimeTicks")),
+        "media_kind": kind.lower() if isinstance(kind, str) and kind else None,
+    }
+
+
+# ── Library snapshot helper ─────────────────────────────────────────
+
+
+def library_snapshot(limit: int = _DEFAULT_LIMIT) -> dict:
+    """Roll-up of artists / albums / tracks / genres / playlists.
+
+    Used by the recommendation layer so it can ask for "the music
+    library" once instead of issuing five separate requests itself.
+    Never raises; failure paths yield empty lists so the caller can
+    still render a calm "library is empty / unreachable" message.
+    """
+    return {
+        "artists": list_artists(limit=limit),
+        "albums": list_albums(limit=limit),
+        "tracks": list_tracks(limit=limit),
+        "genres": list_genres(limit=limit),
+        "playlists": list_playlists(limit=limit),
+        "read_only": True,
+    }

--- a/core/integrations/media/recommendations.py
+++ b/core/integrations/media/recommendations.py
@@ -1,0 +1,513 @@
+"""
+Read-only local playlist recommendation helper (Phase 1).
+
+This module sits on top of the read-only media provider(s) and turns
+a sanitised list of tracks into a short list of *suggested* playlists.
+Nova is a local media *assistant* — never an autonomous media
+manager — so every decision here is deterministic, explainable, and
+harmless:
+
+  * pure-Python scoring on the sanitised dicts produced by
+    ``core.integrations.media.jellyfin.list_tracks`` (no extra HTTP
+    calls, no provider-specific code paths);
+  * no LLM call, no embeddings, no ML — only label / genre / title /
+    duration heuristics;
+  * never mutates anything on the media server (no playlist create,
+    update, delete; no play / queue / shuffle);
+  * never persists anything to disk or the database;
+  * never sends library data to any cloud service.
+
+The user always picks what to play. Nova's role is to surface a short
+list of *ideas* with reasons; nothing here starts playback, edits a
+playlist, or talks to a third-party service.
+
+Future direction (NOT in this PR):
+
+  * Playlist creation behind an explicit per-request confirmation
+    and a separate write switch.
+  * Plex provider plugged in behind the same sanitised-track shape.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+NAME = "media_recommendations"
+
+CONFIDENCE_LOW = "low"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_HIGH = "high"
+
+# Caps mirror the underlying provider so a single response can never
+# balloon Nova's chat context. The visible top-N defaults are small;
+# the per-playlist track cap is small enough to fit comfortably into
+# a chat reply.
+_DEFAULT_MOODS_LIMIT = 8
+_MAX_MOODS_LIMIT = 12
+_DEFAULT_TRACKS_PER_PLAYLIST = 12
+_MAX_TRACKS_PER_PLAYLIST = 25
+_MIN_TRACKS_PER_PLAYLIST = 3
+
+# Genre dictionaries are stored lowercase so every lookup is routed
+# through ``_norm``. Words longer than the literal label are matched
+# as substrings ("hard rock" matches "rock"), which keeps the
+# heuristics robust to small label variations across libraries.
+
+# Genre → mood weights. A positive weight nudges a track toward the
+# mood; a negative weight discourages it. Zero weights are omitted
+# from the dict so the lookup stays fast.
+_GENRE_MOOD_WEIGHTS: dict[str, dict[str, int]] = {
+    "ambient":      {"chill": 4, "focus": 4, "coding": 3, "night drive": 2},
+    "classical":    {"chill": 3, "focus": 4, "coding": 3, "sad": 2},
+    "lo-fi":        {"chill": 4, "focus": 4, "coding": 4, "night drive": 2},
+    "lofi":         {"chill": 4, "focus": 4, "coding": 4, "night drive": 2},
+    "acoustic":     {"chill": 3, "focus": 2, "sad": 2},
+    "folk":         {"chill": 3, "sad": 2, "focus": 2},
+    "indie":        {"chill": 2, "focus": 2, "night drive": 2},
+    "jazz":         {"chill": 3, "focus": 3, "coding": 2, "night drive": 2},
+    "blues":        {"chill": 2, "sad": 3},
+    "soundtrack":   {"focus": 3, "coding": 3, "chill": 2, "night drive": 2},
+    "instrumental": {"focus": 4, "coding": 4, "chill": 3},
+    "electronic":   {"focus": 2, "coding": 2, "upbeat": 3, "night drive": 3},
+    "synthwave":    {"night drive": 4, "coding": 3, "focus": 2, "dark": 2},
+    "house":        {"upbeat": 3, "gym": 3, "night drive": 2},
+    "techno":       {"upbeat": 3, "gym": 3, "dark": 2, "night drive": 2},
+    "trance":       {"upbeat": 3, "focus": 2, "night drive": 2},
+    "edm":          {"upbeat": 4, "gym": 4, "night drive": 2},
+    "dance":        {"upbeat": 4, "gym": 3, "night drive": 2},
+    "pop":          {"upbeat": 3, "gym": 2},
+    "rock":         {"upbeat": 3, "gym": 3},
+    "hard rock":    {"gym": 4, "upbeat": 3, "dark": 2},
+    "metal":        {"gym": 4, "dark": 4, "upbeat": 2},
+    "punk":         {"gym": 3, "upbeat": 3, "dark": 2},
+    "hip hop":      {"gym": 3, "upbeat": 3, "coding": 2, "night drive": 2},
+    "hip-hop":      {"gym": 3, "upbeat": 3, "coding": 2, "night drive": 2},
+    "rap":          {"gym": 3, "upbeat": 3, "night drive": 2},
+    "trap":         {"gym": 3, "dark": 2, "night drive": 2},
+    "drill":        {"dark": 3, "gym": 2},
+    "r&b":          {"chill": 3, "night drive": 2, "sad": 2},
+    "rnb":          {"chill": 3, "night drive": 2, "sad": 2},
+    "soul":         {"chill": 3, "sad": 2, "night drive": 2},
+    "country":      {"chill": 2, "sad": 2, "upbeat": 1},
+    "reggae":       {"chill": 4, "upbeat": 2},
+    "world":        {"chill": 2, "focus": 1},
+    "post-rock":    {"focus": 3, "chill": 3, "coding": 3},
+    "shoegaze":     {"chill": 3, "sad": 3, "dark": 2},
+    "darkwave":     {"dark": 4, "night drive": 3, "sad": 2},
+    "industrial":   {"dark": 4, "gym": 2, "upbeat": 1},
+    "goth":         {"dark": 4, "sad": 3, "night drive": 2},
+    "emo":          {"sad": 4, "dark": 2},
+    "screamo":      {"dark": 3, "sad": 2},
+}
+
+# Title-token signals. These are coarse — a track called "Save Me"
+# is not always sad — but they let the heuristic move a track toward
+# a mood when the genre is missing or ambiguous. Tokens are matched
+# as lowercase whole-word substrings against the title.
+_TITLE_MOOD_TOKENS: dict[str, dict[str, int]] = {
+    "chill":     {"chill": 3, "focus": 1},
+    "relax":     {"chill": 3},
+    "calm":      {"chill": 2, "focus": 1},
+    "study":     {"focus": 3, "coding": 2},
+    "focus":     {"focus": 4, "coding": 2},
+    "work":      {"focus": 2, "coding": 2},
+    "code":      {"coding": 4, "focus": 2},
+    "coding":    {"coding": 4, "focus": 2},
+    "night":     {"night drive": 3, "dark": 1},
+    "midnight":  {"night drive": 3, "dark": 2},
+    "drive":     {"night drive": 3, "upbeat": 1},
+    "highway":   {"night drive": 2, "upbeat": 1},
+    "run":       {"gym": 2, "upbeat": 2},
+    "fire":      {"upbeat": 2, "gym": 1},
+    "energy":    {"upbeat": 3, "gym": 2},
+    "party":     {"upbeat": 3},
+    "happy":     {"upbeat": 3},
+    "joy":       {"upbeat": 2},
+    "sun":       {"upbeat": 2, "chill": 1},
+    "summer":    {"upbeat": 2, "chill": 1},
+    "sad":       {"sad": 4, "dark": 1},
+    "cry":       {"sad": 3},
+    "tears":     {"sad": 3},
+    "alone":     {"sad": 2, "dark": 1},
+    "lonely":    {"sad": 3, "dark": 1},
+    "lost":      {"sad": 2, "dark": 1},
+    "save":      {"sad": 2, "dark": 1},
+    "dark":      {"dark": 4, "night drive": 1},
+    "shadow":    {"dark": 3, "night drive": 1},
+    "demons":    {"dark": 3},
+    "death":     {"dark": 2, "sad": 1},
+    "broken":    {"sad": 2, "dark": 1},
+    "pain":      {"sad": 2, "dark": 1},
+    "winter":    {"chill": 2, "sad": 1},
+    "rain":      {"chill": 2, "sad": 1},
+    "sleep":     {"chill": 3, "focus": 1},
+    "dream":     {"chill": 2, "focus": 1, "night drive": 1},
+}
+
+# Mood catalogue: each entry is the public face of a recommendation.
+# ``description`` is a calm, neutral one-liner; ``min_tracks`` lets
+# us drop moods that did not match anything reasonable.
+_MOOD_CATALOGUE: dict[str, dict] = {
+    "chill":       {
+        "title": "Chill Wind-Down",
+        "description": "Calm tracks for unwinding without going to sleep.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "focus":       {
+        "title": "Deep Focus",
+        "description": "Low-distraction tracks for sustained concentration.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "gym":         {
+        "title": "Gym Push",
+        "description": "High-energy tracks for a workout block.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "dark":        {
+        "title": "Dark and Heavy",
+        "description": "Heavier, moodier tracks for a darker session.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "upbeat":      {
+        "title": "Upbeat Pickup",
+        "description": "Bright, energetic tracks for a quick mood lift.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "sad":         {
+        "title": "Quiet Reflection",
+        "description": "Slower, more contemplative tracks for a quiet hour.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "night drive": {
+        "title": "Night Drive",
+        "description": "Late-night driving tracks with steady forward motion.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+    "coding":      {
+        "title": "Night Coding",
+        "description": "Calm tracks for late-night development.",
+        "min_tracks": _MIN_TRACKS_PER_PLAYLIST,
+    },
+}
+
+# Stable ordering for the mood catalogue. The output preserves this
+# order so two runs against the same library produce the same list.
+MOOD_ORDER: tuple[str, ...] = tuple(_MOOD_CATALOGUE.keys())
+
+
+# ── Normalisation helpers ──────────────────────────────────────────
+
+
+def _norm(value) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
+
+
+def _clamp(value, lo: int, hi: int, default: int) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    if n < lo:
+        return lo
+    if n > hi:
+        return hi
+    return n
+
+
+def _title_tokens(title) -> set[str]:
+    if not isinstance(title, str):
+        return set()
+    out: set[str] = set()
+    cleaned = title.lower()
+    for token in _TITLE_MOOD_TOKENS:
+        if token in cleaned:
+            out.add(token)
+    return out
+
+
+# ── Per-track scoring ──────────────────────────────────────────────
+
+
+def score_track(track: dict) -> dict[str, int]:
+    """Return ``{mood: score}`` for one sanitised track dict.
+
+    Empty when nothing matched. Pure-Python, deterministic; identical
+    input yields identical output.
+    """
+    if not isinstance(track, dict):
+        return {}
+    scores: dict[str, int] = {}
+
+    # Genre signals — exact and substring match. Substring matching
+    # makes "post-rock" pick up the "rock" entry as a weaker hint.
+    raw_genres = track.get("genres") or []
+    if isinstance(raw_genres, list):
+        for genre in raw_genres:
+            normalised = _norm(genre)
+            if not normalised:
+                continue
+            weights = _GENRE_MOOD_WEIGHTS.get(normalised)
+            if weights:
+                for mood, weight in weights.items():
+                    scores[mood] = scores.get(mood, 0) + weight
+                continue
+            # Substring fallback: pick the strongest match so a
+            # multi-word genre like "alternative rock" still maps
+            # to the "rock" entry.
+            for key, weights in _GENRE_MOOD_WEIGHTS.items():
+                if key in normalised:
+                    for mood, weight in weights.items():
+                        scores[mood] = scores.get(mood, 0) + max(weight - 1, 1)
+                    break
+
+    # Title-token signals — additive but capped per token so a flashy
+    # title cannot dominate a track with no matching genre.
+    for token in _title_tokens(track.get("title")):
+        for mood, weight in _TITLE_MOOD_TOKENS[token].items():
+            scores[mood] = scores.get(mood, 0) + weight
+
+    # Duration nudge: very short tracks are unlikely to be a sustained
+    # focus / coding pick; very long tracks lean toward chill / focus.
+    duration = track.get("duration")
+    if isinstance(duration, int) and duration > 0:
+        if duration < 90:
+            for mood in ("focus", "coding", "chill", "night drive"):
+                if mood in scores:
+                    scores[mood] = max(scores[mood] - 1, 0)
+        elif duration >= 300:
+            for mood in ("focus", "coding", "chill"):
+                scores[mood] = scores.get(mood, 0) + 1
+
+    return {mood: score for mood, score in scores.items() if score > 0}
+
+
+def _reason_for(track: dict, mood: str) -> str:
+    """Short, calm explanation of why this track was picked for ``mood``."""
+    raw_genres = track.get("genres") or []
+    genre_hits: list[str] = []
+    if isinstance(raw_genres, list):
+        for genre in raw_genres:
+            normalised = _norm(genre)
+            if not normalised:
+                continue
+            weights = _GENRE_MOOD_WEIGHTS.get(normalised)
+            if weights and weights.get(mood):
+                genre_hits.append(genre)
+                continue
+            for key, weights in _GENRE_MOOD_WEIGHTS.items():
+                if key in normalised and weights.get(mood):
+                    genre_hits.append(genre)
+                    break
+
+    title_hits = sorted(
+        token for token in _title_tokens(track.get("title"))
+        if _TITLE_MOOD_TOKENS[token].get(mood)
+    )
+
+    parts: list[str] = []
+    if genre_hits:
+        parts.append(f"genre {', '.join(sorted(set(genre_hits)))}")
+    if title_hits:
+        parts.append(f"title hints '{', '.join(title_hits)}'")
+    if not parts:
+        parts.append("matched on duration / fallback heuristics")
+    return f"matches {mood} mood: " + "; ".join(parts) + "."
+
+
+# ── Playlist builder ───────────────────────────────────────────────
+
+
+def _pick_tracks_for_mood(
+    tracks: Iterable[dict],
+    mood: str,
+    per_playlist: int,
+) -> list[dict]:
+    """Return up to ``per_playlist`` track entries scored for ``mood``.
+
+    Tie-break: highest mood score first, then track title ascending so
+    the order is stable across runs against the same library.
+    """
+    scored: list[tuple[int, str, dict]] = []
+    for track in tracks:
+        if not isinstance(track, dict):
+            continue
+        score = score_track(track).get(mood, 0)
+        if score <= 0:
+            continue
+        title = track.get("title") or ""
+        scored.append((score, title.lower() if isinstance(title, str) else "", track))
+    scored.sort(key=lambda r: (-r[0], r[1]))
+    out: list[dict] = []
+    for _, _, track in scored[:per_playlist]:
+        out.append({
+            "id": track.get("id"),
+            "title": track.get("title"),
+            "artist": track.get("artist"),
+            "album": track.get("album"),
+            "duration": track.get("duration"),
+            "reason": _reason_for(track, mood),
+        })
+    return out
+
+
+def _confidence(track_count: int, library_size: int) -> str:
+    """Confidence label for a playlist based on signal strength."""
+    if track_count >= 8:
+        return CONFIDENCE_HIGH
+    if track_count >= 5:
+        return CONFIDENCE_MEDIUM
+    return CONFIDENCE_LOW
+
+
+def _estimated_duration(tracks: list[dict]) -> Optional[int]:
+    total = 0
+    counted = 0
+    for track in tracks:
+        if not isinstance(track, dict):
+            continue
+        duration = track.get("duration")
+        if isinstance(duration, int) and duration > 0:
+            total += duration
+            counted += 1
+    if counted == 0:
+        return None
+    return total
+
+
+def build_playlist(
+    tracks: Iterable[dict],
+    mood: str,
+    per_playlist: int = _DEFAULT_TRACKS_PER_PLAYLIST,
+    library_size: int = 0,
+) -> Optional[dict]:
+    """Build a single playlist suggestion for ``mood``, or ``None``.
+
+    Returns ``None`` when the mood is unknown or the library yields
+    fewer than the mood's ``min_tracks`` matches. The caller filters
+    ``None``s out of the recommendation list.
+    """
+    catalogue_entry = _MOOD_CATALOGUE.get(mood)
+    if catalogue_entry is None:
+        return None
+    if not isinstance(tracks, list):
+        tracks = list(tracks)
+    picked = _pick_tracks_for_mood(
+        tracks,
+        mood,
+        _clamp(per_playlist, _MIN_TRACKS_PER_PLAYLIST,
+               _MAX_TRACKS_PER_PLAYLIST, _DEFAULT_TRACKS_PER_PLAYLIST),
+    )
+    if len(picked) < catalogue_entry["min_tracks"]:
+        return None
+    estimated_duration = _estimated_duration(picked)
+    confidence = _confidence(len(picked), library_size or len(tracks))
+    return {
+        "title": catalogue_entry["title"],
+        "mood": mood,
+        "description": catalogue_entry["description"],
+        "estimated_duration": estimated_duration,
+        "tracks": picked,
+        "confidence": confidence,
+    }
+
+
+def recommend_playlists(
+    tracks: Iterable[dict],
+    moods: Optional[Iterable[str]] = None,
+    limit: int = _DEFAULT_MOODS_LIMIT,
+    per_playlist: int = _DEFAULT_TRACKS_PER_PLAYLIST,
+) -> list[dict]:
+    """Return a list of playlist suggestions for the given tracks.
+
+    ``moods`` is an optional caller-supplied filter; entries not in
+    the mood catalogue are dropped. ``limit`` clamps to a maximum of
+    :data:`_MAX_MOODS_LIMIT`; ``per_playlist`` clamps to a maximum of
+    :data:`_MAX_TRACKS_PER_PLAYLIST`.
+
+    Empty list on empty input or when every mood fails to meet its
+    minimum-track threshold. The output is deterministic: identical
+    inputs yield identical outputs (insertion order matches the
+    :data:`MOOD_ORDER` constant).
+    """
+    if not isinstance(tracks, list):
+        tracks = list(tracks)
+    if not tracks:
+        return []
+
+    if moods is None:
+        wanted_order = MOOD_ORDER
+    else:
+        normalised = {_norm(m) for m in moods if isinstance(m, str)}
+        wanted_order = tuple(
+            mood for mood in MOOD_ORDER if mood in normalised
+        )
+        if not wanted_order:
+            return []
+
+    limit_n = _clamp(limit, 1, _MAX_MOODS_LIMIT, _DEFAULT_MOODS_LIMIT)
+    per_playlist_n = _clamp(
+        per_playlist, _MIN_TRACKS_PER_PLAYLIST,
+        _MAX_TRACKS_PER_PLAYLIST, _DEFAULT_TRACKS_PER_PLAYLIST,
+    )
+
+    out: list[dict] = []
+    library_size = len(tracks)
+    for mood in wanted_order:
+        playlist = build_playlist(
+            tracks, mood,
+            per_playlist=per_playlist_n,
+            library_size=library_size,
+        )
+        if playlist is None:
+            continue
+        out.append(playlist)
+        if len(out) >= limit_n:
+            break
+    return out
+
+
+# ── Provider-backed convenience entry point ────────────────────────
+
+
+def recommend_from_jellyfin(
+    moods: Optional[Iterable[str]] = None,
+    limit: int = _DEFAULT_MOODS_LIMIT,
+    per_playlist: int = _DEFAULT_TRACKS_PER_PLAYLIST,
+    track_pool: int = 200,
+) -> list[dict]:
+    """Fetch tracks from the Jellyfin bridge and run :func:`recommend_playlists`.
+
+    Empty list when the bridge is disabled / not configured /
+    unreachable. Never raises. ``track_pool`` clamps to the
+    provider's per-request cap so a single recommendation request
+    cannot overwhelm Jellyfin.
+
+    This convenience wrapper keeps the recommendation module free of
+    direct HTTP code; the heuristics themselves operate on the
+    sanitised track shape and never know which provider produced it.
+    """
+    from . import jellyfin as _jellyfin
+
+    if not _jellyfin.is_enabled() or not _jellyfin._has_api_key():
+        return []
+    if not _jellyfin._has_base_url():
+        return []
+    tracks = _jellyfin.list_tracks(limit=track_pool)
+    return recommend_playlists(
+        tracks, moods=moods, limit=limit, per_playlist=per_playlist,
+    )
+
+
+def is_available() -> bool:
+    """True when the recommendation pipeline has at least one provider on."""
+    from . import jellyfin as _jellyfin
+    return (
+        _jellyfin.is_enabled()
+        and _jellyfin._has_api_key()
+        and _jellyfin._has_base_url()
+    )

--- a/docs/jellyfin-integration.md
+++ b/docs/jellyfin-integration.md
@@ -1,0 +1,194 @@
+# Local media assistant — Jellyfin (Phase 1)
+
+Nova is a **local media assistant**, not an autonomous media manager.
+The Phase-1 Jellyfin bridge lets a Nova admin help users *explore*
+their locally-hosted Jellyfin music library and surface deterministic
+playlist suggestions — without sending library data to any cloud
+service and without modifying Jellyfin's state.
+
+This document describes the Phase-1 scope, the configuration surface,
+the endpoints, and the privacy / safety contract. It is the
+companion reference for the section in [README.md](../README.md).
+
+## Scope (Phase 1)
+
+What the bridge does:
+
+- check the Jellyfin connection status,
+- list music artists, albums, tracks, genres, and playlists,
+- generate deterministic playlist suggestions from local metadata.
+
+What the bridge does **not** do (now or via this PR):
+
+- create, edit, or delete playlists on Jellyfin,
+- stream, transcode, or copy any media file,
+- start playback, queue tracks, or autoplay anything,
+- change Jellyfin server settings,
+- talk to any cloud music API (Spotify, Tidal, Deezer, YouTube,
+  SoundCloud, etc.),
+- scan local disk outside of Jellyfin's own metadata,
+- poll Jellyfin in the background or run scheduled work,
+- modify Auryn behaviour or be involved in Auryn's library
+  population — those remain a separate project.
+
+## Configuration
+
+All switches default to OFF. An unconfigured Nova install **never**
+contacts Jellyfin, even for an admin.
+
+```ini
+NOVA_JELLYFIN_ENABLED=true
+NOVA_JELLYFIN_URL=http://127.0.0.1:8096
+NOVA_JELLYFIN_API_KEY=your_local_jellyfin_api_key
+NOVA_JELLYFIN_USER_ID=                   # optional Jellyfin user GUID
+NOVA_JELLYFIN_READ_ONLY=true             # default; Phase 1 has no writes
+NOVA_JELLYFIN_TIMEOUT_SECONDS=5.0
+```
+
+### Generating a Jellyfin API key
+
+1. Open Jellyfin's web UI and sign in as an admin.
+2. Go to *Dashboard → API Keys*.
+3. Click *+* and provide a label (e.g. `nova-local-bridge`).
+4. Copy the generated key into `NOVA_JELLYFIN_API_KEY`.
+
+The key only needs **read** scopes. Nova never performs write
+operations against Jellyfin in Phase 1, so there is no need to give
+the key admin or playback-control permissions.
+
+### Choosing a user ID (optional)
+
+`NOVA_JELLYFIN_USER_ID` is optional. When set to a valid Jellyfin
+user GUID, library reads are scoped to that user's view (so per-user
+library visibility in Jellyfin is honoured). When empty, the bridge
+falls back to server-wide read endpoints.
+
+## Endpoints
+
+All endpoints are admin-only. Non-admin and restricted users receive
+a 403; the configured key, URL, and user ID are never serialised
+into any response body.
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /integrations/media/jellyfin/status`     | Calm snapshot of the bridge. |
+| `GET /integrations/media/jellyfin/artists`    | List music artists. |
+| `GET /integrations/media/jellyfin/albums`     | List music albums. |
+| `GET /integrations/media/jellyfin/tracks`     | List music tracks. |
+| `GET /integrations/media/jellyfin/genres`     | List music genres. |
+| `GET /integrations/media/jellyfin/playlists`  | List playlists (read-only). |
+| `GET /integrations/media/recommendations`     | Playlist suggestions. |
+
+### Status states
+
+- `disabled` — host operator has not set `NOVA_JELLYFIN_ENABLED=true`.
+- `not_configured` — the URL or the API key is missing.
+- `unavailable` — Jellyfin returned an error or could not be reached.
+  The detail field is a short, hard-coded summary; it never echoes
+  the raw exception or the response body.
+- `connected_read_only` — the bridge is reachable and authenticated
+  in read-only mode.
+
+### Recommendation payload
+
+`GET /integrations/media/recommendations` returns a list of playlist
+ideas. Each entry has the shape:
+
+```json
+{
+  "title": "Night Coding",
+  "mood": "coding",
+  "description": "Calm tracks for late-night development.",
+  "estimated_duration": 3600,
+  "confidence": "high",
+  "tracks": [
+    {
+      "id": "track-1",
+      "title": "Lo-Fi Study",
+      "artist": "Example Artist",
+      "album": "Example Album",
+      "duration": 200,
+      "reason": "matches coding mood: genre lo-fi; title hints 'study'."
+    }
+  ]
+}
+```
+
+- `estimated_duration` is the sum of the picked tracks' durations in
+  whole seconds, or `null` when no track in the playlist reports one.
+- `confidence` is `low` / `medium` / `high` based on the number of
+  strong-signal tracks.
+- `reason` is a short, sanitised explanation of why the track was
+  picked — never an LLM call, never a cloud lookup.
+
+Available moods: `chill`, `focus`, `gym`, `dark`, `upbeat`, `sad`,
+`night drive`, `coding`.
+
+Query params:
+
+- `mood=chill,focus` — comma-separated filter (entries not in the
+  catalogue are dropped),
+- `limit=8` — clamp to 1..12 (default 8),
+- `per_playlist=12` — clamp to 3..25 (default 12).
+
+The output is deterministic: identical libraries produce identical
+suggestions.
+
+## Privacy and safety contract
+
+- **Local-first.** The bridge talks to your configured Jellyfin
+  server only. No request ever leaves your network on Nova's behalf.
+- **No cloud music APIs.** Nova does not contact Spotify, Tidal,
+  Deezer, YouTube, SoundCloud, or any similar service.
+- **No telemetry.** The bridge does not phone home and does not
+  emit usage analytics anywhere.
+- **No streaming or file copying.** The bridge reads metadata via
+  Jellyfin's REST API. It does not download, stream, transcode, or
+  cache audio data.
+- **No autoplay.** The bridge does not start playback, queue tracks,
+  or instruct Jellyfin to play anything.
+- **No background polling.** Every request is initiated by an admin
+  call to the corresponding endpoint.
+- **Admin-only.** Both the configuration and the endpoints are
+  gated to the `admin` role. The aggregate `/integrations/status`
+  payload reports `disabled` for non-admin users so a non-admin UI
+  cannot infer the configured state.
+- **Sanitised errors.** Every error response is a short, hard-coded
+  summary. Raw exception text, response bodies, and the configured
+  key are never surfaced.
+
+### API-key handling
+
+- The key lives in env-local config only.
+- The key is sent as the `X-Emby-Token` request header — never in
+  URLs, query params, or JSON request bodies.
+- Logger messages identify exceptions by type only (e.g.
+  `"jellyfin status failed: ConnectError"`); the raw exception
+  repr is never logged because it could leak the header.
+- The key is not stored in the database in this PR.
+
+## Architecture
+
+The Phase-1 bridge intentionally splits into two small modules:
+
+- `core/integrations/media/jellyfin.py` — read-only HTTP client. It
+  knows how to talk to *one* media server (Jellyfin) and returns
+  sanitised dicts.
+- `core/integrations/media/recommendations.py` — pure-Python
+  heuristics. It operates on the sanitised track shape and is
+  provider-agnostic so a future Plex provider can plug in without
+  touching playlist logic.
+
+This split keeps the heuristics deterministic and explainable, and
+lets contributors add a new provider in a single small module.
+
+## Future direction (NOT in this PR)
+
+- **Plex support** behind the same provider interface.
+- **Playlist creation** behind a per-request confirmation in the UI
+  and a separate write switch. Nova will never create a playlist
+  without an explicit "yes" from the user, and the action will carry
+  audit logging when it is introduced.
+- **Auryn integration** can eventually help populate a local library,
+  but Auryn remains a separate project. This bridge does not change
+  Auryn's behaviour, and Auryn does not run as part of Nova.

--- a/tests/test_integrations_media_jellyfin.py
+++ b/tests/test_integrations_media_jellyfin.py
@@ -1,0 +1,950 @@
+"""
+Tests for the optional read-only Jellyfin music bridge (Phase 1).
+
+Scope of the suite mirrors the design brief's testing requirements:
+
+  * disabled bridge reports ``disabled`` and never reaches the wire,
+  * missing API key reports ``not_configured`` without leaking secrets,
+  * invalid Jellyfin / HTTP errors are sanitised and surface as
+    ``unavailable`` with no key bleed,
+  * read-only listing of artists / albums / tracks / genres /
+    playlists works against a mocked Jellyfin response,
+  * empty libraries return an empty result without raising,
+  * the bridge module exposes no write helpers and contains no
+    POST / PUT / PATCH / DELETE / playlist-create-style calls,
+  * the FastAPI endpoints are admin-only — non-admin and restricted
+    users get a 403,
+  * the configured API key never appears in any returned JSON body,
+  * the recommendation helper is deterministic.
+
+The HTTP transport is stubbed via the same ``httpx.Client`` factory
+swap pattern used by the GitHub integration tests, so no real
+network call is ever issued.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import sqlite3
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from core import memory as core_memory, users
+from core.integrations.media import jellyfin as jf
+from core.integrations.media import recommendations as rec
+from memory import store as natural_store
+
+
+SECRET_KEY = "jf_SECRET_must_never_leak_abcdef1234567890"
+SECRET_FRAGMENT = "SECRET_must_never_leak"
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+# ── Fake httpx client ───────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any = None,
+                 raise_decode: bool = False):
+        self.status_code = status_code
+        self._payload = payload
+        self._raise_decode = raise_decode
+
+    def json(self):
+        if self._raise_decode:
+            raise ValueError("decode error")
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, scripted: dict, calls: list,
+                 raise_on: set | None = None, headers: dict | None = None):
+        self._scripted = scripted
+        self._calls = calls
+        self._raise_on = raise_on or set()
+        self._headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def _record(self, method: str, path: str, **kwargs):
+        self._calls.append(
+            {"method": method, "path": path, "kwargs": kwargs,
+             "headers": dict(self._headers)},
+        )
+        if path in self._raise_on:
+            raise httpx.ConnectError("boom")
+        return self._scripted.get((method, path), _FakeResponse(404))
+
+    def get(self, path: str, **kwargs):
+        return self._record("GET", path, **kwargs)
+
+
+@pytest.fixture
+def jellyfin_stub(monkeypatch):
+    """Replace ``httpx.Client`` in the bridge and enable the integration.
+
+    Returns ``(install, calls)``; ``install(scripted, raise_on=...)``
+    sets the scripted responses, and ``calls`` accumulates every
+    outbound request (method, path, kwargs, captured headers).
+    """
+    calls: list = []
+    state: dict = {"scripted": {}, "raise_on": set()}
+
+    monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", True)
+    monkeypatch.setattr(jf, "NOVA_JELLYFIN_URL", "http://127.0.0.1:8096")
+    monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", SECRET_KEY)
+    monkeypatch.setattr(
+        jf, "NOVA_JELLYFIN_USER_ID", "00000000-0000-0000-0000-000000000001",
+    )
+    monkeypatch.setattr(jf, "NOVA_JELLYFIN_READ_ONLY", True)
+
+    def factory(*args, **kwargs):
+        return _FakeClient(
+            state["scripted"], calls, state["raise_on"],
+            headers=kwargs.get("headers", {}),
+        )
+
+    monkeypatch.setattr(jf.httpx, "Client", factory)
+
+    def install(scripted: dict, raise_on: set | None = None):
+        state["scripted"] = scripted
+        state["raise_on"] = raise_on or set()
+
+    return install, calls
+
+
+# ── Switches ────────────────────────────────────────────────────────
+
+
+class TestSwitches:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        assert jf.is_enabled() is False
+
+    def test_enabled_when_env_true(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", True)
+        assert jf.is_enabled() is True
+
+    def test_read_only_default_true(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_READ_ONLY", True)
+        assert jf.is_read_only() is True
+
+
+# ── Status states ───────────────────────────────────────────────────
+
+
+class TestStatus:
+    def test_disabled_when_switch_off(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", SECRET_KEY)
+        s = jf.status()
+        assert s.state == jf.STATE_DISABLED
+        assert s.enabled is False
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", True)
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_URL", "http://127.0.0.1:8096")
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", "")
+        s = jf.status()
+        assert s.state == jf.STATE_NOT_CONFIGURED
+        assert s.enabled is True
+        assert SECRET_FRAGMENT not in s.detail
+
+    def test_not_configured_when_url_missing(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", True)
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_URL", "")
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", SECRET_KEY)
+        s = jf.status()
+        assert s.state == jf.STATE_NOT_CONFIGURED
+        assert s.enabled is True
+
+    def test_connected_on_2xx(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox", "Version": "10.8.13"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": [
+                    {"Name": "Music", "CollectionType": "music"},
+                ]}),
+        })
+        s = jf.status()
+        assert s.state == jf.STATE_CONNECTED
+        assert s.server_name == "JellyBox"
+        assert s.server_version == "10.8.13"
+        assert s.library_kinds == ("music",)
+
+    def test_unavailable_on_401(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({("GET", "/System/Info/Public"): _FakeResponse(401)})
+        s = jf.status()
+        assert s.state == jf.STATE_UNAVAILABLE
+        assert SECRET_FRAGMENT not in s.detail
+
+    def test_unavailable_on_5xx(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({("GET", "/System/Info/Public"): _FakeResponse(503)})
+        s = jf.status()
+        assert s.state == jf.STATE_UNAVAILABLE
+
+    def test_unavailable_on_network_error(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({}, raise_on={"/System/Info/Public"})
+        s = jf.status()
+        assert s.state == jf.STATE_UNAVAILABLE
+        assert SECRET_FRAGMENT not in s.detail
+
+    def test_no_http_when_disabled(self, monkeypatch, jellyfin_stub):
+        install, calls = jellyfin_stub
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        install({("GET", "/System/Info/Public"): _FakeResponse(200, {})})
+        jf.status()
+        assert calls == []
+
+    def test_no_http_when_key_missing(self, monkeypatch, jellyfin_stub):
+        install, calls = jellyfin_stub
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", "")
+        install({("GET", "/System/Info/Public"): _FakeResponse(200, {})})
+        jf.status()
+        assert calls == []
+
+
+# ── Read API ────────────────────────────────────────────────────────
+
+
+_ARTIST_PAYLOAD = {
+    "Id": "artist-1",
+    "Name": "Josh A",
+    "Genres": ["Hip-Hop", "Emo"],
+}
+
+_ALBUM_PAYLOAD = {
+    "Id": "album-1",
+    "Name": "The Forest",
+    "AlbumArtist": "Josh A",
+    "ProductionYear": 2020,
+    "Genres": ["Hip-Hop"],
+}
+
+_TRACK_PAYLOAD = {
+    "Id": "track-1",
+    "Name": "Save Me",
+    "Artists": ["Josh A"],
+    "AlbumArtist": "Josh A",
+    "Album": "The Forest",
+    "ProductionYear": 2020,
+    "Genres": ["Hip-Hop"],
+    "RunTimeTicks": 200 * 10_000_000,  # 200 seconds
+}
+
+_GENRE_PAYLOAD = {
+    "Id": "genre-1",
+    "Name": "Hip-Hop",
+}
+
+_PLAYLIST_PAYLOAD = {
+    "Id": "pl-1",
+    "Name": "Late Night",
+    "ChildCount": 17,
+    "RunTimeTicks": 3600 * 10_000_000,
+    "MediaType": "Audio",
+}
+
+_USER_ITEMS_PATH = "/Users/00000000-0000-0000-0000-000000000001/Items"
+
+
+class TestListArtists:
+    def test_returns_sanitised_artists(self, jellyfin_stub):
+        install, calls = jellyfin_stub
+        install({
+            ("GET", "/Artists"): _FakeResponse(
+                200, {"Items": [_ARTIST_PAYLOAD]},
+            ),
+        })
+        result = jf.list_artists()
+        assert result == [{
+            "id": "artist-1",
+            "name": "Josh A",
+            "genres": ["Hip-Hop", "Emo"],
+        }]
+        assert calls[-1]["kwargs"]["params"]["IncludeItemTypes"] == "MusicArtist"
+
+    def test_empty_when_disabled(self, monkeypatch, jellyfin_stub):
+        install, calls = jellyfin_stub
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        install({("GET", "/Artists"): _FakeResponse(200, {"Items": []})})
+        assert jf.list_artists() == []
+        assert calls == []
+
+    def test_empty_on_network_error(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({}, raise_on={"/Artists"})
+        assert jf.list_artists() == []
+
+    def test_empty_on_malformed_response(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({("GET", "/Artists"): _FakeResponse(200, "not-a-dict")})
+        assert jf.list_artists() == []
+
+    def test_limit_clamped(self, jellyfin_stub):
+        install, calls = jellyfin_stub
+        install({("GET", "/Artists"): _FakeResponse(200, {"Items": []})})
+        jf.list_artists(limit=10_000)
+        assert calls[-1]["kwargs"]["params"]["Limit"] == 200
+
+
+class TestListAlbums:
+    def test_returns_sanitised_albums(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(
+                200, {"Items": [_ALBUM_PAYLOAD]},
+            ),
+        })
+        result = jf.list_albums()
+        assert result == [{
+            "id": "album-1",
+            "name": "The Forest",
+            "artist": "Josh A",
+            "year": 2020,
+            "genres": ["Hip-Hop"],
+        }]
+
+    def test_empty_when_url_missing(self, monkeypatch, jellyfin_stub):
+        install, calls = jellyfin_stub
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_URL", "")
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(
+                200, {"Items": [_ALBUM_PAYLOAD]},
+            ),
+        })
+        assert jf.list_albums() == []
+        assert calls == []
+
+
+class TestListTracks:
+    def test_returns_sanitised_tracks(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(
+                200, {"Items": [_TRACK_PAYLOAD]},
+            ),
+        })
+        result = jf.list_tracks()
+        assert result == [{
+            "id": "track-1",
+            "title": "Save Me",
+            "artist": "Josh A",
+            "artists": ["Josh A"],
+            "album": "The Forest",
+            "year": 2020,
+            "genres": ["Hip-Hop"],
+            "duration": 200,
+        }]
+
+    def test_duration_none_when_ticks_missing(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        item = {**_TRACK_PAYLOAD}
+        item.pop("RunTimeTicks")
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": [item]}),
+        })
+        result = jf.list_tracks()
+        assert result[0]["duration"] is None
+
+    def test_empty_library_returns_empty_list(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": []}),
+        })
+        assert jf.list_tracks() == []
+
+
+class TestListGenres:
+    def test_returns_sanitised_genres(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/MusicGenres"): _FakeResponse(
+                200, {"Items": [_GENRE_PAYLOAD]},
+            ),
+        })
+        assert jf.list_genres() == [{"id": "genre-1", "name": "Hip-Hop"}]
+
+
+class TestListPlaylists:
+    def test_returns_sanitised_playlists(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(
+                200, {"Items": [_PLAYLIST_PAYLOAD]},
+            ),
+        })
+        result = jf.list_playlists()
+        assert result == [{
+            "id": "pl-1",
+            "name": "Late Night",
+            "track_count": 17,
+            "duration": 3600,
+            "media_kind": "audio",
+        }]
+
+    def test_empty_when_unreachable(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({}, raise_on={_USER_ITEMS_PATH})
+        assert jf.list_playlists() == []
+
+
+class TestLibrarySnapshot:
+    def test_aggregates_helpers(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/Artists"): _FakeResponse(200, {"Items": [_ARTIST_PAYLOAD]}),
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": []}),
+            ("GET", "/MusicGenres"): _FakeResponse(200, {"Items": []}),
+        })
+        snap = jf.library_snapshot()
+        assert snap["read_only"] is True
+        assert isinstance(snap["artists"], list)
+        assert isinstance(snap["tracks"], list)
+
+
+# ── Key safety ──────────────────────────────────────────────────────
+
+
+class TestApiKeySafety:
+    def test_key_not_in_status_payload(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox", "Version": "10.8"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": []}),
+        })
+        serialised = repr(jf.status().as_dict())
+        assert SECRET_FRAGMENT not in serialised
+
+    def test_key_not_in_track_payload(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(
+                200, {"Items": [_TRACK_PAYLOAD]},
+            ),
+        })
+        out = jf.list_tracks()
+        assert SECRET_FRAGMENT not in repr(out)
+
+    def test_key_only_in_header(self, jellyfin_stub):
+        install, calls = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": []}),
+        })
+        jf.status()
+        assert calls, "expected at least one outbound request"
+        captured = calls[0]["headers"]
+        assert captured.get(jf.API_KEY_HEADER) == SECRET_KEY
+        for call in calls:
+            assert SECRET_FRAGMENT not in call["path"]
+            assert SECRET_FRAGMENT not in repr(call["kwargs"])
+
+    def test_logger_messages_omit_key(self, monkeypatch, jellyfin_stub, caplog):
+        install, _ = jellyfin_stub
+        install({}, raise_on={"/System/Info/Public"})
+        with caplog.at_level("DEBUG", logger=jf.logger.name):
+            jf.status()
+        for record in caplog.records:
+            assert SECRET_FRAGMENT not in record.getMessage()
+            assert SECRET_FRAGMENT not in str(record.args or "")
+
+
+# ── Module-level "no write code" enforcement ────────────────────────
+
+
+class TestNoWriteCode:
+    """The Phase-1 module must not call any write verb against Jellyfin.
+
+    A future PR can add playlist-creation helpers, but they must come
+    with their own gating + audit + confirmation logic. This test
+    fails fast if POST / PUT / PATCH / DELETE leak into the read-only
+    module by accident.
+    """
+
+    def test_module_has_no_write_helpers(self):
+        for name in (
+            "create_playlist", "update_playlist", "delete_playlist",
+            "add_to_playlist", "remove_from_playlist",
+            "play", "queue_track", "start_playback",
+        ):
+            assert not hasattr(jf, name), (
+                f"{name!r} should not exist in the Phase-1 bridge"
+            )
+
+    def test_module_never_calls_write_verbs(self):
+        with open(jf.__file__, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+        forbidden = {"post", "put", "patch", "delete"}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            attr = getattr(func, "attr", None)
+            if isinstance(attr, str) and attr.lower() in forbidden:
+                raise AssertionError(
+                    f"forbidden write verb {attr!r} called at line {node.lineno}"
+                )
+
+    def test_module_does_not_import_cloud_music_apis(self):
+        with open(jf.__file__, "r", encoding="utf-8") as f:
+            text = f.read()
+        for forbidden in ("spotify", "tidal", "deezer", "youtube", "soundcloud"):
+            assert forbidden not in text.lower(), (
+                f"bridge must not reference cloud provider {forbidden!r}"
+            )
+
+
+# ── Endpoint: admin-only enforcement ────────────────────────────────
+
+
+class TestEndpointsAdminOnly:
+    @pytest.fixture(autouse=True)
+    def _stub(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": []}),
+            ("GET", "/Artists"): _FakeResponse(200, {"Items": [_ARTIST_PAYLOAD]}),
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": []}),
+            ("GET", "/MusicGenres"): _FakeResponse(200, {"Items": []}),
+        })
+
+    @pytest.mark.parametrize("path", [
+        "/integrations/media/jellyfin/status",
+        "/integrations/media/jellyfin/artists",
+        "/integrations/media/jellyfin/albums",
+        "/integrations/media/jellyfin/tracks",
+        "/integrations/media/jellyfin/genres",
+        "/integrations/media/jellyfin/playlists",
+        "/integrations/media/recommendations",
+    ])
+    def test_non_admin_user_forbidden(self, web_client, user_token, path):
+        resp = web_client.get(path, headers=_h(user_token))
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("path", [
+        "/integrations/media/jellyfin/status",
+        "/integrations/media/jellyfin/tracks",
+        "/integrations/media/recommendations",
+    ])
+    def test_restricted_user_forbidden(self, web_client, restricted_token, path):
+        resp = web_client.get(path, headers=_h(restricted_token))
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("path", [
+        "/integrations/media/jellyfin/status",
+        "/integrations/media/jellyfin/tracks",
+        "/integrations/media/recommendations",
+    ])
+    def test_unauthenticated_blocked(self, web_client, path):
+        resp = web_client.get(path)
+        assert resp.status_code in (401, 403)
+
+
+# ── Endpoint: admin happy path ──────────────────────────────────────
+
+
+class TestEndpointsAdmin:
+    @pytest.fixture(autouse=True)
+    def _stub(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox", "Version": "10.8.13"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": [
+                    {"Name": "Music", "CollectionType": "music"},
+                ]}),
+            ("GET", "/Artists"): _FakeResponse(200, {"Items": [_ARTIST_PAYLOAD]}),
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": [_TRACK_PAYLOAD]}),
+            ("GET", "/MusicGenres"): _FakeResponse(200, {"Items": [_GENRE_PAYLOAD]}),
+        })
+
+    def test_status_endpoint(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/media/jellyfin/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == jf.STATE_CONNECTED
+        assert body["read_only"] is True
+        assert body["server_name"] == "JellyBox"
+        assert "api_key" not in body
+        assert SECRET_FRAGMENT not in resp.text
+
+    def test_status_disabled_when_switch_off(
+        self, monkeypatch, web_client, admin_token,
+    ):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        resp = web_client.get(
+            "/integrations/media/jellyfin/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == jf.STATE_DISABLED
+
+    def test_list_artists(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/media/jellyfin/artists", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["read_only"] is True
+        assert body["artists"][0]["name"] == "Josh A"
+        assert SECRET_FRAGMENT not in resp.text
+
+    def test_list_tracks(self, web_client, admin_token):
+        resp = web_client.get(
+            "/integrations/media/jellyfin/tracks", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tracks"][0]["title"] == "Save Me"
+        assert body["tracks"][0]["duration"] == 200
+
+    def test_endpoints_503_when_unconfigured(
+        self, monkeypatch, web_client, admin_token, jellyfin_stub,
+    ):
+        install, _ = jellyfin_stub
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", "")
+        install({})
+        resp = web_client.get(
+            "/integrations/media/jellyfin/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == jf.STATE_NOT_CONFIGURED
+        for path in (
+            "/integrations/media/jellyfin/artists",
+            "/integrations/media/jellyfin/albums",
+            "/integrations/media/jellyfin/tracks",
+            "/integrations/media/jellyfin/genres",
+            "/integrations/media/jellyfin/playlists",
+            "/integrations/media/recommendations",
+        ):
+            resp = web_client.get(path, headers=_h(admin_token))
+            assert resp.status_code == 503, path
+
+    def test_endpoints_404_when_disabled(
+        self, monkeypatch, web_client, admin_token,
+    ):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        for path in (
+            "/integrations/media/jellyfin/artists",
+            "/integrations/media/jellyfin/tracks",
+            "/integrations/media/recommendations",
+        ):
+            resp = web_client.get(path, headers=_h(admin_token))
+            assert resp.status_code == 404, path
+
+    def test_endpoint_errors_do_not_leak_key(
+        self, web_client, admin_token, jellyfin_stub,
+    ):
+        install, _ = jellyfin_stub
+        install({}, raise_on={"/System/Info/Public", "/Artists"})
+        for path in (
+            "/integrations/media/jellyfin/status",
+            "/integrations/media/jellyfin/artists",
+        ):
+            resp = web_client.get(path, headers=_h(admin_token))
+            assert SECRET_FRAGMENT not in resp.text, path
+
+    def test_recommendations_endpoint(self, web_client, admin_token, jellyfin_stub):
+        # Populate the track pool with enough chill/focus material to
+        # produce at least one playlist (min_tracks = 3).
+        install, _ = jellyfin_stub
+        items = [
+            {**_TRACK_PAYLOAD, "Id": f"t{i}", "Name": f"Lo-Fi Study {i}",
+             "Genres": ["Lo-Fi", "Ambient"]}
+            for i in range(6)
+        ]
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": []}),
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": items}),
+        })
+        resp = web_client.get(
+            "/integrations/media/recommendations", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["read_only"] is True
+        assert isinstance(body["recommendations"], list)
+        moods = {p["mood"] for p in body["recommendations"]}
+        # The lo-fi tracks lean toward focus/coding/chill.
+        assert "focus" in moods or "coding" in moods or "chill" in moods
+
+
+# ── Aggregate /integrations/status surface ──────────────────────────
+
+
+class TestAggregateStatus:
+    def test_admin_sees_jellyfin_state(self, web_client, admin_token, jellyfin_stub):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox"},
+            ),
+            ("GET", "/Users/00000000-0000-0000-0000-000000000001/Views"):
+                _FakeResponse(200, {"Items": []}),
+        })
+        resp = web_client.get("/integrations/status", headers=_h(admin_token))
+        assert resp.status_code == 200
+        jellyfin = resp.json()["jellyfin"]
+        assert jellyfin["state"] == jf.STATE_CONNECTED
+
+    def test_non_admin_sees_disabled_jellyfin(
+        self, web_client, user_token, jellyfin_stub,
+    ):
+        install, _ = jellyfin_stub
+        install({
+            ("GET", "/System/Info/Public"): _FakeResponse(
+                200, {"ServerName": "JellyBox"},
+            ),
+        })
+        resp = web_client.get("/integrations/status", headers=_h(user_token))
+        assert resp.status_code == 200
+        jellyfin = resp.json()["jellyfin"]
+        assert jellyfin["state"] == jf.STATE_DISABLED
+        assert jellyfin["enabled"] is False
+
+
+# ── Recommendation heuristics ───────────────────────────────────────
+
+
+def _track(title, genres=None, duration=200, **extra):
+    out = {
+        "id": title.lower().replace(" ", "-"),
+        "title": title,
+        "artist": "Test Artist",
+        "artists": ["Test Artist"],
+        "album": "Test Album",
+        "year": 2020,
+        "genres": list(genres) if genres else [],
+        "duration": duration,
+    }
+    out.update(extra)
+    return out
+
+
+class TestRecommendations:
+    def test_empty_library_returns_empty_list(self):
+        assert rec.recommend_playlists([]) == []
+
+    def test_only_unmatched_moods_returns_empty(self):
+        tracks = [_track("Mystery", genres=["Polka"])]
+        assert rec.recommend_playlists(tracks) == []
+
+    def test_chill_playlist_from_lofi(self):
+        tracks = [
+            _track(f"Lo-Fi {i}", genres=["Lo-Fi", "Ambient"])
+            for i in range(6)
+        ]
+        out = rec.recommend_playlists(tracks)
+        moods = [p["mood"] for p in out]
+        assert "chill" in moods
+        chill = next(p for p in out if p["mood"] == "chill")
+        assert chill["title"] == "Chill Wind-Down"
+        assert chill["description"]
+        assert len(chill["tracks"]) >= 3
+        for entry in chill["tracks"]:
+            assert "reason" in entry and entry["reason"]
+
+    def test_gym_playlist_from_metal(self):
+        tracks = [
+            _track(f"Heavy {i}", genres=["Metal"]) for i in range(6)
+        ]
+        out = rec.recommend_playlists(tracks, moods=["gym", "dark"])
+        moods = [p["mood"] for p in out]
+        assert "gym" in moods
+        assert "dark" in moods
+
+    def test_deterministic_output(self):
+        tracks = [
+            _track(f"Chill {i}", genres=["Ambient"]) for i in range(8)
+        ]
+        first = rec.recommend_playlists(tracks)
+        second = rec.recommend_playlists(tracks)
+        assert first == second
+
+    def test_estimated_duration_sums_track_seconds(self):
+        tracks = [
+            _track(f"Chill {i}", genres=["Ambient"], duration=180)
+            for i in range(5)
+        ]
+        out = rec.recommend_playlists(tracks, moods=["chill"])
+        assert out[0]["estimated_duration"] is not None
+        assert out[0]["estimated_duration"] >= 180 * len(out[0]["tracks"]) - 5
+
+    def test_estimated_duration_none_when_durations_missing(self):
+        tracks = [
+            _track(f"Chill {i}", genres=["Ambient"], duration=None)
+            for i in range(5)
+        ]
+        out = rec.recommend_playlists(tracks, moods=["chill"])
+        assert out[0]["estimated_duration"] is None
+
+    def test_title_token_signal(self):
+        tracks = [
+            _track("Night Drive Anthem", genres=["Pop"]),
+            _track("Midnight Highway", genres=["Pop"]),
+            _track("Drive Home", genres=["Pop"]),
+            _track("Late Night Cruise", genres=["Pop"]),
+        ]
+        out = rec.recommend_playlists(tracks, moods=["night drive"])
+        assert out and out[0]["mood"] == "night drive"
+
+    def test_limit_clamps(self):
+        tracks = [
+            _track(f"Mix {i}", genres=["Lo-Fi", "Metal", "EDM"])
+            for i in range(20)
+        ]
+        out = rec.recommend_playlists(tracks, limit=999)
+        # _MAX_MOODS_LIMIT = 12; the mood catalogue currently has 8
+        # entries so the upper bound is the catalogue size.
+        assert len(out) <= 12
+
+    def test_per_playlist_clamps(self):
+        tracks = [
+            _track(f"Chill {i}", genres=["Ambient"]) for i in range(50)
+        ]
+        out = rec.recommend_playlists(
+            tracks, moods=["chill"], per_playlist=999,
+        )
+        assert len(out[0]["tracks"]) <= 25
+
+    def test_unknown_mood_filtered_out(self):
+        tracks = [
+            _track(f"Chill {i}", genres=["Ambient"]) for i in range(5)
+        ]
+        # Unknown moods produce an empty list, not an error.
+        assert rec.recommend_playlists(tracks, moods=["banana"]) == []
+
+    def test_reason_string_explains_why(self):
+        tracks = [
+            _track(f"Sad Track {i}", genres=["Blues"]) for i in range(5)
+        ]
+        out = rec.recommend_playlists(tracks, moods=["sad"])
+        for entry in out[0]["tracks"]:
+            assert entry["reason"].startswith("matches sad mood")
+
+
+class TestRecommendationsFromJellyfin:
+    def test_disabled_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", False)
+        assert rec.recommend_from_jellyfin() == []
+
+    def test_missing_key_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_ENABLED", True)
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_URL", "http://x")
+        monkeypatch.setattr(jf, "NOVA_JELLYFIN_API_KEY", "")
+        assert rec.recommend_from_jellyfin() == []
+
+    def test_pulls_tracks_and_recommends(self, jellyfin_stub):
+        install, _ = jellyfin_stub
+        items = [
+            {**_TRACK_PAYLOAD, "Id": f"t{i}",
+             "Name": f"Chill Vibes {i}",
+             "Genres": ["Lo-Fi", "Ambient"]}
+            for i in range(8)
+        ]
+        install({
+            ("GET", _USER_ITEMS_PATH): _FakeResponse(200, {"Items": items}),
+        })
+        out = rec.recommend_from_jellyfin()
+        assert out, "expected at least one playlist suggestion"
+        for playlist in out:
+            for entry in playlist["tracks"]:
+                assert SECRET_FRAGMENT not in str(entry)

--- a/web.py
+++ b/web.py
@@ -60,6 +60,8 @@ from core.integrations import silentguard as _silentguard_integration
 from core.integrations import nexanote as _nexanote_integration
 from core.integrations import github as _github_integration
 from core.integrations import github_triage as _github_triage
+from core.integrations.media import jellyfin as _jellyfin_integration
+from core.integrations.media import recommendations as _media_recommendations
 from core.security import ensure_silentguard_running as _ensure_silentguard_running
 from core.security import lifecycle as _silentguard_lifecycle
 from core.security import SilentGuardProvider as _SilentGuardProvider
@@ -1020,6 +1022,7 @@ def integrations_status(user: CurrentUser = Depends(get_current_user)):
     }
     if user.role == "admin":
         payload["github"] = _github_integration.status().as_dict()
+        payload["jellyfin"] = _jellyfin_integration.status().as_dict()
     else:
         payload["github"] = {
             "name": _github_integration.NAME,
@@ -1030,6 +1033,18 @@ def integrations_status(user: CurrentUser = Depends(get_current_user)):
             "read_only": True,
             "authenticated_login": None,
             "scopes": [],
+        }
+        payload["jellyfin"] = {
+            "name": _jellyfin_integration.NAME,
+            "enabled": False,
+            "state": _jellyfin_integration.STATE_DISABLED,
+            "detail": "Jellyfin bridge is admin-only.",
+            "server_name": None,
+            "server_version": None,
+            "read_only": True,
+            "user_id_configured": False,
+            "base_url_configured": False,
+            "library_kinds": [],
         }
     return payload
 
@@ -2106,6 +2121,168 @@ def github_recommendations(
     )
     return {
         "repo": f"{owner}/{name}",
+        "recommendations": recommendations,
+        "read_only": True,
+    }
+
+
+# ── ADMIN: OPTIONAL LOCAL MEDIA ASSISTANT (Jellyfin, read-only) ────
+# Phase-1 admin-only window into a *local* Jellyfin music library and
+# a small deterministic playlist-suggestion helper. Every endpoint is
+# wrapped with ``require_admin`` so non-admin / restricted users get a
+# 403 — never a leak of the configured server URL, user GUID, or
+# bridge state. The underlying ``core.integrations.media`` modules
+# are strictly read-only: nothing in this PR creates, edits, or
+# deletes playlists on Jellyfin; nothing streams or copies media
+# files; nothing talks to any cloud music API. The API key configured
+# in ``NOVA_JELLYFIN_API_KEY`` is never serialised into any response,
+# header, or log line surfaced here — it lives only inside the
+# bridge's private ``X-Emby-Token`` header.
+
+
+def _require_jellyfin_ready(
+    status: _jellyfin_integration.JellyfinStatus,
+) -> None:
+    """Translate a non-connected bridge status into a clean 503/404.
+
+    Keeps the response shape consistent so the UI never has to peek at
+    ``status.state`` to know whether to retry.
+    """
+    if status.state == _jellyfin_integration.STATE_DISABLED:
+        raise HTTPException(
+            status_code=404,
+            detail="Jellyfin bridge is disabled on this Nova host.",
+        )
+    if status.state == _jellyfin_integration.STATE_NOT_CONFIGURED:
+        raise HTTPException(
+            status_code=503,
+            detail="Jellyfin bridge is not configured.",
+        )
+    if status.state == _jellyfin_integration.STATE_UNAVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail="Jellyfin bridge is unavailable.",
+        )
+
+
+@app.get("/integrations/media/jellyfin/status")
+def jellyfin_status(_: CurrentUser = Depends(require_admin)):
+    """Calm read-only snapshot of the Jellyfin bridge.
+
+    Returns one of the four documented states — ``disabled``,
+    ``not_configured``, ``unavailable``, ``connected_read_only`` —
+    plus the server name / version (when reachable) and the
+    ``read_only`` flag. The API key is intentionally absent from
+    the payload.
+    """
+    return _jellyfin_integration.status().as_dict()
+
+
+@app.get("/integrations/media/jellyfin/artists")
+def jellyfin_list_artists(
+    limit: int = 50,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised music artists from the configured Jellyfin library."""
+    _require_jellyfin_ready(_jellyfin_integration.status())
+    return {
+        "artists": _jellyfin_integration.list_artists(limit=limit),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/media/jellyfin/albums")
+def jellyfin_list_albums(
+    limit: int = 50,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised music albums from the configured Jellyfin library."""
+    _require_jellyfin_ready(_jellyfin_integration.status())
+    return {
+        "albums": _jellyfin_integration.list_albums(limit=limit),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/media/jellyfin/tracks")
+def jellyfin_list_tracks(
+    limit: int = 50,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised music tracks (Audio items) from the library."""
+    _require_jellyfin_ready(_jellyfin_integration.status())
+    return {
+        "tracks": _jellyfin_integration.list_tracks(limit=limit),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/media/jellyfin/genres")
+def jellyfin_list_genres(
+    limit: int = 50,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised music genres available in the library."""
+    _require_jellyfin_ready(_jellyfin_integration.status())
+    return {
+        "genres": _jellyfin_integration.list_genres(limit=limit),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/media/jellyfin/playlists")
+def jellyfin_list_playlists(
+    limit: int = 50,
+    _: CurrentUser = Depends(require_admin),
+):
+    """List sanitised playlists from the library.
+
+    Phase 1 *reads* playlists only. The endpoint never creates,
+    edits, or deletes playlists on the Jellyfin server.
+    """
+    _require_jellyfin_ready(_jellyfin_integration.status())
+    return {
+        "playlists": _jellyfin_integration.list_playlists(limit=limit),
+        "read_only": True,
+    }
+
+
+@app.get("/integrations/media/recommendations")
+def media_recommendations(
+    mood: str | None = None,
+    limit: int = 8,
+    per_playlist: int = 12,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Return deterministic playlist suggestions for the local library.
+
+    Read-only and deterministic: the response is computed from the
+    sanitised output of the configured local media provider (Jellyfin
+    in Phase 1) with pure-Python heuristics (genre dictionaries,
+    title-token signals, track-duration nudges). Nova never decides
+    *for* the user what to play — this endpoint just surfaces a short
+    list of playlist *ideas* with reasons. No media-server mutation
+    is performed and the configured API key is never echoed back in
+    the response.
+
+    Optional query params:
+      * ``mood=chill,focus``    — comma-separated filter; entries not
+                                  in the catalogue are dropped.
+      * ``limit=8``             — clamp to 1..12; default 8.
+      * ``per_playlist=12``     — clamp to 3..25; default 12.
+
+    Errors mirror the rest of the Jellyfin bridge:
+      * 404 when the bridge is disabled,
+      * 503 when the bridge is not configured / unreachable.
+    """
+    _require_jellyfin_ready(_jellyfin_integration.status())
+    moods_filter = None
+    if mood:
+        moods_filter = [m.strip() for m in mood.split(",") if m.strip()]
+    recommendations = _media_recommendations.recommend_from_jellyfin(
+        moods=moods_filter, limit=limit, per_playlist=per_playlist,
+    )
+    return {
         "recommendations": recommendations,
         "read_only": True,
     }


### PR DESCRIPTION
## Summary

Phase-1 **local media assistant foundation**: a strictly read-only
Jellyfin bridge plus a small deterministic playlist-recommendation
helper. Nova is a *local media assistant*, not an autonomous media
manager — every switch defaults to off, no media files are streamed
or copied, no cloud music API is contacted, no playlist is created
or modified on the Jellyfin server, and the configured API key
never leaves env-local config or the bridge's private
`X-Emby-Token` header.

## Surface (admin-only)

- `GET /integrations/media/jellyfin/status`
- `GET /integrations/media/jellyfin/artists`
- `GET /integrations/media/jellyfin/albums`
- `GET /integrations/media/jellyfin/tracks`
- `GET /integrations/media/jellyfin/genres`
- `GET /integrations/media/jellyfin/playlists`
- `GET /integrations/media/recommendations`

Aggregate `/integrations/status` reports `state: "disabled"` for the
Jellyfin entry to non-admin callers so the UI never leaks the
configured state.

## Modules

- `core/integrations/media/jellyfin.py` — read-only HTTP client
  (status + music artists / albums / tracks / genres / playlists).
- `core/integrations/media/recommendations.py` — pure-Python
  heuristics (genre dictionaries, title-token signals, duration
  nudges) operating on the sanitised track shape so a future Plex
  provider can plug in without touching the playlist logic.

## Configuration

```ini
NOVA_JELLYFIN_ENABLED=false              # default; flip to true to opt in
NOVA_JELLYFIN_URL=http://127.0.0.1:8096
NOVA_JELLYFIN_API_KEY=
NOVA_JELLYFIN_USER_ID=
NOVA_JELLYFIN_READ_ONLY=true             # default; Phase 1 has no writes
NOVA_JELLYFIN_TIMEOUT_SECONDS=5.0
```

## Privacy / safety

- Local-first; no cloud music APIs (Spotify, Tidal, Deezer,
  YouTube, SoundCloud) anywhere in the code path.
- No telemetry, no background polling, no autoplay.
- Read-only HTTP; no playlist create / edit / delete in this PR.
- API key never returned in any JSON, chat context, log, or error.
- Errors are sanitised to short, hard-coded summaries.
- Admin-only endpoints with restricted/non-admin paths returning 403.
- Module-level test asserts no `post / put / patch / delete` calls
  appear in the bridge source.

## Future direction (NOT in this PR)

- Plex support behind the same provider interface.
- Playlist creation gated by an explicit per-request confirmation
  and a separate write switch.
- Auryn-led library population, as a separate project.

## Test plan

- [x] Disabled integration reports `disabled`; no HTTP issued.
- [x] Missing URL / API key reports `not_configured`; no HTTP issued.
- [x] Jellyfin 401 / 5xx / network error sanitised to `unavailable`.
- [x] Artists / albums / tracks / genres / playlists parsing works
      against a mocked Jellyfin response.
- [x] Empty library returns an empty result without raising.
- [x] Recommendation helper is deterministic (same input → same
      output) and produces explainable per-track reasons.
- [x] API key never appears in any response body, header echo, or
      log line.
- [x] Endpoints are admin-only (non-admin / restricted / anonymous
      → 401/403).
- [x] Existing GitHub / SilentGuard / NexaNote / auth / admin tests
      still pass.

Tests added: `tests/test_integrations_media_jellyfin.py` (71 tests).
Docs added: `docs/jellyfin-integration.md`. README updated with the
walkthrough and a one-line privacy commitment.


---
_Generated by [Claude Code](https://claude.ai/code/session_019egmcfQvxrs3ExPHUPLp8i)_