### PR TITLE
feat(chat): edit and delete sent chat messages (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 ### Added
+- Edit and delete sent chat messages from the chat UI (issue #94). Two
+  new auth-gated endpoints, `PUT /messages/{id}` and
+  `DELETE /messages/{id}`, accept content edits and message deletes
+  scoped to the caller's conversations. Cross-user requests return 404
+  to avoid leaking existence. Deleting a user message can optionally
+  remove the paired assistant reply by passing
+  `?cascade_assistant=true`; assistant deletes never cascade. Editing
+  rewrites the message in place — it does not regenerate Nova's reply
+  (regenerate-after-edit is left as an explicit follow-up). Memory
+  entries are deliberately untouched: editing or deleting a chat
+  message never removes memories already extracted from it. Feedback
+  rows attached to a deleted message id are cleaned up so the local
+  feedback table never carries dangling references. The chat-stream
+  `done` event now also surfaces `user_message_id` so the browser can
+  attach edit/delete controls to the just-sent user bubble without a
+  conversation reload.
 - Read-only GitHub maintainer triage helper (issue #119 follow-up).
   A new admin-only endpoint, `GET /integrations/github/recommendations`,
   surfaces a short ranked list of open issues a maintainer might want

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Shipped today:
   override the identity contract or the Nova Safety and Trust Contract.
   See [docs/nova-safety-and-trust-contract.md](docs/nova-safety-and-trust-contract.md)
   for the boundaries this layer sits inside.
+- **Edit and delete sent messages.** Every chat message can be edited
+  (user messages) or deleted (user and assistant messages) from the
+  chat UI. Deleting a user message can optionally remove the paired
+  assistant reply in the same exchange. Editing rewrites the message
+  in place; it does not regenerate Nova's reply — re-send the edited
+  text as a new message if you want a fresh answer. Memory cleanup is
+  intentionally a separate, explicit action: editing or deleting a
+  chat message never erases memories that were already extracted from
+  it. Endpoints: `PUT /messages/{id}` and `DELETE /messages/{id}`,
+  both auth-gated and scoped to the caller's conversations.
 - **Voice / read-aloud.** Every assistant message has a "Read aloud"
   button. The default engine is the browser's local
   `speechSynthesis` API; an optional local [Piper](https://github.com/rhasspy/piper)

--- a/core/memory.py
+++ b/core/memory.py
@@ -370,6 +370,171 @@ def delete_conversation(conversation_id: int, user_id: int) -> bool:
     return True
 
 
+# Cap on edited message length. The textarea in the chat input is
+# unbounded, but a server-side cap stops a crafted client from writing a
+# multi-megabyte row that would later inflate the prompt history.
+MESSAGE_CONTENT_MAX_LEN = 32_000
+
+
+def get_owned_message(message_id: int, user_id: int) -> Optional[dict]:
+    """Return ``{id, conversation_id, role, content, model, created}`` for
+    a message that belongs to a conversation owned by ``user_id``, else
+    ``None``.
+
+    The ownership check goes through the conversations table so a user
+    cannot read or mutate another user's message even if they guessed
+    the id.
+    """
+    with _get_connection() as conn:
+        row = conn.execute(
+            "SELECT m.id, m.conversation_id, m.role, m.content, m.model, "
+            "       m.created "
+            "FROM messages m "
+            "JOIN conversations c ON c.id = m.conversation_id "
+            "WHERE m.id = ? AND c.user_id = ?",
+            (message_id, user_id),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "conversation_id": row["conversation_id"],
+        "role": row["role"],
+        "content": row["content"],
+        "model": row["model"],
+        "created": row["created"],
+    }
+
+
+def update_message_content(
+    message_id: int, user_id: int, content: str
+) -> Optional[dict]:
+    """
+    Replace the content of an owned message and return its new state.
+
+    Ownership is enforced via ``get_owned_message`` so a foreign user
+    cannot mutate someone else's row. The conversation's ``updated``
+    timestamp is bumped so the sidebar reflects the recent activity.
+
+    Returns ``None`` when the message does not exist or does not belong
+    to ``user_id``. The caller is responsible for length / emptiness
+    validation: this helper trusts its inputs.
+    """
+    existing = get_owned_message(message_id, user_id)
+    if existing is None:
+        return None
+    with _get_connection() as conn:
+        conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            (content, message_id),
+        )
+    update_conversation_timestamp(existing["conversation_id"])
+    existing["content"] = content
+    return existing
+
+
+def find_following_assistant_message(message_id: int) -> Optional[int]:
+    """
+    Return the id of the assistant message that immediately follows
+    ``message_id`` within the same conversation, or ``None`` if the
+    next message is not from the assistant (or there is no next
+    message).
+
+    Used by the optional cascade in :func:`delete_message` so deleting a
+    user message can clean up the paired assistant reply in the same
+    exchange.
+    """
+    with _get_connection() as conn:
+        row = conn.execute(
+            "SELECT conversation_id, created FROM messages WHERE id = ?",
+            (message_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        # The "next" message is the one with the smallest (created, id)
+        # tuple strictly greater than the current row's. Tie-breaking on
+        # id keeps the order deterministic when two rows share a
+        # timestamp (which can happen in fast tests).
+        nxt = conn.execute(
+            "SELECT id, role FROM messages "
+            "WHERE conversation_id = ? "
+            "  AND (created > ? OR (created = ? AND id > ?)) "
+            "ORDER BY created ASC, id ASC "
+            "LIMIT 1",
+            (row["conversation_id"], row["created"], row["created"], message_id),
+        ).fetchone()
+    if nxt is None or nxt["role"] != "assistant":
+        return None
+    return int(nxt["id"])
+
+
+def delete_message(
+    message_id: int,
+    user_id: int,
+    cascade_assistant: bool = False,
+) -> Optional[dict]:
+    """
+    Delete an owned message. When ``cascade_assistant`` is True and the
+    deleted message is a user message whose next sibling is an assistant
+    reply, that assistant reply is removed as part of the same
+    transaction.
+
+    Any feedback rows attached to a deleted message id are removed too,
+    so the local feedback table never carries an entry whose target is
+    gone. Memory entries are deliberately left alone — memory cleanup
+    is a separate, explicit user action (see issue #94).
+
+    Returns a small summary dict on success:
+
+      ``{"deleted_id": <id>, "cascaded_assistant_id": <id or None>}``
+
+    Returns ``None`` if the message does not exist or does not belong to
+    ``user_id`` — the caller translates that into a 404 so cross-user
+    access never leaks existence.
+    """
+    existing = get_owned_message(message_id, user_id)
+    if existing is None:
+        return None
+
+    cascaded_assistant_id: Optional[int] = None
+    if cascade_assistant and existing["role"] == "user":
+        cascaded_assistant_id = find_following_assistant_message(message_id)
+
+    with _get_connection() as conn:
+        conn.execute(
+            "DELETE FROM messages WHERE id = ?", (message_id,),
+        )
+        # Best-effort cleanup of any feedback row whose target message
+        # is now gone. The table exists once the feedback migration has
+        # run; on a partially-initialised DB the OperationalError is
+        # ignored so message deletion still succeeds.
+        try:
+            conn.execute(
+                "DELETE FROM message_feedback WHERE message_id = ?",
+                (message_id,),
+            )
+        except sqlite3.OperationalError:
+            pass
+        if cascaded_assistant_id is not None:
+            conn.execute(
+                "DELETE FROM messages WHERE id = ?",
+                (cascaded_assistant_id,),
+            )
+            try:
+                conn.execute(
+                    "DELETE FROM message_feedback WHERE message_id = ?",
+                    (cascaded_assistant_id,),
+                )
+            except sqlite3.OperationalError:
+                pass
+
+    update_conversation_timestamp(existing["conversation_id"])
+    return {
+        "deleted_id": message_id,
+        "cascaded_assistant_id": cascaded_assistant_id,
+    }
+
+
 def list_memories(user_id: int) -> list[dict]:
     """Liste les souvenirs de `user_id` avec id et created — pour l'interface web."""
     with _get_connection() as conn:

--- a/static/index.html
+++ b/static/index.html
@@ -1415,6 +1415,208 @@
             background: var(--cyan-soft);
         }
 
+        /* ── PER-MESSAGE EDIT / DELETE ──
+           A second, smaller action row that appears next to each user
+           message (and a single delete control on assistant messages).
+           Kept visually quieter than the feedback row so it never
+           competes with the existing thumbs-up / thumbs-down chrome.
+
+           Visibility: actions are dimmed at rest and fade up on hover
+           or keyboard focus inside the row. Touch devices keep them
+           visible because hover state never resolves. */
+        .msg-edit-actions {
+            display: flex;
+            gap: 2px;
+            margin-top: 4px;
+            opacity: 0;
+            transition: opacity var(--t-base);
+        }
+        .message-row:hover .msg-edit-actions,
+        .message-row:focus-within .msg-edit-actions {
+            opacity: 1;
+        }
+        @media (hover: none) {
+            .msg-edit-actions { opacity: 0.8; }
+        }
+        .message-row.user .msg-edit-actions {
+            align-self: flex-end;
+        }
+        .message-row.nova .msg-edit-actions {
+            align-self: flex-start;
+            /* Sits between the bubble and the feedback row to keep the
+               visual hierarchy: bubble → quick actions → feedback. */
+            margin-top: 2px;
+        }
+
+        .msg-edit-action {
+            appearance: none;
+            -webkit-appearance: none;
+            background: transparent;
+            border: none;
+            border-radius: var(--r-sm);
+            color: var(--text-dim);
+            cursor: pointer;
+            padding: 0;
+            width: 26px;
+            height: 26px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition:
+                color var(--t-base),
+                background var(--t-base),
+                transform var(--t-fast);
+        }
+        .msg-edit-action svg {
+            width: 14px;
+            height: 14px;
+            display: block;
+            stroke: currentColor;
+        }
+        .msg-edit-action:hover {
+            color: var(--text);
+            background: rgba(255, 255, 255, 0.05);
+        }
+        .msg-edit-action:focus { outline: none; }
+        .msg-edit-action:focus-visible {
+            color: var(--text);
+            box-shadow: 0 0 0 2px var(--cyan-glow);
+        }
+        .msg-edit-action.danger:hover {
+            color: var(--danger);
+            background: rgba(224, 136, 129, 0.07);
+        }
+        .msg-edit-action:active { transform: scale(0.94); }
+
+        /* Inline edit form replacing the user bubble while editing.
+           Mirrors the calm visual language of the feedback reason
+           form: soft border, gentle background, no hard shadows. */
+        .msg-edit-form {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            width: 100%;
+            max-width: 75%;
+            padding: 8px 10px;
+            border: 1px solid var(--border-soft);
+            border-radius: var(--r-md);
+            background: rgba(255, 255, 255, 0.025);
+        }
+        .message-row.user .msg-edit-form { align-self: flex-end; }
+        .message-row.nova .msg-edit-form { align-self: flex-start; }
+        .msg-edit-input {
+            width: 100%;
+            min-height: 60px;
+            max-height: 240px;
+            resize: vertical;
+            padding: 6px 8px;
+            background: transparent;
+            color: var(--text);
+            border: 1px solid var(--border-soft);
+            border-radius: var(--r-sm);
+            font: inherit;
+            font-size: 0.9rem;
+            line-height: 1.45;
+        }
+        .msg-edit-input:focus {
+            outline: none;
+            border-color: var(--cyan-glow);
+            box-shadow: 0 0 0 1px var(--cyan-glow);
+        }
+        .msg-edit-btns {
+            display: flex;
+            justify-content: flex-end;
+            gap: 6px;
+        }
+        .msg-edit-save,
+        .msg-edit-cancel {
+            appearance: none;
+            -webkit-appearance: none;
+            background: transparent;
+            border: 1px solid var(--border-soft);
+            color: var(--text-dim);
+            border-radius: var(--r-sm);
+            padding: 4px 12px;
+            font: inherit;
+            font-size: 0.78rem;
+            letter-spacing: 0.02em;
+            cursor: pointer;
+            transition:
+                color var(--t-base),
+                border-color var(--t-base),
+                background var(--t-base);
+        }
+        .msg-edit-save:hover,
+        .msg-edit-cancel:hover { color: var(--text); }
+        .msg-edit-save {
+            color: var(--cyan);
+            border-color: var(--cyan-glow);
+        }
+        .msg-edit-save:hover { background: var(--cyan-soft); }
+        .msg-edit-save:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+        .msg-edit-note {
+            font-size: 0.7rem;
+            color: var(--text-dim);
+            line-height: 1.35;
+            margin-top: -2px;
+        }
+
+        /* Inline confirmation that replaces the action row when the
+           user clicks "delete". Reuses the same visual language as
+           the conversation-delete confirm in the sidebar. */
+        .msg-delete-confirm {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-top: 4px;
+            padding: 4px 8px;
+            border: 1px solid var(--border-soft);
+            border-radius: var(--r-sm);
+            background: rgba(224, 136, 129, 0.05);
+            font-size: 0.75rem;
+            color: var(--text-dim);
+        }
+        .message-row.user .msg-delete-confirm { align-self: flex-end; }
+        .message-row.nova .msg-delete-confirm { align-self: flex-start; }
+        .msg-delete-confirm-text {
+            line-height: 1.35;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 360px;
+        }
+        .msg-delete-confirm-btns {
+            display: inline-flex;
+            gap: 4px;
+            flex-shrink: 0;
+        }
+        .msg-delete-confirm-yes,
+        .msg-delete-confirm-no {
+            appearance: none;
+            -webkit-appearance: none;
+            background: transparent;
+            border: 1px solid var(--border-soft);
+            color: var(--text-dim);
+            border-radius: var(--r-sm);
+            padding: 2px 8px;
+            font: inherit;
+            font-size: 0.74rem;
+            cursor: pointer;
+            transition:
+                color var(--t-base),
+                border-color var(--t-base),
+                background var(--t-base);
+        }
+        .msg-delete-confirm-no:hover { color: var(--text); }
+        .msg-delete-confirm-yes:hover {
+            color: var(--danger);
+            border-color: rgba(224, 136, 129, 0.4);
+            background: rgba(224, 136, 129, 0.08);
+        }
+
         /* ── "Nova is speaking" indicator ──
            Sits inside the assistant message row, just below the bubble and
            above the action row, only while audio is playing. Designed to
@@ -3173,6 +3375,17 @@
             feedback_reason_saved: "Préférence enregistrée.",
             feedback_reason_error: "Impossible d'enregistrer la préférence.",
             nova_actions: "Actions du message",
+            message_actions_label: "Modifier ou supprimer ce message",
+            edit_message: "Modifier ce message",
+            delete_message: "Supprimer ce message",
+            edit_save: "Enregistrer",
+            edit_cancel: "Annuler",
+            edit_empty_error: "Le message ne peut pas être vide.",
+            edit_save_error: "Impossible d'enregistrer la modification.",
+            edit_no_regenerate_note: "Modifier ne régénère pas la réponse de Nova. Envoie le texte modifié comme nouveau message pour obtenir une nouvelle réponse.",
+            delete_confirm: "Supprimer ce message ?",
+            delete_confirm_with_reply: "Supprimer ce message et la réponse de Nova qui le suit ?",
+            delete_error: "Impossible de supprimer ce message.",
             mode: "Mode",
             mode_auto_desc: "Choisit automatiquement le bon mode",
             mode_chat_desc: "Conversation et questions du jour",
@@ -3346,6 +3559,17 @@
             feedback_reason_saved: "Preference noted.",
             feedback_reason_error: "Could not save preference.",
             nova_actions: "Message actions",
+            message_actions_label: "Edit or delete this message",
+            edit_message: "Edit this message",
+            delete_message: "Delete this message",
+            edit_save: "Save",
+            edit_cancel: "Cancel",
+            edit_empty_error: "Message cannot be empty.",
+            edit_save_error: "Could not save the edit.",
+            edit_no_regenerate_note: "Editing does not regenerate Nova's reply. Send the edited text as a new message to get a fresh answer.",
+            delete_confirm: "Delete this message?",
+            delete_confirm_with_reply: "Delete this message and the Nova reply that follows it?",
+            delete_error: "Could not delete this message.",
             mode: "Mode",
             mode_auto_desc: "Picks the right mode automatically",
             mode_chat_desc: "Everyday chat and questions",
@@ -5295,6 +5519,8 @@
         check: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12.5l4 4 10-10"/></svg>`,
         speaker: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 5L6 9H4a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h2l5 4z"/><path d="M15.5 8.5a5 5 0 0 1 0 7"/><path d="M18.5 5.5a9 9 0 0 1 0 13"/></svg>`,
         stop: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="6.5" y="6.5" width="11" height="11" rx="2"/></svg>`,
+        edit: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.5 4.5l5 5"/><path d="M4 20l4.5-1 11-11a1.8 1.8 0 0 0 0-2.5l-1-1a1.8 1.8 0 0 0-2.5 0l-11 11L4 20z"/></svg>`,
+        trash: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M9 7V5a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 5v2"/><path d="M6 7l1 12.5A1.5 1.5 0 0 0 8.5 21h7a1.5 1.5 0 0 0 1.5-1.5L18 7"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>`,
     };
 
     function makeActionButton(kind, label, html) {
@@ -5634,6 +5860,10 @@
         // Raw model id is kept on the row for devtools-only inspection;
         // it is intentionally not rendered in the user-facing label.
         if (model) row.dataset.model = model;
+        // Stable message id (when known) drives the edit/delete
+        // endpoints. Kept on the row dataset so the inline edit/delete
+        // helpers can find it regardless of which descendant was clicked.
+        if (messageId != null) row.dataset.messageId = String(messageId);
 
         const label = document.createElement("div");
         label.className = "message-label";
@@ -5645,6 +5875,9 @@
         // message-level copy button reproduces exactly what Nova returned,
         // without the noise of injected copy-button labels.
         if (role === "nova" && content) bubble.dataset.rawText = content;
+        // User bubbles need the raw text too so the inline editor can
+        // populate its textarea with the exact original message.
+        if (role === "user" && content) bubble.dataset.rawText = content;
 
         if (imageB64) {
             const img = document.createElement("img");
@@ -5669,6 +5902,16 @@
         row.appendChild(label);
         row.appendChild(bubble);
 
+        // Per-message edit/delete row. User messages get edit + delete,
+        // assistant messages get delete only (editing the model's reply
+        // is intentionally out of scope for v1 — see issue #94). Image
+        // only turns and rows without a known message id show no
+        // controls so the user can never click against a non-targetable
+        // bubble.
+        if (messageId != null && content) {
+            buildEditDeleteActions(row, bubble, role);
+        }
+
         if (role === "nova" && content) {
             // The integrated action row (like / dislike / copy / read-aloud)
             // sits as a sibling of the bubble inside the row. Skipping it
@@ -5686,6 +5929,273 @@
             badge.dataset.model = model;
         }
         return bubble;
+    }
+
+    // ── PER-MESSAGE EDIT / DELETE ──
+    //
+    // Adds the quiet "edit" / "delete" pair next to a rendered message
+    // row. The handlers below talk to the PUT/DELETE /messages/{id}
+    // endpoints and update the DOM in place — there is no full page
+    // reload, but reloading the conversation must produce the same
+    // state because the backend is the source of truth.
+    //
+    // A few small invariants:
+    //   * The row's `data-message-id` is required for any action; if
+    //     it is missing (image-only turns, mid-stream rows) the
+    //     controls are not built at all.
+    //   * `cascade_assistant` is requested only when deleting a user
+    //     message whose immediate sibling in the DOM is a Nova row —
+    //     this mirrors the "same exchange" rule the backend enforces.
+    //   * Memory entries are intentionally never touched by these
+    //     handlers; the user controls memory cleanup separately.
+
+    function getMessageId(row) {
+        const raw = row && row.dataset ? row.dataset.messageId : null;
+        const n = raw ? parseInt(raw, 10) : NaN;
+        return Number.isFinite(n) ? n : null;
+    }
+
+    function hasFollowingAssistantSibling(row) {
+        const next = row.nextElementSibling;
+        return !!(next && next.classList && next.classList.contains("message-row")
+            && next.classList.contains("nova"));
+    }
+
+    function buildEditDeleteActions(row, bubble, role) {
+        const actions = document.createElement("div");
+        actions.className = "msg-edit-actions";
+        actions.setAttribute("role", "toolbar");
+        actions.setAttribute("aria-label", t("message_actions_label"));
+
+        if (role === "user") {
+            const editBtn = document.createElement("button");
+            editBtn.type = "button";
+            editBtn.className = "msg-edit-action";
+            editBtn.setAttribute("aria-label", t("edit_message"));
+            editBtn.setAttribute("title", t("edit_message"));
+            editBtn.innerHTML = ACTION_SVG.edit;
+            editBtn.onclick = (e) => {
+                e.stopPropagation();
+                openInlineEditor(row, bubble);
+            };
+            actions.appendChild(editBtn);
+        }
+
+        const deleteBtn = document.createElement("button");
+        deleteBtn.type = "button";
+        deleteBtn.className = "msg-edit-action danger";
+        deleteBtn.setAttribute("aria-label", t("delete_message"));
+        deleteBtn.setAttribute("title", t("delete_message"));
+        deleteBtn.innerHTML = ACTION_SVG.trash;
+        deleteBtn.onclick = (e) => {
+            e.stopPropagation();
+            openDeleteConfirm(row, role);
+        };
+        actions.appendChild(deleteBtn);
+
+        row.appendChild(actions);
+        return actions;
+    }
+
+    function openInlineEditor(row, bubble) {
+        const id = getMessageId(row);
+        if (id == null) return;
+        // Replace the bubble with a textarea + save/cancel pair. The
+        // raw text is taken from the bubble dataset so we recover the
+        // exact original (no markdown re-parsing artefacts for user
+        // messages, which are plain text anyway).
+        if (row.querySelector(".msg-edit-form")) return;
+
+        const original = bubble.dataset.rawText || bubble.innerText || "";
+
+        const form = document.createElement("div");
+        form.className = "msg-edit-form";
+
+        const ta = document.createElement("textarea");
+        ta.className = "msg-edit-input";
+        ta.value = original;
+        ta.maxLength = 32000;
+        ta.setAttribute("aria-label", t("edit_message"));
+
+        const note = document.createElement("div");
+        note.className = "msg-edit-note";
+        note.textContent = t("edit_no_regenerate_note");
+
+        const btns = document.createElement("div");
+        btns.className = "msg-edit-btns";
+        const cancelBtn = document.createElement("button");
+        cancelBtn.type = "button";
+        cancelBtn.className = "msg-edit-cancel";
+        cancelBtn.textContent = t("edit_cancel");
+        const saveBtn = document.createElement("button");
+        saveBtn.type = "button";
+        saveBtn.className = "msg-edit-save";
+        saveBtn.textContent = t("edit_save");
+
+        btns.appendChild(cancelBtn);
+        btns.appendChild(saveBtn);
+        form.appendChild(ta);
+        form.appendChild(note);
+        form.appendChild(btns);
+
+        // Hide the bubble and the action row while editing — keeps the
+        // surface uncluttered and prevents the user from interacting
+        // with stale rendered content.
+        bubble.style.display = "none";
+        const editActions = row.querySelector(".msg-edit-actions");
+        if (editActions) editActions.style.display = "none";
+
+        row.appendChild(form);
+        ta.focus();
+        // Place caret at the end so the textarea feels like a natural
+        // continuation of the original message.
+        try { ta.setSelectionRange(ta.value.length, ta.value.length); } catch {}
+
+        const restoreBubble = () => {
+            if (form.isConnected) form.remove();
+            bubble.style.display = "";
+            if (editActions) editActions.style.display = "";
+        };
+
+        cancelBtn.onclick = (e) => {
+            e.stopPropagation();
+            restoreBubble();
+        };
+
+        ta.addEventListener("keydown", (e) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                restoreBubble();
+            } else if ((e.key === "Enter") && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                saveBtn.click();
+            }
+        });
+
+        saveBtn.onclick = async (e) => {
+            e.stopPropagation();
+            const next = ta.value;
+            if (!next.trim()) {
+                showInlineError(form, t("edit_empty_error"));
+                return;
+            }
+            if (next === original) {
+                restoreBubble();
+                return;
+            }
+            saveBtn.disabled = true;
+            try {
+                const res = await fetch(`/messages/${id}`, {
+                    method: "PUT",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Authorization": `Bearer ${token}`,
+                    },
+                    body: JSON.stringify({ content: next }),
+                });
+                if (res.status === 401) { logout(); return; }
+                if (!res.ok) {
+                    let detail = "";
+                    try { detail = (await res.json())?.detail || ""; } catch {}
+                    showInlineError(form, detail || t("edit_save_error"));
+                    saveBtn.disabled = false;
+                    return;
+                }
+                // Success: update the bubble text + dataset, restore.
+                bubble.dataset.rawText = next;
+                bubble.textContent = "";
+                const span = document.createElement("span");
+                span.textContent = next;
+                bubble.appendChild(span);
+                restoreBubble();
+            } catch {
+                showInlineError(form, t("edit_save_error"));
+                saveBtn.disabled = false;
+            }
+        };
+    }
+
+    function showInlineError(container, text) {
+        let err = container.querySelector(".msg-edit-error");
+        if (!err) {
+            err = document.createElement("div");
+            err.className = "msg-edit-error msg-edit-note";
+            err.style.color = "var(--danger)";
+            container.appendChild(err);
+        }
+        err.textContent = text;
+    }
+
+    function openDeleteConfirm(row, role) {
+        const id = getMessageId(row);
+        if (id == null) return;
+        if (row.querySelector(".msg-delete-confirm")) return;
+
+        const editActions = row.querySelector(".msg-edit-actions");
+        if (editActions) editActions.style.display = "none";
+
+        const willCascade = role === "user" && hasFollowingAssistantSibling(row);
+        const confirm = document.createElement("div");
+        confirm.className = "msg-delete-confirm";
+
+        const text = document.createElement("span");
+        text.className = "msg-delete-confirm-text";
+        text.textContent = willCascade
+            ? t("delete_confirm_with_reply")
+            : t("delete_confirm");
+        confirm.appendChild(text);
+
+        const btns = document.createElement("span");
+        btns.className = "msg-delete-confirm-btns";
+        const noBtn = document.createElement("button");
+        noBtn.type = "button";
+        noBtn.className = "msg-delete-confirm-no";
+        noBtn.textContent = t("confirm_no");
+        const yesBtn = document.createElement("button");
+        yesBtn.type = "button";
+        yesBtn.className = "msg-delete-confirm-yes";
+        yesBtn.textContent = t("confirm_yes");
+        btns.appendChild(noBtn);
+        btns.appendChild(yesBtn);
+        confirm.appendChild(btns);
+        row.appendChild(confirm);
+
+        const restore = () => {
+            if (confirm.isConnected) confirm.remove();
+            if (editActions) editActions.style.display = "";
+        };
+        noBtn.onclick = (e) => {
+            e.stopPropagation();
+            restore();
+        };
+        yesBtn.onclick = async (e) => {
+            e.stopPropagation();
+            yesBtn.disabled = true;
+            try {
+                const qs = willCascade ? "?cascade_assistant=true" : "";
+                const res = await fetch(`/messages/${id}${qs}`, {
+                    method: "DELETE",
+                    headers: { "Authorization": `Bearer ${token}` },
+                });
+                if (res.status === 401) { logout(); return; }
+                if (!res.ok) {
+                    yesBtn.disabled = false;
+                    text.textContent = t("delete_error");
+                    return;
+                }
+                // Drop this row from the DOM, and the next assistant
+                // row too if we asked the backend to cascade.
+                const next = row.nextElementSibling;
+                if (row.parentNode) row.parentNode.removeChild(row);
+                if (willCascade && next && next.classList.contains("message-row")
+                    && next.classList.contains("nova")) {
+                    if (next.parentNode) next.parentNode.removeChild(next);
+                }
+            } catch {
+                yesBtn.disabled = false;
+                text.textContent = t("delete_error");
+            }
+        };
     }
 
     // Append an empty Nova bubble that the streaming reader will fill in
@@ -5779,6 +6289,18 @@
                 bubble.appendChild(rendered);
                 attachCodeBlockCopyButtons(rendered);
 
+                // Stamp the row with the assistant message id so the
+                // edit/delete helpers can target it later. The user
+                // bubble immediately above will also have its id set
+                // by the next conversation reload; for now, the user
+                // row stays editable through whatever id was assigned
+                // when the message was first sent (which is null until
+                // the conversation is reloaded — that's fine for v1).
+                if (messageId != null) {
+                    row.dataset.messageId = String(messageId);
+                    buildEditDeleteActions(row, bubble, "nova");
+                }
+
                 buildAssistantActions(row, bubble, buffer, messageId || null);
                 if (isScrolledNearBottom(messagesEl)) {
                     messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -5821,7 +6343,12 @@
         userCancelledChat = false;
         setSendButtonToStop();
 
-        appendMessage("user", text || "", null, currentImage);
+        // The just-rendered user bubble; once the stream's `done`
+        // event arrives we stamp the row with its persisted id so the
+        // edit/delete controls have a target.
+        const userBubble = appendMessage("user", text || "", null, currentImage);
+        const userRow = userBubble && userBubble.parentNode
+            ? userBubble.parentNode : null;
 
         const messagesEl = document.getElementById("messages");
         const thinkingRow = document.createElement("div");
@@ -5869,7 +6396,7 @@
                 return;
             }
 
-            const result = await consumeChatStream(res.body, thinkingRow);
+            const result = await consumeChatStream(res.body, thinkingRow, userRow);
 
             if (!userCancelledChat && result.conversationId) {
                 currentConvId = result.conversationId;
@@ -5912,7 +6439,7 @@
     // uses to decide post-stream actions (refresh sidebar, surface
     // errors). Resolves cleanly on `done`, `error`, or end-of-stream;
     // throws only on AbortError (handled upstream).
-    async function consumeChatStream(body, thinkingRow) {
+    async function consumeChatStream(body, thinkingRow, userRow) {
         const reader = body.getReader();
         const decoder = new TextDecoder("utf-8");
         let pending = "";
@@ -5920,6 +6447,7 @@
         const result = {
             conversationId: null,
             model: null,
+            userMessageId: null,
             assistantMessageId: null,
             errored: false,
             errorDetail: "",
@@ -5956,6 +6484,9 @@
                         result.conversationId = event.conversation_id;
                     }
                     if (event.model) result.model = event.model;
+                    if (event.user_message_id != null) {
+                        result.userMessageId = event.user_message_id;
+                    }
                     if (event.assistant_message_id != null) {
                         result.assistantMessageId = event.assistant_message_id;
                     }
@@ -5976,6 +6507,18 @@
                         result.errorDetail = result.errorDetail
                             || "Nova didn't produce a reply. Please try again.";
                         break;
+                    }
+                    // Stamp the user bubble with its persisted id and
+                    // attach the same quiet edit/delete controls the
+                    // conversation-reload path uses. The user row is
+                    // already in the DOM at this point.
+                    if (userRow && result.userMessageId != null
+                            && !userRow.dataset.messageId) {
+                        userRow.dataset.messageId = String(result.userMessageId);
+                        const userBubble = userRow.querySelector(".message.user");
+                        if (userBubble) {
+                            buildEditDeleteActions(userRow, userBubble, "user");
+                        }
                     }
                     activeStreamBubble.finalise(
                         result.model,

--- a/tests/test_message_edit_delete.py
+++ b/tests/test_message_edit_delete.py
@@ -1,0 +1,504 @@
+"""
+HTTP + data-layer tests for the message edit / delete endpoints
+(issue #94 — PUT/DELETE /messages/{id}).
+
+The tests pin the user-visible contract:
+
+  * a user can edit / delete their own chat messages;
+  * ownership is enforced at every level — a cross-user request gets
+    a 404, never a 200 + silent failure or a 403 that leaks existence;
+  * editing rejects empty / oversized content with a sanitised error;
+  * deleting a user message can optionally cascade to the immediately
+    following assistant reply (and only when explicitly asked);
+  * deleting a message does NOT remove memory entries — memory cleanup
+    is a separate, explicit user action;
+  * a conversation reload after edit/delete reflects the new state.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import memory as core_memory, users, feedback as core_feedback  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password, role=role)
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_exchange(db_path, owner_id, *, user_text="hello", reply_text="hi"):
+    """Create a conversation owned by `owner_id` and a user/assistant pair.
+
+    Returns ``(conversation_id, user_message_id, assistant_message_id)``.
+    """
+    conv_id = core_memory.create_conversation("exchange", owner_id)
+    user_id_msg = core_memory.save_message(conv_id, "user", user_text)
+    asst_id_msg = core_memory.save_message(
+        conv_id, "assistant", reply_text, "stub-model"
+    )
+    return conv_id, user_id_msg, asst_id_msg
+
+
+# ── Data-layer ──────────────────────────────────────────────────────────────
+
+
+class TestDataLayer:
+    def test_get_owned_message_returns_dict_for_owner(self, db_path):
+        a = _make_user(db_path, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, a)
+        row = core_memory.get_owned_message(uid_msg, a)
+        assert row is not None
+        assert row["role"] == "user"
+        assert row["content"] == "hello"
+
+    def test_get_owned_message_returns_none_for_other_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, a)
+        assert core_memory.get_owned_message(uid_msg, b) is None
+
+    def test_get_owned_message_returns_none_for_missing_id(self, db_path):
+        a = _make_user(db_path, "alice")
+        assert core_memory.get_owned_message(99999, a) is None
+
+    def test_update_message_content_persists(self, db_path):
+        a = _make_user(db_path, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, a)
+        updated = core_memory.update_message_content(uid_msg, a, "edited!")
+        assert updated is not None
+        assert updated["content"] == "edited!"
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT content FROM messages WHERE id = ?", (uid_msg,)
+            ).fetchone()
+        assert row[0] == "edited!"
+
+    def test_update_message_content_refuses_other_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, a)
+        assert core_memory.update_message_content(uid_msg, b, "hax") is None
+        # Alice's content survives.
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT content FROM messages WHERE id = ?", (uid_msg,)
+            ).fetchone()
+        assert row[0] == "hello"
+
+    def test_delete_message_removes_only_target_by_default(self, db_path):
+        a = _make_user(db_path, "alice")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, a)
+        result = core_memory.delete_message(uid_msg, a)
+        assert result == {"deleted_id": uid_msg, "cascaded_assistant_id": None}
+        with sqlite3.connect(db_path) as conn:
+            ids = {
+                r[0] for r in conn.execute(
+                    "SELECT id FROM messages"
+                ).fetchall()
+            }
+        # The assistant reply is left alone unless cascade is requested.
+        assert ids == {aid_msg}
+
+    def test_delete_message_cascades_following_assistant(self, db_path):
+        a = _make_user(db_path, "alice")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, a)
+        result = core_memory.delete_message(
+            uid_msg, a, cascade_assistant=True
+        )
+        assert result["deleted_id"] == uid_msg
+        assert result["cascaded_assistant_id"] == aid_msg
+        with sqlite3.connect(db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert count == 0
+
+    def test_cascade_no_op_when_next_is_not_assistant(self, db_path):
+        """User → user → assistant: deleting the first user message with
+        cascade must not remove a non-assistant sibling."""
+        a = _make_user(db_path, "alice")
+        conv_id = core_memory.create_conversation("multi", a)
+        m1 = core_memory.save_message(conv_id, "user", "one")
+        m2 = core_memory.save_message(conv_id, "user", "two")
+        m3 = core_memory.save_message(conv_id, "assistant", "reply")
+        result = core_memory.delete_message(m1, a, cascade_assistant=True)
+        assert result["cascaded_assistant_id"] is None
+        with sqlite3.connect(db_path) as conn:
+            ids = {
+                r[0] for r in conn.execute(
+                    "SELECT id FROM messages WHERE conversation_id = ?",
+                    (conv_id,),
+                ).fetchall()
+            }
+        # m1 is gone; m2 and m3 survive.
+        assert ids == {m2, m3}
+
+    def test_assistant_delete_never_cascades(self, db_path):
+        """Cascade flag is ignored when the deleted row is itself an
+        assistant reply — predictable v1 behaviour."""
+        a = _make_user(db_path, "alice")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, a)
+        result = core_memory.delete_message(
+            aid_msg, a, cascade_assistant=True
+        )
+        assert result["deleted_id"] == aid_msg
+        assert result["cascaded_assistant_id"] is None
+        with sqlite3.connect(db_path) as conn:
+            ids = {
+                r[0] for r in conn.execute(
+                    "SELECT id FROM messages"
+                ).fetchall()
+            }
+        assert ids == {uid_msg}
+
+    def test_delete_message_refuses_other_user(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, a)
+        assert core_memory.delete_message(uid_msg, b) is None
+        # Both rows survive.
+        with sqlite3.connect(db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert count == 2
+
+    def test_delete_message_cleans_up_feedback(self, db_path):
+        a = _make_user(db_path, "alice")
+        _conv_id, _uid_msg, aid_msg = _seed_exchange(db_path, a)
+        core_feedback.record_feedback(
+            a, "positive", message_id=aid_msg, db_path=db_path,
+        )
+        # Sanity check: the feedback row exists.
+        rows = core_feedback.list_feedback(a, db_path=db_path)
+        assert len(rows) == 1
+
+        core_memory.delete_message(aid_msg, a)
+
+        # The orphan feedback row is gone, so the local table never
+        # carries a dangling reference.
+        rows = core_feedback.list_feedback(a, db_path=db_path)
+        assert rows == []
+
+    def test_delete_message_does_not_touch_memories(self, db_path):
+        """Memory cleanup must remain a separate explicit action."""
+        a = _make_user(db_path, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, a)
+        core_memory.save_memory("preferences", "alice prefers calm tone", a)
+        assert len(core_memory.load_memories(a)) == 1
+
+        core_memory.delete_message(uid_msg, a, cascade_assistant=True)
+
+        # Memory survives unchanged.
+        mems = core_memory.load_memories(a)
+        assert len(mems) == 1
+        assert mems[0]["content"] == "alice prefers calm tone"
+
+
+# ── HTTP endpoints ──────────────────────────────────────────────────────────
+
+
+class TestPutMessageEndpoint:
+    def test_owner_can_edit_their_message(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+
+        resp = web_client.put(
+            f"/messages/{uid_msg}",
+            json={"content": "corrected"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["content"] == "corrected"
+
+        # Conversation reload returns the new content.
+        msgs = web_client.get(
+            f"/conversations/{_conv_id}/messages", headers=_h(token)
+        ).json()
+        contents = [m["content"] for m in msgs]
+        assert "corrected" in contents
+
+    def test_cannot_edit_other_users_message_returns_404(
+        self, db_path, web_client,
+    ):
+        a = _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        b_token = _login(web_client, "bob")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, a)
+
+        resp = web_client.put(
+            f"/messages/{uid_msg}",
+            json={"content": "hax"},
+            headers=_h(b_token),
+        )
+        assert resp.status_code == 404
+
+        # Alice's content survives.
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT content FROM messages WHERE id = ?", (uid_msg,)
+            ).fetchone()
+        assert row[0] == "hello"
+
+    def test_unknown_id_returns_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.put(
+            "/messages/99999",
+            json={"content": "anything"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 404
+
+    def test_empty_edit_is_rejected(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+        for empty in ("", "   ", "\n\t  "):
+            resp = web_client.put(
+                f"/messages/{uid_msg}",
+                json={"content": empty},
+                headers=_h(token),
+            )
+            assert resp.status_code == 422, (empty, resp.text)
+
+    def test_too_long_edit_is_rejected(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+        too_long = "x" * (core_memory.MESSAGE_CONTENT_MAX_LEN + 1)
+        resp = web_client.put(
+            f"/messages/{uid_msg}",
+            json={"content": too_long},
+            headers=_h(token),
+        )
+        assert resp.status_code == 422
+        # Original content survives.
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT content FROM messages WHERE id = ?", (uid_msg,)
+            ).fetchone()
+        assert row[0] == "hello"
+
+    def test_missing_auth_rejected(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+        resp = web_client.put(
+            f"/messages/{uid_msg}", json={"content": "x"},
+        )
+        # FastAPI's HTTPBearer dependency returns 401 (some configs 403);
+        # the contract is "no anonymous writes".
+        assert resp.status_code in (401, 403)
+
+
+class TestDeleteMessageEndpoint:
+    def test_owner_can_delete_their_message(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, uid)
+
+        resp = web_client.delete(
+            f"/messages/{uid_msg}", headers=_h(token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["deleted_id"] == uid_msg
+        assert body["cascaded_assistant_id"] is None
+
+        # Conversation reload no longer shows the deleted row.
+        msgs = web_client.get(
+            f"/conversations/{_conv_id}/messages", headers=_h(token)
+        ).json()
+        assert [m["id"] for m in msgs] == [aid_msg]
+
+    def test_cascade_assistant_removes_following_reply(
+        self, db_path, web_client,
+    ):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, uid)
+
+        resp = web_client.delete(
+            f"/messages/{uid_msg}?cascade_assistant=true",
+            headers=_h(token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["deleted_id"] == uid_msg
+        assert body["cascaded_assistant_id"] == aid_msg
+
+        msgs = web_client.get(
+            f"/conversations/{_conv_id}/messages", headers=_h(token)
+        ).json()
+        assert msgs == []
+
+    def test_cannot_delete_other_users_message_returns_404(
+        self, db_path, web_client,
+    ):
+        a = _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        b_token = _login(web_client, "bob")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, a)
+
+        resp = web_client.delete(
+            f"/messages/{uid_msg}", headers=_h(b_token),
+        )
+        assert resp.status_code == 404
+
+        # Both messages survive in Alice's conversation.
+        with sqlite3.connect(db_path) as conn:
+            ids = {
+                r[0] for r in conn.execute(
+                    "SELECT id FROM messages WHERE conversation_id = ?",
+                    (_conv_id,),
+                ).fetchall()
+            }
+        assert ids == {uid_msg, aid_msg}
+
+    def test_unknown_id_returns_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.delete("/messages/99999", headers=_h(token))
+        assert resp.status_code == 404
+
+    def test_delete_assistant_message_alone(self, db_path, web_client):
+        """Deleting an assistant message removes only that row, even when
+        the cascade flag is set (no chain reaction on assistant deletes)."""
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, aid_msg = _seed_exchange(db_path, uid)
+
+        resp = web_client.delete(
+            f"/messages/{aid_msg}?cascade_assistant=true",
+            headers=_h(token),
+        )
+        assert resp.status_code == 200
+        msgs = web_client.get(
+            f"/conversations/{_conv_id}/messages", headers=_h(token)
+        ).json()
+        assert [m["id"] for m in msgs] == [uid_msg]
+
+    def test_delete_does_not_remove_memories(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+        core_memory.save_memory("preferences", "alice likes brevity", uid)
+
+        web_client.delete(
+            f"/messages/{uid_msg}?cascade_assistant=true",
+            headers=_h(token),
+        )
+
+        listed = web_client.get("/memories", headers=_h(token)).json()
+        assert [m["content"] for m in listed] == ["alice likes brevity"]
+
+    def test_delete_cleans_up_feedback(self, db_path, web_client):
+        """Feedback rows for a deleted message must not linger in the
+        local feedback table — the safety contract is "no orphan
+        feedback"."""
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, _uid_msg, aid_msg = _seed_exchange(db_path, uid)
+        # Rate the assistant reply.
+        web_client.post(
+            "/feedback",
+            json={"sentiment": "positive", "message_id": aid_msg},
+            headers=_h(token),
+        )
+        assert len(web_client.get("/feedback", headers=_h(token)).json()) == 1
+
+        # Delete that assistant reply.
+        web_client.delete(f"/messages/{aid_msg}", headers=_h(token))
+
+        # The feedback row is gone, not orphaned.
+        assert web_client.get("/feedback", headers=_h(token)).json() == []
+
+    def test_missing_auth_rejected(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+        resp = web_client.delete(f"/messages/{uid_msg}")
+        assert resp.status_code in (401, 403)
+
+
+class TestConversationReloadAfterEditDelete:
+    def test_reload_reflects_edited_content(self, db_path, web_client):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        _conv_id, uid_msg, _aid_msg = _seed_exchange(db_path, uid)
+        web_client.put(
+            f"/messages/{uid_msg}",
+            json={"content": "rewritten"},
+            headers=_h(token),
+        )
+        msgs = web_client.get(
+            f"/conversations/{_conv_id}/messages", headers=_h(token),
+        ).json()
+        edited = next(m for m in msgs if m["id"] == uid_msg)
+        assert edited["content"] == "rewritten"
+
+    def test_reload_preserves_order_after_partial_delete(
+        self, db_path, web_client,
+    ):
+        uid = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        conv_id = core_memory.create_conversation("ordered", uid)
+        m1 = core_memory.save_message(conv_id, "user", "one")
+        _m2 = core_memory.save_message(conv_id, "assistant", "two")
+        m3 = core_memory.save_message(conv_id, "user", "three")
+        m4 = core_memory.save_message(conv_id, "assistant", "four")
+        # Delete the second user message; its assistant reply stays.
+        web_client.delete(f"/messages/{m3}", headers=_h(token))
+
+        msgs = web_client.get(
+            f"/conversations/{conv_id}/messages", headers=_h(token),
+        ).json()
+        assert [m["id"] for m in msgs] == [m1, _m2, m4]

--- a/web.py
+++ b/web.py
@@ -30,7 +30,7 @@ from core.memory import (
     conversation_belongs_to,
     get_setting, save_setting,
     list_memories, update_memory, delete_memory,
-    get_owned_message, update_message_content, delete_message,
+    update_message_content, delete_message,
     MESSAGE_CONTENT_MAX_LEN,
 )
 from core import feedback as _feedback

--- a/web.py
+++ b/web.py
@@ -30,6 +30,8 @@ from core.memory import (
     conversation_belongs_to,
     get_setting, save_setting,
     list_memories, update_memory, delete_memory,
+    get_owned_message, update_message_content, delete_message,
+    MESSAGE_CONTENT_MAX_LEN,
 )
 from core import feedback as _feedback
 from core.settings import (
@@ -282,6 +284,33 @@ class MemoryUpdateRequest(BaseModel):
     content: str
 
 
+class MessageUpdateRequest(BaseModel):
+    """Body for ``PUT /messages/{id}`` — the new content for a message.
+
+    The textarea on the client is shown with a maxlength matching
+    ``MESSAGE_CONTENT_MAX_LEN``; the server re-applies the same cap so a
+    crafted client cannot smuggle a longer payload past the UI.
+    Whitespace-only edits are rejected to match the chat input's own
+    "non-empty after trim" guard.
+    """
+    model_config = {"extra": "forbid"}
+
+    content: str
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v):
+        if not isinstance(v, str):
+            raise ValueError("content must be a string")
+        if not v.strip():
+            raise ValueError("content cannot be empty")
+        if len(v) > MESSAGE_CONTENT_MAX_LEN:
+            raise ValueError(
+                f"content too long (max {MESSAGE_CONTENT_MAX_LEN} characters)"
+            )
+        return v
+
+
 class MemoryAddRequest(BaseModel):
     category: str
     content: str
@@ -471,6 +500,81 @@ def remove_conversation(
     return {"ok": True}
 
 
+# ── MESSAGE EDIT / DELETE ──
+#
+# Per-message edit + delete endpoints (issue #94). Ownership is enforced
+# through the conversations table — a user can only touch messages from
+# a conversation they own. Editing only rewrites the row; it never
+# regenerates the assistant reply (regeneration is an explicit v2
+# follow-up). Deleting a user message optionally also removes the
+# paired assistant reply when the client passes
+# ``?cascade_assistant=true``; we keep the cascade off by default so the
+# behaviour is predictable from the API side.
+#
+# Memory entries are deliberately *not* touched here: editing or
+# deleting a chat message must not erase facts the user already chose
+# to remember. Memory cleanup remains a separate user action (see
+# ``/memories`` endpoints and the natural-memory "forget X" commands).
+
+@app.put("/messages/{message_id}")
+def update_message_endpoint(
+    message_id: int,
+    request: MessageUpdateRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Replace the content of a chat message the caller owns.
+
+    Returns 404 (not 403) when the message either doesn't exist or
+    belongs to another user, so cross-user probing cannot reveal
+    existence. Pydantic has already enforced non-empty + length cap on
+    the body.
+    """
+    updated = update_message_content(message_id, user.id, request.content)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Message introuvable.")
+    # The row is returned in the same shape the conversation-load
+    # endpoint emits, so the client can reuse its rendering helpers.
+    return {
+        "ok": True,
+        "id": updated["id"],
+        "conversation_id": updated["conversation_id"],
+        "role": updated["role"],
+        "content": updated["content"],
+        "model": updated["model"],
+    }
+
+
+@app.delete("/messages/{message_id}")
+def delete_message_endpoint(
+    message_id: int,
+    cascade_assistant: bool = False,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Remove a chat message owned by the caller.
+
+    When the caller passes ``?cascade_assistant=true`` and the deleted
+    row is a *user* message immediately followed by an assistant reply
+    in the same conversation, that paired assistant reply is also
+    removed. Assistant message deletes never cascade — the client is
+    expected to ignore the flag in that case, but the data layer
+    silently does the right thing regardless.
+
+    Memory entries are not touched. Feedback rows whose ``message_id``
+    is removed are cleaned up so the local feedback table never carries
+    a dangling reference.
+    """
+    result = delete_message(
+        message_id, user.id, cascade_assistant=cascade_assistant
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Message introuvable.")
+    return {
+        "ok": True,
+        "deleted_id": result["deleted_id"],
+        "cascaded_assistant_id": result["cascaded_assistant_id"],
+    }
+
+
 def _chat_preflight(request: ChatRequest, user: CurrentUser):
     """Shared validation + memory-command handling for chat endpoints.
 
@@ -625,7 +729,9 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         policy=policy,
     )
 
-    save_message(conversation_id, "user", request.message)
+    user_message_id = save_message(
+        conversation_id, "user", request.message
+    )
     assistant_message_id = save_message(
         conversation_id, "assistant", response, model_used
     )
@@ -637,6 +743,7 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         "response": response,
         "model": model_used,
         "conversation_id": conversation_id,
+        "user_message_id": user_message_id,
         "assistant_message_id": assistant_message_id,
     }
 
@@ -754,7 +861,9 @@ def chat_stream_endpoint(
                     # Persist only once we know the full reply landed
                     # cleanly. A client disconnect at this point is
                     # acceptable: the response is already saved.
-                    save_message(conversation_id, "user", request.message)
+                    user_message_id = save_message(
+                        conversation_id, "user", request.message
+                    )
                     assistant_message_id = save_message(
                         conversation_id, "assistant",
                         final_reply, final_model,
@@ -763,14 +872,16 @@ def chat_stream_endpoint(
                         update_conversation_title(
                             conversation_id, request.message[:40]
                         )
-                    # The assistant_message_id is what the feedback
-                    # endpoint accepts; surface it on `done` so the
-                    # client can wire thumbs up / thumbs down to the
-                    # exact row that was just persisted.
+                    # `assistant_message_id` is what the feedback
+                    # endpoint accepts; `user_message_id` lets the
+                    # browser attach the per-message edit/delete
+                    # controls to the user bubble it just rendered
+                    # without forcing a conversation reload.
                     yield _stream_event({
                         "type": "done",
                         "model": final_model,
                         "conversation_id": conversation_id,
+                        "user_message_id": user_message_id,
                         "assistant_message_id": assistant_message_id,
                     })
                     return


### PR DESCRIPTION
Closes #94.

## Summary

- Adds two auth-gated endpoints — `PUT /messages/{id}` and `DELETE /messages/{id}` — that let a user edit and delete their own chat messages. Ownership is enforced via the conversations table so cross-user calls return 404 (no existence leak).
- Adds quiet inline edit/delete controls to each rendered chat message in the web UI. User messages support edit + delete; assistant messages support delete only (editing assistant replies is intentionally out of scope for v1). The controls match Nova's calm visual language and stay out of the way at rest.
- Deleting a user message accepts an optional `?cascade_assistant=true` so the paired assistant reply in the same exchange is removed atomically. Assistant deletes never cascade, regardless of the flag.
- Editing rewrites the message in place and **does not** regenerate Nova's reply. The inline editor surfaces this explicitly ("Editing does not regenerate Nova's reply. Send the edited text as a new message to get a fresh answer."). Regenerate-after-edit is left as a follow-up.
- Memory entries are deliberately untouched. Editing or deleting a chat message never removes memories already extracted from it — memory cleanup stays a separate, explicit user action.
- Feedback rows whose `message_id` is deleted are cleaned up so the local feedback table never carries dangling references.
- The chat-stream `done` event now also surfaces `user_message_id` so the browser can attach edit/delete controls to the just-sent user bubble without forcing a conversation reload.

## Files changed

- `core/memory.py` — new helpers: `get_owned_message`, `update_message_content`, `delete_message`, `find_following_assistant_message`, plus `MESSAGE_CONTENT_MAX_LEN` cap.
- `web.py` — new `MessageUpdateRequest` body model and the two endpoints. Both `/chat` paths now return `user_message_id` alongside `assistant_message_id`.
- `static/index.html` — new edit/delete controls, inline editor, delete-confirm flow, and i18n strings (fr/en). Existing feedback / read-aloud chrome is untouched.
- `tests/test_message_edit_delete.py` — 28 new tests covering data-layer + HTTP behaviour, ownership, validation, cascade, memory + feedback safety, and conversation reload.
- `README.md`, `CHANGELOG.md` — short user-facing notes.

## Out of scope

- Conversation branching / version history.
- Memory rollback.
- Regenerate-after-edit (see TODO above; can land as a separate PR).
- Multi-user conflict handling.

## Test plan

- [x] `python -m pytest tests/test_message_edit_delete.py` — 28 new tests pass.
- [x] `python -m pytest tests/test_conversation_scoping.py tests/test_feedback_endpoints.py` — 31 existing tests still pass (regression coverage for message id, conversation ownership, and feedback).
- [x] Wider suite: pre-existing failures only (test environment lacks a real ollama install; the failing tests fail identically on `main`).
- [ ] Manual smoke test in the chat UI: send a message, edit it, delete a user message both with and without cascading the assistant reply, delete an assistant message and confirm the matching feedback row is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APJBEPJYKqXh41RGv8zXp4)_