### PR TITLE
feat(chat): smoother stream rendering, calmer style, expressive emoji level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 ### Added
+- Smoother streamed chat experience: the streaming bubble now coalesces
+  incoming Ollama tokens on a short flush window (~28 ms) and only
+  paints once per cycle, so single-character chunks no longer cause
+  visible jitter. The final Markdown is still rendered once, on the
+  `done` event, so half-formed code fences never flicker into the
+  wrong layout. The endpoint still forwards every Ollama chunk as its
+  own NDJSON `delta` event; coalescing lives in the renderer.
+- `expressive` emoji preference level. A fourth choice in Settings →
+  Personalization → Emoji level lets users opt into a slightly warmer
+  feel in casual chat (one or two emojis per reply, never in clusters).
+  Code, PR, documentation, and security replies stay sober regardless
+  — that rule is restated in the prompt, not left to the model.
+- Calmer / more human style guidance in the system prompt. The
+  RESPONSE_STYLE_BLOCK now includes explicit TON / PERTINENCE /
+  HONNÊTETÉ guidance: acknowledge intent briefly, stay project-focused
+  on Nova / SilentGuard / PR / security questions, be honest about
+  limits, and never claim to feel emotions or be conscious. The Nova
+  Safety and Trust Contract still wins — the new lines are a tone
+  reminder, not a new capability.
 - Edit and delete sent chat messages from the chat UI (issue #94). Two
   new auth-gated endpoints, `PUT /messages/{id}` and
   `DELETE /messages/{id}`, accept content edits and message deletes

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Shipped today:
   when a model is missing.
 - **Streaming replies.** Assistant messages stream into the UI as they
   are generated, with a calm typing indicator while Nova is thinking.
+  The browser coalesces incoming tokens on a short flush window
+  (~28 ms) so text reveals smoothly instead of jittering on every
+  one-character token, and the final Markdown is rendered in a single
+  pass once the stream completes. Backend errors surface inline rather
+  than leaving an empty bubble.
 - **Persistent memory.** A local SQLite database stores conversations,
   user-authored memories, and per-user settings. Manual commands
   (`Retiens ça:`, `Souviens-toi:`) let users save explicit facts;
@@ -56,9 +61,12 @@ Shipped today:
   admin-managed user list, per-user settings, and an optional
   family-controls layer for restricted roles.
 - **Personalization preferences.** Response length, warmth,
-  enthusiasm, emoji density, and free-text custom instructions are
-  stored per user and shape Nova's tone without leaking into other
-  accounts.
+  enthusiasm, emoji density (none / low / medium / expressive), and
+  free-text custom instructions are stored per user and shape Nova's
+  tone without leaking into other accounts. Technical / code / PR /
+  security replies stay sober regardless of the emoji level — the
+  preference shapes casual chat only and never overrides the Nova
+  Safety and Trust Contract.
 - **Local response feedback.** Thumbs up / thumbs down under each
   assistant message records a per-user preference signal in the local
   SQLite database; a thumbs-down accepts an optional short reason such

--- a/core/nova_contract.py
+++ b/core/nova_contract.py
@@ -47,9 +47,19 @@ LANGUE: Détecte automatiquement la langue et réponds TOUJOURS dans cette langu
 LONGUEUR:
 - Salutation, small talk → 1 à 3 phrases maximum
 - Question simple → réponse directe sans introduction
-- Explication → paragraphes clairs et concis
+- Explication → paragraphes clairs et concis, pas de liste à puces forcée
+- Architecture / sécurité / code → développe seulement quand l'utilisateur le demande
 - Code → complet en un seul bloc
-Ne commence jamais par "Bien sûr!", "Certainement!", "Absolument!". Va droit au but."""
+Ne commence jamais par "Bien sûr!", "Certainement!", "Absolument!". Va droit au but.
+TON:
+- Parle naturellement, sans formules corporate ni listes inutiles.
+- Reconnais brièvement l'intention de l'utilisateur quand c'est utile, puis donne la suite concrète.
+- Reste chaleureuse et claire — comme un humain calme qui aide, pas comme un répondeur automatique.
+- N'imite jamais une émotion, ne prétends jamais ressentir, être consciente, ou avoir une expérience personnelle.
+- Si tu ne sais pas, dis-le. Ne prétends jamais avoir fait quelque chose que tu n'as pas fait.
+PERTINENCE:
+- Pour les questions sur Nova, SilentGuard, le code, les PR ou la sécurité du projet, reste centrée sur le projet — ne dérive pas vers des conseils personnels génériques.
+- Pour les conversations personnelles, sois soutien mais honnête sur tes limites."""
 
 
 # ── Personalization → prompt instructions ────────────────────────────────────
@@ -82,10 +92,21 @@ _EMOJI_LINES = {
     # "low" is the storage default and intentionally absent here so a fresh
     # user pays no token cost. Only the explicit non-default choices add a
     # directive to the prompt.
-    "none": "Emoji: ne pas en utiliser.",
+    "none": (
+        "Emoji: ne pas en utiliser, même dans les échanges informels. "
+        "Les réponses techniques, de code, de PR, ou de sécurité doivent "
+        "rester sobres et sans emoji."
+    ),
     "medium": (
         "Emoji: utilise des emojis pertinents dans les échanges informels "
-        "(jamais dans le code, jamais dans les réponses techniques sérieuses)."
+        "(jamais dans le code, les PR, les docs, ou les réponses techniques "
+        "ou de sécurité sérieuses)."
+    ),
+    "expressive": (
+        "Emoji: un peu plus expressif dans les échanges informels — un ou "
+        "deux emojis bien choisis par réponse maximum, jamais en grappe. "
+        "Toujours absents du code, des PR, de la documentation, et des "
+        "réponses techniques ou de sécurité."
     ),
 }
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -30,7 +30,7 @@ PERSONALIZATION_ENUMS: dict[str, frozenset[str]] = {
     "response_style": frozenset({"default", "concise", "detailed", "technical"}),
     "warmth_level": frozenset({"low", "normal", "high"}),
     "enthusiasm_level": frozenset({"low", "normal", "high"}),
-    "emoji_level": frozenset({"none", "low", "medium"}),
+    "emoji_level": frozenset({"none", "low", "medium", "expressive"}),
 }
 
 PERSONALIZATION_DEFAULTS: dict[str, str] = {

--- a/docs/feedback-and-preferences.md
+++ b/docs/feedback-and-preferences.md
@@ -160,3 +160,58 @@ Deleting the user account cascades (`ON DELETE CASCADE`) to remove all
 feedback rows for that user. Deleting a conversation sets
 `conversation_id` to NULL on its rows (`ON DELETE SET NULL`) so the
 preference signal survives even when the original chat is gone.
+
+## Emoji preference levels
+
+Settings → Personalization → *Emoji level* shapes the tone Nova picks
+in casual chat. The stored value lands in the per-user preference
+block in the system prompt; it never overrides the safety contract
+and never changes how Nova answers technical / code / PR / security
+questions — those replies stay sober regardless.
+
+| Level | Meaning |
+| --- | --- |
+| `none` | No emoji at all. Sober tone everywhere, technical or not. |
+| `low` *(default)* | Quiet by default. Nova may, very rarely, use a single emoji in a casual reply if it adds clarity. |
+| `medium` | Pertinent emojis allowed in casual chat. Code / PR / docs / security replies stay emoji-free. |
+| `expressive` | One or two emojis per casual reply if they fit naturally. Never in clusters, never in code / PR / docs / security. |
+
+The preference is per-user. The default for fresh accounts is `low` so
+the prompt cost is zero until the user opens the panel and picks
+something explicit.
+
+Feedback (thumbs up / down) can also nudge Nova's tone, but it cannot
+override the emoji level the user picked here, and neither can override
+the safety / identity contract.
+
+## Progressive streaming and the assistant bubble
+
+Chat replies are streamed token-by-token from Ollama to the browser as
+NDJSON events (see `core.chat.chat_stream` and the `/chat/stream`
+endpoint). The browser appends incoming deltas to a streaming bubble
+and flushes the accumulated text on a short cadence (~28 ms) so the
+text "types out" smoothly without re-rendering the whole conversation
+on every token.
+
+Behaviour guarantees:
+
+- the assistant bubble is created the moment the first delta arrives,
+  never before — empty model output surfaces an inline error and
+  drops the bubble cleanly instead of persisting a stray empty row;
+- the bubble shows plain text while the stream is in flight, then
+  swaps to rendered Markdown once `done` arrives so half-formed
+  fenced blocks never flicker into the wrong layout;
+- the action row (thumbs / copy / read aloud) attaches *after*
+  `done` only, so it can never be clicked against an in-progress
+  response;
+- `assistant_message_id` is included on the `done` event so the
+  feedback buttons can attach the rating to the row that was just
+  saved;
+- cancelling mid-stream (Stop button) discards the bubble and
+  persists nothing — reloading the conversation does not show a
+  half-baked message.
+
+If a backend stream error fires (Ollama unreachable, model returned
+nothing), the endpoint emits an `error` NDJSON event and persists
+nothing. The browser shows a calm fallback message inline instead
+of an empty Nova bubble.

--- a/static/index.html
+++ b/static/index.html
@@ -543,10 +543,10 @@
         #messages {
             flex: 1;
             overflow-y: auto;
-            padding: 24px 26px 14px;
+            padding: 24px 26px 16px;
             display: flex;
             flex-direction: column;
-            gap: 14px;
+            gap: 18px;
             scroll-behavior: smooth;
         }
 
@@ -562,6 +562,14 @@
             to   { opacity: 1; transform: translateY(0); }
         }
 
+        /* Users with prefers-reduced-motion shouldn't see bubbles slide up
+           on every message; keep them present, just static. The streaming
+           caret has its own reduced-motion override below. */
+        @media (prefers-reduced-motion: reduce) {
+            .message-row { animation: none; }
+            #messages { scroll-behavior: auto; }
+        }
+
         .message-row.user { align-items: flex-end; }
         .message-row.nova { align-items: flex-start; }
 
@@ -575,13 +583,14 @@
         }
 
         .message {
-            max-width: 75%;
-            padding: 10px 14px;
+            max-width: 76%;
+            padding: 11px 16px;
             border-radius: var(--r-lg);
-            line-height: 1.55;
+            line-height: 1.62;
             white-space: pre-wrap;
             word-break: break-word;
-            font-size: 0.92rem;
+            font-size: 0.94rem;
+            letter-spacing: 0.005em;
         }
 
         .message.user {
@@ -633,6 +642,13 @@
 
         @keyframes caret-blink {
             50% { opacity: 0; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .streaming-caret {
+                animation: none;
+                opacity: 0.6;
+            }
         }
 
         #empty-state {
@@ -1087,23 +1103,27 @@
         }
 
         /* ── MARKDOWN ──
-           Markdown spacing inside Nova bubbles is intentionally tight: the
-           bubble itself already has comfortable padding and the
-           1.55 line-height makes prose readable without large block gaps.
+           Markdown spacing inside Nova bubbles is intentionally calm: the
+           bubble itself already has comfortable padding and the ~1.62
+           line-height makes prose readable without feeling cramped.
            Headings, paragraphs and lists collapse first-/last-child margins
-           so the bubble never reserves empty vertical space at the edges. */
+           so the bubble never reserves empty vertical space at the edges.
+           Paragraphs and list items get a touch more breathing room than a
+           dense doc dump so long replies stay scannable. */
         .message.nova h1, .message.nova h2, .message.nova h3 {
             color: var(--text);
-            margin: 10px 0 4px;
+            margin: 12px 0 6px;
             font-weight: 600;
             letter-spacing: -0.005em;
         }
-        .message.nova h1 { font-size: 1.15rem; }
-        .message.nova h2 { font-size: 1.02rem; }
-        .message.nova h3 { font-size: 0.95rem; color: var(--cyan); }
-        .message.nova p { margin: 4px 0; }
-        .message.nova ul, .message.nova ol { padding-left: 20px; margin: 4px 0; }
-        .message.nova li { margin: 2px 0; }
+        .message.nova h1 { font-size: 1.16rem; }
+        .message.nova h2 { font-size: 1.04rem; }
+        .message.nova h3 { font-size: 0.96rem; color: var(--cyan); }
+        .message.nova p { margin: 7px 0; }
+        .message.nova ul, .message.nova ol { padding-left: 22px; margin: 7px 0; }
+        .message.nova li { margin: 4px 0; }
+        .message.nova li > p { margin: 2px 0; }
+        .message.nova li + li { margin-top: 5px; }
         .message.nova > div > *:first-child,
         .message.nova > *:first-child { margin-top: 0; }
         .message.nova > div > *:last-child,
@@ -1202,7 +1222,7 @@
             padding: 6px 4px 2px;
             margin-top: 2px;
             width: 100%;
-            max-width: 75%;
+            max-width: 76%;
             position: relative;
         }
 
@@ -1634,7 +1654,7 @@
             padding: 6px 12px 6px 10px;
             margin: 8px 0 0;
             width: fit-content;
-            max-width: 75%;
+            max-width: 76%;
             background: var(--cyan-soft);
             border: 1px solid var(--cyan-glow);
             border-radius: var(--r-pill);
@@ -3128,9 +3148,10 @@
                             </div>
                         </div>
                         <select id="pers-emoji" class="pers-select" onchange="savePersonalizationField('emoji_level', this.value)">
-                            <option value="none">None</option>
-                            <option value="low" selected>Low</option>
-                            <option value="medium">Medium</option>
+                            <option value="none" id="pers-emoji-opt-none">None</option>
+                            <option value="low" id="pers-emoji-opt-low" selected>Low</option>
+                            <option value="medium" id="pers-emoji-opt-medium">Medium</option>
+                            <option value="expressive" id="pers-emoji-opt-expressive">Expressive</option>
                         </select>
                     </div>
 
@@ -3469,7 +3490,11 @@
             pers_enth_title: "Enthousiasme",
             pers_enth_hint: "Énergie des réponses.",
             pers_emoji_title: "Niveau d'emoji",
-            pers_emoji_hint: "Fréquence des emoji.",
+            pers_emoji_hint: "Fréquence des emoji. Les réponses techniques restent sobres quoi qu'il arrive.",
+            pers_emoji_opt_none: "Aucun",
+            pers_emoji_opt_low: "Discret",
+            pers_emoji_opt_medium: "Modéré",
+            pers_emoji_opt_expressive: "Expressif",
             pers_instr_title: "Instructions personnalisées",
             pers_instr_hint: "Une note courte que Nova garde en tête pour tes messages.",
             coming_soon: "bientôt",
@@ -3653,7 +3678,11 @@
             pers_enth_title: "Enthusiasm",
             pers_enth_hint: "How energetic Nova's replies should feel.",
             pers_emoji_title: "Emoji level",
-            pers_emoji_hint: "How often Nova may use emoji.",
+            pers_emoji_hint: "How often Nova may use emoji. Technical answers stay sober regardless.",
+            pers_emoji_opt_none: "None",
+            pers_emoji_opt_low: "Low",
+            pers_emoji_opt_medium: "Medium",
+            pers_emoji_opt_expressive: "Expressive",
             pers_instr_title: "Custom instructions",
             pers_instr_hint: "A short note Nova should keep in mind for your messages.",
             coming_soon: "coming soon",
@@ -3832,6 +3861,10 @@
         _setText("pers-enth-hint", t("pers_enth_hint"));
         _setText("pers-emoji-title", t("pers_emoji_title"));
         _setText("pers-emoji-hint", t("pers_emoji_hint"));
+        _setText("pers-emoji-opt-none", t("pers_emoji_opt_none"));
+        _setText("pers-emoji-opt-low", t("pers_emoji_opt_low"));
+        _setText("pers-emoji-opt-medium", t("pers_emoji_opt_medium"));
+        _setText("pers-emoji-opt-expressive", t("pers_emoji_opt_expressive"));
         _setText("pers-instr-title", t("pers_instr_title"));
         _setText("pers-instr-hint", t("pers_instr_hint"));
 
@@ -6204,6 +6237,13 @@
     // completes successfully, so they can never be clicked against an
     // incomplete response. The returned object exposes the helpers the
     // caller needs to push tokens and finalise the message.
+    //
+    // Tokens arrive in bursts of 1–3 characters from Ollama. Writing each
+    // one straight into the DOM produces visible jitter on small chunks
+    // and forces a layout pass on every single token. We coalesce incoming
+    // deltas into a short flush window (~28 ms) and write the accumulated
+    // text once per frame — this gives the smooth "typing" feel the UI
+    // wants without lying about progress.
     function createStreamingAssistantBubble() {
         const emptyState = document.getElementById("empty-state");
         if (emptyState) emptyState.remove();
@@ -6237,29 +6277,63 @@
         messagesEl.appendChild(row);
         messagesEl.scrollTop = messagesEl.scrollHeight;
 
+        // ``buffer`` is the text already visible in the bubble. ``pending``
+        // holds deltas that arrived since the last flush — they will land
+        // in the DOM on the next animation frame (or ~28 ms tick) and on
+        // ``finalise()``. Keeping them separate means ``getBuffer()`` can
+        // report the true content of the bubble for error / cancel paths
+        // even before the flush has fired.
         let buffer = "";
+        let pending = "";
+        let flushTimer = null;
+        const FLUSH_MS = 28;
+
+        function flush() {
+            if (flushTimer != null) {
+                clearTimeout(flushTimer);
+                flushTimer = null;
+            }
+            if (!pending) return;
+            buffer += pending;
+            pending = "";
+            textNode.data = buffer;
+            bubble.dataset.rawText = buffer;
+            // Auto-scroll only when the user is already pinned to the
+            // bottom; otherwise leave their scroll position alone so they
+            // can read earlier messages while Nova is still writing.
+            if (isScrolledNearBottom(messagesEl)) {
+                messagesEl.scrollTop = messagesEl.scrollHeight;
+            }
+        }
+
+        function scheduleFlush() {
+            if (flushTimer != null) return;
+            flushTimer = setTimeout(flush, FLUSH_MS);
+        }
 
         return {
             row,
             bubble,
             appendDelta(chunk) {
-                buffer += chunk;
-                textNode.data = buffer;
-                bubble.dataset.rawText = buffer;
-                // Auto-scroll only when the user is already pinned to
-                // the bottom; otherwise leave their scroll position
-                // alone so they can read earlier messages while Nova
-                // is still writing.
-                if (isScrolledNearBottom(messagesEl)) {
-                    messagesEl.scrollTop = messagesEl.scrollHeight;
-                }
+                if (!chunk) return;
+                pending += chunk;
+                scheduleFlush();
             },
             reset() {
+                if (flushTimer != null) {
+                    clearTimeout(flushTimer);
+                    flushTimer = null;
+                }
                 buffer = "";
+                pending = "";
                 textNode.data = "";
                 bubble.dataset.rawText = "";
             },
             finalise(model, messageId) {
+                // Drain any deltas that arrived inside the last flush
+                // window so the rendered markdown matches the bytes the
+                // server told us it persisted.
+                flush();
                 if (!buffer) {
                     // Nothing was streamed — drop the bubble entirely
                     // so we never leave a stray Nova label with no
@@ -6307,7 +6381,10 @@
                 }
             },
             getBuffer() {
-                return buffer;
+                // Includes deltas that have not flushed yet so abort /
+                // error paths read the *true* state of the bubble, not
+                // just the slice of text already painted.
+                return buffer + pending;
             },
         };
     }

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -202,6 +202,36 @@ class TestChatStreamEndpoint:
             ).fetchall()
         assert rows == [("user", "salut"), ("assistant", "hello")]
 
+    def test_many_small_chunks_each_emit_a_delta(self, db_path, web_client):
+        # Ollama frequently emits 1–2 character chunks. The endpoint must
+        # forward each one as its own `delta` event so the frontend's
+        # buffered renderer can flush them at its own cadence — never
+        # batch them server-side. The total concatenated text must still
+        # match exactly what was sent and what gets persisted.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        pieces = ["H", "el", "lo", ", ", "Nova", "!", " "]
+        with stub_chat_stream_runtime(pieces):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "salut", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        deltas = [e["content"] for e in events if e["type"] == "delta"]
+        # Each chunk arrives as its own delta — no server-side coalescing.
+        assert deltas == pieces
+        # And the final, persisted reply concatenates exactly the same bytes.
+        done = next(e for e in events if e["type"] == "done")
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT content FROM messages WHERE id = ?",
+                (done["assistant_message_id"],),
+            ).fetchone()
+        assert row[0] == "".join(pieces)
+
     def test_first_message_updates_conversation_title(self, db_path, web_client):
         _make_user(db_path, "alice")
         token = _login(web_client, "alice")

--- a/tests/test_nova_contract.py
+++ b/tests/test_nova_contract.py
@@ -42,6 +42,40 @@ class TestBlocks:
     def test_response_style_forbids_filler_openers(self):
         assert "Bien sûr" in RESPONSE_STYLE_BLOCK
 
+    def test_response_style_has_human_calm_tone_guidance(self):
+        # Nova should sound like a calm human helper, not a corporate
+        # template. The TON block makes that explicit.
+        assert "TON" in RESPONSE_STYLE_BLOCK
+
+    def test_response_style_does_not_claim_emotions(self):
+        # Hard rule from the safety contract: Nova may sound warm but
+        # never claims to *feel*, be *conscious*, or have personal
+        # experiences. The style block must state this so the user
+        # never reads a fake-sentience answer.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "n'imite jamais une émotion" in lower
+        assert "consciente" in lower
+
+    def test_response_style_acknowledges_intent(self):
+        # The TON block should remind Nova to acknowledge intent
+        # naturally before launching into steps.
+        assert "intention" in RESPONSE_STYLE_BLOCK.lower()
+
+    def test_response_style_demands_honesty_about_limits(self):
+        # If Nova doesn't know, it should say so — and never claim to
+        # have done something it didn't do.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "si tu ne sais pas" in lower or "honnêteté" in lower
+        assert "prétends" in lower
+
+    def test_response_style_keeps_project_focus(self):
+        # When asked about Nova / SilentGuard / PRs / project security,
+        # Nova should stay on topic instead of sliding into generic
+        # personal advice.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "silentguard" in lower
+        assert "projet" in lower or "project" in lower
+
 
 class TestCapabilitiesBlock:
     def test_has_capabilities_label(self):
@@ -171,6 +205,38 @@ class TestBuildPersonalizationBlock:
         # The "medium" line explicitly *allows* emojis; the "no emoji" wording
         # of the "none" preset must not appear.
         assert "ne pas en utiliser" not in out.lower()
+
+    def test_emoji_expressive_is_allowed(self):
+        out = build_personalization_block({"emoji_level": "expressive"})
+        # The expressive line opts the user into a touch more emoji in
+        # casual chat — it still names technical / PR / security as off
+        # limits so the prompt stays consistent with the safety framing.
+        lower = out.lower()
+        assert "emoji" in lower
+        assert "expressif" in lower or "expressive" in lower or "expressi" in lower
+        assert "technique" in lower or "sécurité" in lower or "pr" in lower
+
+    def test_emoji_expressive_keeps_technical_replies_sober(self):
+        # The expressive directive is for casual chat only; security /
+        # code / PR responses must not be invited to sprout emojis.
+        out = build_personalization_block({"emoji_level": "expressive"})
+        lower = out.lower()
+        assert any(
+            marker in lower
+            for marker in ("code", "pr", "documentation", "doc", "technique", "sécurité")
+        )
+
+    def test_emoji_none_extends_to_technical(self):
+        # The hardened "none" directive must mention that technical /
+        # security / code replies are also kept emoji-free, not just
+        # casual chat.
+        out = build_personalization_block({"emoji_level": "none"})
+        lower = out.lower()
+        assert "ne pas en utiliser" in lower
+        assert any(
+            marker in lower
+            for marker in ("technique", "sécurité", "code", "pr")
+        )
 
     def test_custom_instructions_are_quoted_into_block(self):
         out = build_personalization_block(

--- a/tests/test_personalization_chat_wiring.py
+++ b/tests/test_personalization_chat_wiring.py
@@ -129,6 +129,23 @@ class TestBuildMessagesPersonalization:
         sys_msg = msgs[0]["content"].lower()
         assert "emoji" in sys_msg and "ne pas" in sys_msg
 
+    def test_emoji_expressive_lands_in_system_prompt(self):
+        # The expressive level is opt-in: the user wants a slightly
+        # warmer feel in casual chat, with the same sober behaviour on
+        # code / PR / security still spelled out.
+        msgs = build_messages(
+            [], "hi", [], None, None, None,
+            personalization={"emoji_level": "expressive"},
+        )
+        sys_msg = msgs[0]["content"].lower()
+        assert "emoji" in sys_msg
+        # The expressive line must mention the sober domains so the
+        # directive cannot leak into technical replies.
+        assert any(
+            marker in sys_msg
+            for marker in ("technique", "code", "pr", "sécurité", "doc")
+        )
+
     def test_high_warmth_lands_in_system_prompt(self):
         msgs = build_messages(
             [], "hi", [], None, None, None,

--- a/tests/test_personalization_settings.py
+++ b/tests/test_personalization_settings.py
@@ -105,8 +105,12 @@ class TestPersonalizationConstants:
         assert core_settings.PERSONALIZATION_ENUMS["enthusiasm_level"] == frozenset(
             {"low", "normal", "high"}
         )
+        # `expressive` lets the user opt into a slightly warmer tone with a
+        # rare emoji or two in casual chat. Technical / security responses
+        # still stay sober — that rule lives in the contract block, not in
+        # the enum.
         assert core_settings.PERSONALIZATION_ENUMS["emoji_level"] == frozenset(
-            {"none", "low", "medium"}
+            {"none", "low", "medium", "expressive"}
         )
 
     def test_defaults_cover_every_field(self):


### PR DESCRIPTION
## Summary

Tightens Nova's conversation feel without expanding capabilities. Local-first behaviour, the Safety and Trust Contract, and SilentGuard / GitHub / maintenance / auth / channel surfaces are all unchanged.

### Streaming bubble — smoother token reveal
- Frontend now coalesces incoming Ollama deltas on a short flush window (~28 ms) before writing to the DOM. 1–2 character chunks no longer produce visible jitter; the bubble still types out smoothly.
- The backend still emits **every** Ollama chunk as its own NDJSON `delta` event — coalescing lives in the renderer, not the wire (new test guards this).
- Plain text while streaming, Markdown rendered once on `done`, action row attached after a clean completion only, `assistant_message_id` preserved for feedback. Empty / whitespace / mid-stream-error replies still surface a calm inline error and persist nothing.
- `getBuffer()` now includes the not-yet-flushed pending text so abort / error paths read the true bubble state.

### Assistant bubble layout
- Slightly larger font (`0.92rem` → `0.94rem`), more comfortable line-height (`1.55` → `1.62`).
- More breathing room between paragraphs (`4px` → `7px`) and list items (`2px` → `4–5px`); lists no longer look like dense walls.
- Padding and max-width adjusted (and aligned across bubble, action row, "Nova is speaking" indicator).
- `@media (prefers-reduced-motion: reduce)` now disables the message fade-up and the streaming caret blink.

### Response style — calmer, more human, still honest
The system-prompt `RESPONSE_STYLE_BLOCK` gains TON / PERTINENCE / HONNÊTETÉ sections that ask Nova to:
- talk naturally, acknowledge intent briefly before steps, sound like a calm human helper rather than a corporate template;
- stay project-focused on Nova / SilentGuard / PR / security questions instead of drifting into generic personal advice;
- be honest about limits and never claim to have done something it hasn't.

Hard guardrails restated **in the prompt itself**: never imitate emotion, never claim consciousness, never invent personal experience. The Identity Contract and the Safety and Trust Contract still sit above this and override it.

### Emoji preferences
- Adds `expressive` as a fourth per-user emoji level (`none` / `low` / `medium` / `expressive`).
- `none` and `medium` lines are hardened to explicitly keep code / PR / docs / security replies emoji-free regardless of preference.
- Default stays `low` so fresh accounts pay zero prompt cost.
- Wired through Settings UI with FR/EN labels.

### Voice / "Nova is speaking" indicator
- No behavioural change required — the existing speaking indicator, Piper opt-in, browser fallback, Test voice button, Linux hint, and `prefers-reduced-motion` handling already meet the brief. Bubble max-width was nudged to keep the indicator in visual lockstep.

### Docs
- `docs/feedback-and-preferences.md`: new "Emoji preference levels" and "Progressive streaming and the assistant bubble" sections.
- `README.md`: streaming description mentions the buffered renderer; personalization line lists all four emoji levels and the no-cloud / no-override framing.
- `CHANGELOG.md` updated under *Unreleased*.

### Tests
1681 passing locally. New / updated cases:
- `tests/test_chat_stream.py::test_many_small_chunks_each_emit_a_delta` — backend never coalesces.
- `tests/test_personalization_settings.py` — enum now includes `expressive`.
- `tests/test_personalization_chat_wiring.py::test_emoji_expressive_lands_in_system_prompt`.
- `tests/test_nova_contract.py` — new tests covering the expressive emoji directive, the technical-still-sober rule, and the TON / PERTINENCE / HONNÊTETÉ guidance (no fake-sentience, acknowledges intent, demands honesty about limits, keeps project focus).

## Test plan
- [x] `python -m pytest tests/ -q` → 1681 passed, 3 deprecation warnings (pre-existing).
- [x] `python -m pytest tests/test_chat_stream.py tests/test_voice.py tests/test_feedback.py tests/test_nova_contract.py tests/test_personalization_settings.py tests/test_personalization_chat_wiring.py -q` → all green.
- [ ] Manual: send several chat messages with chunked Ollama output and confirm the bubble types smoothly with no jitter, that Markdown renders once on completion, and that the speaking indicator behaves correctly across stop / new conversation / logout.
- [ ] Manual: try each emoji level in Settings → Personalization and confirm casual chat tracks the preference while a code / PR / security question still stays sober.

https://claude.ai/code/session_01PitqnEDgtWXGTCncoE3VM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PitqnEDgtWXGTCncoE3VM6)_