### PR TITLE
perf: batch delete matching memories

### DIFF
--- a/memory/store.py
+++ b/memory/store.py
@@ -203,30 +203,39 @@ def delete_memories_matching(query: str, user_id: int, db_path: str | None = Non
     Deletes ALL of `user_id`'s memories matching the query keywords.
     Returns the count deleted. Memories belonging to other users are
     never touched.
+
+    Uses a single connection/transaction: the read + matching scan + delete
+    all happen on the same `sqlite3.Connection` to avoid the N+1 reconnect
+    pattern that opened a fresh connection per deleted row.
     """
     db_path = _resolve_db_path(db_path)
     words = _tokenize(query)
     if not words:
         return 0
 
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    try:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
         rows = conn.execute(
-            "SELECT * FROM natural_memories WHERE user_id = ?",
+            "SELECT id, topic, content FROM natural_memories WHERE user_id = ?",
             (user_id,),
         ).fetchall()
-    finally:
-        conn.close()
 
-    to_delete = [
-        _row_to_memory(r).id
-        for r in rows
-        if any(w in set(_tokenize(f"{r['topic']} {r['content']}")) for w in words)
-    ]
-    for memory_id in to_delete:
-        delete_memory(memory_id, user_id, db_path=db_path)
-    return len(to_delete)
+        to_delete = [
+            r["id"]
+            for r in rows
+            if any(w in set(_tokenize(f"{r['topic']} {r['content']}")) for w in words)
+        ]
+        if not to_delete:
+            return 0
+
+        # Placeholders are built from a fixed `?` literal, never user input,
+        # so this remains a fully parameterized query.
+        placeholders = ",".join(["?"] * len(to_delete))
+        conn.execute(
+            f"DELETE FROM natural_memories WHERE user_id = ? AND id IN ({placeholders})",
+            (user_id, *to_delete),
+        )
+        return len(to_delete)
 
 
 # ── private helpers ────────────────────────────────────────────────────────────

--- a/tests/test_natural_memory.py
+++ b/tests/test_natural_memory.py
@@ -325,6 +325,55 @@ class TestForgetCommand:
         count = delete_memories_matching("kubernetes", uid, db_path=tmp_db)
         assert count == 0
 
+    def test_forget_empty_query_returns_zero(self, tmp_db, uid):
+        save_memory(_mem(topic="fedora", content="User prefers Fedora."), uid, db_path=tmp_db)
+        assert delete_memories_matching("", uid, db_path=tmp_db) == 0
+        assert delete_memories_matching("   ", uid, db_path=tmp_db) == 0
+        # Memory must remain untouched.
+        assert len(list_memories(uid, db_path=tmp_db)) == 1
+
+    def test_forget_one_match_deletes_only_that_memory(self, tmp_db, uid):
+        save_memory(_mem(topic="fedora", content="User prefers Fedora KDE."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="neovim", content="User uses neovim."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="hardware", content="User has 32GB RAM."), uid, db_path=tmp_db)
+        count = delete_memories_matching("fedora", uid, db_path=tmp_db)
+        assert count == 1
+        remaining = list_memories(uid, db_path=tmp_db)
+        assert len(remaining) == 2
+        assert all("Fedora" not in m.content for m in remaining)
+
+    def test_forget_does_not_open_a_connection_per_match(self, tmp_db, uid):
+        """
+        Regression for issue #68: deleting N matching memories must not
+        delegate to `delete_memory()` in a loop (which would open a new
+        SQLite connection per row).
+        """
+        save_memory(_mem(topic="ubuntu", content="User tried Ubuntu once."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="ubuntu2", content="User disliked Ubuntu."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="ubuntu3", content="User uninstalled Ubuntu."), uid, db_path=tmp_db)
+        with patch("memory.store.delete_memory") as mock_delete:
+            count = delete_memories_matching("ubuntu", uid, db_path=tmp_db)
+        assert count == 3
+        mock_delete.assert_not_called()
+        assert list_memories(uid, db_path=tmp_db) == []
+
+    def test_forget_does_not_touch_other_users(self, tmp_db, uid):
+        # Second user with an Ubuntu memory must survive a forget by `uid`.
+        with sqlite3.connect(tmp_db) as conn:
+            users.create_user(conn, "bob", "pw", role=users.ROLE_USER)
+            other_uid = conn.execute(
+                "SELECT id FROM users WHERE username = ?", ("bob",)
+            ).fetchone()[0]
+        save_memory(_mem(topic="ubuntu", content="Alice tried Ubuntu."), uid, db_path=tmp_db)
+        save_memory(_mem(topic="ubuntu", content="Bob loves Ubuntu."), other_uid, db_path=tmp_db)
+
+        count = delete_memories_matching("ubuntu", uid, db_path=tmp_db)
+        assert count == 1
+        assert list_memories(uid, db_path=tmp_db) == []
+        remaining_other = list_memories(other_uid, db_path=tmp_db)
+        assert len(remaining_other) == 1
+        assert "Bob" in remaining_other[0].content
+
 
 # ── v2: embeddings ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes the N+1 SQLite connection/transaction pattern in `memory/store.py::delete_memories_matching()` (issue #68). Previously the function read all candidate rows on one connection, then called `delete_memory()` in a loop — each iteration opened a fresh `sqlite3.connect(...)` and committed its own transaction.

Now the read, the keyword-match scan, and the delete all run on a single `sqlite3.Connection`. Deletion uses one parameterized `DELETE … WHERE user_id = ? AND id IN (?, ?, …)` statement. The placeholder list is built from a fixed `?` literal (never from user input), so the query stays fully parameterized and SQL-injection-safe.

Short-circuits unchanged: empty / whitespace queries and no-match runs return `0` without issuing a DELETE.

## Behaviour preserved

- Same matching semantics (`_tokenize` keyword overlap)
- Same scoping (other users' memories are never touched)
- Same return value (count of deleted rows)
- No changes to schema, extractor, policy, retriever, importer, feedback, chat, or web routes

## Test plan

- [x] New `tests/test_natural_memory.py::TestForgetCommand` cases:
  - `test_forget_empty_query_returns_zero` — empty + whitespace-only queries return 0 and leave rows intact
  - `test_forget_one_match_deletes_only_that_memory` — single match deletes exactly one row, non-matches survive
  - `test_forget_does_not_open_a_connection_per_match` — patches `memory.store.delete_memory` and asserts it is **not** called when 3 rows match (regression guard)
  - `test_forget_does_not_touch_other_users` — multi-user isolation still holds
- [x] All existing `TestForgetCommand` cases still pass (single match, multi match, no match)
- [x] `tests/test_natural_memory.py` — 70/70 pass
- [x] `tests/test_memory.py`, `test_memory_command.py`, `test_memory_parsing.py`, `test_memory_scoping.py` — 57/57 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwHfjmbof13VDV3kuoyXS3)_