### PR TITLE
feat(paths): add NOVA_DATA_DIR foundation for portable data storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,35 @@ NOVA_USERNAME=admin
 NOVA_PASSWORD=changeme
 NOVA_SECRET_KEY=change-this-to-a-long-random-string
 
+# ── Nova data directory ───────────────────────────────────────────
+# Where Nova stores its runtime state (nova.db, backups, exports,
+# memory packs, logs). Leave empty to keep the legacy behaviour:
+# nova.db is created in the working directory of the running process,
+# typically the Nova checkout itself.
+#
+# Setting NOVA_DATA_DIR moves the entire data root to that path:
+#   <NOVA_DATA_DIR>/nova.db
+#   <NOVA_DATA_DIR>/nova.db.backup     (sidecar backup; see core/memory.py)
+#   <NOVA_DATA_DIR>/backups/           (reserved for future explicit backups)
+#   <NOVA_DATA_DIR>/exports/           (reserved for future user exports)
+#   <NOVA_DATA_DIR>/memory-packs/      (reserved for future memory packs)
+#   <NOVA_DATA_DIR>/logs/              (reserved for future local log files)
+#
+# Recommended locations:
+#   /mnt/fastdata/NovaData   — active database on a fast SSD.
+#   /mnt/archive/NovaData    — archive / backup copy on slower storage.
+#
+# Use stable mount paths defined in /etc/fstab, not transient ones
+# such as /run/media/<user>/<disk>. The latter only exist while the
+# disk is mounted by the desktop session and disappear when the
+# session ends, which is unsafe for a long-running service.
+#
+# Migration is NOT automatic. If you previously ran Nova without
+# NOVA_DATA_DIR and now want the new directory, stop Nova, copy
+# nova.db manually (see docs/data-directory.md), then start Nova.
+# Nova never deletes or overwrites an existing database on startup.
+NOVA_DATA_DIR=
+
 # ── Release channel ───────────────────────────────────────────
 # Controls which release tier this instance serves.
 # Values: stable | beta | alpha

--- a/README.md
+++ b/README.md
@@ -786,6 +786,7 @@ All configuration is read from `.env` at startup. Key variables:
 | `NOVA_USERNAME` | — | Login username for the seeded admin |
 | `NOVA_PASSWORD` | — | Login password for the seeded admin |
 | `NOVA_SECRET_KEY` | — | JWT signing secret |
+| `NOVA_DATA_DIR` | — | Optional absolute path that holds `nova.db`, backups, and reserved subdirectories. Blank = legacy layout (DB next to the checkout). See [`docs/data-directory.md`](docs/data-directory.md). |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
 | `NOVA_AUTO_WEB_LEARNING` | `false` | Enable background RSS/web learning |
 | `LOGIN_RATE_LIMIT_MAX` | `5` | Max login attempts per window |

--- a/core/memory.py
+++ b/core/memory.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 import shutil
 import os
@@ -5,6 +6,11 @@ from datetime import datetime
 from typing import Optional
 from memory.store import initialize_memory_database as _init_natural_memory
 from core import users as _users
+from core.paths import (
+    database_path as _resolved_db_path,
+    describe_legacy_migration as _describe_legacy_migration,
+    prepare as _prepare_data_dir,
+)
 from core.settings import migrate_user_settings as _migrate_user_settings
 from core.policies import migrate_family_controls as _migrate_family_controls
 from core.model_registry import (
@@ -16,7 +22,39 @@ from core.model_access import migrate as _migrate_model_access
 from core.local_models import migrate as _migrate_local_models
 from core.feedback import migrate as _migrate_feedback
 
-DB_PATH = "nova.db"
+logger = logging.getLogger(__name__)
+
+# Resolved at import time from ``core.paths``. When ``NOVA_DATA_DIR``
+# is set, this becomes ``<NOVA_DATA_DIR>/nova.db``; otherwise it stays
+# the legacy relative path. Tests still monkeypatch this attribute
+# directly (``monkeypatch.setattr(core.memory, "DB_PATH", path)``) and
+# every code path in this file reads ``DB_PATH`` as a module attribute,
+# so the override propagates unchanged.
+DB_PATH = str(_resolved_db_path())
+
+
+def _log_legacy_migration_advice() -> None:
+    """Warn once when ``NOVA_DATA_DIR`` is set but the DB is still legacy.
+
+    The Phase-1 contract is "no automatic migration": if an operator
+    configured ``NOVA_DATA_DIR`` after running Nova for a while, the
+    legacy ``./nova.db`` is still there and the configured target is
+    empty. Nova will start fresh under the new path; the operator
+    almost certainly wants to copy the legacy DB over by hand
+    (``docs/data-directory.md`` walks through it). A single WARN-level
+    log line makes that situation visible without touching any file.
+    """
+    status = _describe_legacy_migration()
+    if status is None or not status.should_advise_copy:
+        return
+    logger.warning(
+        "Nova legacy database detected at %s but NOVA_DATA_DIR expects it "
+        "at %s. Nova will start fresh under NOVA_DATA_DIR; copy the legacy "
+        "database manually if you want to keep its data. See "
+        "docs/data-directory.md for the documented procedure.",
+        status.legacy_db_path,
+        status.configured_db_path,
+    )
 
 
 def backup_db():
@@ -61,6 +99,13 @@ def save_setting(key: str, value: str):
 
 def initialize_db():
     """Crée toutes les tables si elles n'existent pas encore."""
+    # When ``NOVA_DATA_DIR`` is configured, make sure the directory and
+    # its subdirectories exist and are writable before opening the
+    # database. ``prepare()`` is a no-op when the env var is unset, so
+    # legacy installs and tests that bypass the data-dir story keep
+    # working unchanged.
+    _prepare_data_dir()
+    _log_legacy_migration_advice()
     with _get_connection() as conn:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS settings (

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,236 @@
+"""Nova data directory resolution helpers (Phase 1).
+
+This module centralises the question "where does Nova store its
+runtime data?". Today that data is a single SQLite file (``nova.db``)
+plus a small set of sidecar backups, written next to the application
+checkout. Operators who want to put Nova's data on a dedicated disk
+should set::
+
+    NOVA_DATA_DIR=/mnt/fastdata/NovaData
+
+and Nova will use that directory as the parent of ``nova.db`` and any
+other persistent runtime files. When the environment variable is unset
+(or empty), Nova preserves its legacy behaviour — files are written
+relative to the current working directory, exactly as before this
+module existed.
+
+Design contracts:
+
+* Path resolution always returns ``pathlib.Path`` objects so callers
+  do not have to think about leading slashes or trailing separators.
+* :func:`prepare` is the single side-effecting function. It creates
+  Nova-owned subdirectories only when ``NOVA_DATA_DIR`` is set, and it
+  raises a clear :class:`RuntimeError` if the directory cannot be used.
+  When ``NOVA_DATA_DIR`` is unset, :func:`prepare` is a strict no-op
+  so existing installs and tests that point Nova at a ``tmp_path`` are
+  not affected.
+* No data is moved, copied, or deleted by this module. Migration from
+  a legacy ``./nova.db`` is documented in ``docs/data-directory.md``
+  and remains a manual operator step in Phase 1.
+* The module has no Nova-internal imports — it is import-cycle safe.
+  ``core.memory`` and ``memory.store`` import from here, never the
+  other way around.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+# Environment variable that selects the Nova data root. Reading the
+# variable each call (instead of caching at import time) lets pytest's
+# ``monkeypatch.setenv`` propagate without forcing a module reload.
+ENV_VAR = "NOVA_DATA_DIR"
+
+# Names of the canonical files / subdirectories under the data root.
+# Listed centrally so docs and systemd guidance can point at a single
+# place when an operator wants to back the directory up, set
+# permissions, or audit what Nova writes.
+DB_FILENAME = "nova.db"
+BACKUPS_SUBDIR = "backups"
+EXPORTS_SUBDIR = "exports"
+MEMORY_PACKS_SUBDIR = "memory-packs"
+LOGS_SUBDIR = "logs"
+
+_SUBDIRS: tuple[str, ...] = (
+    BACKUPS_SUBDIR,
+    EXPORTS_SUBDIR,
+    MEMORY_PACKS_SUBDIR,
+    LOGS_SUBDIR,
+)
+
+
+def configured_data_dir() -> Path | None:
+    """Return the configured Nova data directory, or ``None`` when unset.
+
+    ``NOVA_DATA_DIR`` is read fresh on every call so tests can override
+    it through ``monkeypatch.setenv``. Empty / whitespace-only values
+    normalise to ``None`` so a blank line in ``.env`` behaves the same
+    as "not configured" — Nova never silently writes to ``""``.
+    """
+    raw = os.environ.get(ENV_VAR, "")
+    if not raw or not raw.strip():
+        return None
+    return Path(raw.strip()).expanduser()
+
+
+def database_path() -> Path:
+    """Return the path to ``nova.db`` honouring ``NOVA_DATA_DIR``.
+
+    With ``NOVA_DATA_DIR`` unset the function returns the legacy
+    relative path (``nova.db`` in the current working directory) so
+    existing installs keep working unchanged. With it set, the path
+    is ``<NOVA_DATA_DIR>/nova.db``.
+    """
+    root = configured_data_dir()
+    if root is None:
+        return Path(DB_FILENAME)
+    return root / DB_FILENAME
+
+
+def backups_dir() -> Path:
+    """Return the path of the ``backups`` subdirectory.
+
+    Falls back to a relative ``backups`` path when ``NOVA_DATA_DIR`` is
+    unset. The directory is created by :func:`prepare` only when the
+    env var is set; callers that bypass :func:`prepare` should still
+    tolerate its absence.
+    """
+    root = configured_data_dir()
+    if root is None:
+        return Path(BACKUPS_SUBDIR)
+    return root / BACKUPS_SUBDIR
+
+
+def exports_dir() -> Path:
+    """Return the path of the ``exports`` subdirectory."""
+    root = configured_data_dir()
+    if root is None:
+        return Path(EXPORTS_SUBDIR)
+    return root / EXPORTS_SUBDIR
+
+
+def memory_packs_dir() -> Path:
+    """Return the path of the ``memory-packs`` subdirectory."""
+    root = configured_data_dir()
+    if root is None:
+        return Path(MEMORY_PACKS_SUBDIR)
+    return root / MEMORY_PACKS_SUBDIR
+
+
+def logs_dir() -> Path:
+    """Return the path of the ``logs`` subdirectory."""
+    root = configured_data_dir()
+    if root is None:
+        return Path(LOGS_SUBDIR)
+    return root / LOGS_SUBDIR
+
+
+@dataclass(frozen=True)
+class LegacyMigrationStatus:
+    """Read-only snapshot of the legacy → ``NOVA_DATA_DIR`` state.
+
+    Returned by :func:`describe_legacy_migration` so operators (and
+    future admin endpoints) can see what *would* be migrated without
+    performing any move. The dataclass deliberately exposes no methods —
+    it is a value object, not a worker.
+    """
+
+    legacy_db_path: Path
+    configured_db_path: Path
+    legacy_exists: bool
+    configured_exists: bool
+    should_advise_copy: bool
+
+
+def describe_legacy_migration() -> LegacyMigrationStatus | None:
+    """Return a snapshot of the legacy → ``NOVA_DATA_DIR`` migration state.
+
+    Returns ``None`` when ``NOVA_DATA_DIR`` is unset — there is no
+    target to migrate to. Otherwise the returned status reports:
+
+    * ``legacy_db_path`` — the absolute legacy location (``./nova.db``).
+    * ``configured_db_path`` — the absolute path under ``NOVA_DATA_DIR``.
+    * ``legacy_exists`` / ``configured_exists`` — file presence flags.
+    * ``should_advise_copy`` — true only when a legacy DB is sitting
+      next to the checkout and ``NOVA_DATA_DIR`` is empty.
+
+    The function is **read-only**. It never moves files, never deletes
+    anything, and never writes. ``docs/data-directory.md`` documents
+    the manual copy procedure an operator should follow.
+    """
+    root = configured_data_dir()
+    if root is None:
+        return None
+    legacy = Path(DB_FILENAME).resolve()
+    configured = (root / DB_FILENAME).resolve()
+    legacy_exists = legacy.exists()
+    configured_exists = configured.exists()
+    should_advise_copy = (
+        legacy_exists
+        and not configured_exists
+        and legacy != configured
+    )
+    return LegacyMigrationStatus(
+        legacy_db_path=legacy,
+        configured_db_path=configured,
+        legacy_exists=legacy_exists,
+        configured_exists=configured_exists,
+        should_advise_copy=should_advise_copy,
+    )
+
+
+def prepare() -> Path | None:
+    """Create the Nova data directory and its subdirectories.
+
+    When ``NOVA_DATA_DIR`` is unset, this is a strict no-op and returns
+    ``None`` — legacy behaviour is preserved, and tests that point Nova
+    at a ``tmp_path`` see no extra side effects.
+
+    When ``NOVA_DATA_DIR`` is set, this function:
+
+    * Creates the data directory with ``mkdir -p`` semantics.
+    * Creates the standard subdirectories (``backups``, ``exports``,
+      ``memory-packs``, ``logs``) so future PRs do not have to
+      defensively re-create them.
+    * Verifies the directory is writable by the running process.
+
+    Raises :class:`RuntimeError` with a sanitised message when the
+    directory is unusable. The error references the configured path
+    and the underlying syscall failure — it never leaks internal state.
+    """
+    root = configured_data_dir()
+    if root is None:
+        return None
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Nova data directory {root!s} could not be created: "
+            f"{exc.strerror or exc}"
+        ) from exc
+
+    if not root.is_dir():
+        raise RuntimeError(
+            f"Nova data directory {root!s} exists but is not a directory."
+        )
+
+    if not os.access(root, os.W_OK):
+        raise RuntimeError(
+            f"Nova data directory {root!s} is not writable by the "
+            "current user."
+        )
+
+    for name in _SUBDIRS:
+        sub = root / name
+        try:
+            sub.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Nova data subdirectory {sub!s} could not be created: "
+                f"{exc.strerror or exc}"
+            ) from exc
+
+    return root

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -88,12 +88,54 @@ this hardening to the container/VM host as well.
 For the authoritative reference, see
 [`systemd.exec(5)`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html).
 
+## Storing Nova data on a dedicated disk (`NOVA_DATA_DIR`)
+
+By default Nova writes `nova.db` and its sidecar files
+(`nova.db.backup`, `nova.db.preupgrade-*`) next to the checkout. If you
+want to move the database to a separate disk — for example, an SSD for
+the live database and an HDD for archives — point Nova at a dedicated
+data directory:
+
+```ini
+[Service]
+Environment="NOVA_DATA_DIR=/mnt/fastdata/NovaData"
+ReadWritePaths=/path/to/Nova
+ReadWritePaths=/mnt/fastdata/NovaData
+```
+
+When the data directory lives on a mount, also tell systemd to wait
+for the mount before starting Nova (and to stop Nova cleanly if the
+disk is unmounted):
+
+```ini
+[Unit]
+After=network-online.target
+Wants=network-online.target
+RequiresMountsFor=/mnt/fastdata
+```
+
+Configure the mount in `/etc/fstab` so it comes up at boot. Avoid
+desktop-session paths such as `/run/media/<user>/<disk>` — those only
+exist while a graphical session is logged in and disappear at logout,
+which is unsafe for a long-running service.
+
+The active database should ideally live on **SSD** so the chat path
+stays snappy. The slower HDD path is fine for archive copies (`rsync`
+the SSD directory periodically) but not for the live `nova.db`.
+
+See [`docs/data-directory.md`](../../docs/data-directory.md) for the
+manual database copy procedure and the full layout under
+`NOVA_DATA_DIR`.
+
 ## Installing the hardened unit
 
 1. Edit `deploy/systemd/nova.service` and replace the placeholders:
    - `USERNAME` → the local Linux account that owns the Nova checkout.
    - `/path/to/Nova` → the absolute path of the checkout (the directory
-     that contains `web.py` and where `nova.db` lives).
+     that contains `web.py` and where `nova.db` lives by default).
+   - Optionally uncomment the `NOVA_DATA_DIR=` line, the second
+     `ReadWritePaths=` line, and the `RequiresMountsFor=` block under
+     `[Unit]` to store the database on a dedicated mount.
 
 2. Install, reload, and start:
 

--- a/deploy/systemd/nova.service
+++ b/deploy/systemd/nova.service
@@ -10,14 +10,23 @@
 #   1. Replace USERNAME with the local Linux account that owns the Nova checkout.
 #   2. Replace /path/to/Nova with the absolute path of your Nova checkout
 #      (the directory that contains web.py and nova.db).
-#   3. If you keep nova.db somewhere other than the checkout, add that path to
-#      ReadWritePaths= as well.
+#   3. If you keep nova.db somewhere other than the checkout (see
+#      NOVA_DATA_DIR below), add that path to ReadWritePaths= as well
+#      and uncomment the matching RequiresMountsFor= line so systemd
+#      waits for the disk before starting Nova.
 #
 # See deploy/systemd/README.md for the full guide and a per-option explanation.
 
 [Unit]
 Description=Nova AI Assistant (hardened)
 After=network.target ollama.service
+# Uncomment when Nova's data lives on a mounted disk (see NOVA_DATA_DIR
+# in [Service] below). systemd will then wait for the mount to be
+# present before starting the unit, and will stop Nova cleanly if the
+# disk is unmounted.
+# After=network-online.target
+# Wants=network-online.target
+# RequiresMountsFor=/mnt/fastdata
 
 [Service]
 Type=simple
@@ -28,6 +37,12 @@ ExecStart=/path/to/Nova/.venv/bin/uvicorn web:app --host 0.0.0.0 --port 8080
 Restart=always
 RestartSec=5
 Environment="PATH=/path/to/Nova/.venv/bin:/usr/bin:/usr/local/bin"
+# Optional: move Nova's runtime data (nova.db, backups/, exports/,
+# memory-packs/, logs/) to a dedicated disk. Leave commented out to
+# keep the legacy layout (nova.db in WorkingDirectory). When you set
+# this, also add the path to ReadWritePaths= below and uncomment the
+# RequiresMountsFor= line under [Unit] so systemd waits for the mount.
+# Environment="NOVA_DATA_DIR=/mnt/fastdata/NovaData"
 
 # ── Sandbox hardening ──────────────────────────────────────────────────────
 # These directives restrict what the Nova process can see and do on the host.
@@ -51,8 +66,10 @@ ProtectHome=read-only
 
 # Restore write access to the Nova checkout so nova.db, backups, and any
 # file written under WorkingDirectory continue to work. Adjust this list if
-# the database lives outside the checkout.
+# the database lives outside the checkout — add the NOVA_DATA_DIR path
+# (e.g. /mnt/fastdata/NovaData) here so Nova can write its DB there.
 ReadWritePaths=/path/to/Nova
+# ReadWritePaths=/mnt/fastdata/NovaData
 
 # Drop every Linux capability. Nova is a userspace HTTP app and needs none
 # of them.

--- a/docs/data-directory.md
+++ b/docs/data-directory.md
@@ -1,0 +1,168 @@
+# Nova data directory (`NOVA_DATA_DIR`)
+
+Nova stores its runtime state — the SQLite database, sidecar backups,
+and a few reserved subdirectories — in a single, configurable
+directory. This document explains the layout, how to move existing
+data onto a dedicated disk, and how to back it up and restore it.
+
+This is the **Phase 1 foundation**. Nova does not auto-migrate, does
+not auto-back up, and does not run a wizard. Moving data is a
+deliberate operator step that you can review before it happens and
+revert by hand if anything looks wrong.
+
+## What `NOVA_DATA_DIR` is
+
+`NOVA_DATA_DIR` is an environment variable that selects the parent
+directory of every persistent file Nova writes. The default —
+empty / unset — preserves Nova's legacy behaviour: `nova.db` is
+created in the working directory of the running process (typically
+the Nova checkout). Existing installs do not need to set anything for
+this PR; nothing changes for them.
+
+When set to an absolute path, Nova:
+
+* uses `<NOVA_DATA_DIR>/nova.db` as its SQLite database,
+* creates the standard subdirectories listed below on startup,
+* refuses to start if the directory is not writable, with a clear
+  error message that names the path.
+
+Nova never silently creates data in a different location when the
+configured directory is unavailable. The service fails loudly so an
+operator notices and can fix the mount, permission, or path.
+
+## Recommended layout
+
+```
+NOVA_DATA_DIR/
+├── nova.db                # SQLite database (live)
+├── nova.db.backup         # sidecar backup written before destructive ops
+├── nova.db.preupgrade-*   # pre-migration backups (timestamped)
+├── backups/               # reserved for future explicit backup exports
+├── exports/               # reserved for future user-facing exports
+├── memory-packs/          # reserved for future memory pack imports
+└── logs/                  # reserved for future local log files
+```
+
+The four reserved subdirectories are created on startup but not
+written to by any current Nova feature. They exist so future PRs can
+land cleanly without each one having to re-derive a layout convention.
+
+## Recommended locations
+
+| Path                             | Use                                   |
+|----------------------------------|---------------------------------------|
+| `/mnt/fastdata/NovaData`         | active database — fast SSD.           |
+| `/mnt/archive/NovaData`          | archive / backup copy — slower disk.  |
+| `/var/lib/nova` (system-managed) | acceptable for a single dedicated host. |
+
+Use **stable mount paths** declared in `/etc/fstab`. Avoid
+`/run/media/<user>/<disk>` — those exist only while a desktop session
+is logged in and disappear at logout, which is unsafe for a long-running
+service. systemd will not wait for a `/run/media` mount either.
+
+The active database should ideally live on **SSD**: SQLite touches
+the file synchronously on every transaction, and an HDD makes chat
+feel laggy. Archive copies on HDD are fine.
+
+## Moving an existing `nova.db`
+
+Phase 1 does **not** auto-migrate. The procedure below is the
+documented manual step. It is the same on every host shape (bare
+metal, systemd, Docker, dev box).
+
+```bash
+# 1. Stop Nova so the database is not being written to.
+sudo systemctl stop nova
+
+# 2. Create the new data directory and make sure Nova owns it.
+sudo mkdir -p /mnt/fastdata/NovaData
+sudo chown -R nova:nova /mnt/fastdata/NovaData
+
+# 3. Copy nova.db (and its sidecar files) into the new location.
+#    Use rsync -a so timestamps and permissions are preserved.
+sudo -u nova rsync -a /path/to/Nova/nova.db /mnt/fastdata/NovaData/
+sudo -u nova rsync -a /path/to/Nova/nova.db.backup /mnt/fastdata/NovaData/ 2>/dev/null || true
+
+# 4. Configure systemd to point Nova at the new directory.
+#    Edit /etc/systemd/system/nova.service and add:
+#        Environment="NOVA_DATA_DIR=/mnt/fastdata/NovaData"
+#        ReadWritePaths=/mnt/fastdata/NovaData
+#    (See deploy/systemd/nova.service for the documented placeholders.)
+sudo systemctl daemon-reload
+
+# 5. Start Nova and confirm it picked up the new path.
+sudo systemctl restart nova
+journalctl -u nova -n 50 --no-pager
+
+# 6. Verify in the web UI that memories, conversations, and
+#    feedback are present. Keep the OLD database file as a backup
+#    until you have verified the migration end-to-end.
+```
+
+If you change your mind, stop Nova, remove the `NOVA_DATA_DIR`
+environment line, and restart. Nova falls back to the legacy path
+(the original `nova.db` next to the checkout) automatically.
+
+Nova never deletes the old database on its own. The legacy file
+remains in place until you remove it by hand.
+
+### What the startup log says
+
+When `NOVA_DATA_DIR` is set, Nova prints a `WARNING` log line if:
+
+* the legacy `./nova.db` still exists next to the checkout, AND
+* the configured `NOVA_DATA_DIR/nova.db` does not yet exist.
+
+That is the "you probably want to copy your database" reminder. Nova
+will still start fresh under the new path — copying is up to you, and
+the warning intentionally never touches a file.
+
+## Backups
+
+Treat the data directory as the single thing to back up. Everything
+Nova writes lives under it.
+
+```bash
+# Snapshot the whole directory (compressed, timestamped).
+sudo -u nova rsync -a /mnt/fastdata/NovaData/ \
+                     /mnt/archive/NovaData-$(date +%Y%m%dT%H%M%SZ)/
+
+# Or a simple SQLite-aware dump for the database alone.
+sudo -u nova sqlite3 /mnt/fastdata/NovaData/nova.db \
+    ".backup '/mnt/archive/nova-$(date +%Y%m%dT%H%M%SZ).db'"
+```
+
+Encrypt offline copies — the database contains conversation history,
+user-authored memories, and per-user settings.
+
+## Restore
+
+The restore path is the inverse of the migration above:
+
+```bash
+sudo systemctl stop nova
+sudo -u nova rsync -a /mnt/archive/NovaData-<stamp>/nova.db \
+                     /mnt/fastdata/NovaData/nova.db
+sudo systemctl start nova
+journalctl -u nova -n 50 --no-pager
+```
+
+Always test the restore path on a non-production host first.
+
+## Safety guarantees
+
+These are firm boundaries — they are reasons this PR is small and
+deliberate, not future work.
+
+* Nova **never** moves data automatically. The operator copies.
+* Nova **never** overwrites an existing `nova.db`.
+* Nova **never** deletes the legacy database.
+* Nova **never** runs `sudo`, `pkexec`, or any shell command as part
+  of path handling. Permission setup is the operator's job.
+* Nova fails loudly when `NOVA_DATA_DIR` is unwritable — it does not
+  silently fall back to a different path.
+
+If a future Nova release introduces an opt-in migration helper, it
+will be additive (a single explicit command), preserve the legacy
+file, and require explicit confirmation. Nothing about the current
+data is at risk from this PR.

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -157,9 +157,13 @@ mean the unit is misconfigured.
 - Anything you explicitly add, such as a database directory outside
   the checkout, or a log directory.
 
-If you keep `nova.db` somewhere else, **add only that directory** to
-`ReadWritePaths=`. Avoid giving Nova write access to the whole home
-directory.
+If you move `nova.db` onto a dedicated disk by setting
+`NOVA_DATA_DIR=/mnt/fastdata/NovaData`, **add only that directory**
+to `ReadWritePaths=` and add `RequiresMountsFor=/mnt/fastdata` under
+`[Unit]` so systemd waits for the mount. Avoid giving Nova write
+access to the whole home directory. See
+[`docs/data-directory.md`](data-directory.md) for the documented
+copy / migration procedure.
 
 ### What stays reachable
 
@@ -223,14 +227,17 @@ sudo -u nova sudo -l   # should print "Sorry, user nova may not run sudo"
 
 ## Backups
 
-- `nova.db` and `nova.db.backup` live in the Nova checkout. Back the
-  whole directory up — there are no out-of-band state files.
+- `nova.db` and `nova.db.backup` live in the Nova checkout by default.
+  If you set `NOVA_DATA_DIR=/mnt/fastdata/NovaData` (see
+  [`docs/data-directory.md`](data-directory.md)), they live there
+  instead — back up that directory in one shot.
 - Treat backups as **sensitive**: they contain conversation history,
   per-user settings, and (if you enabled the natural memory layer)
   user-authored memories. Encrypt at rest.
 - Test the restore path before you need it. The simplest restore is
   `sudo systemctl stop nova && cp nova.db.backup nova.db && sudo
-  systemctl start nova`.
+  systemctl start nova` (run the `cp` against the same directory the
+  active `nova.db` lives in).
 
 ## Audit and logs
 

--- a/memory/store.py
+++ b/memory/store.py
@@ -3,10 +3,17 @@ import re
 import sqlite3
 from datetime import datetime
 
+from core.paths import database_path as _resolved_db_path
 from memory.embeddings import generate_embedding, cosine_similarity
 from memory.schema import Memory
 
-DB_PATH = "nova.db"
+# Resolved at import time from ``core.paths``. With ``NOVA_DATA_DIR``
+# set this becomes ``<NOVA_DATA_DIR>/nova.db``; otherwise it remains
+# the legacy relative path so existing installs are unaffected. Tests
+# still monkeypatch ``memory.store.DB_PATH`` directly, and every call
+# path resolves the attribute via :func:`_resolve_db_path` below — so
+# the override propagates unchanged.
+DB_PATH = str(_resolved_db_path())
 
 # Thresholds for deciding whether a new memory duplicates an existing one.
 # Cosine similarity is used when both memories have embeddings; Jaccard token

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,407 @@
+"""Tests for the Nova data-directory foundation (``core.paths``).
+
+The contract under test:
+
+* When ``NOVA_DATA_DIR`` is unset, every path helper returns the same
+  legacy values Nova used before this PR, and :func:`prepare` is a
+  strict no-op. Existing installs and existing tests that bypass the
+  data-dir story must not be disturbed.
+* When ``NOVA_DATA_DIR`` is set, the database lives under it, the
+  documented subdirectories are created by :func:`prepare`, an
+  unwritable target raises a clear error, and the legacy-migration
+  reporter describes (without performing) what the operator would
+  need to copy.
+* ``core.memory`` and ``memory.store`` agree with ``core.paths`` on
+  the live database path at module-import time.
+
+These tests never set ``NOVA_DATA_DIR`` to a user-specific absolute
+path — every concrete location is rooted at ``tmp_path`` so the suite
+can run on any developer host and on CI without local cleanup.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Heavy / optional deps that ``core.memory`` ultimately pulls in via
+# its migration imports. Stub them defensively so importing this test
+# module never depends on the host having ollama, feedparser, etc.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    sys.modules.setdefault(_mod, MagicMock())
+
+from core import paths as core_paths  # noqa: E402
+
+
+# ── default / unset NOVA_DATA_DIR ───────────────────────────────────
+
+
+class TestDefaultBehaviour:
+    """When ``NOVA_DATA_DIR`` is unset, paths match legacy behaviour."""
+
+    def test_configured_data_dir_returns_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        assert core_paths.configured_data_dir() is None
+
+    def test_configured_data_dir_returns_none_when_blank(self, monkeypatch):
+        monkeypatch.setenv(core_paths.ENV_VAR, "")
+        assert core_paths.configured_data_dir() is None
+
+    def test_configured_data_dir_returns_none_when_whitespace(self, monkeypatch):
+        # A blank line in .env should not silently send Nova to "".
+        monkeypatch.setenv(core_paths.ENV_VAR, "   ")
+        assert core_paths.configured_data_dir() is None
+
+    def test_database_path_is_legacy_relative_when_unset(self, monkeypatch):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        # The legacy default — relative ``nova.db`` in the working
+        # directory — must be preserved bit-for-bit.
+        assert core_paths.database_path() == Path("nova.db")
+
+    def test_database_path_returns_pathlib_path(self, monkeypatch):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        assert isinstance(core_paths.database_path(), Path)
+
+    def test_subdirs_are_relative_when_unset(self, monkeypatch):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        assert core_paths.backups_dir() == Path("backups")
+        assert core_paths.exports_dir() == Path("exports")
+        assert core_paths.memory_packs_dir() == Path("memory-packs")
+        assert core_paths.logs_dir() == Path("logs")
+
+    def test_prepare_is_noop_when_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        # Run prepare() in a clean cwd; it must not create directories
+        # underneath us and must return None.
+        monkeypatch.chdir(tmp_path)
+        result = core_paths.prepare()
+        assert result is None
+        # Nothing should have been touched on disk.
+        assert sorted(p.name for p in tmp_path.iterdir()) == []
+
+    def test_describe_legacy_migration_returns_none_when_unset(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        assert core_paths.describe_legacy_migration() is None
+
+
+# ── NOVA_DATA_DIR configured ────────────────────────────────────────
+
+
+class TestConfiguredDirectory:
+    """When ``NOVA_DATA_DIR`` is set, every helper points under it."""
+
+    def test_configured_data_dir_returns_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path / "NovaData"))
+        configured = core_paths.configured_data_dir()
+        assert configured == tmp_path / "NovaData"
+        assert isinstance(configured, Path)
+
+    def test_database_path_lives_under_configured_root(
+        self, monkeypatch, tmp_path
+    ):
+        root = tmp_path / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        assert core_paths.database_path() == root / "nova.db"
+
+    def test_subdirs_live_under_configured_root(self, monkeypatch, tmp_path):
+        root = tmp_path / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        assert core_paths.backups_dir() == root / "backups"
+        assert core_paths.exports_dir() == root / "exports"
+        assert core_paths.memory_packs_dir() == root / "memory-packs"
+        assert core_paths.logs_dir() == root / "logs"
+
+    def test_user_expansion(self, monkeypatch, tmp_path):
+        # ``~`` should expand against the user's home; for the test we
+        # point ``HOME`` at a tmp dir so the assertion is deterministic.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(core_paths.ENV_VAR, "~/NovaData")
+        assert core_paths.configured_data_dir() == tmp_path / "NovaData"
+
+
+class TestPrepare:
+    """``prepare()`` creates the layout when ``NOVA_DATA_DIR`` is set."""
+
+    def test_creates_root_and_subdirs(self, monkeypatch, tmp_path):
+        root = tmp_path / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        returned = core_paths.prepare()
+        assert returned == root
+        assert root.is_dir()
+        for name in ("backups", "exports", "memory-packs", "logs"):
+            assert (root / name).is_dir(), f"{name} should be created"
+
+    def test_idempotent(self, monkeypatch, tmp_path):
+        root = tmp_path / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        # Pre-create the root and one subdir to simulate a second run.
+        (root / "backups").mkdir(parents=True)
+        # Drop a marker file to prove prepare() does not nuke contents.
+        marker = root / "backups" / "keep.txt"
+        marker.write_text("hello", encoding="utf-8")
+
+        core_paths.prepare()
+        core_paths.prepare()
+
+        assert marker.exists()
+        assert marker.read_text(encoding="utf-8") == "hello"
+
+    def test_existing_file_at_root_path_is_rejected(
+        self, monkeypatch, tmp_path
+    ):
+        # An existing file (not a directory) at the data-dir path must
+        # be reported clearly rather than silently coerced.
+        path = tmp_path / "NovaData"
+        path.write_text("not a directory", encoding="utf-8")
+        monkeypatch.setenv(core_paths.ENV_VAR, str(path))
+
+        with pytest.raises(RuntimeError) as exc_info:
+            core_paths.prepare()
+        # ``mkdir(exist_ok=True)`` raises ``FileExistsError`` (a subclass
+        # of ``OSError``) when the path is a regular file; either that
+        # branch or the explicit ``is_dir`` check should fire.
+        message = str(exc_info.value)
+        assert str(path) in message
+
+    def test_unwritable_directory_is_rejected(self, monkeypatch, tmp_path):
+        # Skip on platforms where chmod cannot make a directory
+        # unwritable (e.g. running as root, which is the default in the
+        # CI sandbox). ``os.access`` uses the effective uid; root sees
+        # every directory as writable, so we cannot exercise this path.
+        if os.geteuid() == 0:
+            pytest.skip("running as root — cannot make a directory unwritable")
+
+        root = tmp_path / "NovaData"
+        root.mkdir()
+        # Remove write bits for the user — Nova must refuse, not retry.
+        os.chmod(root, stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+            with pytest.raises(RuntimeError) as exc_info:
+                core_paths.prepare()
+            assert "not writable" in str(exc_info.value)
+        finally:
+            # Restore so pytest can clean tmp_path on teardown.
+            os.chmod(root, stat.S_IRWXU)
+
+
+class TestLegacyMigrationReport:
+    """``describe_legacy_migration()`` reports without moving anything."""
+
+    def test_should_advise_copy_when_legacy_exists_and_target_empty(
+        self, monkeypatch, tmp_path
+    ):
+        # Pretend the current working directory holds a legacy DB.
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+        legacy_db = cwd / "nova.db"
+        legacy_db.write_bytes(b"")  # empty file is enough for the check.
+
+        target_root = tmp_path / "NovaData"
+        target_root.mkdir()
+
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv(core_paths.ENV_VAR, str(target_root))
+
+        status = core_paths.describe_legacy_migration()
+        assert status is not None
+        assert status.legacy_exists is True
+        assert status.configured_exists is False
+        assert status.should_advise_copy is True
+
+        # Critically: the report must not have touched either file.
+        assert legacy_db.exists()
+        assert not (target_root / "nova.db").exists()
+
+    def test_no_advice_when_target_already_has_db(
+        self, monkeypatch, tmp_path
+    ):
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+        (cwd / "nova.db").write_bytes(b"")
+        target_root = tmp_path / "NovaData"
+        target_root.mkdir()
+        (target_root / "nova.db").write_bytes(b"")
+
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv(core_paths.ENV_VAR, str(target_root))
+
+        status = core_paths.describe_legacy_migration()
+        assert status is not None
+        assert status.configured_exists is True
+        assert status.should_advise_copy is False
+
+    def test_no_advice_when_no_legacy_db(self, monkeypatch, tmp_path):
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+        target_root = tmp_path / "NovaData"
+        target_root.mkdir()
+
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv(core_paths.ENV_VAR, str(target_root))
+
+        status = core_paths.describe_legacy_migration()
+        assert status is not None
+        assert status.legacy_exists is False
+        assert status.should_advise_copy is False
+
+
+# ── integration with ``core.memory`` and ``memory.store`` ───────────
+
+
+class TestModuleIntegration:
+    """The DB path attributes pick up ``core.paths`` resolution."""
+
+    def test_core_memory_module_db_path_is_a_string(self):
+        # Tests monkeypatch ``core.memory.DB_PATH`` to a plain string;
+        # the module attribute must therefore be a string, not a Path,
+        # to keep that contract intact.
+        from core import memory as core_memory
+        assert isinstance(core_memory.DB_PATH, str)
+
+    def test_memory_store_module_db_path_is_a_string(self):
+        from memory import store as natural_store
+        assert isinstance(natural_store.DB_PATH, str)
+
+    def test_initialize_db_creates_db_at_configured_path(
+        self, monkeypatch, tmp_path
+    ):
+        # End-to-end: with NOVA_DATA_DIR set, ``initialize_db`` should
+        # create the database at the configured location and the
+        # standard subdirectories alongside it.
+        root = tmp_path / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        monkeypatch.setenv("NOVA_USERNAME", "admin")
+        monkeypatch.setenv("NOVA_PASSWORD", "pw")
+
+        db_path = str(root / "nova.db")
+        from core import memory as core_memory
+        from memory import store as natural_store
+        monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+        monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+
+        core_memory.initialize_db()
+
+        assert (root / "nova.db").is_file()
+        # Subdirectories should have been created by prepare().
+        for name in ("backups", "exports", "memory-packs", "logs"):
+            assert (root / name).is_dir(), f"{name} should be created"
+
+        # The migrated users table should exist with the seeded admin.
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT username FROM users WHERE username = ?", ("admin",)
+            ).fetchone()
+        assert row is not None
+
+    def test_initialize_db_warns_when_legacy_db_present(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        # When NOVA_DATA_DIR is set and the legacy ./nova.db still
+        # exists, ``initialize_db`` should emit a single WARNING log
+        # line. The legacy file must remain untouched.
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+        legacy_db = cwd / "nova.db"
+        legacy_db.write_bytes(b"")
+        target_root = tmp_path / "NovaData"
+
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv(core_paths.ENV_VAR, str(target_root))
+        monkeypatch.setenv("NOVA_USERNAME", "admin")
+        monkeypatch.setenv("NOVA_PASSWORD", "pw")
+
+        db_path = str(target_root / "nova.db")
+        from core import memory as core_memory
+        from memory import store as natural_store
+        monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+        monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="core.memory"):
+            core_memory.initialize_db()
+
+        assert legacy_db.exists()
+        assert legacy_db.read_bytes() == b""
+        warned = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "legacy database" in r.getMessage()
+        ]
+        assert warned, "Expected a WARNING about the legacy database"
+
+    def test_initialize_db_does_not_overwrite_existing_db(
+        self, monkeypatch, tmp_path
+    ):
+        # An existing database at the configured path must be left
+        # alone. ``initialize_db`` is idempotent — it CREATES TABLE
+        # IF NOT EXISTS — and must not truncate, replace, or move the
+        # underlying file.
+        root = tmp_path / "NovaData"
+        root.mkdir()
+        db_path = root / "nova.db"
+        # Seed a DB with one row of recognisable content. We use the
+        # ``settings`` table since the schema knows about it.
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "CREATE TABLE settings (key TEXT PRIMARY KEY, "
+                "value TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO settings(key, value) VALUES (?, ?)",
+                ("preexisting", "yes"),
+            )
+
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        monkeypatch.setenv("NOVA_USERNAME", "admin")
+        monkeypatch.setenv("NOVA_PASSWORD", "pw")
+        from core import memory as core_memory
+        from memory import store as natural_store
+        monkeypatch.setattr(core_memory, "DB_PATH", str(db_path))
+        monkeypatch.setattr(natural_store, "DB_PATH", str(db_path))
+
+        core_memory.initialize_db()
+
+        # The pre-existing row must survive.
+        with sqlite3.connect(str(db_path)) as conn:
+            row = conn.execute(
+                "SELECT value FROM settings WHERE key = 'preexisting'"
+            ).fetchone()
+        assert row is not None
+        assert row[0] == "yes"
+
+
+# ── stability of path helpers ───────────────────────────────────────
+
+
+class TestStability:
+    """Path helpers return stable values across repeated calls."""
+
+    def test_repeated_calls_return_equal_paths_when_unset(self, monkeypatch):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        assert core_paths.database_path() == core_paths.database_path()
+        assert core_paths.backups_dir() == core_paths.backups_dir()
+
+    def test_repeated_calls_return_equal_paths_when_set(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path / "x"))
+        assert core_paths.database_path() == core_paths.database_path()
+        assert core_paths.exports_dir() == core_paths.exports_dir()
+
+    def test_changing_env_changes_resolution(self, monkeypatch, tmp_path):
+        # Reading the env on every call is a deliberate contract — it
+        # is what lets pytest's ``monkeypatch.setenv`` propagate. Pin
+        # that behaviour with a direct test.
+        monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path / "a"))
+        assert core_paths.database_path() == tmp_path / "a" / "nova.db"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path / "b"))
+        assert core_paths.database_path() == tmp_path / "b" / "nova.db"


### PR DESCRIPTION
## Summary

Phase 1 of the "make Nova's data easy to move between disks" effort.
Adds a small, opt-in foundation for relocating `nova.db` and Nova's
runtime state onto a dedicated disk via a single environment variable —
no behavioural changes for existing installs.

- New `core/paths.py` resolves a configured `NOVA_DATA_DIR`, exposes
  `pathlib.Path` helpers for the database, backups, exports, memory
  packs, and logs, and a single side-effecting `prepare()` that creates
  the layout and verifies writability. Empty / unset → strict no-op.
- `core/memory.py` and `memory/store.py` derive `DB_PATH` from
  `core.paths` at import time; the module attributes are still plain
  strings, so existing tests that `monkeypatch.setattr(..., "DB_PATH",
  path)` keep working unchanged.
- `initialize_db()` calls `prepare()` first, then emits a single
  `WARNING` log line when the legacy `./nova.db` exists but
  `NOVA_DATA_DIR/nova.db` does not — telling the operator to copy the
  database manually. Nova **never** moves, overwrites, or deletes the
  legacy file on its own.
- `docs/data-directory.md` documents the layout, recommended locations
  (`/mnt/fastdata/NovaData` for SSD, `/mnt/archive/NovaData` for HDD),
  the manual migration procedure, the backup/restore steps, and the
  safety guarantees.
- `deploy/systemd/nova.service` + `deploy/systemd/README.md` show the
  optional `Environment=NOVA_DATA_DIR=…`, a second `ReadWritePaths=`,
  and `RequiresMountsFor=` lines so systemd waits for the data mount
  before starting Nova.
- `tests/test_paths.py` (27 tests) covers default behaviour, configured
  behaviour, `prepare()` idempotency / error paths, the legacy
  migration reporter, and end-to-end integration with
  `core.memory.initialize_db()`.

## What this PR explicitly does NOT do

- No automatic migration. The operator copies `nova.db` by hand.
- No auto-overwrite or auto-delete. An existing DB is left alone.
- No broad filesystem access. Only the configured directory is touched.
- No `sudo`, no shell commands, no privilege escalation.
- No redesign of the memory layer or chat/feedback behaviour.

## Test plan

- [x] `python -m pytest tests/test_paths.py -v` — 26 pass, 1 skipped
  (`test_unwritable_directory_is_rejected` skips when running as root).
- [x] `python -m pytest tests/test_memory.py tests/test_migration.py
  tests/test_memory_command.py tests/test_memory_parsing.py
  tests/test_memory_importer.py tests/test_systemd_unit.py
  tests/test_identity.py` — 172 passed, 1 skipped.
- [x] `python -m pytest tests/test_auth.py tests/test_users.py
  tests/test_alpha_auth.py tests/test_admin_users.py
  tests/test_settings_scoping.py` — 120 passed.
- [x] `python -m pytest tests/test_feedback.py
  tests/test_feedback_endpoints.py tests/test_conversation_scoping.py
  tests/test_chat_stream.py` — 82 passed.
- [x] `python -m pytest tests/test_personalization_settings.py
  tests/test_personalization_chat_wiring.py
  tests/test_message_edit_delete.py tests/test_security_lifecycle.py
  tests/test_security_feed.py tests/test_session_continuity.py` — 163
  passed.
- [ ] Manual smoke: start Nova with `NOVA_DATA_DIR=/tmp/nova-test`
  on a clean checkout, confirm `nova.db`, `backups/`, `exports/`,
  `memory-packs/`, `logs/` are created under the configured root.
- [ ] Manual smoke: start Nova with `NOVA_DATA_DIR` pointing at an
  unwritable directory; confirm Nova fails loudly with a clear error.
- [ ] Manual smoke: with a legacy `./nova.db` already in the checkout,
  set `NOVA_DATA_DIR` to a new path and confirm the `WARNING` log line
  fires and the legacy file is left untouched.

https://claude.ai/code/session_011Fkm7unbCDMZGWw8kxM6vV

---
_Generated by [Claude Code](https://claude.ai/code/session_011Fkm7unbCDMZGWw8kxM6vV)_