### PR TITLE
fix(chat): handle ollama-python ChatResponse stream events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- Streaming chat no longer surfaces "Nova didn't produce a reply." for
+  every prompt. The chunk extractor used to filter Ollama events with
+  `isinstance(event, dict)`, but `ollama-python>=0.4` streams Pydantic
+  `ChatResponse` objects — subscriptable, but not `dict` instances.
+  That filter silently dropped every production chunk, leaving the
+  accumulator empty and tripping the empty-reply fallback even for a
+  trivial "bonjour". The extractor now duck-types on the `.get` API
+  both shapes expose, with a `getattr` fallback for unexpected event
+  types. Regression tests cover both the dict (legacy) and
+  `SubscriptableBaseModel` (production) shapes end-to-end.
+
 ### Added
 - Smoother streamed chat experience: the streaming bubble now coalesces
   incoming Ollama tokens on a short flush window (~28 ms) and only

--- a/core/chat.py
+++ b/core/chat.py
@@ -48,19 +48,46 @@ def _reply_is_uncertain(reply: str) -> bool:
 def _iter_content_chunks(stream) -> Iterator[str]:
     """Yield non-empty `message.content` strings from an Ollama stream.
 
-    Ollama's chat-stream generator yields dicts shaped like
-    ``{"message": {"content": "..."}, "done": bool}``. Some intermediate
-    events have empty content (e.g. metadata frames) and the final
-    ``done`` event also carries a synthetic empty content — skipping
-    empties keeps the wire format tidy without affecting correctness.
+    Ollama's chat-stream generator yields events shaped like
+    ``{"message": {"content": "..."}, "done": bool}`` — but the concrete
+    type depends on the installed ollama-python client. ``ollama>=0.4``
+    streams ``ChatResponse`` Pydantic models (subscriptable but **not**
+    ``dict`` instances); older releases and our tests yield plain dicts.
+    We duck-type on the ``.get`` API both shapes expose so neither one
+    is silently dropped — an ``isinstance(event, dict)`` filter here was
+    the source of empty-reply regressions in production. Some
+    intermediate events have empty content (e.g. metadata frames) and
+    the final ``done`` event also carries a synthetic empty content —
+    skipping empties keeps the wire format tidy without affecting
+    correctness.
     """
     for event in stream:
-        if not isinstance(event, dict):
+        if event is None:
             continue
-        msg = event.get("message") or {}
-        chunk = msg.get("content") or ""
-        if chunk:
+        msg = _safe_get(event, "message") or {}
+        chunk = _safe_get(msg, "content") or ""
+        if isinstance(chunk, str) and chunk:
             yield chunk
+
+
+def _safe_get(obj, key: str):
+    """Read ``key`` from a dict-like or Pydantic ``SubscriptableBaseModel``.
+
+    Both shapes expose ``.get`` with the same contract, but a non-dict,
+    non-Pydantic object (e.g. an unexpected string event) would raise on
+    subscript. Falling back to ``getattr`` keeps the streaming loop
+    robust without re-introducing an ``isinstance(dict)`` filter that
+    silently drops valid ``ChatResponse`` events.
+    """
+    if obj is None:
+        return None
+    getter = getattr(obj, "get", None)
+    if callable(getter):
+        try:
+            return getter(key)
+        except TypeError:
+            pass
+    return getattr(obj, key, None)
 
 
 MEMORY_EXTRACTION_PROMPT = """Analyse cette conversation et extrait UNIQUEMENT les informations personnelles importantes sur l'utilisateur.

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -76,20 +76,56 @@ def _h(token):
     return {"Authorization": f"Bearer {token}"}
 
 
+class _SubscriptableEvent:
+    """Stand-in for ``ollama.ChatResponse`` (a ``SubscriptableBaseModel``).
+
+    Real ollama-python streams Pydantic objects that expose ``.get()``
+    and ``[key]`` access but are **not** ``dict`` instances. The plain
+    dict mocks elsewhere in this file happen to satisfy any
+    ``isinstance(event, dict)`` filter; production ``ChatResponse``
+    objects do not — that mismatch was the root cause of empty replies
+    in production. Using this shape in regression tests pins the
+    contract without importing the live ollama package.
+    """
+
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def get(self, key, default=None):
+        return self._fields.get(key, default)
+
+    def __getitem__(self, key):
+        return self._fields[key]
+
+
 @contextlib.contextmanager
-def stub_chat_stream_runtime(chunks):
+def stub_chat_stream_runtime(chunks, *, event_shape="dict"):
     """Replace Ollama's chat() with a fake streaming iterator.
 
     ``chunks`` is a list of strings to surface as message.content
-    fragments. Routing, weather, search, security and memory hooks are
-    all neutralised so the generator follows the plain chat path.
+    fragments. ``event_shape`` controls whether each streamed event is a
+    plain ``dict`` (legacy) or a ``_SubscriptableEvent`` mirroring the
+    real ``ollama.ChatResponse`` Pydantic model — the latter is the
+    shape that ships in production and the one that broke generation
+    before this guardrail existed. Routing, weather, search, security
+    and memory hooks are all neutralised so the generator follows the
+    plain chat path.
     """
+    def _wrap(content, done):
+        payload = {"message": {"content": content}, "done": done}
+        if event_shape == "subscriptable":
+            return _SubscriptableEvent(
+                message=_SubscriptableEvent(content=content),
+                done=done,
+            )
+        return payload
+
     def fake_chat(*args, **kwargs):
         if kwargs.get("stream"):
             def gen():
                 for c in chunks:
-                    yield {"message": {"content": c}, "done": False}
-                yield {"message": {"content": ""}, "done": True}
+                    yield _wrap(c, False)
+                yield _wrap("", True)
             return gen()
         # Non-streaming fallback (e.g. memory extractor) — return single shot.
         return {"message": {"content": "".join(chunks)}}
@@ -132,6 +168,25 @@ class TestChatStreamGenerator:
         assert events[0]["type"] == "meta"
         assert events[-1]["type"] == "done"
         assert events[-1]["reply"] == ""
+
+    def test_subscriptable_chat_response_events_are_not_dropped(self, db_path):
+        # Regression guard: ``ollama>=0.4`` streams ``ChatResponse``
+        # Pydantic objects, which are subscriptable but **not** ``dict``
+        # instances. A previous implementation used
+        # ``isinstance(event, dict)`` to filter the stream and silently
+        # dropped every production chunk — leaving the final accumulator
+        # empty and surfacing "Nova didn't produce a reply." for even a
+        # trivial "bonjour". This exercises the same shape end-to-end.
+        alice = _make_user(db_path, "alice")
+        with stub_chat_stream_runtime(
+            ["bon", "jour"], event_shape="subscriptable",
+        ):
+            events = list(chat_stream([], "bonjour", [], alice))
+        deltas = [e["content"] for e in events if e["type"] == "delta"]
+        assert deltas == ["bon", "jour"]
+        done = events[-1]
+        assert done["type"] == "done"
+        assert done["reply"] == "bonjour"
 
     def test_ollama_unreachable_yields_error(self, db_path):
         alice = _make_user(db_path, "alice")
@@ -444,6 +499,41 @@ class TestChatStreamEndpoint:
         with sqlite3.connect(db_path) as conn:
             count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
         assert count == 0
+
+    def test_bonjour_produces_reply_not_empty_fallback(
+        self, db_path, web_client,
+    ):
+        # End-to-end regression: a simple "bonjour" prompt against a
+        # production-shaped Ollama stream (``ChatResponse`` Pydantic
+        # objects, not dicts) must produce a real assistant reply and
+        # **not** the "Nova didn't produce a reply." fallback. This is
+        # the exact user-visible bug that motivated this regression set.
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+
+        with stub_chat_stream_runtime(
+            ["Bon", "jour", " !"], event_shape="subscriptable",
+        ):
+            resp = web_client.post(
+                "/chat/stream",
+                json={"message": "bonjour", "mode": "chat"},
+                headers=_h(token),
+            )
+        assert resp.status_code == 200
+        events = _decode_ndjson(resp.content)
+        types = [e["type"] for e in events]
+        assert "done" in types
+        assert "error" not in types
+        deltas = [e["content"] for e in events if e["type"] == "delta"]
+        assert "".join(deltas) == "Bonjour !"
+
+        done = next(e for e in events if e["type"] == "done")
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT role, content FROM messages WHERE id = ?",
+                (done["assistant_message_id"],),
+            ).fetchone()
+        assert row == ("assistant", "Bonjour !")
 
     def test_assistant_message_id_only_emitted_when_persisted(
         self, db_path, web_client


### PR DESCRIPTION
## Summary

- `_iter_content_chunks` filtered with `isinstance(event, dict)`, but `ollama-python>=0.4` streams `ChatResponse` Pydantic objects that are subscriptable but **not** `dict` instances. The filter silently dropped every production chunk, leaving the streaming accumulator empty and surfacing "Nova didn't produce a reply." for even a trivial "bonjour".
- The extractor now duck-types on the `.get` API both shapes expose, with a `getattr` fallback for unexpected event types. No other behavior changes — same wire format, same empty-reply error path when the model genuinely produces nothing.

## Why it broke

`/chat/stream` → `chat_stream()` → `_stream_and_accumulate()` → `_iter_content_chunks()`. Every Ollama event in production is a `ChatResponse(SubscriptableBaseModel)` instance:

```python
>>> isinstance(ollama.ChatResponse(...), dict)
False
>>> ollama.ChatResponse(...).get("message")  # works
Message(role='assistant', content='bon', ...)
```

The dict-only filter meant `parts` stayed `[]`, `reply` returned `""`, and the endpoint's `if not final_reply.strip()` branch emitted the `EMPTY_REPLY_DETAIL` error event.

The existing tests masked this because they stub `client.chat` with raw dict events — those satisfy `isinstance(_, dict)`, the real `ChatResponse` does not.

## Test plan

- [x] `tests/test_chat_stream.py` — all 18 tests pass (16 existing + 2 new regression cases).
- [x] New `test_subscriptable_chat_response_events_are_not_dropped` exercises the generator with `SubscriptableBaseModel`-shaped events.
- [x] New `test_bonjour_produces_reply_not_empty_fallback` exercises the full `/chat/stream` endpoint with production-shaped events and asserts no `error` event is emitted.
- [x] Standalone reproducer with real `ollama.ChatResponse` objects: pre-fix yields `[]`, post-fix yields the expected chunks.
- [x] Backwards compat: the `event_shape="dict"` default path is unchanged, every previous test still passes.

## Scope

Focused fix per the issue scope. No UI changes, no changes to SilentGuard, GitHub connector, maintenance, or feedback storage.

---
_Generated by [Claude Code](https://claude.ai/code/session_0168UkChhypGmnHUbu5bhDjt)_