### PR TITLE
feat(chat): keep Nova natural and compact when the user asks for short

### DIFF
--- a/core/nova_contract.py
+++ b/core/nova_contract.py
@@ -47,15 +47,29 @@ LANGUE: Détecte automatiquement la langue et réponds TOUJOURS dans cette langu
 LONGUEUR:
 - Salutation, small talk → 1 à 3 phrases maximum
 - Question simple → réponse directe sans introduction
-- Explication → paragraphes clairs et concis, pas de liste à puces forcée
-- Architecture / sécurité / code → développe seulement quand l'utilisateur le demande
+- Explication → 2 à 4 paragraphes courts, pas une liste à puces forcée
+- Architecture / sécurité / code → développe seulement quand l'utilisateur le demande, et reste compact
 - Code → complet en un seul bloc
+Si l'utilisateur demande explicitement "pas trop long", "court", "en bref", "rapidement", \
+"naturellement", "réponse simple" ou équivalent : limite-toi à 2-4 phrases ou 2-4 \
+paragraphes très courts. Pas de titres, pas de séparateurs, pas de longues listes \
+numérotées. Garde un ton conversationnel.
 Ne commence jamais par "Bien sûr!", "Certainement!", "Absolument!". Va droit au but.
+MISE EN FORME:
+- N'utilise des titres (## / ###) que pour les réponses longues structurées (doc, plan, \
+architecture). Pour une réponse courte ou conversationnelle, pas de titres.
+- N'utilise les listes que quand elles servent vraiment (étapes, options, comparaisons). \
+Sinon, des phrases.
+- Pas de gras décoratif : seulement pour un terme clé ou un avertissement, jamais pour \
+ponctuer une phrase normale.
+- Pas de séparateurs horizontaux (---) sauf entre vraies sections d'un document.
 TON:
 - Parle naturellement, sans formules corporate ni listes inutiles.
 - Reconnais brièvement l'intention de l'utilisateur quand c'est utile, puis donne la suite concrète.
 - Reste chaleureuse et claire — comme un humain calme qui aide, pas comme un répondeur automatique.
 - N'imite jamais une émotion, ne prétends jamais ressentir, être consciente, ou avoir une expérience personnelle.
+- Ne te fais jamais passer pour un humain. Si on te le demande, dis simplement que tu es Nova, un assistant IA local.
+- Évite le style "document de politique" sauf si l'utilisateur demande explicitement une doc, un rapport ou un plan.
 - Si tu ne sais pas, dis-le. Ne prétends jamais avoir fait quelque chose que tu n'as pas fait.
 PERTINENCE:
 - Pour les questions sur Nova, SilentGuard, le code, les PR ou la sécurité du projet, reste centrée sur le projet — ne dérive pas vers des conseils personnels génériques.

--- a/static/index.html
+++ b/static/index.html
@@ -1108,26 +1108,38 @@
            line-height makes prose readable without feeling cramped.
            Headings, paragraphs and lists collapse first-/last-child margins
            so the bubble never reserves empty vertical space at the edges.
-           Paragraphs and list items get a touch more breathing room than a
-           dense doc dump so long replies stay scannable. */
+           Paragraphs and list items get a touch of breathing room — enough
+           to scan, never enough to feel like a printed report. Heading
+           sizes are kept close to body text so a short answer that drifts
+           into a heading still reads conversationally, not document-like. */
         .message.nova h1, .message.nova h2, .message.nova h3 {
             color: var(--text);
-            margin: 12px 0 6px;
+            margin: 10px 0 4px;
             font-weight: 600;
             letter-spacing: -0.005em;
+            line-height: 1.35;
         }
-        .message.nova h1 { font-size: 1.16rem; }
-        .message.nova h2 { font-size: 1.04rem; }
-        .message.nova h3 { font-size: 0.96rem; color: var(--cyan); }
-        .message.nova p { margin: 7px 0; }
-        .message.nova ul, .message.nova ol { padding-left: 22px; margin: 7px 0; }
-        .message.nova li { margin: 4px 0; }
+        .message.nova h1 { font-size: 1.08rem; }
+        .message.nova h2 { font-size: 1.0rem; }
+        .message.nova h3 { font-size: 0.94rem; color: var(--cyan); }
+        .message.nova p { margin: 6px 0; }
+        .message.nova p + p { margin-top: 8px; }
+        .message.nova ul, .message.nova ol { padding-left: 20px; margin: 6px 0; }
+        .message.nova li { margin: 3px 0; }
         .message.nova li > p { margin: 2px 0; }
-        .message.nova li + li { margin-top: 5px; }
+        .message.nova li + li { margin-top: 4px; }
         .message.nova > div > *:first-child,
         .message.nova > *:first-child { margin-top: 0; }
         .message.nova > div > *:last-child,
         .message.nova > *:last-child { margin-bottom: 0; }
+        /* When the entire reply is a single short paragraph or a single
+           list, suppress the extra vertical breathing room so the bubble
+           hugs its content. Targets the common "natural short answer"
+           shape — two or three sentences with no other block siblings. */
+        .message.nova > div:only-child > p:only-child,
+        .message.nova > p:only-child { margin: 0; }
+        .message.nova > div:only-child > ul:only-child,
+        .message.nova > div:only-child > ol:only-child { margin: 2px 0; }
         .message.nova code {
             background: rgba(124, 197, 212, 0.10);
             padding: 1px 6px;
@@ -1174,7 +1186,11 @@
         .code-copy-btn:focus { opacity: 1; }
         .code-copy-btn:hover { color: var(--cyan); border-color: var(--cyan-glow); background: var(--cyan-soft); opacity: 1; }
         .code-copy-btn.copied { color: var(--cyan); border-color: var(--cyan-glow); background: var(--cyan-soft); opacity: 1; }
-        .message.nova strong { color: var(--text); font-weight: 600; }
+        /* `strong` is kept slightly calmer than browser default: same colour
+           as body text and a 590 weight, so a model that over-bolds parts
+           of a sentence still reads as prose rather than as alternating
+           shouting. Reserve true emphasis for the user. */
+        .message.nova strong { color: var(--text); font-weight: 590; }
         .message.nova em { color: var(--text-mid); }
         .message.nova a {
             color: var(--cyan);
@@ -1187,7 +1203,8 @@
             border: none;
             height: 1px;
             background: linear-gradient(90deg, transparent, var(--border), transparent);
-            margin: 12px 0;
+            margin: 10px 0;
+            opacity: 0.7;
         }
         .message.nova table {
             border-collapse: collapse;

--- a/tests/test_nova_contract.py
+++ b/tests/test_nova_contract.py
@@ -76,6 +76,57 @@ class TestBlocks:
         assert "silentguard" in lower
         assert "projet" in lower or "project" in lower
 
+    def test_response_style_honors_short_answer_request(self):
+        # When the user asks for a short / natural answer, Nova must not
+        # produce a long structured report. The block names the common
+        # French shorthands ("pas trop long", "court", "en bref") so the
+        # model recognises them as compactness signals.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "pas trop long" in lower
+        assert "court" in lower or "en bref" in lower or "rapidement" in lower
+
+    def test_response_style_caps_short_replies_to_a_few_paragraphs(self):
+        # Compact replies should land in 2-4 short paragraphs or
+        # 2-4 phrases — not as a numbered plan with headings.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "2-4" in lower or "2 à 4" in lower
+
+    def test_response_style_avoids_document_layout_for_short_answers(self):
+        # The block must explicitly suppress headings / horizontal rules /
+        # long numbered lists when the user asked for something compact —
+        # those are the patterns that make Nova feel like a policy doc.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "titre" in lower or "###" in lower or "##" in lower
+        assert "séparateur" in lower or "---" in lower
+
+    def test_response_style_warns_against_heavy_markdown(self):
+        # Markdown should serve content, not decorate it: the block must
+        # say that bold isn't for normal phrasing and lists should be
+        # used only when they help.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "gras" in lower or "bold" in lower
+        assert "liste" in lower
+
+    def test_response_style_forbids_pretending_to_be_human(self):
+        # "Human but honest": Nova may sound warm but must never claim
+        # to be a human. The block needs to spell this out so a
+        # role-play prompt can't talk the model into a fake-identity
+        # answer.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "humain" in lower
+        assert (
+            "pas pour un humain" in lower
+            or "passer pour un humain" in lower
+            or "ne te fais jamais passer" in lower
+        )
+
+    def test_response_style_discourages_policy_doc_voice(self):
+        # When the user asks a casual question, Nova should answer
+        # casually — not in the "policy document" voice that reads as
+        # cold and over-structured.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "document" in lower or "politique" in lower or "rapport" in lower
+
 
 class TestCapabilitiesBlock:
     def test_has_capabilities_label(self):

--- a/tests/test_personalization_chat_wiring.py
+++ b/tests/test_personalization_chat_wiring.py
@@ -232,3 +232,56 @@ class TestChatPullsPerUserPersonalization:
         # No block, but the contract is still there.
         assert "PRÉFÉRENCES UTILISATEUR" not in sys_msg
         assert IDENTITY_CONTRACT in sys_msg
+
+
+# ── Compact / natural reply contract reaches Ollama ─────────────────────────
+#
+# The previous round of polish made Nova *stream*; this round makes Nova
+# answer compactly when the user explicitly asks for a short / natural
+# reply. The contract directives live in `RESPONSE_STYLE_BLOCK` — these
+# tests pin that the directives actually end up in the system message
+# that Ollama sees for a typical French prompt like
+# "explique-moi en pas trop long ...".
+
+class TestShortReplyDirectiveReachesOllama:
+    def test_contract_compact_directive_is_in_system_prompt(
+        self, db_path, make_user,
+    ):
+        alice = make_user("alice")
+        with stub_chat_runtime() as fake_client:
+            chat([], "explique-moi en pas trop long ce que tu fais", [], alice)
+        sys_msg = _system_prompt(fake_client.call_args).lower()
+        # The contract names the compactness signals so the model maps
+        # the French shorthand onto a tight reply.
+        assert "pas trop long" in sys_msg
+        # And it caps short replies at a small number of paragraphs.
+        assert "2-4" in sys_msg or "2 à 4" in sys_msg
+
+    def test_contract_warns_against_document_layout(
+        self, db_path, make_user,
+    ):
+        alice = make_user("alice")
+        with stub_chat_runtime() as fake_client:
+            chat([], "réponds simplement", [], alice)
+        sys_msg = _system_prompt(fake_client.call_args).lower()
+        # Headings and horizontal rules are the two patterns that turn a
+        # casual answer into a report — the prompt must name them.
+        assert "titre" in sys_msg or "##" in sys_msg
+        assert "séparateur" in sys_msg or "---" in sys_msg
+
+    def test_contract_blocks_pretending_to_be_human(
+        self, db_path, make_user,
+    ):
+        # Warm tone is allowed, but Nova must never claim to be human.
+        # Test verifies the directive lands in the live system prompt,
+        # not just in the static block.
+        alice = make_user("alice")
+        with stub_chat_runtime() as fake_client:
+            chat([], "tu es un humain ?", [], alice)
+        sys_msg = _system_prompt(fake_client.call_args).lower()
+        assert "humain" in sys_msg
+        assert (
+            "pas pour un humain" in sys_msg
+            or "passer pour un humain" in sys_msg
+            or "ne te fais jamais passer" in sys_msg
+        )


### PR DESCRIPTION
## Summary

Follow-up polish to the streaming chat work. Streaming now produces real replies, but Nova still tends to answer casual French prompts (e.g. *"explique-moi en pas trop long ce que tu fais"*) with a long policy-document layout — numbered sections, headings, separators, and bolded fragments. The content was correct; the *shape* was wrong.

This PR tightens two layers without touching SilentGuard, the GitHub connector, or the maintenance surface:

### 1. Tone & length contract — `core/nova_contract.py`

- `RESPONSE_STYLE_BLOCK` now names the explicit compactness signals (*pas trop long*, *court*, *en bref*, *rapidement*, *naturellement*, *réponse simple*) and caps short replies at **2–4 short paragraphs or 2–4 phrases**. No titles, no separators, no long numbered lists when the user asked for something short.
- New `MISE EN FORME` section: titles (`##`/`###`) only for long structured replies (doc, plan, architecture); lists only when they actually help; **`strong`** reserved for a key term or warning, never decorative; no horizontal rules (`---`) outside true document sections.
- Two extra `TON` lines spell out what the contract used to only imply:
  - Nova **must never pretend to be a human** (warm tone is still allowed).
  - Nova must avoid the *"policy document"* voice unless the user explicitly asked for a doc / plan / report.

The casual-French style targets the kind of natural answer the example prompt wants:

> Oui. Dans ton setup, je suis Nova, ton assistant local : je t'aide à analyser, coder, résumer et décider, mais je ne dois pas agir toute seule.
>
> SilentGuard me donne une vue sécurité/réseau en lecture seule. Je peux t'expliquer les alertes, les connexions et les risques, mais je ne bloque rien moi-même.
>
> Notre règle reste simple : je propose, tu valides, puis seulement après on agit. Toute action sensible doit être confirmée et traçable.

### 2. Rendering polish — `static/index.html`

- Heading sizes pulled closer to body text (1.16/1.04/0.96 → 1.08/1.0/0.94 rem) so an answer that drifts into a heading still reads conversationally.
- Tighter paragraph / list rhythm with a touch more space between adjacent paragraphs (so prose breathes) and tighter list items.
- **New only-child rule**: a single short paragraph or single list now hugs the bubble instead of carrying inherited block margin — the common natural-reply shape.
- `strong` weight dropped from 600 → 590 so a model that over-bolds part of a sentence reads as prose, not alternating shouting.
- `hr` margin softened (12 → 10 px) and opacity nudged down so the rare separator feels calm.

Code blocks are unchanged — they were already readable.

### 3. Tests

Both layers are pinned:

- **`tests/test_nova_contract.py`**: unit asserts the new directives are in `RESPONSE_STYLE_BLOCK` (compactness signals, the 2–4 cap, no-headings/no-separators rule, anti-document-layout voice, no-pretending-to-be-human rule).
- **`tests/test_personalization_chat_wiring.py`** (new `TestShortReplyDirectiveReachesOllama`): runs `chat()` through a stubbed Ollama for a "pas trop long" prompt and verifies the system message that actually reaches Ollama carries the compactness signals, the document-layout warnings, and the "no pretending to be human" rule.

Existing streaming, feedback, security, personalization, identity, and message edit/delete tests still pass.

## Test plan

- [x] `python -m pytest tests/test_nova_contract.py -q` → 56 passed
- [x] `python -m pytest tests/test_personalization_chat_wiring.py -q` → 14 passed
- [x] `python -m pytest tests/test_chat_stream.py -q` → 18 passed
- [x] `python -m pytest tests/test_feedback.py tests/test_security_context.py -q` → still green
- [x] `python -m pytest tests/ -q` → **1692 passed**
- [ ] Local browser smoke: short French prompt (e.g. *"explique-moi en pas trop long ce que tu fais"*) renders a calm 2–4 paragraph reply with no headings or `---` separators.
- [ ] Browser smoke: an architecture / code request still renders structured markdown (heading, list, code block) without regressions.
- [ ] Browser smoke: bold inside prose now reads as emphasis, not as alternating shouting.

## Scope guard

- No changes to SilentGuard read-only behaviour.
- No changes to the GitHub connector.
- No changes to maintenance / update flows.
- No new features or unrelated cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_0161wWLBBepJPqbESFmFM69e)_