### PR TITLE
feat(storage): admin-only Storage & Migration Center foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,40 @@ optionally set up a user-level Nova unit if you want the restart
 button to work without leaving the secure-deployment guide's
 boundaries.
 
+## Optional admin Storage & Migration Center
+
+Nova ships an **optional**, **admin-only** Storage & Migration
+surface that reports where Nova stores its data, builds portable
+data export packages, and lets an administrator inspect an existing
+package before restoring it on another machine. Every endpoint is
+read-only or confirmation-gated; nothing in this feature moves,
+overwrites, or deletes Nova data on its own.
+
+The full walkthrough lives in
+[`docs/storage-and-migration.md`](docs/storage-and-migration.md).
+The three endpoints are:
+
+* `GET /admin/storage/status` — calm read-only snapshot of the
+  data directory, database file, reserved subdirectories, free
+  disk space, mount-class warnings, and (informational) Ollama
+  models path. Warns when `NOVA_DATA_DIR` is unset or on a
+  transient mount such as `/run/media/...`.
+* `POST /admin/storage/export` — builds a `nova-data-export-<UTC
+  stamp>.tar.gz` package containing `manifest.json`, `RESTORE.md`,
+  and an **allowlisted** copy of Nova's runtime data. Requires
+  `{"confirm": true}`. The export never includes `.env`, `.git`,
+  `.venv`, caches, Ollama models, media libraries, SSH keys, or
+  anything outside the data directory; symlinks whose target
+  resolves outside the data root are skipped.
+* `POST /admin/storage/inspect-export` — validates an existing
+  archive in the configured exports directory. Parses the
+  manifest, refuses path traversal or symlink-escape members, and
+  returns a structured report. Read-only.
+
+Restore in Phase 1 is the documented **manual** procedure in
+`docs/storage-and-migration.md`. The dry-run plan (no file writes)
+refuses to proceed when the target already contains a `nova.db`.
+
 ## Voice and TTS
 
 Every assistant message has a "Read aloud" button. By default Nova uses

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1,0 +1,1289 @@
+"""Nova data export package builder + inspector (Phase 1).
+
+This module is the export half of the Storage & Migration Center.
+It builds a **portable, local, data-only** export package the
+operator can move to another machine and inspect / dry-run-restore
+on the target. Phase 1 ships:
+
+* :func:`create_data_export` — builds a gzipped tar archive
+  containing ``manifest.json``, ``RESTORE.md``, and a strict
+  allowlist of Nova data files (the SQLite database, its sidecar
+  backups, and the four reserved subdirectories).
+* :func:`inspect_export` — validates an existing archive in
+  read-only mode: parses the manifest, checks every member for path
+  traversal / symlink escape, surfaces warnings, and returns a
+  structured report.
+* :func:`plan_restore` — dry-run only. Returns the files that would
+  be restored, refuses overwrite by default if the target already
+  has a ``nova.db``, and validates archive paths against path
+  traversal. **No file is written** by this function.
+
+Safety contract (enforced):
+
+* **Allowlist only.** Only ``nova.db``, files matching
+  ``nova.db.*`` (sidecar / pre-upgrade backups), and the four
+  reserved subdirectories (``backups/``, ``exports/``,
+  ``memory-packs/``, ``logs/``) are eligible for inclusion. The
+  Nova checkout, ``.git``, ``.venv``, caches, media libraries,
+  Ollama models, ``.env`` files, ``.ssh`` / ``.gnupg`` / token-
+  shaped files are never included — even when the export runs
+  against a legacy data root that happens to overlap with the
+  checkout.
+* **No symlink escape.** Walking the allowlist uses
+  ``os.walk(followlinks=False)``. Each file encountered is checked
+  for symlink-target escape outside the data root before being
+  added; offending entries are recorded in ``excluded`` with reason
+  ``symlink_escape``.
+* **No path traversal on inspect / restore.** Every archive member
+  name is validated lexically (no ``..``, no leading ``/``, no
+  drive letters) and re-checked after resolution against the
+  intended root.
+* **No automatic restore.** Phase 1 only inspects and plans. No
+  file is written, moved, or deleted by this module. Restore
+  itself remains a documented manual operator step (see
+  ``docs/storage-and-migration.md``).
+* **No shell, no subprocess, no network.** The module relies on
+  ``tarfile``, ``hashlib``, ``os.walk``, and ``shutil``. Nothing
+  else.
+* **No secret leakage.** Manifests never contain absolute paths
+  outside the data root, never include env vars, and never echo
+  ``.env`` / token-shaped file contents.
+
+The module is admin-only at the API layer — the web endpoints that
+expose it are wrapped with ``require_admin`` and require an
+explicit ``confirm`` payload.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import os
+import re
+import tarfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Optional
+
+from core import paths as _paths
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public constants ────────────────────────────────────────────────
+
+#: Export package format identifier — pinned in every manifest so a
+#: future format change can be detected explicitly rather than
+#: silently misread.
+FORMAT_ID = "nova-data-export"
+FORMAT_VERSION = 1
+
+#: Allowed export modes. Phase 1 ships the safe ``data-only`` default;
+#: ``workspace`` is reserved for a follow-up PR and currently rejected.
+MODE_DATA_ONLY = "data-only"
+MODE_WORKSPACE = "workspace"
+_ALLOWED_MODES: frozenset[str] = frozenset({MODE_DATA_ONLY})
+
+#: Filename layout inside the archive. Everything Nova-owned lives
+#: under ``data/`` so the archive root is reserved for the manifest
+#: and the operator-facing restore instructions.
+ARCHIVE_DATA_PREFIX = "data"
+ARCHIVE_MANIFEST_NAME = "manifest.json"
+ARCHIVE_RESTORE_DOC_NAME = "RESTORE.md"
+ARCHIVE_ALLOWED_TOP_LEVEL: frozenset[str] = frozenset({
+    ARCHIVE_MANIFEST_NAME, ARCHIVE_RESTORE_DOC_NAME, ARCHIVE_DATA_PREFIX,
+})
+
+#: Default filename stem for new export packages. The timestamp is
+#: UTC ISO 8601 compact form so packages sort lexicographically by
+#: creation time.
+DEFAULT_EXPORT_STEM = "nova-data-export"
+
+#: Hash chunk size used when summing files into the manifest.
+_HASH_CHUNK_BYTES = 64 * 1024
+
+#: Maximum manifest read size during inspection. The manifest is a
+#: small JSON file in practice; a runaway / hostile manifest is
+#: rejected so we never read a multi-gigabyte blob into memory.
+_MAX_MANIFEST_BYTES = 1 * 1024 * 1024
+
+#: Filenames that look like secrets and must never appear inside an
+#: export. We match by the lowercased basename so a hostile path is
+#: rejected regardless of the parent directory. The list is
+#: deliberately conservative — false positives are preferable to
+#: silently exporting a credential.
+_SECRET_BASENAMES: frozenset[str] = frozenset({
+    ".env", ".envrc", ".netrc", ".npmrc", ".pypirc",
+    "credentials", "credentials.json", "credentials.yaml",
+    "secrets", "secrets.json", "secrets.yaml",
+    "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519",
+})
+
+#: Filename suffixes / patterns that signal a secret. Matched case-
+#: insensitively against the basename.
+_SECRET_SUFFIX_RE = re.compile(
+    r"(?:\.env|\.envrc|\.pem|\.key|\.p12|\.pfx|\.crt|\.cer|"
+    r"\.gpg|\.asc|_token|_secret|_credentials)$",
+    re.IGNORECASE,
+)
+
+#: Directory names that should never be walked into during an
+#: export. They are never created by Nova under the data root, but
+#: defense-in-depth: a misconfigured legacy data dir overlapping the
+#: checkout would have these.
+_FORBIDDEN_DIR_BASENAMES: frozenset[str] = frozenset({
+    ".git", ".venv", "venv", "__pycache__", ".pytest_cache",
+    ".mypy_cache", ".ruff_cache", "node_modules",
+    ".ssh", ".gnupg", ".aws", ".gcloud", ".kube",
+})
+
+#: Top-level entries that are eligible for inclusion. The matcher is
+#: lexical: ``nova.db`` and any ``nova.db.*`` sidecar / backup file
+#: are matched explicitly; the reserved subdirectories are matched
+#: by exact name. Anything else under the data root is **silently
+#: ignored** so a legacy install with files next to ``nova.db``
+#: never accidentally exports them.
+_ALLOWED_TOP_FILES: frozenset[str] = frozenset({
+    _paths.DB_FILENAME,  # nova.db
+})
+_ALLOWED_TOP_FILE_PREFIXES: tuple[str, ...] = (
+    _paths.DB_FILENAME + ".",  # nova.db.backup, nova.db.preupgrade-*, …
+)
+_ALLOWED_TOP_DIRS: frozenset[str] = frozenset({
+    _paths.BACKUPS_SUBDIR,
+    _paths.EXPORTS_SUBDIR,
+    _paths.MEMORY_PACKS_SUBDIR,
+    _paths.LOGS_SUBDIR,
+})
+
+
+# ── Exclusion reasons (stable wire-format strings) ──────────────────
+
+REASON_SECRET = "secret"
+REASON_VCS = "vcs"
+REASON_VENV = "venv"
+REASON_CACHE = "cache"
+REASON_NODE_MODULES = "node_modules"
+REASON_OLLAMA_MODEL = "ollama_model"
+REASON_OUTSIDE_DATA_DIR = "outside_data_dir"
+REASON_SYMLINK_ESCAPE = "symlink_escape"
+REASON_NOT_ALLOWLISTED = "not_allowlisted"
+REASON_UNREADABLE = "unreadable"
+REASON_PATH_TRAVERSAL = "path_traversal"
+REASON_DEVICE_OR_OTHER = "device_or_other"
+
+
+# ── Dataclasses ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExcludedEntry:
+    """A path that was considered but deliberately not included.
+
+    The wire shape is ``{"path": <relative>, "reason": <reason>}`` —
+    short, stable strings the UI can switch on. Paths are recorded
+    relative to the source data root so they are safe to render.
+    """
+
+    path: str
+    reason: str
+
+    def as_dict(self) -> dict:
+        return {"path": self.path, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class IncludedEntry:
+    """A file that was included in the export, with its integrity hash.
+
+    Sizes are in bytes; hashes are SHA-256 hex digests. Paths are
+    POSIX-style (forward slashes) relative to the archive's
+    ``data/`` prefix so the restore instructions can reference them
+    verbatim.
+    """
+
+    path: str
+    size: int
+    sha256: str
+
+    def as_dict(self) -> dict:
+        return {"path": self.path, "size": self.size, "sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """Outcome of a single :func:`create_data_export` call.
+
+    ``archive_path`` is the absolute path of the produced tar.gz
+    file. ``manifest`` is the serialised manifest body so the caller
+    does not need to re-open the archive to display the summary.
+    ``excluded`` lists every path that was considered but skipped
+    (with a reason); ``warnings`` carries any soft issues that did
+    not prevent the export.
+    """
+
+    archive_path: str
+    archive_size: int
+    archive_sha256: str
+    manifest: dict
+    included: tuple[IncludedEntry, ...]
+    excluded: tuple[ExcludedEntry, ...]
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "archive_path": self.archive_path,
+            "archive_size": self.archive_size,
+            "archive_sha256": self.archive_sha256,
+            "manifest": self.manifest,
+            "included": [e.as_dict() for e in self.included],
+            "excluded": [e.as_dict() for e in self.excluded],
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class InspectionResult:
+    """Read-only structural report on an existing archive.
+
+    Returned by :func:`inspect_export`. ``valid`` is the bottom-line
+    flag the UI can switch on; ``errors`` lists any structural
+    problems (missing manifest, path traversal, version mismatch).
+    The list of files reflects what the archive *contains*, not what
+    a restore would *do* — see :func:`plan_restore` for the restore
+    dry-run.
+    """
+
+    archive_path: str
+    valid: bool
+    manifest: Optional[dict]
+    files: tuple[str, ...]
+    total_uncompressed_size: int
+    errors: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "archive_path": self.archive_path,
+            "valid": self.valid,
+            "manifest": self.manifest,
+            "files": list(self.files),
+            "total_uncompressed_size": self.total_uncompressed_size,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class RestorePlan:
+    """Dry-run plan for restoring an archive into the configured data dir.
+
+    Phase 1 returns the plan only — no file is written. ``allowed``
+    is ``True`` when the target is safe to restore into (no existing
+    ``nova.db`` collision, no path traversal in the archive); when
+    ``False``, ``refuse_reason`` and ``conflicts`` explain why and
+    the UI must refuse to proceed.
+    """
+
+    archive_path: str
+    target_data_dir: str
+    allowed: bool
+    refuse_reason: str
+    conflicts: tuple[str, ...]
+    would_restore: tuple[str, ...]
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    manifest: Optional[dict] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "archive_path": self.archive_path,
+            "target_data_dir": self.target_data_dir,
+            "allowed": self.allowed,
+            "refuse_reason": self.refuse_reason,
+            "conflicts": list(self.conflicts),
+            "would_restore": list(self.would_restore),
+            "warnings": list(self.warnings),
+            "manifest": self.manifest,
+        }
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _now_iso_utc() -> str:
+    """Return the current UTC timestamp in ISO 8601 compact form.
+
+    Centralised so tests can monkeypatch this single function. The
+    format ``YYYYMMDDTHHMMSSZ`` is filesystem-safe (no colons) and
+    sorts lexicographically.
+    """
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def _nova_version() -> str:
+    """Return the Nova version string, or ``""`` if unknown.
+
+    Nova does not currently ship a ``__version__`` constant. We try
+    the ``CHANGELOG.md`` heading as a fallback so the manifest can
+    record *something* useful; the empty-string case is acceptable
+    when even that is missing (the manifest field is informational).
+    """
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        changelog = repo_root / "CHANGELOG.md"
+        if changelog.is_file():
+            for line in changelog.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()[:20]:
+                stripped = line.strip()
+                # Match either "## 0.4.0" or "## [0.4.0]" headings.
+                m = re.match(r"^##\s*\[?(\d+\.\d+(?:\.\d+)?)\]?", stripped)
+                if m:
+                    return m.group(1)
+    except OSError:
+        return ""
+    return ""
+
+
+def _sha256_file(path: Path) -> str:
+    """Return a SHA-256 hex digest of ``path``'s content.
+
+    Chunked read so a multi-gigabyte SQLite database does not blow
+    up the process memory.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(_HASH_CHUNK_BYTES)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _is_secret_name(basename: str) -> bool:
+    """Return True when ``basename`` looks like a secret file.
+
+    Case-insensitive: ``.env``, ``credentials.json``, ``id_rsa``,
+    ``*.pem``, ``*.key``, ``*_token``, etc. We never read the file
+    content — name-based detection is enough to refuse inclusion.
+    """
+    if not basename:
+        return False
+    lower = basename.lower()
+    if lower in _SECRET_BASENAMES:
+        return True
+    if _SECRET_SUFFIX_RE.search(lower):
+        return True
+    return False
+
+
+def _classify_exclusion(rel_parts: tuple[str, ...]) -> Optional[str]:
+    """Return an exclusion reason for ``rel_parts``, or ``None``.
+
+    ``rel_parts`` is the path relative to the data root, broken into
+    components. The function checks each component against the
+    forbidden-dir set and the secret-name set; the first match wins.
+    Returning ``None`` means the entry is provisionally eligible —
+    further checks (symlink escape, top-level allowlist) still apply.
+    """
+    if not rel_parts:
+        return None
+    for part in rel_parts:
+        lower = part.lower()
+        if part in _FORBIDDEN_DIR_BASENAMES:
+            if part == ".git":
+                return REASON_VCS
+            if part in {".venv", "venv"}:
+                return REASON_VENV
+            if part == "node_modules":
+                return REASON_NODE_MODULES
+            if part in {"__pycache__", ".pytest_cache",
+                        ".mypy_cache", ".ruff_cache"}:
+                return REASON_CACHE
+            if part in {".ssh", ".gnupg", ".aws", ".gcloud", ".kube"}:
+                return REASON_SECRET
+        if _is_secret_name(part):
+            return REASON_SECRET
+        if lower == "ollama" or lower.endswith(".gguf"):
+            return REASON_OLLAMA_MODEL
+    return None
+
+
+def _safe_under(root: Path, candidate: Path) -> bool:
+    """Return True when ``candidate`` resolves under ``root``.
+
+    Both arguments are resolved before comparison so a path like
+    ``root/sub/../sub`` is treated correctly. We never raise: an
+    OS error during resolution returns ``False`` so the caller
+    treats the candidate as unsafe.
+    """
+    try:
+        root_resolved = root.resolve()
+        candidate_resolved = candidate.resolve()
+    except OSError:
+        return False
+    try:
+        candidate_resolved.relative_to(root_resolved)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_safe_member_name(name: str) -> bool:
+    """Return True when ``name`` is a safe in-archive path.
+
+    A safe name:
+      * is non-empty,
+      * does not start with ``/``,
+      * does not contain a Windows drive letter,
+      * does not contain a ``..`` component,
+      * does not contain backslashes (we render POSIX archive paths),
+      * does not contain control characters.
+    The check is purely lexical — the structural validation in
+    :func:`inspect_export` re-runs it before each member is inspected.
+    """
+    if not name or name.startswith("/") or name.startswith("\\"):
+        return False
+    if "\x00" in name or "\\" in name:
+        return False
+    if re.match(r"^[A-Za-z]:", name):
+        return False
+    parts = PurePosixPath(name).parts
+    for part in parts:
+        if part in ("..",):
+            return False
+    return True
+
+
+# ── Export builder ─────────────────────────────────────────────────
+
+
+def _walk_allowlisted(
+    root: Path,
+) -> tuple[list[tuple[Path, tuple[str, ...]]], list[ExcludedEntry]]:
+    """Walk the data root and collect (file, rel_parts) for inclusion.
+
+    Returns ``(included, excluded)``. The walk is **strict allowlist**:
+    only the documented top-level files (``nova.db`` and ``nova.db.*``)
+    and the four reserved subdirectories are descended into. Anything
+    else under ``root`` is silently skipped — this is the property
+    that keeps a legacy data root pointing at a Nova checkout from
+    accidentally including source code.
+
+    Within an allowed subdirectory the walk uses
+    ``os.walk(followlinks=False)`` and rejects:
+
+    * any path component matching a forbidden directory name,
+    * any basename matching the secret pattern,
+    * any symlink whose resolved target is not under ``root``.
+    """
+    included: list[tuple[Path, tuple[str, ...]]] = []
+    excluded: list[ExcludedEntry] = []
+
+    # Top-level enumeration — we do NOT use ``os.walk`` here so we
+    # can apply the allowlist before recursing.
+    try:
+        entries = sorted(root.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return included, excluded
+
+    for entry in entries:
+        name = entry.name
+        if entry.is_symlink():
+            # A top-level symlink is fine if it lands inside the data
+            # root; we still resolve and check. Unsafe links are
+            # recorded.
+            if not _safe_under(root, entry):
+                excluded.append(ExcludedEntry(name, REASON_SYMLINK_ESCAPE))
+                continue
+        if entry.is_dir():
+            if name in _ALLOWED_TOP_DIRS:
+                _walk_subdir(root, entry, name, included, excluded)
+            else:
+                # Silently skip — we never document or echo files
+                # outside the allowlist, so a legacy install with the
+                # repo as data root doesn't leak source paths.
+                excluded.append(ExcludedEntry(name + "/", REASON_NOT_ALLOWLISTED))
+            continue
+        if entry.is_file():
+            if name in _ALLOWED_TOP_FILES or any(
+                name.startswith(p) for p in _ALLOWED_TOP_FILE_PREFIXES
+            ):
+                if _is_secret_name(name):
+                    excluded.append(ExcludedEntry(name, REASON_SECRET))
+                    continue
+                included.append((entry, (name,)))
+            else:
+                excluded.append(ExcludedEntry(name, REASON_NOT_ALLOWLISTED))
+            continue
+        # Sockets, fifos, block devices, etc. — never included.
+        excluded.append(ExcludedEntry(name, REASON_DEVICE_OR_OTHER))
+
+    return included, excluded
+
+
+def _walk_subdir(
+    root: Path,
+    subdir: Path,
+    subdir_name: str,
+    included: list[tuple[Path, tuple[str, ...]]],
+    excluded: list[ExcludedEntry],
+) -> None:
+    """Recurse into ``subdir`` and collect eligible files.
+
+    Mutates ``included`` and ``excluded`` in place. ``followlinks``
+    is disabled so a hostile symlink cannot pull a directory tree
+    from outside the data root into the export.
+    """
+    for dirpath, dirnames, filenames in os.walk(
+        subdir, followlinks=False
+    ):
+        dirpath_p = Path(dirpath)
+        # Filter forbidden subdirectories in place so os.walk does
+        # not descend into them.
+        keep_dirs = []
+        for d in list(dirnames):
+            if d in _FORBIDDEN_DIR_BASENAMES:
+                rel = dirpath_p.relative_to(root) / d
+                # Pick the most specific reason we can.
+                rel_parts = rel.parts
+                reason = _classify_exclusion(rel_parts) or REASON_NOT_ALLOWLISTED
+                excluded.append(ExcludedEntry(rel.as_posix() + "/", reason))
+                continue
+            keep_dirs.append(d)
+        dirnames[:] = keep_dirs
+
+        for fname in sorted(filenames):
+            file_p = dirpath_p / fname
+            try:
+                rel = file_p.relative_to(root)
+            except ValueError:
+                excluded.append(
+                    ExcludedEntry(fname, REASON_OUTSIDE_DATA_DIR)
+                )
+                continue
+            rel_parts = rel.parts
+            # The top component must be the original subdir name.
+            if not rel_parts or rel_parts[0] != subdir_name:
+                excluded.append(
+                    ExcludedEntry(rel.as_posix(), REASON_OUTSIDE_DATA_DIR)
+                )
+                continue
+            reason = _classify_exclusion(rel_parts)
+            if reason is not None:
+                excluded.append(ExcludedEntry(rel.as_posix(), reason))
+                continue
+            if file_p.is_symlink():
+                if not _safe_under(root, file_p):
+                    excluded.append(
+                        ExcludedEntry(rel.as_posix(), REASON_SYMLINK_ESCAPE)
+                    )
+                    continue
+            if not file_p.is_file():
+                # Sockets / fifos / etc.
+                excluded.append(
+                    ExcludedEntry(rel.as_posix(), REASON_DEVICE_OR_OTHER)
+                )
+                continue
+            included.append((file_p, rel_parts))
+
+
+def create_data_export(
+    *,
+    dest_dir: Optional[str | os.PathLike[str]] = None,
+    mode: str = MODE_DATA_ONLY,
+    stem: Optional[str] = None,
+) -> ExportResult:
+    """Build a portable, allowlisted data-only export package.
+
+    ``dest_dir`` selects the directory the archive is written to.
+    The default is :func:`core.paths.exports_dir`, which lives under
+    ``NOVA_DATA_DIR/exports`` when configured. The directory is
+    created (``mkdir -p`` semantics) if it does not exist; the
+    archive itself is written atomically: first to a temporary
+    ``.partial`` file, then renamed.
+
+    ``mode`` must be ``"data-only"`` in Phase 1. The ``"workspace"``
+    mode is reserved for a future PR and currently raises a
+    :class:`ValueError`.
+
+    ``stem`` overrides the default filename stem
+    (``nova-data-export``). The final filename is
+    ``<stem>-<timestamp>.tar.gz``.
+
+    Raises:
+        :class:`ValueError` for an unknown mode.
+        :class:`RuntimeError` when the source data root cannot be
+            located or the destination cannot be written. Error
+            messages are short and frontend-safe — they never
+            include env vars or absolute paths outside the data
+            root.
+    """
+    if mode not in _ALLOWED_MODES:
+        raise ValueError(
+            f"Export mode {mode!r} is not supported. "
+            "Phase 1 supports 'data-only' only."
+        )
+
+    # Validate ``stem`` before touching the filesystem so a bad
+    # value never leaves a freshly-created destination behind.
+    final_stem = (stem or DEFAULT_EXPORT_STEM).strip() or DEFAULT_EXPORT_STEM
+    if not re.match(r"^[A-Za-z0-9._-]+$", final_stem):
+        raise ValueError(
+            "Export stem must contain only letters, digits, '.', '_' or '-'."
+        )
+
+    # Resolve the source data root. In legacy mode this is the CWD;
+    # the allowlist below ensures we still only pick up canonical
+    # Nova files in that case.
+    data_dir = _paths.configured_data_dir()
+    source_root = _paths.effective_data_root()
+    try:
+        source_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Source data directory {source_root!s} is not accessible: "
+            f"{exc.strerror or 'OS error'}"
+        ) from exc
+
+    # Resolve the destination directory.
+    if dest_dir is None:
+        dest_path = _paths.exports_dir()
+        if not dest_path.is_absolute():
+            dest_path = source_root / dest_path.name
+    else:
+        dest_path = Path(os.fspath(dest_dir)).expanduser()
+    try:
+        dest_path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Export destination {dest_path!s} could not be created: "
+            f"{exc.strerror or 'OS error'}"
+        ) from exc
+
+    # Build the archive filename. ``final_stem`` was validated above.
+    timestamp = _now_iso_utc()
+    archive_name = f"{final_stem}-{timestamp}.tar.gz"
+    archive_path = dest_path / archive_name
+    partial_path = dest_path / (archive_name + ".partial")
+
+    # Walk the data root and collect the included / excluded sets.
+    included_pairs, excluded_entries = _walk_allowlisted(source_root)
+
+    # Build the manifest and the included entry list. We hash each
+    # file once, while the export builder iterates them, so the
+    # disk only has to be touched once per file.
+    included_entries: list[IncludedEntry] = []
+    archive_files: list[tuple[Path, str]] = []
+    for file_p, rel_parts in included_pairs:
+        try:
+            size = int(file_p.stat().st_size)
+        except OSError:
+            excluded_entries.append(ExcludedEntry(
+                "/".join(rel_parts), REASON_UNREADABLE,
+            ))
+            continue
+        try:
+            digest = _sha256_file(file_p)
+        except OSError:
+            excluded_entries.append(ExcludedEntry(
+                "/".join(rel_parts), REASON_UNREADABLE,
+            ))
+            continue
+        rel_posix = "/".join(rel_parts)
+        included_entries.append(IncludedEntry(
+            path=rel_posix, size=size, sha256=digest,
+        ))
+        archive_files.append((file_p, rel_posix))
+
+    manifest = _build_manifest(
+        mode=mode,
+        timestamp=timestamp,
+        source_root=source_root,
+        included=included_entries,
+        excluded=excluded_entries,
+    )
+
+    # Write the archive atomically: build under .partial, rename.
+    # ``dereference=True`` ensures every symlink that survived the
+    # safety check is stored as the *target file's* content, so the
+    # restored copy on another machine never depends on a symlink
+    # being recreatable on that host. Unsafe symlinks have already
+    # been removed during the walk above.
+    try:
+        with tarfile.open(partial_path, mode="w:gz", dereference=True) as tar:
+            manifest_bytes = json.dumps(
+                manifest, indent=2, sort_keys=True,
+            ).encode("utf-8")
+            _add_bytes_to_tar(
+                tar, ARCHIVE_MANIFEST_NAME, manifest_bytes,
+            )
+            restore_doc_bytes = _build_restore_doc(manifest).encode("utf-8")
+            _add_bytes_to_tar(
+                tar, ARCHIVE_RESTORE_DOC_NAME, restore_doc_bytes,
+            )
+            for file_p, rel_posix in archive_files:
+                arcname = f"{ARCHIVE_DATA_PREFIX}/{rel_posix}"
+                if not _is_safe_member_name(arcname):
+                    # Should not happen with the allowlist, but
+                    # defense-in-depth: skip rather than write a
+                    # bogus member.
+                    excluded_entries.append(
+                        ExcludedEntry(rel_posix, REASON_PATH_TRAVERSAL)
+                    )
+                    continue
+                # ``dereference=True`` ensures symlink targets that
+                # passed the safety check are stored as real files
+                # — the restored copy never depends on a symlink
+                # being present on the target machine.
+                tar.add(
+                    str(file_p),
+                    arcname=arcname,
+                    recursive=False,
+                    filter=_tar_filter,
+                )
+        partial_path.replace(archive_path)
+    except OSError as exc:
+        # Clean up the partial file on failure so we never leave a
+        # half-written ``.partial`` next to a real archive.
+        try:
+            partial_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise RuntimeError(
+            f"Export archive could not be written: "
+            f"{exc.strerror or 'OS error'}"
+        ) from exc
+
+    archive_size = archive_path.stat().st_size
+    archive_sha = _sha256_file(archive_path)
+
+    warnings: list[str] = []
+    if data_dir is None:
+        warnings.append(
+            "NOVA_DATA_DIR is not configured. The export was built "
+            "against the legacy data root; only the canonical Nova "
+            "data files were included. See "
+            "docs/storage-and-migration.md."
+        )
+    if not included_entries:
+        warnings.append(
+            "Export contains no Nova data files. Has Nova ever run on "
+            "this host?"
+        )
+
+    return ExportResult(
+        archive_path=str(archive_path),
+        archive_size=int(archive_size),
+        archive_sha256=archive_sha,
+        manifest=manifest,
+        included=tuple(included_entries),
+        excluded=tuple(excluded_entries),
+        warnings=tuple(warnings),
+    )
+
+
+def _build_manifest(
+    *,
+    mode: str,
+    timestamp: str,
+    source_root: Path,
+    included: list[IncludedEntry],
+    excluded: list[ExcludedEntry],
+) -> dict:
+    """Return the manifest dict written into the archive.
+
+    The manifest pins:
+      * the format identifier and version (so future readers can
+        refuse a v2 archive cleanly),
+      * the export mode,
+      * the creation timestamp,
+      * the Nova version, when known,
+      * the source data directory (absolute path — already inside
+        the operator's trust boundary),
+      * the included entries (path / size / sha256),
+      * the excluded entries (path / reason),
+      * a static list of warnings the operator should keep in mind
+        when restoring (e.g. "Ollama models are not included").
+    """
+    return {
+        "format": FORMAT_ID,
+        "format_version": FORMAT_VERSION,
+        "mode": mode,
+        "created_at": timestamp,
+        "nova_version": _nova_version(),
+        "source_data_dir": str(source_root),
+        "files": [e.as_dict() for e in included],
+        "excluded": [e.as_dict() for e in excluded],
+        "warnings": [
+            "Ollama models are NOT included in this package. Re-pull "
+            "models on the target machine with `ollama pull <name>` "
+            "after restoring.",
+            "Media libraries (Jellyfin, Plex, …) are NOT included. "
+            "Those services own their own data directories.",
+            "Secrets (.env, credentials, SSH keys) are NEVER included. "
+            "Configure them on the target machine, not in the export.",
+        ],
+    }
+
+
+def _build_restore_doc(manifest: dict) -> str:
+    """Return the body of the in-archive ``RESTORE.md`` file.
+
+    The text is informational only — Phase 1 does not perform an
+    automated restore. The instructions mirror the manual procedure
+    documented in ``docs/storage-and-migration.md``.
+    """
+    return (
+        "# Nova Data Export — Restore\n"
+        "\n"
+        f"Created at: {manifest.get('created_at', '')}\n"
+        f"Source data directory: {manifest.get('source_data_dir', '')}\n"
+        f"Format: {manifest.get('format', '')} "
+        f"v{manifest.get('format_version', '')}\n"
+        f"Mode: {manifest.get('mode', '')}\n"
+        "\n"
+        "## What this archive contains\n"
+        "\n"
+        "* `manifest.json` — file list, hashes, and metadata.\n"
+        "* `data/` — Nova's runtime data (nova.db, sidecar backups,\n"
+        "  and the four reserved subdirectories under NOVA_DATA_DIR).\n"
+        "\n"
+        "## What this archive does NOT contain\n"
+        "\n"
+        "* Ollama model files (re-pull on the target machine).\n"
+        "* Media libraries (Jellyfin / Plex own their own data).\n"
+        "* `.env` files, credentials, SSH keys, OAuth tokens.\n"
+        "* The Nova Git checkout, `.venv`, caches, or node_modules.\n"
+        "\n"
+        "## Restoring (manual, Phase 1)\n"
+        "\n"
+        "1. Stop Nova on the target machine: `sudo systemctl stop nova`.\n"
+        "2. Inspect this archive with Nova's admin UI or with `tar tvf`.\n"
+        "3. Make sure NOVA_DATA_DIR is set on the target.\n"
+        "4. Back up any existing nova.db on the target.\n"
+        "5. Extract: `tar -xzf <archive> -C /tmp/nova-restore` and copy\n"
+        "   `/tmp/nova-restore/data/*` into NOVA_DATA_DIR.\n"
+        "6. Start Nova: `sudo systemctl start nova` and verify the\n"
+        "   web UI shows your memories and conversations.\n"
+        "\n"
+        "Nova never restores automatically. See "
+        "docs/storage-and-migration.md for the full procedure.\n"
+    )
+
+
+def _add_bytes_to_tar(tar: tarfile.TarFile, name: str, body: bytes) -> None:
+    """Add a synthetic file with ``body`` content under ``name`` in ``tar``.
+
+    Used for the manifest and the RESTORE.md doc. The tar entry is
+    given a stable mode (0o644), uid/gid 0, and the current archive
+    timestamp so the produced archive is reasonably deterministic
+    across runs at the same UTC second.
+    """
+    info = tarfile.TarInfo(name=name)
+    info.size = len(body)
+    info.mode = 0o644
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = int(time.time())
+    info.type = tarfile.REGTYPE
+    tar.addfile(info, io.BytesIO(body))
+
+
+def _tar_filter(info: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+    """Normalise tar headers before they reach the archive.
+
+    Strips owner / group names and resets mode bits so the archive
+    is reproducible enough for a manual diff. Returns ``None`` for
+    any non-regular file that slipped through (defence in depth —
+    the walk above already rejects them).
+    """
+    if not info.isfile():
+        return None
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    # Force a stable, owner-only mode on the contents. The operator
+    # can re-chmod after restore if a wider mode is required.
+    info.mode = 0o600
+    return info
+
+
+# ── Inspection ─────────────────────────────────────────────────────
+
+
+def inspect_export(archive_path: str | os.PathLike[str]) -> InspectionResult:
+    """Validate ``archive_path`` and return a structured report.
+
+    The check is read-only: the archive is opened in stream mode,
+    every member is examined, but no file is written to disk. The
+    function never raises into the caller — every failure mode
+    surfaces as ``valid=False`` with a short, frontend-safe error
+    string.
+
+    Validation pins:
+      * the file exists and is a tar archive,
+      * a single ``manifest.json`` is present at the root and
+        parses as JSON within ``_MAX_MANIFEST_BYTES``,
+      * the manifest declares the expected format ID and version,
+      * every member name is safe (no path traversal, no absolute
+        path, no Windows drive letter),
+      * every member sits under ``data/`` (except the manifest and
+        the optional RESTORE.md),
+      * no member is a symlink whose target escapes ``data/``,
+      * no member is a hardlink, device, or other non-file type.
+    """
+    archive_path = str(archive_path)
+    errors: list[str] = []
+    warnings: list[str] = []
+    file_names: list[str] = []
+    total_size = 0
+    manifest: Optional[dict] = None
+
+    if not os.path.isfile(archive_path):
+        return InspectionResult(
+            archive_path=archive_path,
+            valid=False,
+            manifest=None,
+            files=(),
+            total_uncompressed_size=0,
+            errors=("Archive does not exist or is not a regular file.",),
+        )
+
+    if not tarfile.is_tarfile(archive_path):
+        return InspectionResult(
+            archive_path=archive_path,
+            valid=False,
+            manifest=None,
+            files=(),
+            total_uncompressed_size=0,
+            errors=("File is not a tar archive.",),
+        )
+
+    try:
+        with tarfile.open(archive_path, mode="r:*") as tar:
+            for member in tar:
+                if not _is_safe_member_name(member.name):
+                    errors.append(
+                        f"Unsafe archive member name: {member.name!r}."
+                    )
+                    continue
+                # Forbid hardlinks, devices, fifos.
+                if member.islnk() or member.isdev() or member.isfifo():
+                    errors.append(
+                        f"Disallowed member type for {member.name!r}."
+                    )
+                    continue
+                # Symlinks must point at a name still inside the
+                # archive — not an absolute path, no ``..``.
+                if member.issym():
+                    target = member.linkname or ""
+                    if (
+                        not target
+                        or target.startswith("/")
+                        or ".." in PurePosixPath(target).parts
+                    ):
+                        errors.append(
+                            f"Unsafe symlink target for {member.name!r}."
+                        )
+                        continue
+                parts = PurePosixPath(member.name).parts
+                if not parts:
+                    continue
+                top = parts[0]
+                if top not in ARCHIVE_ALLOWED_TOP_LEVEL:
+                    errors.append(
+                        f"Disallowed archive entry at root: {top!r}."
+                    )
+                    continue
+                if (
+                    top == ARCHIVE_DATA_PREFIX
+                    and len(parts) == 1
+                    and not member.isdir()
+                ):
+                    # A bare ``data`` regular file is not how we
+                    # construct exports; reject it.
+                    errors.append(
+                        "Archive contains a 'data' entry that is not "
+                        "a directory."
+                    )
+                    continue
+                file_names.append(member.name)
+                if member.isfile():
+                    total_size += int(member.size)
+
+                if member.name == ARCHIVE_MANIFEST_NAME and member.isfile():
+                    if member.size > _MAX_MANIFEST_BYTES:
+                        errors.append(
+                            "manifest.json is larger than the allowed "
+                            "size — refusing to read."
+                        )
+                        continue
+                    extracted = tar.extractfile(member)
+                    if extracted is None:
+                        errors.append(
+                            "manifest.json could not be read."
+                        )
+                        continue
+                    try:
+                        body = extracted.read()
+                    finally:
+                        extracted.close()
+                    try:
+                        manifest = json.loads(body.decode("utf-8"))
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        errors.append("manifest.json is not valid JSON.")
+                        manifest = None
+    except tarfile.TarError as exc:
+        return InspectionResult(
+            archive_path=archive_path,
+            valid=False,
+            manifest=None,
+            files=(),
+            total_uncompressed_size=0,
+            errors=(f"Archive could not be parsed: {exc.__class__.__name__}.",),
+        )
+    except OSError as exc:
+        return InspectionResult(
+            archive_path=archive_path,
+            valid=False,
+            manifest=None,
+            files=(),
+            total_uncompressed_size=0,
+            errors=(f"Archive could not be opened: "
+                    f"{exc.strerror or 'OS error'}.",),
+        )
+
+    if manifest is None and not any(
+        n.endswith(ARCHIVE_MANIFEST_NAME) for n in file_names
+    ):
+        errors.append("Archive is missing manifest.json.")
+
+    if isinstance(manifest, dict):
+        fmt = manifest.get("format")
+        ver = manifest.get("format_version")
+        if fmt != FORMAT_ID:
+            errors.append(
+                f"Manifest format is {fmt!r}, expected {FORMAT_ID!r}."
+            )
+        if ver != FORMAT_VERSION:
+            errors.append(
+                f"Manifest format_version is {ver!r}, expected "
+                f"{FORMAT_VERSION}."
+            )
+        if not isinstance(manifest.get("files", []), list):
+            errors.append("Manifest 'files' is not a list.")
+    elif manifest is not None:
+        errors.append("Manifest is not a JSON object.")
+        manifest = None
+
+    if not any(
+        n == ARCHIVE_MANIFEST_NAME or n.startswith(f"{ARCHIVE_DATA_PREFIX}/")
+        for n in file_names
+    ):
+        warnings.append(
+            "Archive does not appear to contain any Nova data files."
+        )
+
+    return InspectionResult(
+        archive_path=archive_path,
+        valid=not errors,
+        manifest=manifest,
+        files=tuple(file_names),
+        total_uncompressed_size=int(total_size),
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+# ── Restore plan (dry-run only) ─────────────────────────────────────
+
+
+def plan_restore(
+    archive_path: str | os.PathLike[str],
+    *,
+    target_data_dir: Optional[str | os.PathLike[str]] = None,
+) -> RestorePlan:
+    """Return a dry-run plan for restoring ``archive_path``.
+
+    The function does **not** write, move, or delete anything. It
+    inspects the archive, resolves the target data directory (from
+    the argument or from ``NOVA_DATA_DIR``), checks whether the
+    target already contains ``nova.db``, and reports the result.
+
+    Refusal reasons (``allowed == False``):
+      * the archive is invalid (see :func:`inspect_export`);
+      * the target data directory cannot be resolved;
+      * the target already contains ``nova.db`` (overwrite is
+        explicitly refused — Nova never overwrites memory without
+        an out-of-band confirmation step);
+      * any archive member would resolve outside the target data
+        directory after extraction.
+    """
+    inspection = inspect_export(archive_path)
+    archive_path_s = str(archive_path)
+    if not inspection.valid:
+        return RestorePlan(
+            archive_path=archive_path_s,
+            target_data_dir="",
+            allowed=False,
+            refuse_reason="Archive is not valid: " + "; ".join(inspection.errors),
+            conflicts=(),
+            would_restore=(),
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    if target_data_dir is None:
+        configured = _paths.configured_data_dir()
+        if configured is None:
+            return RestorePlan(
+                archive_path=archive_path_s,
+                target_data_dir="",
+                allowed=False,
+                refuse_reason=(
+                    "NOVA_DATA_DIR is not set. Configure a target data "
+                    "directory before planning a restore."
+                ),
+                conflicts=(),
+                would_restore=(),
+                manifest=inspection.manifest,
+            )
+        target_root = configured
+    else:
+        target_root = Path(os.fspath(target_data_dir)).expanduser()
+    target_root_resolved = target_root.resolve() if target_root.exists() \
+        else target_root.absolute()
+
+    # Translate archive member names into would-be target paths and
+    # check each one for path traversal after resolution.
+    would_restore: list[str] = []
+    conflicts: list[str] = []
+    refuse_reason = ""
+
+    for member_name in inspection.files:
+        if member_name in (ARCHIVE_MANIFEST_NAME, ARCHIVE_RESTORE_DOC_NAME):
+            continue
+        parts = PurePosixPath(member_name).parts
+        if not parts or parts[0] != ARCHIVE_DATA_PREFIX:
+            # Already filtered by inspect_export, but be defensive.
+            continue
+        relative = PurePosixPath(*parts[1:])
+        if not str(relative):
+            continue
+        candidate = target_root_resolved / Path(*relative.parts)
+        # Lexical traversal check (no ``..``, no absolute relative).
+        if ".." in relative.parts or relative.is_absolute():
+            refuse_reason = (
+                "Archive contains an unsafe path "
+                f"({member_name!r}). Refusing to plan a restore."
+            )
+            would_restore = []
+            break
+        # Post-resolution containment check. We do not require the
+        # candidate to exist (it usually doesn't) but its absolute
+        # form must sit under the target root.
+        try:
+            candidate_abs = candidate.resolve(strict=False)
+        except OSError:
+            refuse_reason = (
+                f"Archive member {member_name!r} could not be resolved."
+            )
+            would_restore = []
+            break
+        try:
+            candidate_abs.relative_to(target_root_resolved)
+        except ValueError:
+            refuse_reason = (
+                f"Archive member {member_name!r} would land outside "
+                "the target data directory."
+            )
+            would_restore = []
+            break
+        would_restore.append(str(relative))
+        if candidate.exists():
+            conflicts.append(str(relative))
+
+    if refuse_reason:
+        return RestorePlan(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_root_resolved),
+            allowed=False,
+            refuse_reason=refuse_reason,
+            conflicts=tuple(conflicts),
+            would_restore=(),
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    # Overwrite refusal: nova.db on the target is sacred.
+    nova_db_target = target_root_resolved / _paths.DB_FILENAME
+    if nova_db_target.exists():
+        return RestorePlan(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_root_resolved),
+            allowed=False,
+            refuse_reason=(
+                "Target data directory already contains nova.db. "
+                "Refusing to overwrite an existing database. Move or "
+                "rename the existing file by hand before restoring."
+            ),
+            conflicts=tuple(conflicts),
+            would_restore=tuple(would_restore),
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    warnings: list[str] = list(inspection.warnings)
+    if conflicts:
+        warnings.append(
+            f"{len(conflicts)} file(s) already exist at the target — "
+            "they would be overwritten by a restore."
+        )
+
+    return RestorePlan(
+        archive_path=archive_path_s,
+        target_data_dir=str(target_root_resolved),
+        allowed=True,
+        refuse_reason="",
+        conflicts=tuple(conflicts),
+        would_restore=tuple(would_restore),
+        warnings=tuple(warnings),
+        manifest=inspection.manifest,
+    )
+
+
+__all__ = [
+    "ARCHIVE_DATA_PREFIX",
+    "ARCHIVE_MANIFEST_NAME",
+    "ARCHIVE_RESTORE_DOC_NAME",
+    "DEFAULT_EXPORT_STEM",
+    "ExcludedEntry",
+    "ExportResult",
+    "FORMAT_ID",
+    "FORMAT_VERSION",
+    "IncludedEntry",
+    "InspectionResult",
+    "MODE_DATA_ONLY",
+    "MODE_WORKSPACE",
+    "REASON_CACHE",
+    "REASON_NODE_MODULES",
+    "REASON_NOT_ALLOWLISTED",
+    "REASON_OLLAMA_MODEL",
+    "REASON_OUTSIDE_DATA_DIR",
+    "REASON_SECRET",
+    "REASON_SYMLINK_ESCAPE",
+    "REASON_VCS",
+    "REASON_VENV",
+    "RestorePlan",
+    "create_data_export",
+    "inspect_export",
+    "plan_restore",
+]

--- a/core/paths.py
+++ b/core/paths.py
@@ -102,6 +102,23 @@ def database_path() -> Path:
     return root / DB_FILENAME
 
 
+def effective_data_root() -> Path:
+    """Return the absolute parent directory of every Nova-owned file.
+
+    With ``NOVA_DATA_DIR`` set this is identical to
+    :func:`configured_data_dir`. Without it, Nova runs in legacy mode
+    and the data root is the parent of the resolved
+    :func:`database_path` — i.e. the current working directory. The
+    helper exists so downstream modules (status reporter, export
+    builder, admin endpoints) all agree on a single "where does Nova
+    live?" answer instead of re-deriving the fallback.
+    """
+    root = configured_data_dir()
+    if root is not None:
+        return root
+    return database_path().resolve().parent
+
+
 def backups_dir() -> Path:
     """Return the path of the ``backups`` subdirectory.
 

--- a/core/storage_status.py
+++ b/core/storage_status.py
@@ -1,0 +1,582 @@
+"""Nova storage status reporter (Phase 1 of the Storage & Migration Center).
+
+This module answers the question "where is Nova storing its data,
+and is that location healthy?" — calmly, read-only, with no side
+effects on disk.
+
+What the module reports for each known Nova path
+(``NOVA_DATA_DIR``, the database file, ``backups/``, ``exports/``,
+``memory-packs/``, ``logs/``, optional Ollama models path):
+
+* the configured / resolved absolute path,
+* whether the path exists, is a directory, and is writable,
+* a best-effort free-disk-space figure (``None`` when the call fails),
+* a coarse mount classification (``stable`` / ``transient`` /
+  ``user_home`` / ``tmp`` / ``other``) used to warn operators when
+  Nova is pointed at a path that is unsafe for a 24/7 service
+  (``/run/media/...``, ``/tmp/...``, …),
+* free-form warnings the UI can render verbatim.
+
+Safety contract:
+
+* The module **never writes, moves, or deletes** anything. The
+  status snapshot is computed from ``os.stat`` / ``os.access`` /
+  ``shutil.disk_usage`` and a small handful of string heuristics.
+* It **never follows symlinks**: the mount classification reads the
+  lexical path, the existence / writability probes use ``os.access``
+  / ``os.path.isdir`` without resolving symlinks. We rely on
+  ``Path.is_dir`` (which does follow symlinks) only for explicit
+  "is this path a directory?" probes — the result is a flag, not an
+  action.
+* It **never imports ``subprocess``** and never reaches the network.
+* It **never imports ``core.memory``**: the path layer lives in
+  ``core.paths`` and this module imports only from there. No import
+  cycles.
+* It **never reveals secrets**. The Ollama path is the only env-derived
+  value surfaced, and only the directory itself — never its contents.
+
+The module is the read-only foundation under the admin-only
+``/admin/storage/status`` endpoint. ``core/data_export.py`` reuses
+the path resolution but performs its own (also explicit) safety
+checks before reading any file content.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+from core import paths as _paths
+
+logger = logging.getLogger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────
+
+#: Coarse mount classifications. Each value is a fixed string the UI
+#: can switch on without re-deriving the rules.
+MOUNT_STABLE = "stable"           # /mnt/..., /var/lib/..., /srv/..., /opt/...
+MOUNT_TRANSIENT = "transient"     # /run/media/..., /media/...
+MOUNT_USER_HOME = "user_home"     # under $HOME
+MOUNT_TMP = "tmp"                 # /tmp/..., /var/tmp/...
+MOUNT_OTHER = "other"             # anything else (incl. relative paths)
+
+#: Mount classes that should raise a warning for a long-running service.
+_WARN_MOUNT_CLASSES: frozenset[str] = frozenset({MOUNT_TRANSIENT, MOUNT_TMP})
+
+#: Path prefixes that signal each mount class. Order matters: the
+#: first prefix that matches wins. The lists are intentionally
+#: conservative — Nova warns only on paths it is confident about.
+_STABLE_PREFIXES: tuple[str, ...] = (
+    "/mnt/", "/var/lib/", "/srv/", "/opt/", "/data/",
+)
+_TRANSIENT_PREFIXES: tuple[str, ...] = (
+    "/run/media/", "/media/",
+)
+_TMP_PREFIXES: tuple[str, ...] = (
+    "/tmp/", "/var/tmp/",
+)
+
+#: Optional Ollama models environment variable. Empty / unset means
+#: "Ollama uses its default model location" — usually ``~/.ollama/models``
+#: on Linux. Nova never moves Ollama models; this status is purely
+#: informational.
+OLLAMA_MODELS_ENV = "OLLAMA_MODELS"
+OLLAMA_DEFAULT_REL = ".ollama/models"
+
+
+# ── Dataclasses ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PathStatus:
+    """Health snapshot for a single Nova path.
+
+    Every attribute is safe to serialise to JSON. Paths are surfaced
+    as strings (their absolute form) so the admin UI does not have to
+    deal with ``Path`` objects. ``None`` values are kept as ``None``
+    so the UI can render "unknown" rather than guessing.
+
+    The fields are deliberately read-only:
+
+    * ``name`` — short identifier the UI can switch on (``data_dir``,
+      ``database``, ``backups``, …).
+    * ``label`` — human-readable label for display.
+    * ``path`` — absolute path string, or ``""`` when unconfigured.
+    * ``configured`` — true when the underlying env var is set or
+      the path is otherwise an explicit user choice.
+    * ``exists`` — ``os.path.exists`` on the path.
+    * ``is_dir`` — ``Path.is_dir()`` on the path (False for files,
+      missing entries, or anything else).
+    * ``writable`` — best-effort ``os.access(..., os.W_OK)`` on the
+      path (or its first existing parent when the path itself is
+      missing) — ``None`` when we cannot probe.
+    * ``free_bytes`` — ``shutil.disk_usage(path).free`` against the
+      first existing component, or ``None`` on failure.
+    * ``total_bytes`` — ``shutil.disk_usage(path).total`` likewise.
+    * ``mount_class`` — coarse classification (``stable`` /
+      ``transient`` / ``user_home`` / ``tmp`` / ``other``).
+    * ``warnings`` — short messages the UI can render verbatim.
+    """
+
+    name: str
+    label: str
+    path: str
+    configured: bool
+    exists: bool = False
+    is_dir: bool = False
+    writable: Optional[bool] = None
+    free_bytes: Optional[int] = None
+    total_bytes: Optional[int] = None
+    mount_class: str = MOUNT_OTHER
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "path": self.path,
+            "configured": self.configured,
+            "exists": self.exists,
+            "is_dir": self.is_dir,
+            "writable": self.writable,
+            "free_bytes": self.free_bytes,
+            "total_bytes": self.total_bytes,
+            "mount_class": self.mount_class,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class StorageStatus:
+    """Top-level storage report for the admin UI / API.
+
+    The structure is intentionally flat: a list of :class:`PathStatus`
+    entries (in display order), plus a small set of top-level
+    warnings that apply to the deployment as a whole (for example:
+    ``NOVA_DATA_DIR`` is unset, or the data dir lives inside a Git
+    checkout). The recommendations field is a static list the UI can
+    render under a "Recommended layout" header — it never changes
+    based on what is on disk so the wording stays stable.
+    """
+
+    data_dir_configured: bool
+    data_dir: str
+    paths: tuple[PathStatus, ...]
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    recommendations: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "data_dir_configured": self.data_dir_configured,
+            "data_dir": self.data_dir,
+            "paths": [p.as_dict() for p in self.paths],
+            "warnings": list(self.warnings),
+            "recommendations": list(self.recommendations),
+        }
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def classify_mount(path: str | os.PathLike[str]) -> str:
+    """Return a coarse mount classification for ``path``.
+
+    The classification is **lexical only** — we never call ``stat``,
+    never read ``/proc/mounts``, and never follow symlinks. The goal
+    is to surface a clear warning for paths that are known-unsafe for
+    a long-running service (``/run/media/...``, ``/tmp/...``), not to
+    prove that a path is mounted correctly.
+
+    Returns one of ``MOUNT_STABLE`` / ``MOUNT_TRANSIENT`` /
+    ``MOUNT_USER_HOME`` / ``MOUNT_TMP`` / ``MOUNT_OTHER``. Empty or
+    relative paths normalise to ``MOUNT_OTHER`` — Nova never assumes
+    a relative path is on a stable disk.
+    """
+    if not path:
+        return MOUNT_OTHER
+    s = str(path)
+    if not s.startswith("/"):
+        return MOUNT_OTHER
+    # Normalise trailing slashes so "/run/media" classifies the same
+    # as "/run/media/" without re-deriving the boundary in each rule.
+    probe = s if s.endswith("/") else s + "/"
+    for prefix in _TRANSIENT_PREFIXES:
+        if probe.startswith(prefix):
+            return MOUNT_TRANSIENT
+    for prefix in _TMP_PREFIXES:
+        if probe.startswith(prefix):
+            return MOUNT_TMP
+    for prefix in _STABLE_PREFIXES:
+        if probe.startswith(prefix):
+            return MOUNT_STABLE
+    home = os.environ.get("HOME", "")
+    if home and home.startswith("/"):
+        home_prefix = home if home.endswith("/") else home + "/"
+        if probe.startswith(home_prefix) or s == home:
+            return MOUNT_USER_HOME
+    return MOUNT_OTHER
+
+
+def _first_existing_ancestor(path: Path) -> Optional[Path]:
+    """Return the first existing ancestor of ``path`` (including itself).
+
+    Used by ``disk_usage`` and writability probes when the target path
+    does not yet exist — we still want to report the disk it would
+    land on. Returns ``None`` if no ancestor exists (only possible on
+    a bizarre filesystem).
+    """
+    current: Optional[Path] = path
+    while current is not None:
+        try:
+            if current.exists():
+                return current
+        except OSError:
+            return None
+        if current.parent == current:
+            return None
+        current = current.parent
+    return None
+
+
+def _safe_disk_usage(path: Path) -> tuple[Optional[int], Optional[int]]:
+    """Return ``(free, total)`` bytes for the disk hosting ``path``.
+
+    Falls back to the first existing ancestor when ``path`` itself is
+    missing — this lets the UI report disk space for a configured but
+    not-yet-created data directory. Returns ``(None, None)`` on any
+    OS-level failure so callers can render "unknown" without crashing.
+    """
+    target = path if path.exists() else _first_existing_ancestor(path)
+    if target is None:
+        return None, None
+    try:
+        usage = shutil.disk_usage(str(target))
+    except (OSError, ValueError):
+        return None, None
+    return int(usage.free), int(usage.total)
+
+
+def _safe_writable(path: Path) -> Optional[bool]:
+    """Return whether the running user can write to ``path``.
+
+    When the path itself exists, ``os.access(path, W_OK)`` is the
+    direct answer. When it does not, we probe its first existing
+    ancestor — that is the directory ``prepare()`` would try to
+    ``mkdir`` into. Returns ``None`` on probe failure.
+    """
+    try:
+        if path.exists():
+            return bool(os.access(str(path), os.W_OK))
+    except OSError:
+        return None
+    parent = _first_existing_ancestor(path)
+    if parent is None:
+        return None
+    try:
+        return bool(os.access(str(parent), os.W_OK))
+    except OSError:
+        return None
+
+
+def _is_dir(path: Path) -> bool:
+    """Return ``True`` if ``path`` is a directory, ``False`` otherwise."""
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
+def _exists(path: Path) -> bool:
+    """Return ``True`` if ``path`` exists, ``False`` otherwise."""
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
+def _looks_like_repo_root(path: Path) -> bool:
+    """Return True when ``path`` itself contains a ``.git`` directory.
+
+    Used to detect "Nova data is sitting inside the Git checkout" —
+    the layout the safety contract calls out as a leak risk. We do
+    not walk parents: the legacy mode lands ``nova.db`` at the
+    checkout root, which is the case we care about.
+    """
+    try:
+        return (path / ".git").exists()
+    except OSError:
+        return False
+
+
+# ── Per-path builders ───────────────────────────────────────────────
+
+
+def _build_path_status(
+    name: str,
+    label: str,
+    path: Path,
+    *,
+    configured: bool,
+    require_dir: bool,
+    extra_warnings: Iterable[str] = (),
+    disk_usage: Optional[tuple[Optional[int], Optional[int]]] = None,
+) -> PathStatus:
+    """Compute a :class:`PathStatus` for a single Nova path.
+
+    The function deliberately avoids any side effects: no ``mkdir``,
+    no ``touch``, no symlink resolution. ``require_dir`` controls
+    whether the absence of the path counts as a problem worth
+    surfacing as a warning (``True`` for directories, ``False`` for
+    the database file which is allowed to be missing before first
+    run). ``disk_usage`` lets callers pass a pre-computed
+    ``(free, total)`` so we don't statvfs every row when all paths
+    share a filesystem.
+    """
+    abs_path = str(path)
+    exists = _exists(path)
+    is_dir = _is_dir(path) if exists else False
+    writable = _safe_writable(path)
+    if disk_usage is None:
+        free_bytes, total_bytes = _safe_disk_usage(path)
+    else:
+        free_bytes, total_bytes = disk_usage
+    mount_class = classify_mount(abs_path)
+
+    warnings: list[str] = list(extra_warnings)
+    if mount_class == MOUNT_TRANSIENT:
+        warnings.append(
+            "Path is on a transient mount (e.g. /run/media/...). "
+            "systemd will not wait for it and the disk disappears on "
+            "logout — unsafe for a 24/7 service. Move data to a stable "
+            "mount declared in /etc/fstab."
+        )
+    elif mount_class == MOUNT_TMP:
+        warnings.append(
+            "Path is under /tmp. /tmp is cleared on reboot — data "
+            "stored here will not survive a restart."
+        )
+    if exists and require_dir and not is_dir:
+        warnings.append(
+            "Path exists but is not a directory."
+        )
+    if exists and writable is False:
+        warnings.append(
+            "Path is not writable by the running user."
+        )
+
+    return PathStatus(
+        name=name,
+        label=label,
+        path=abs_path,
+        configured=configured,
+        exists=exists,
+        is_dir=is_dir,
+        writable=writable,
+        free_bytes=free_bytes,
+        total_bytes=total_bytes,
+        mount_class=mount_class,
+        warnings=tuple(warnings),
+    )
+
+
+def _ollama_models_path() -> tuple[Path, bool]:
+    """Return ``(path, configured)`` for the Ollama models directory.
+
+    ``OLLAMA_MODELS`` selects the directory; when unset, Nova falls
+    back to the documented Linux default ``~/.ollama/models`` (purely
+    informational — Nova never moves Ollama models). ``configured``
+    is ``True`` when the env var is set.
+    """
+    raw = os.environ.get(OLLAMA_MODELS_ENV, "").strip()
+    if raw:
+        return Path(raw).expanduser(), True
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser() / OLLAMA_DEFAULT_REL, False
+    # No HOME, no OLLAMA_MODELS — return a clearly-unconfigured
+    # marker that the UI can render as "unknown".
+    return Path(""), False
+
+
+# ── Public entry point ─────────────────────────────────────────────
+
+
+def _recommendations() -> tuple[str, ...]:
+    """Return the static recommendations rendered under the report.
+
+    These are intentionally fixed strings — the recommendation set
+    does not depend on what is on disk, so the wording stays stable
+    across calls and is easy to test. Keep this aligned with
+    ``docs/data-directory.md`` and ``docs/storage-and-migration.md``.
+    """
+    return (
+        "Active database belongs on SSD — for example "
+        "/mnt/fastdata/NovaData. SQLite writes are synchronous and "
+        "HDDs make chat feel laggy.",
+        "Backups and archives belong on HDD or NAS — for example "
+        "/mnt/archive/Backups/Nova. Backups are written rarely and "
+        "do not need fast random access.",
+        "Use stable mount paths declared in /etc/fstab. Avoid "
+        "/run/media/<user>/<disk> for a long-running service; it "
+        "disappears on logout and corrupts the database mid-write.",
+        "Do not store Nova's runtime data inside the Git checkout — "
+        "private data must never be committed.",
+        "Ollama models are owned by Ollama, not by Nova. Nova export "
+        "packages do not include model files; re-pull on the target "
+        "machine after restore.",
+    )
+
+
+def get_storage_status() -> StorageStatus:
+    """Return a calm, read-only snapshot of Nova's storage layout.
+
+    Safe to call at any time and from any thread; never raises into
+    the caller. A probe failure (a permission error, a stat failure,
+    a missing parent) surfaces as ``None`` in the affected field
+    rather than as an exception.
+    """
+    data_dir = _paths.configured_data_dir()
+    data_dir_configured = data_dir is not None
+    effective_root = _paths.effective_data_root()
+
+    paths: list[PathStatus] = []
+
+    # Memoise disk-usage calls by filesystem device: every Nova path
+    # is usually on the same disk, so we shouldn't call statvfs once
+    # per row.
+    disk_cache: dict[int, tuple[Optional[int], Optional[int]]] = {}
+
+    def _disk_usage(path: Path) -> tuple[Optional[int], Optional[int]]:
+        target = path if path.exists() else _first_existing_ancestor(path)
+        if target is None:
+            return None, None
+        try:
+            dev = os.stat(str(target)).st_dev
+        except OSError:
+            return _safe_disk_usage(path)
+        if dev in disk_cache:
+            return disk_cache[dev]
+        result = _safe_disk_usage(path)
+        disk_cache[dev] = result
+        return result
+
+    data_warnings: list[str] = []
+    if not data_dir_configured:
+        data_warnings.append(
+            "NOVA_DATA_DIR is not set. Nova stores nova.db next to "
+            "the running checkout — set NOVA_DATA_DIR=/mnt/fastdata/"
+            "NovaData (or similar) so private data lives on a "
+            "dedicated disk."
+        )
+    if _looks_like_repo_root(effective_root):
+        data_warnings.append(
+            "Data directory contains a .git directory — private "
+            "runtime data is sitting inside a Git checkout. Move "
+            "the data directory outside the repository."
+        )
+    paths.append(_build_path_status(
+        name="data_dir",
+        label="Nova data directory",
+        path=effective_root,
+        configured=data_dir_configured,
+        require_dir=True,
+        extra_warnings=data_warnings,
+        disk_usage=_disk_usage(effective_root),
+    ))
+
+    # ``require_dir=False`` for the database: it is a file, and a
+    # pre-first-run install may not have it yet.
+    db_path = _paths.database_path()
+    db_abs = db_path if db_path.is_absolute() else (effective_root / db_path.name)
+    db_warnings: list[str] = []
+    if _exists(db_abs) and not db_abs.is_file():
+        db_warnings.append("Database path exists but is not a regular file.")
+    paths.append(_build_path_status(
+        name="database",
+        label="SQLite database (nova.db)",
+        path=db_abs,
+        configured=data_dir_configured,
+        require_dir=False,
+        extra_warnings=db_warnings,
+        disk_usage=_disk_usage(db_abs),
+    ))
+
+    for name, label, sub in (
+        ("backups", "Backups directory", _paths.BACKUPS_SUBDIR),
+        ("exports", "Exports directory", _paths.EXPORTS_SUBDIR),
+        ("memory_packs", "Memory packs directory", _paths.MEMORY_PACKS_SUBDIR),
+        ("logs", "Logs directory", _paths.LOGS_SUBDIR),
+    ):
+        sub_abs = effective_root / sub
+        paths.append(_build_path_status(
+            name=name,
+            label=label,
+            path=sub_abs,
+            configured=data_dir_configured,
+            require_dir=True,
+            disk_usage=_disk_usage(sub_abs),
+        ))
+
+    ollama_path, ollama_configured = _ollama_models_path()
+    ollama_warnings: list[str] = []
+    if not ollama_configured:
+        ollama_warnings.append(
+            "OLLAMA_MODELS is not set; falling back to the documented "
+            "default. This is informational only — Nova never moves "
+            "Ollama models and never includes them in export packages."
+        )
+    paths.append(_build_path_status(
+        name="ollama_models",
+        label="Ollama models directory (informational)",
+        path=ollama_path,
+        configured=ollama_configured,
+        require_dir=True,
+        extra_warnings=ollama_warnings,
+        disk_usage=_disk_usage(ollama_path) if str(ollama_path) else (None, None),
+    ))
+
+    # Promote any per-path warning that should also be visible at the
+    # top level. Today this is just the "data directory inside a
+    # checkout" rule — the mount-class warnings stay per-path so the
+    # UI can highlight the specific row.
+    top_warnings: list[str] = []
+    if not data_dir_configured:
+        top_warnings.append(
+            "NOVA_DATA_DIR is not set. Nova is running in legacy mode; "
+            "see docs/storage-and-migration.md for the recommended "
+            "configuration."
+        )
+    for entry in paths:
+        if entry.name == "data_dir":
+            for warning in entry.warnings:
+                # Forward the "inside git checkout" warning specifically.
+                if "Git checkout" in warning:
+                    top_warnings.append(warning)
+
+    return StorageStatus(
+        data_dir_configured=data_dir_configured,
+        data_dir=str(effective_root),
+        paths=tuple(paths),
+        warnings=tuple(top_warnings),
+        recommendations=_recommendations(),
+    )
+
+
+__all__ = [
+    "MOUNT_OTHER",
+    "MOUNT_STABLE",
+    "MOUNT_TMP",
+    "MOUNT_TRANSIENT",
+    "MOUNT_USER_HOME",
+    "OLLAMA_DEFAULT_REL",
+    "OLLAMA_MODELS_ENV",
+    "PathStatus",
+    "StorageStatus",
+    "classify_mount",
+    "get_storage_status",
+]

--- a/docs/data-directory.md
+++ b/docs/data-directory.md
@@ -172,3 +172,13 @@ If a future Nova release introduces an opt-in migration helper, it
 will be additive (a single explicit command), preserve the legacy
 file, and require explicit confirmation. Nothing about the current
 data is at risk from this PR.
+
+## See also
+
+* [`docs/portable-workspace.md`](portable-workspace.md) — wrap the
+  Nova checkout, data directory, logs, backups, and config under
+  one parent folder so the whole thing can be moved as a unit.
+* [`docs/storage-and-migration.md`](storage-and-migration.md) —
+  admin-only Storage & Migration Center: read-only status report,
+  portable data export packages, and a dry-run inspection / restore
+  plan for moving Nova between machines safely.

--- a/docs/storage-and-migration.md
+++ b/docs/storage-and-migration.md
@@ -1,0 +1,478 @@
+# Nova Storage & Migration Center
+
+> **Status: Phase 1 — backend + docs.** Nova ships a small, admin-only
+> surface that reports where Nova stores its data, builds a portable
+> data export package, and lets you inspect an existing package
+> before you restore. Every action is opt-in, confirmation-gated, and
+> safe by default. No data is ever moved, overwritten, or deleted by
+> Nova itself.
+
+This document is the operator-facing companion to
+[`docs/data-directory.md`](data-directory.md) and
+[`docs/portable-workspace.md`](portable-workspace.md). Together they
+answer three questions:
+
+* **Where does Nova store its data?** — `data-directory.md`.
+* **How do I keep code, data, config, and backups under one roof?**
+  — `portable-workspace.md`.
+* **How do I report on, export, and inspect that data — safely — when
+  I need to back it up or move it to another machine?** — this file.
+
+If you are setting up Nova for the first time, start with
+`data-directory.md`. Come back here when you want to:
+
+* see at a glance whether `NOVA_DATA_DIR` is on a stable disk,
+* produce a portable backup of Nova's memory to move between machines,
+* validate an export package before you restore it.
+
+---
+
+## What the Storage & Migration Center covers
+
+Nova exposes three things to the admin in Phase 1:
+
+1. **Storage status** — a read-only report on Nova's path layout:
+   `NOVA_DATA_DIR`, the resolved `nova.db` path, the four reserved
+   subdirectories (`backups/`, `exports/`, `memory-packs/`, `logs/`),
+   whether each path exists, whether it is writable, how much disk
+   space remains, and whether the mount looks safe for a 24/7
+   service.
+2. **Data export** — a portable, allowlisted, data-only `tar.gz`
+   archive containing `manifest.json`, a `RESTORE.md` instruction
+   sheet, and the canonical Nova data files. Nothing outside the
+   data directory is included; secrets, caches, `.git`, `.venv`,
+   media libraries, and Ollama models are never bundled.
+3. **Export inspection** — a read-only structural check on an
+   existing archive. The manifest is parsed, every member is
+   validated against path traversal and symlink escape, and the
+   result is returned in a structured form the admin UI can render.
+
+Restore itself stays a **manual operator step** in Phase 1. The
+inspection result includes the dry-run plan (what files would land
+where) so you can review it before you copy anything. Nova never
+overwrites a `nova.db` automatically.
+
+---
+
+## TL;DR
+
+* Set `NOVA_DATA_DIR=/mnt/fastdata/NovaData` on the active host. Keep
+  `/mnt/archive/Backups/Nova` for backups on slower disk.
+* Stop Nova before snapshotting `nova.db` from disk; otherwise use
+  the export package, which uses SQLite-aware file copying via the
+  filesystem.
+* Move the export package to the target machine via the channel of
+  your choice (rsync, removable disk, encrypted blob). Nova does
+  not upload anything.
+* On the target machine, inspect the package first. Refuse to
+  proceed if the target already has a `nova.db`.
+
+---
+
+## Recommended layout
+
+| Path                                     | Purpose                                     |
+|------------------------------------------|---------------------------------------------|
+| `/mnt/fastdata/NovaData`                 | **Active data** — SSD, mounted via `/etc/fstab`. |
+| `/mnt/archive/Backups/Nova`              | **Backups / archives** — HDD or NAS.        |
+| `/mnt/archive/Backups/Nova/exports`      | **Export packages** ready to move.          |
+| `~/.ollama/models` (or `OLLAMA_MODELS`)  | **Ollama models** — owned by Ollama, **not** Nova. |
+
+The Storage & Migration Center reports on the first three. The Ollama
+path is shown for context (so you know where models live and that
+they survive a Nova restore) but **Nova never moves Ollama models**.
+
+### Why SSD for active data
+
+SQLite touches the database synchronously on every transaction. On an
+HDD, chat feels laggy; on an SSD it stays calm. The active database
+should always live on the fastest disk you have.
+
+### Why HDD or NAS for backups
+
+Backups are written rarely (once a day, once a week, before an
+upgrade) and read even more rarely (only on restore). They do not
+need fast random access and they benefit from cheap, large, durable
+storage. NAS volumes work fine as long as the mount is stable.
+
+### Why stable `/mnt/...` mounts
+
+Long-running services need their data path to exist at boot and
+survive a desktop logout. `/etc/fstab` mounts under `/mnt/...` or
+`/srv/...` are stable; `/run/media/<user>/<disk>` is **transient** —
+it only exists while a desktop session is logged in and disappears
+on logout, taking the live database with it. That is the easy way to
+corrupt `nova.db` mid-write. The status report warns explicitly when
+Nova's data lives on a transient mount.
+
+---
+
+## Reading the storage status
+
+```http
+GET /admin/storage/status
+Authorization: Bearer <admin-token>
+```
+
+The response is a calm, read-only JSON snapshot. Example fragment:
+
+```json
+{
+  "data_dir_configured": true,
+  "data_dir": "/mnt/fastdata/NovaData",
+  "paths": [
+    {
+      "name": "data_dir",
+      "label": "Nova data directory",
+      "path": "/mnt/fastdata/NovaData",
+      "configured": true,
+      "exists": true,
+      "is_dir": true,
+      "writable": true,
+      "free_bytes": 12345678901,
+      "total_bytes": 256000000000,
+      "mount_class": "stable",
+      "warnings": []
+    },
+    {
+      "name": "database",
+      "label": "SQLite database (nova.db)",
+      "path": "/mnt/fastdata/NovaData/nova.db",
+      "configured": true,
+      "exists": true,
+      "is_dir": false,
+      "writable": true,
+      "free_bytes": 12345678901,
+      "total_bytes": 256000000000,
+      "mount_class": "stable",
+      "warnings": []
+    }
+    // … backups, exports, memory_packs, logs, ollama_models …
+  ],
+  "warnings": [],
+  "recommendations": ["…", "…"]
+}
+```
+
+### Mount classes
+
+| Class        | Meaning                                                |
+|--------------|--------------------------------------------------------|
+| `stable`     | `/mnt/...`, `/var/lib/...`, `/srv/...`, `/opt/...`     |
+| `transient`  | `/run/media/...`, `/media/...` — **warns**.            |
+| `tmp`        | `/tmp/...`, `/var/tmp/...` — **warns** (cleared on reboot). |
+| `user_home`  | Under `$HOME` — acceptable for single-user dev hosts. |
+| `other`      | Anything else (including relative paths).              |
+
+The classifier is purely lexical — Nova never reads `/proc/mounts`,
+never calls `stat -f`, and never follows symlinks. The point is to
+surface a clear warning for paths that are obviously unsafe, not to
+prove that a path is mounted correctly.
+
+### Top-level warnings
+
+Some warnings apply to the whole deployment:
+
+* `NOVA_DATA_DIR is not set` — Nova is running in legacy mode with
+  `nova.db` next to the checkout. The export endpoint still works
+  but only the canonical Nova data files are included.
+* `Data directory contains a .git directory` — your runtime data is
+  sitting inside the Git checkout. This is a leak risk and must be
+  fixed by moving the data directory outside the repository.
+
+---
+
+## Building an export package
+
+```http
+POST /admin/storage/export
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{"confirm": true, "mode": "data-only"}
+```
+
+The endpoint requires `confirm: true` so a stray click never produces
+an archive. The only supported mode in Phase 1 is `data-only`.
+
+The response contains the archive's absolute path, its size, its
+SHA-256, a summary of what was included and excluded, and the full
+manifest body:
+
+```json
+{
+  "archive_path": "/mnt/fastdata/NovaData/exports/nova-data-export-20260514T160000Z.tar.gz",
+  "archive_size": 1048576,
+  "archive_sha256": "…",
+  "manifest": { "format": "nova-data-export", "format_version": 1, "…": "…" },
+  "included": [ {"path": "nova.db", "size": 1048064, "sha256": "…"} ],
+  "excluded": [ {"path": ".env", "reason": "secret"} ],
+  "warnings": []
+}
+```
+
+The archive layout is fixed:
+
+```
+<archive>.tar.gz
+├── manifest.json        — file list, hashes, metadata
+├── RESTORE.md           — operator-facing instructions
+└── data/
+    ├── nova.db
+    ├── nova.db.backup           (if present)
+    ├── nova.db.preupgrade-*     (if present)
+    ├── backups/                 (contents of the backups subdir)
+    ├── exports/                 (contents of the exports subdir)
+    ├── memory-packs/            (contents of the memory-packs subdir)
+    └── logs/                    (contents of the logs subdir)
+```
+
+### What is included
+
+Only the **canonical Nova data files** under the configured data
+root, plus their canonical subdirectories. Every other entry under
+the data root is silently skipped — this is the property that keeps
+a legacy data root (which happens to be the Nova checkout) from
+accidentally exporting source code, `.git`, or `.venv`.
+
+### What is NOT included — ever
+
+* `.env`, `.envrc`, `.netrc`, `.npmrc` files
+* `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.crt`, `*.cer`
+* `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`
+* `credentials*`, `secrets*`
+* Anything matching `*_token`, `*_secret`, `*_credentials`
+* `.ssh/`, `.gnupg/`, `.aws/`, `.gcloud/`, `.kube/`
+* `.git/`, `.venv/`, `venv/`, `__pycache__/`, `.pytest_cache/`,
+  `.mypy_cache/`, `.ruff_cache/`, `node_modules/`
+* Ollama models (`*.gguf`, anything under an `ollama/` directory)
+* Media libraries (Jellyfin, Plex, …)
+* Symlinks whose target resolves outside the data directory
+
+The exclusion list is **conservative by design**: a false positive is
+preferable to silently exporting a credential.
+
+### What about Ollama models?
+
+Ollama models are **separate from Nova data**. The model files are
+usually large (gigabytes), they live in `OLLAMA_MODELS` or
+`~/.ollama/models`, and they belong to the Ollama service, not to
+Nova. Nova export packages do not include them by default. After
+restoring on a new machine, re-pull the models you need:
+
+```bash
+ollama pull gemma3:1b
+ollama pull gemma4
+ollama pull deepseek-coder-v2
+```
+
+The Nova model registry survives the export (it lives inside
+`nova.db`), so Nova will already know which models you had configured;
+the model weights themselves are simply re-downloaded on demand.
+
+### Where the archive lives
+
+The archive is written to `NOVA_DATA_DIR/exports/` when configured
+and to `./exports/` in legacy mode. The filename is
+`nova-data-export-<UTC timestamp>.tar.gz`; multiple exports sort
+lexicographically by creation time so the latest is the last entry.
+
+---
+
+## Inspecting an existing package
+
+```http
+POST /admin/storage/inspect-export
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{"name": "nova-data-export-20260514T160000Z.tar.gz"}
+```
+
+The `name` field is a **plain filename**, not a path. The server
+resolves it against the configured exports directory and refuses any
+name that contains a path separator, a `..`, or a leading dot.
+
+The response is a structured inspection report:
+
+```json
+{
+  "archive_path": "/mnt/fastdata/NovaData/exports/nova-data-export-20260514T160000Z.tar.gz",
+  "valid": true,
+  "manifest": { "format": "nova-data-export", "…": "…" },
+  "files": ["manifest.json", "RESTORE.md", "data/nova.db", "…"],
+  "total_uncompressed_size": 12345678,
+  "errors": [],
+  "warnings": []
+}
+```
+
+Inspection refuses an archive when:
+
+* the file is not a tarball;
+* `manifest.json` is missing, too large, or not JSON;
+* the manifest format identifier or version does not match;
+* any member name contains `..`, an absolute path, a drive letter,
+  or a control character;
+* any member is a hardlink, a device, or a fifo;
+* any symlink member points at an absolute or `..`-containing target;
+* any member lives outside the allowed top-level set
+  (`manifest.json`, `RESTORE.md`, `data/`).
+
+---
+
+## Moving the package between machines
+
+Nova never uploads anything. Moving the archive is a manual operator
+step that goes through a channel you trust. Common options:
+
+```bash
+# rsync over SSH
+rsync -aH --progress \
+    /mnt/fastdata/NovaData/exports/nova-data-export-<stamp>.tar.gz \
+    user@new-host:/mnt/fastdata/NovaData/exports/
+
+# Removable disk
+cp /mnt/fastdata/NovaData/exports/nova-data-export-<stamp>.tar.gz \
+   /run/media/$USER/<disk>/
+
+# Encrypted offline copy
+age -r recipient -o backup.age \
+    /mnt/fastdata/NovaData/exports/nova-data-export-<stamp>.tar.gz
+```
+
+The archive contains your conversation history, user memories, and
+per-user settings. Encrypt offline copies. Treat the file as
+sensitive even though Nova has already filtered out tokens and
+secrets.
+
+---
+
+## Restoring on the target machine (manual, Phase 1)
+
+1. On the target machine, set `NOVA_DATA_DIR` to the new data
+   directory (`/mnt/fastdata/NovaData` is the recommended default).
+2. Stop Nova: `sudo systemctl stop nova`.
+3. If the target already has a `nova.db`, **back it up** by hand
+   before continuing. Nova refuses to overwrite an existing
+   database; do not work around this by deleting the file blindly.
+4. Inspect the package via `/admin/storage/inspect-export` (run it
+   on the target host after starting Nova once with an empty data
+   directory, or use `tar tvf` from the shell to read the file
+   list).
+5. Extract the package somewhere staging:
+
+   ```bash
+   tar -xzf nova-data-export-<stamp>.tar.gz -C /tmp/nova-restore
+   ```
+
+6. Copy the contents of `/tmp/nova-restore/data/` into
+   `NOVA_DATA_DIR` and fix ownership:
+
+   ```bash
+   sudo -u nova rsync -aH /tmp/nova-restore/data/ /mnt/fastdata/NovaData/
+   ```
+
+7. Start Nova: `sudo systemctl start nova` and confirm the web UI
+   shows your memories, conversations, and settings.
+8. Re-pull any Ollama models you had configured on the source host.
+
+Nova's automated restore is **future work**. Today every step above
+is something you do, deliberately, with the database file in your
+hand.
+
+---
+
+## Why GitHub should only contain source code
+
+Nova's GitHub repository is for **public source code**. It must
+never contain:
+
+* `nova.db`,
+* conversation history,
+* user memories,
+* per-user settings,
+* `.env`, secrets, tokens,
+* Ollama models,
+* anything an export package would otherwise exclude.
+
+The `.gitignore` shipped in the repo already ignores `nova.db` and
+`.env`. The portable workspace layout (`docs/portable-workspace.md`)
+puts private data **outside** the Git checkout so a misconfigured
+`.gitignore` cannot accidentally stage it. The Storage & Migration
+Center reinforces this: a status report whose data directory sits
+inside a Git checkout raises a top-level warning, and the export
+package never includes `.git` even if the data root happens to
+contain one.
+
+---
+
+## Safety guarantees
+
+These are firm boundaries of the Phase 1 Storage & Migration Center:
+
+* **Read-only by default.** `/admin/storage/status` and
+  `/admin/storage/inspect-export` never write to disk.
+* **Admin-only.** Every endpoint is wrapped with `require_admin`;
+  non-admin and restricted users see a 403.
+* **Confirmation-gated export.** `/admin/storage/export` requires
+  `{"confirm": true}` in the request body. A missing or false
+  `confirm` returns 400 with no side effects.
+* **Allowlist-only export.** Only Nova's canonical data files
+  (`nova.db`, `nova.db.*`, the four reserved subdirectories) are
+  eligible for inclusion. Source code, `.git`, `.venv`, caches,
+  media libraries, Ollama models, `.env` files, and any
+  token-shaped file are excluded by name.
+* **No symlink escape.** The export walk uses
+  `os.walk(followlinks=False)`. Any symlink whose target resolves
+  outside the data directory is recorded with reason
+  `symlink_escape` and skipped.
+* **No path traversal on inspect / restore.** Every archive member
+  name is validated lexically (no `..`, no leading `/`, no drive
+  letter) and re-checked against the intended root after
+  resolution. Hostile archives are refused with a clear error,
+  never extracted.
+* **No automatic restore.** Phase 1 plans and inspects only. No
+  file is written, moved, or deleted by Nova during a restore.
+* **No overwrite without explicit confirmation.** A restore plan
+  refuses when the target data directory already contains a
+  `nova.db`. The operator removes or renames the existing file by
+  hand, deliberately, before continuing.
+* **No automatic data move.** Nova never copies its data root to a
+  different disk for you. Use `rsync` or the operator's preferred
+  tool, then update `NOVA_DATA_DIR`.
+* **No deletion of old data.** Whatever was there before stays
+  there until you remove it by hand.
+* **No cloud sync.** No outbound calls. No background export.
+* **No shell, no subprocess, no privilege escalation.** The export
+  builder relies on `tarfile`, `hashlib`, `os.walk`, and `shutil`.
+  Nothing else.
+* **No secret leakage in responses.** Manifests never echo the
+  contents of `.env`-shaped files. The inspection / status
+  responses never include env vars. Errors are short and
+  frontend-safe.
+
+If a future Nova release adds an automated restore, it lands behind
+its own opt-in switch, takes its own explicit confirmation, never
+overwrites an existing `nova.db`, and preserves the legacy file. The
+boundaries above are firm.
+
+---
+
+## Future work
+
+These are explicitly **not** in Phase 1:
+
+* A full admin-UI wizard for migration between disks.
+* A `workspace` export mode that snapshots the entire Nova Portable
+  Workspace (code, data, config, scripts) as one archive.
+* Automatic restore with progress reporting.
+* Encrypted-at-rest export packages.
+* Background scheduled exports.
+* Editing `NOVA_DATA_DIR` from the UI (with the matching `systemd`
+  / Docker config updates).
+* Moving Ollama models.
+
+Each of those is a separate PR with its own review. The Phase 1
+boundary keeps the surface area small, the safety contract clear,
+and the existing Nova install untouched.

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1,0 +1,548 @@
+"""Tests for the data export builder, inspector, and restore planner.
+
+Pinned contracts (see ``core/data_export.py``):
+
+* Phase 1 supports only ``mode="data-only"``. Workspace mode raises.
+* The export archive contains a top-level ``manifest.json`` and
+  ``RESTORE.md`` plus a ``data/`` tree of Nova-owned files.
+* Only canonical Nova entries are included: ``nova.db``,
+  ``nova.db.*`` sidecars, and the four reserved subdirectories.
+  ``.env``, ``.git``, ``.venv``, caches, SSH keys, and arbitrary
+  files at the data root are excluded with a reason.
+* Symlinks whose targets escape the data root are recorded as
+  ``symlink_escape`` and never followed.
+* The manifest pins the format identifier and version.
+* Inspect refuses tarballs with path traversal, hardlinks, devices,
+  or symlinks pointing outside the archive.
+* Restore is dry-run only: it refuses to overwrite an existing
+  ``nova.db`` at the target and never writes a file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from core import paths as core_paths
+from core import data_export as de
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _seed_data_dir(root: Path) -> None:
+    """Drop a small canonical Nova data layout into ``root``.
+
+    The helper writes the SQLite-shaped file, one sidecar backup,
+    one preupgrade backup, and one file under each of the reserved
+    subdirectories. Content is deterministic so SHA-256s in the
+    manifest are reproducible across runs.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "nova.db").write_bytes(b"-- fake SQLite content --")
+    (root / "nova.db.backup").write_bytes(b"-- backup --")
+    (root / "nova.db.preupgrade-20260101T000000Z").write_bytes(b"-- preup --")
+    for sub in ("backups", "exports", "memory-packs", "logs"):
+        (root / sub).mkdir(exist_ok=True)
+    (root / "backups" / "nova-2026-05-14.db").write_bytes(b"-- backup pack --")
+    (root / "memory-packs" / "trip-2026.json").write_bytes(b'{"mem": []}')
+    (root / "logs" / "import.log").write_bytes(b"loaded ok\n")
+
+
+@pytest.fixture
+def configured_data_dir(monkeypatch, tmp_path):
+    root = tmp_path / "NovaData"
+    monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+    _seed_data_dir(root)
+    return root
+
+
+# ── create_data_export ──────────────────────────────────────────────
+
+
+class TestCreateExportHappyPath:
+    """The default ``data-only`` export bundles a clean archive."""
+
+    def test_returns_existing_archive(self, configured_data_dir):
+        result = de.create_data_export()
+        assert os.path.isfile(result.archive_path)
+        assert result.archive_size > 0
+        assert len(result.archive_sha256) == 64  # sha256 hex digest
+
+    def test_archive_contains_manifest_and_restore_doc(
+        self, configured_data_dir,
+    ):
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = tar.getnames()
+        assert de.ARCHIVE_MANIFEST_NAME in names
+        assert de.ARCHIVE_RESTORE_DOC_NAME in names
+
+    def test_archive_contains_nova_db_and_subdirs(self, configured_data_dir):
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        # Top-level data files
+        assert "data/nova.db" in names
+        assert "data/nova.db.backup" in names
+        assert any(n.startswith("data/nova.db.preupgrade-") for n in names)
+        # Subdirectory contents
+        assert "data/backups/nova-2026-05-14.db" in names
+        assert "data/memory-packs/trip-2026.json" in names
+        assert "data/logs/import.log" in names
+
+    def test_manifest_pins_format_and_version(self, configured_data_dir):
+        result = de.create_data_export()
+        assert result.manifest["format"] == de.FORMAT_ID
+        assert result.manifest["format_version"] == de.FORMAT_VERSION
+        assert result.manifest["mode"] == de.MODE_DATA_ONLY
+        assert result.manifest["created_at"]
+
+    def test_manifest_lists_included_files_with_sha256(
+        self, configured_data_dir,
+    ):
+        result = de.create_data_export()
+        files = result.manifest["files"]
+        # Build a {path: sha256} map and verify by re-hashing the
+        # corresponding file on disk.
+        paths = {entry["path"]: entry for entry in files}
+        assert "nova.db" in paths
+        on_disk = (configured_data_dir / "nova.db").read_bytes()
+        expected = hashlib.sha256(on_disk).hexdigest()
+        assert paths["nova.db"]["sha256"] == expected
+        assert paths["nova.db"]["size"] == len(on_disk)
+
+    def test_archive_is_atomic_no_partial_left_on_success(
+        self, configured_data_dir,
+    ):
+        result = de.create_data_export()
+        partial = Path(result.archive_path + ".partial")
+        assert not partial.exists()
+
+
+class TestCreateExportSafetyExclusions:
+    """The walk respects the strict allowlist for top-level entries."""
+
+    def test_env_file_at_root_is_excluded(self, configured_data_dir):
+        (configured_data_dir / ".env").write_text(
+            "SECRET_KEY=topsecret\n", encoding="utf-8",
+        )
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        # Nothing called .env should be inside the archive.
+        for n in names:
+            assert os.path.basename(n).lower() != ".env"
+        # And the excluded list must record the reason.
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert ".env" in excluded_names
+
+    def test_git_directory_at_root_is_excluded(self, configured_data_dir):
+        (configured_data_dir / ".git").mkdir()
+        (configured_data_dir / ".git" / "HEAD").write_text(
+            "ref: refs/heads/main\n", encoding="utf-8",
+        )
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        # No .git/* in the archive.
+        for n in names:
+            assert ".git" not in n.split("/")
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert ".git/" in excluded_names
+
+    def test_venv_directory_at_root_is_excluded(self, configured_data_dir):
+        (configured_data_dir / ".venv").mkdir()
+        (configured_data_dir / ".venv" / "pyvenv.cfg").write_text(
+            "ok\n", encoding="utf-8",
+        )
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        for n in names:
+            assert ".venv" not in n.split("/")
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert ".venv/" in excluded_names
+
+    def test_cache_dirs_excluded(self, configured_data_dir):
+        (configured_data_dir / "backups" / "__pycache__").mkdir(parents=True)
+        (configured_data_dir / "backups" / "__pycache__" / "x.pyc").write_bytes(b"")
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        for n in names:
+            assert "__pycache__" not in n.split("/")
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert any("__pycache__" in e for e in excluded_names)
+
+    def test_ssh_directory_excluded(self, configured_data_dir):
+        (configured_data_dir / ".ssh").mkdir()
+        (configured_data_dir / ".ssh" / "id_rsa").write_text(
+            "PRIVATE KEY\n", encoding="utf-8",
+        )
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        # No SSH key, no .ssh directory.
+        for n in names:
+            assert ".ssh" not in n.split("/")
+            assert os.path.basename(n).lower() != "id_rsa"
+
+    def test_arbitrary_file_outside_allowlist_excluded(
+        self, configured_data_dir,
+    ):
+        # A bogus file dropped next to nova.db must not be picked up.
+        (configured_data_dir / "README.txt").write_text(
+            "Surprise!", encoding="utf-8",
+        )
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        assert "data/README.txt" not in names
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert "README.txt" in excluded_names
+
+    def test_secret_file_inside_logs_excluded(self, configured_data_dir):
+        # A .pem file inside an allowed subdirectory still trips the
+        # secret-name detector.
+        (configured_data_dir / "logs" / "leaked.pem").write_text(
+            "BAD\n", encoding="utf-8",
+        )
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        assert "data/logs/leaked.pem" not in names
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert "logs/leaked.pem" in excluded_names
+
+
+class TestCreateExportSymlinks:
+    """Symlinks escaping the data root are recorded but never followed."""
+
+    def test_symlink_escape_excluded(self, configured_data_dir, tmp_path):
+        outside = tmp_path / "outside-secret.txt"
+        outside.write_text("private", encoding="utf-8")
+        link = configured_data_dir / "memory-packs" / "escape.json"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this host")
+
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        assert "data/memory-packs/escape.json" not in names
+        excluded_names = {e["path"] for e in result.manifest["excluded"]}
+        assert "memory-packs/escape.json" in excluded_names
+        # Confirm the reason recorded is the escape one.
+        reasons = {
+            e["path"]: e["reason"]
+            for e in result.manifest["excluded"]
+        }
+        assert reasons["memory-packs/escape.json"] == de.REASON_SYMLINK_ESCAPE
+
+    def test_symlink_within_data_root_is_included(
+        self, configured_data_dir,
+    ):
+        # A file referenced via a symlink that stays inside the data
+        # root is fine — it represents a deliberate operator choice
+        # and Nova dereferences during ``tarfile.add(... filter=...)``
+        # via the manifest entry. The original target file is also
+        # included via its own canonical path.
+        inside = configured_data_dir / "memory-packs" / "real.json"
+        inside.write_text('{"ok": true}', encoding="utf-8")
+        link = configured_data_dir / "memory-packs" / "alias.json"
+        try:
+            link.symlink_to(inside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this host")
+
+        result = de.create_data_export()
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        # The real file is included; the alias is too because it
+        # resolves under the data root.
+        assert "data/memory-packs/real.json" in names
+        assert "data/memory-packs/alias.json" in names
+
+
+class TestCreateExportMode:
+    """Workspace mode is reserved and currently rejected."""
+
+    def test_workspace_mode_rejected(self, configured_data_dir):
+        with pytest.raises(ValueError):
+            de.create_data_export(mode=de.MODE_WORKSPACE)
+
+    def test_unknown_mode_rejected(self, configured_data_dir):
+        with pytest.raises(ValueError):
+            de.create_data_export(mode="everything")
+
+
+class TestCreateExportLegacyMode:
+    """When NOVA_DATA_DIR is unset, exports still work but warn."""
+
+    def test_legacy_mode_warning(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        monkeypatch.chdir(tmp_path)
+        # Seed the CWD with a canonical layout.
+        _seed_data_dir(tmp_path)
+        dest = tmp_path / "exports-out"
+        result = de.create_data_export(dest_dir=dest)
+        assert any(
+            "NOVA_DATA_DIR is not configured" in w
+            for w in result.warnings
+        )
+        # And the archive should still contain nova.db.
+        with tarfile.open(result.archive_path, mode="r:*") as tar:
+            names = set(tar.getnames())
+        assert "data/nova.db" in names
+
+
+# ── inspect_export ─────────────────────────────────────────────────
+
+
+class TestInspectExportHappyPath:
+    """A freshly-built archive inspects clean."""
+
+    def test_valid_archive(self, configured_data_dir):
+        result = de.create_data_export()
+        inspection = de.inspect_export(result.archive_path)
+        assert inspection.valid is True, inspection.errors
+        assert inspection.manifest is not None
+        assert inspection.manifest["format"] == de.FORMAT_ID
+        assert inspection.total_uncompressed_size > 0
+
+
+class TestInspectExportRejections:
+    """Hostile archives are refused with structured errors."""
+
+    def test_missing_archive(self, tmp_path):
+        inspection = de.inspect_export(tmp_path / "nope.tar.gz")
+        assert inspection.valid is False
+        assert any("does not exist" in e for e in inspection.errors)
+
+    def test_not_a_tarball(self, tmp_path):
+        bogus = tmp_path / "fake.tar.gz"
+        bogus.write_text("not a tar", encoding="utf-8")
+        inspection = de.inspect_export(bogus)
+        assert inspection.valid is False
+        assert any("not a tar archive" in e.lower() for e in inspection.errors)
+
+    def test_archive_with_path_traversal_member(self, tmp_path):
+        bad = tmp_path / "bad.tar.gz"
+        with tarfile.open(bad, mode="w:gz") as tar:
+            body = b"oops"
+            info = tarfile.TarInfo(name="../escape.txt")
+            info.size = len(body)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(body))
+        inspection = de.inspect_export(bad)
+        assert inspection.valid is False
+        assert any(
+            "unsafe" in e.lower() or "disallowed" in e.lower()
+            for e in inspection.errors
+        )
+
+    def test_archive_with_absolute_member_name(self, tmp_path):
+        bad = tmp_path / "abs.tar.gz"
+        with tarfile.open(bad, mode="w:gz") as tar:
+            body = b"oops"
+            info = tarfile.TarInfo(name="/etc/passwd")
+            info.size = len(body)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(body))
+        inspection = de.inspect_export(bad)
+        assert inspection.valid is False
+
+    def test_archive_with_disallowed_top_level_entry(self, tmp_path):
+        # A well-formed manifest plus an extra top-level dir Nova
+        # never produces. Must be flagged.
+        bad = tmp_path / "extra.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            payload = b"x"
+            ei = tarfile.TarInfo(name="not-data/x.txt")
+            ei.size = len(payload)
+            ei.mtime = 0
+            tar.addfile(ei, io.BytesIO(payload))
+        inspection = de.inspect_export(bad)
+        assert inspection.valid is False
+        assert any(
+            "Disallowed archive entry at root" in e for e in inspection.errors
+        )
+
+    def test_missing_manifest_invalid(self, tmp_path):
+        bad = tmp_path / "no-manifest.tar.gz"
+        with tarfile.open(bad, mode="w:gz") as tar:
+            payload = b"x"
+            ei = tarfile.TarInfo(name="data/nova.db")
+            ei.size = len(payload)
+            ei.mtime = 0
+            tar.addfile(ei, io.BytesIO(payload))
+        inspection = de.inspect_export(bad)
+        assert inspection.valid is False
+        assert any("manifest" in e.lower() for e in inspection.errors)
+
+    def test_manifest_with_wrong_format_id(self, tmp_path):
+        bad = tmp_path / "wrong-format.tar.gz"
+        manifest = json.dumps({
+            "format": "different-format",
+            "format_version": 1,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+        inspection = de.inspect_export(bad)
+        assert inspection.valid is False
+        assert any("format" in e.lower() for e in inspection.errors)
+
+
+# ── plan_restore ───────────────────────────────────────────────────
+
+
+class TestPlanRestoreDryRun:
+    """plan_restore never touches the disk and refuses to overwrite."""
+
+    def test_plan_refuses_overwrite_when_target_has_nova_db(
+        self, configured_data_dir, tmp_path,
+    ):
+        # Build an export from one data dir.
+        result = de.create_data_export()
+        # Plan a restore into a different target that already has
+        # a nova.db.
+        target = tmp_path / "TargetData"
+        target.mkdir()
+        existing = target / "nova.db"
+        existing.write_bytes(b"-- pre-existing --")
+
+        plan = de.plan_restore(
+            result.archive_path, target_data_dir=target,
+        )
+        assert plan.allowed is False
+        assert "already contains nova.db" in plan.refuse_reason
+        # The existing file must still be there bit-for-bit.
+        assert existing.read_bytes() == b"-- pre-existing --"
+
+    def test_plan_allows_empty_target(self, configured_data_dir, tmp_path):
+        result = de.create_data_export()
+        target = tmp_path / "FreshTarget"
+        target.mkdir()
+        plan = de.plan_restore(
+            result.archive_path, target_data_dir=target,
+        )
+        assert plan.allowed is True, plan.refuse_reason
+        assert plan.target_data_dir == str(target.resolve())
+        assert "nova.db" in plan.would_restore
+        # The target directory remains untouched.
+        assert list(target.iterdir()) == []
+
+    def test_plan_refuses_archive_with_traversal_member(self, tmp_path):
+        bad = tmp_path / "bad.tar.gz"
+        # Build a valid manifest, but then write a member with ../.
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            evil = b"x"
+            ei = tarfile.TarInfo(name="data/../escape.txt")
+            ei.size = len(evil)
+            ei.mtime = 0
+            tar.addfile(ei, io.BytesIO(evil))
+
+        target = tmp_path / "Target"
+        target.mkdir()
+        plan = de.plan_restore(bad, target_data_dir=target)
+        # The inspection step rejects this archive — plan_restore
+        # surfaces that as not-allowed.
+        assert plan.allowed is False
+
+    def test_plan_without_target_uses_configured_data_dir(
+        self, configured_data_dir, monkeypatch, tmp_path,
+    ):
+        # Build the export, then point NOVA_DATA_DIR at a fresh
+        # empty directory and check plan_restore picks it up.
+        result = de.create_data_export()
+        fresh_target = tmp_path / "FreshConfigured"
+        fresh_target.mkdir()
+        monkeypatch.setenv(core_paths.ENV_VAR, str(fresh_target))
+        plan = de.plan_restore(result.archive_path)
+        assert plan.allowed is True
+        assert plan.target_data_dir == str(fresh_target.resolve())
+
+    def test_plan_refuses_when_data_dir_unset(
+        self, configured_data_dir, monkeypatch,
+    ):
+        result = de.create_data_export()
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        plan = de.plan_restore(result.archive_path)
+        assert plan.allowed is False
+        assert "NOVA_DATA_DIR" in plan.refuse_reason
+
+    def test_plan_does_not_write_any_file(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Untouched"
+        target.mkdir()
+        # Take a snapshot of the target tree before and after.
+        before = {p for p in target.rglob("*")}
+        plan = de.plan_restore(result.archive_path, target_data_dir=target)
+        after = {p for p in target.rglob("*")}
+        assert before == after
+        assert plan.allowed is True
+
+
+# ── Read-only inspection of public constants ───────────────────────
+
+
+class TestPublicSurface:
+    """The exported constants are stable enough to be wire format."""
+
+    def test_format_id_is_stable_string(self):
+        assert de.FORMAT_ID == "nova-data-export"
+        assert isinstance(de.FORMAT_VERSION, int)
+        assert de.FORMAT_VERSION >= 1
+
+    def test_mode_data_only_is_string(self):
+        assert de.MODE_DATA_ONLY == "data-only"
+
+    def test_reasons_are_lower_snake(self):
+        for reason in (
+            de.REASON_SECRET, de.REASON_VCS, de.REASON_VENV,
+            de.REASON_CACHE, de.REASON_NODE_MODULES,
+            de.REASON_OLLAMA_MODEL, de.REASON_OUTSIDE_DATA_DIR,
+            de.REASON_SYMLINK_ESCAPE, de.REASON_NOT_ALLOWLISTED,
+            de.REASON_UNREADABLE, de.REASON_PATH_TRAVERSAL,
+            de.REASON_DEVICE_OR_OTHER,
+        ):
+            assert reason == reason.lower()
+            assert " " not in reason

--- a/tests/test_storage_endpoints.py
+++ b/tests/test_storage_endpoints.py
@@ -1,0 +1,294 @@
+"""Tests for the admin-only ``/admin/storage/*`` endpoints.
+
+These pin the wire-level contract: who can call, who can't, and
+which inputs are rejected before the underlying helpers run.
+
+* Non-admin and restricted users get 403.
+* Unauthenticated callers get 401 / 403 (FastAPI's HTTPBearer
+  default).
+* The export endpoint requires ``{"confirm": true}``; a missing or
+  false value returns 400.
+* The inspect endpoint rejects path-traversal-shaped names at the
+  validation layer, returning 422 / 400 without touching the
+  underlying helper.
+* Successful calls return a JSON shape the admin UI can render.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core import memory as core_memory, users  # noqa: E402
+from core import paths as core_paths  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+@pytest.fixture
+def configured_data_root(monkeypatch, tmp_path):
+    """Point NOVA_DATA_DIR at a temporary, populated data directory."""
+    root = tmp_path / "NovaData"
+    root.mkdir()
+    (root / "nova.db").write_bytes(b"-- fake --")
+    for sub in ("backups", "exports", "memory-packs", "logs"):
+        (root / sub).mkdir()
+    monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+    return root
+
+
+# ── Auth gating ─────────────────────────────────────────────────────
+
+
+class TestStorageEndpointsAuth:
+    @pytest.mark.parametrize("method,path,body", [
+        ("GET",  "/admin/storage/status",          None),
+        ("POST", "/admin/storage/export",          {"confirm": True}),
+        ("POST", "/admin/storage/inspect-export",  {"name": "x.tar.gz"}),
+    ])
+    def test_non_admin_forbidden(
+        self, web_client, user_token, method, path, body,
+    ):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(user_token))
+        else:
+            resp = web_client.post(path, headers=_h(user_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", [
+        ("GET",  "/admin/storage/status",          None),
+        ("POST", "/admin/storage/export",          {"confirm": True}),
+        ("POST", "/admin/storage/inspect-export",  {"name": "x.tar.gz"}),
+    ])
+    def test_restricted_forbidden(
+        self, web_client, restricted_token, method, path, body,
+    ):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(restricted_token))
+        else:
+            resp = web_client.post(
+                path, headers=_h(restricted_token), json=body,
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", [
+        ("GET",  "/admin/storage/status",          None),
+        ("POST", "/admin/storage/export",          {"confirm": True}),
+        ("POST", "/admin/storage/inspect-export",  {"name": "x.tar.gz"}),
+    ])
+    def test_unauthenticated_blocked(self, web_client, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path)
+        else:
+            resp = web_client.post(path, json=body)
+        assert resp.status_code in (401, 403)
+
+
+# ── /admin/storage/status ─────────────────────────────────────────
+
+
+class TestStatusEndpoint:
+    def test_status_shape(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.get(
+            "/admin/storage/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_dir_configured"] is True
+        assert body["data_dir"] == str(configured_data_root)
+        assert isinstance(body["paths"], list)
+        names = {p["name"] for p in body["paths"]}
+        assert {
+            "data_dir", "database", "backups", "exports",
+            "memory_packs", "logs", "ollama_models",
+        }.issubset(names)
+        assert isinstance(body["recommendations"], list)
+
+
+# ── /admin/storage/export ─────────────────────────────────────────
+
+
+class TestExportEndpoint:
+    def test_export_requires_confirm(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token), json={"confirm": False},
+        )
+        assert resp.status_code == 400
+
+    def test_export_missing_confirm(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token), json={},
+        )
+        assert resp.status_code == 400
+
+    def test_export_creates_archive(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token), json={"confirm": True},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["archive_path"].endswith(".tar.gz")
+        assert body["archive_size"] > 0
+        assert body["manifest"]["format"] == "nova-data-export"
+        archive = Path(body["archive_path"])
+        assert archive.is_file()
+
+    def test_export_rejects_workspace_mode(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token),
+            json={"confirm": True, "mode": "workspace"},
+        )
+        assert resp.status_code == 400
+
+
+# ── /admin/storage/inspect-export ─────────────────────────────────
+
+
+class TestInspectEndpoint:
+    def test_inspect_rejects_traversal_name(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        # The validator should reject this before the helper runs.
+        resp = web_client.post(
+            "/admin/storage/inspect-export",
+            headers=_h(admin_token), json={"name": "../etc/passwd"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_inspect_rejects_absolute_path(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/inspect-export",
+            headers=_h(admin_token), json={"name": "/etc/passwd"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_inspect_rejects_dotfile(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/inspect-export",
+            headers=_h(admin_token), json={"name": ".bashrc"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_inspect_missing_archive_returns_404(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/inspect-export",
+            headers=_h(admin_token),
+            json={"name": "nonexistent.tar.gz"},
+        )
+        assert resp.status_code == 404
+
+    def test_inspect_returns_report_for_real_archive(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        # First, build an archive via the export endpoint.
+        export = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token), json={"confirm": True},
+        )
+        assert export.status_code == 200, export.text
+        archive_path = Path(export.json()["archive_path"])
+        assert archive_path.is_file()
+
+        # Then inspect it by its basename.
+        resp = web_client.post(
+            "/admin/storage/inspect-export",
+            headers=_h(admin_token),
+            json={"name": archive_path.name},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["valid"] is True
+        assert body["manifest"]["format"] == "nova-data-export"

--- a/tests/test_storage_status.py
+++ b/tests/test_storage_status.py
@@ -1,0 +1,301 @@
+"""Tests for the read-only storage status reporter.
+
+Pinned contracts (see ``core/storage_status.py``):
+
+* the reporter is read-only — no directory is created, no file is
+  touched, no symlink is resolved by the classifier;
+* it reports configured ``NOVA_DATA_DIR``, the resolved database
+  path, and the four reserved subdirectories;
+* it warns when ``NOVA_DATA_DIR`` is unset, when the data directory
+  sits inside a Git checkout, when a configured path is on a
+  transient mount (``/run/media/...``) or in ``/tmp``, and when a
+  directory exists but is not writable;
+* it surfaces Ollama models as informational (``OLLAMA_MODELS``
+  honoured; default falls back to ``~/.ollama/models``);
+* every response field is JSON-serialisable.
+
+The tests never assume host-specific paths — everything is rooted
+at ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from core import paths as core_paths
+from core import storage_status as ss
+
+
+# ── classify_mount ───────────────────────────────────────────────────
+
+
+class TestClassifyMount:
+    """Coarse mount classification is purely lexical and stable."""
+
+    @pytest.mark.parametrize("path,expected", [
+        ("/mnt/fastdata/NovaData", ss.MOUNT_STABLE),
+        ("/var/lib/nova", ss.MOUNT_STABLE),
+        ("/srv/nova-data", ss.MOUNT_STABLE),
+        ("/opt/nova", ss.MOUNT_STABLE),
+        ("/run/media/alice/disk1", ss.MOUNT_TRANSIENT),
+        ("/media/alice/usb", ss.MOUNT_TRANSIENT),
+        ("/tmp/nova-test", ss.MOUNT_TMP),
+        ("/var/tmp/nova-test", ss.MOUNT_TMP),
+        ("/etc/nova", ss.MOUNT_OTHER),
+        ("relative/path", ss.MOUNT_OTHER),
+        ("", ss.MOUNT_OTHER),
+    ])
+    def test_classifies_known_prefixes(self, path, expected, monkeypatch):
+        # HOME is unset so the user_home classifier cannot interfere.
+        monkeypatch.delenv("HOME", raising=False)
+        assert ss.classify_mount(path) == expected
+
+    def test_user_home_under_home(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/alice")
+        assert ss.classify_mount("/home/alice/NovaData") == ss.MOUNT_USER_HOME
+        assert ss.classify_mount("/home/alice") == ss.MOUNT_USER_HOME
+
+    def test_user_home_does_not_match_other_users(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/alice")
+        # A neighbouring user's home is not classified as the running
+        # user's home — that distinction matters for permissions.
+        assert ss.classify_mount("/home/bob/NovaData") == ss.MOUNT_OTHER
+
+
+# ── get_storage_status ──────────────────────────────────────────────
+
+
+class TestStorageStatusUnconfigured:
+    """When NOVA_DATA_DIR is unset, the report is calm but warned."""
+
+    def test_returns_warning_when_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        monkeypatch.chdir(tmp_path)
+        status = ss.get_storage_status()
+        assert status.data_dir_configured is False
+        assert any(
+            "NOVA_DATA_DIR is not set" in w for w in status.warnings
+        )
+
+    def test_warns_when_data_root_contains_git_checkout(
+        self, monkeypatch, tmp_path,
+    ):
+        # Simulate the legacy layout where ``./nova.db`` sits in a
+        # directory that also contains ``.git``. The top-level
+        # warning surface must surface that explicitly.
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+        status = ss.get_storage_status()
+        joined = " | ".join(status.warnings)
+        assert "Git checkout" in joined
+
+    def test_paths_are_serialisable(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        monkeypatch.chdir(tmp_path)
+        status = ss.get_storage_status()
+        # The whole report must be a plain JSON-compatible dict so
+        # the admin endpoint can hand it to FastAPI without
+        # bespoke encoders.
+        body = status.as_dict()
+        rendered = json.dumps(body)
+        parsed = json.loads(rendered)
+        assert parsed["data_dir_configured"] is False
+        # The reporter does not include None for unknown free space
+        # by surfacing it as JSON null — make sure that survives.
+        assert isinstance(parsed["paths"], list)
+
+
+class TestStorageStatusConfigured:
+    """When NOVA_DATA_DIR is set, every helper points under it."""
+
+    @pytest.fixture
+    def configured_root(self, monkeypatch, tmp_path):
+        root = tmp_path / "mnt" / "fastdata" / "NovaData"
+        root.mkdir(parents=True)
+        # Ensure the classifier sees a stable prefix — we deliberately
+        # built ``tmp_path / "mnt" / ...``; since classify_mount is
+        # lexical, the full path under tmp_path resolves to a path
+        # that does NOT start with ``/mnt/``. We use this root mostly
+        # for existence / writability / disk-space assertions.
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        return root
+
+    def test_reports_configured_root(self, configured_root):
+        status = ss.get_storage_status()
+        assert status.data_dir_configured is True
+        assert status.data_dir == str(configured_root)
+
+    def test_each_canonical_path_is_present(self, configured_root):
+        status = ss.get_storage_status()
+        names = {p.name for p in status.paths}
+        assert {
+            "data_dir", "database", "backups", "exports",
+            "memory_packs", "logs", "ollama_models",
+        }.issubset(names)
+
+    def test_database_path_is_under_root(self, configured_root):
+        status = ss.get_storage_status()
+        db_entry = next(p for p in status.paths if p.name == "database")
+        assert db_entry.path == str(configured_root / "nova.db")
+        # Pre-first-run: the DB does not exist yet, but the entry
+        # still resolves cleanly.
+        assert db_entry.exists is False
+
+    def test_subdir_entries_under_root(self, configured_root):
+        status = ss.get_storage_status()
+        for name, sub in (
+            ("backups", "backups"),
+            ("exports", "exports"),
+            ("memory_packs", "memory-packs"),
+            ("logs", "logs"),
+        ):
+            entry = next(p for p in status.paths if p.name == name)
+            assert entry.path == str(configured_root / sub)
+
+    def test_disk_free_is_reported_for_existing_root(self, configured_root):
+        status = ss.get_storage_status()
+        data_entry = next(p for p in status.paths if p.name == "data_dir")
+        # tmp_path lives on a real filesystem; free / total bytes
+        # must be positive integers, not None.
+        assert data_entry.free_bytes is not None
+        assert data_entry.total_bytes is not None
+        assert data_entry.free_bytes >= 0
+        assert data_entry.total_bytes > 0
+
+
+class TestStorageStatusUnwritable:
+    """An unwritable data directory surfaces a clear warning."""
+
+    def test_unwritable_directory_warning(self, monkeypatch, tmp_path):
+        if os.geteuid() == 0:
+            pytest.skip("running as root — cannot make a directory unwritable")
+        root = tmp_path / "ReadOnlyData"
+        root.mkdir()
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        os.chmod(root, stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            status = ss.get_storage_status()
+            data_entry = next(
+                p for p in status.paths if p.name == "data_dir"
+            )
+            assert data_entry.writable is False
+            assert any(
+                "not writable" in w for w in data_entry.warnings
+            )
+        finally:
+            os.chmod(root, stat.S_IRWXU)
+
+
+class TestStorageStatusMissingDirectory:
+    """A configured-but-missing directory is reported, never created."""
+
+    def test_missing_directory_does_not_create_it(
+        self, monkeypatch, tmp_path,
+    ):
+        root = tmp_path / "Missing" / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        assert not root.exists()
+        status = ss.get_storage_status()
+        data_entry = next(p for p in status.paths if p.name == "data_dir")
+        # The reporter must NOT create the directory.
+        assert not root.exists(), (
+            "get_storage_status must not create the data directory"
+        )
+        # exists=False, but the report still produces a value.
+        assert data_entry.exists is False
+
+
+class TestStorageStatusTransientMount:
+    """Transient mount paths trigger a clear warning."""
+
+    def test_run_media_warning(self, monkeypatch):
+        # We don't actually write under /run/media — the classifier
+        # only looks at the lexical path. Set NOVA_DATA_DIR to a
+        # /run/media path and assert the warning is present on the
+        # data_dir entry.
+        monkeypatch.setenv(
+            core_paths.ENV_VAR, "/run/media/alice/disk1/NovaData",
+        )
+        status = ss.get_storage_status()
+        data_entry = next(p for p in status.paths if p.name == "data_dir")
+        assert data_entry.mount_class == ss.MOUNT_TRANSIENT
+        assert any(
+            "transient mount" in w for w in data_entry.warnings
+        )
+
+    def test_tmp_warning(self, monkeypatch):
+        monkeypatch.setenv(core_paths.ENV_VAR, "/tmp/NovaData-test")
+        status = ss.get_storage_status()
+        data_entry = next(p for p in status.paths if p.name == "data_dir")
+        assert data_entry.mount_class == ss.MOUNT_TMP
+        assert any("/tmp" in w for w in data_entry.warnings)
+
+
+class TestOllamaPath:
+    """OLLAMA_MODELS is honoured; default falls back to ~/.ollama/models."""
+
+    def test_configured_env_var(self, monkeypatch, tmp_path):
+        ollama_dir = tmp_path / "ollama-models"
+        ollama_dir.mkdir()
+        monkeypatch.setenv(ss.OLLAMA_MODELS_ENV, str(ollama_dir))
+        monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path / "NovaData"))
+        status = ss.get_storage_status()
+        entry = next(p for p in status.paths if p.name == "ollama_models")
+        assert entry.path == str(ollama_dir)
+        assert entry.configured is True
+
+    def test_default_falls_back_to_home(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(ss.OLLAMA_MODELS_ENV, raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path / "NovaData"))
+        status = ss.get_storage_status()
+        entry = next(p for p in status.paths if p.name == "ollama_models")
+        assert entry.path == str(tmp_path / ".ollama" / "models")
+        assert entry.configured is False
+        # Informational warning explains the fall-back.
+        assert any(
+            "informational" in w.lower() or "default" in w.lower()
+            for w in entry.warnings
+        )
+
+
+class TestRecommendations:
+    """Recommendations are static, stable, and human-readable."""
+
+    def test_recommendations_are_non_empty(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        monkeypatch.chdir(tmp_path)
+        status = ss.get_storage_status()
+        assert len(status.recommendations) >= 3
+        for rec in status.recommendations:
+            assert isinstance(rec, str)
+            assert rec.strip()
+
+    def test_recommendations_mention_ssd_and_ollama(
+        self, monkeypatch, tmp_path,
+    ):
+        monkeypatch.delenv(core_paths.ENV_VAR, raising=False)
+        monkeypatch.chdir(tmp_path)
+        status = ss.get_storage_status()
+        joined = " ".join(status.recommendations)
+        assert "SSD" in joined
+        assert "Ollama" in joined
+
+
+class TestReadOnly:
+    """The reporter must never create or modify files."""
+
+    def test_no_files_created(self, monkeypatch, tmp_path):
+        root = tmp_path / "NovaData"
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        # The data root does not exist before the call.
+        assert not root.exists()
+        ss.get_storage_status()
+        # And it must still not exist after the call — the reporter
+        # is strictly read-only.
+        assert not root.exists()

--- a/web.py
+++ b/web.py
@@ -68,6 +68,8 @@ from core.security import ensure_silentguard_running as _ensure_silentguard_runn
 from core.security import lifecycle as _silentguard_lifecycle
 from core.security import SilentGuardProvider as _SilentGuardProvider
 from core import maintenance as _maintenance
+from core import storage_status as _storage_status
+from core import data_export as _data_export
 from core import voice as _voice
 import sqlite3 as _sqlite3
 from core import users as _users_mod
@@ -2493,6 +2495,134 @@ def maintenance_restart(
     """
     _require_confirm(req)
     return _maintenance.restart().as_dict()
+
+
+# ── ADMIN: STORAGE & MIGRATION CENTER ─────────────────────────────
+# Phase 1 admin-only surface for inspecting Nova's storage layout
+# and building portable data export packages. Every endpoint is
+# wrapped with ``require_admin``. The underlying modules
+# (``core.storage_status`` and ``core.data_export``) enforce:
+#
+#   * read-only status reporting,
+#   * allowlist-only exports (nova.db + sidecars + reserved
+#     subdirectories — never .env, .git, .venv, caches, Ollama
+#     models, or anything else),
+#   * no symlink escape outside the data directory,
+#   * inspection / restore are dry-run only — Phase 1 never writes,
+#     moves, or deletes anything on a restore,
+#   * confirmation-gated export so a stray click never produces an
+#     archive.
+#
+# The export endpoint takes an explicit ``confirm`` payload mirroring
+# the maintenance endpoints. The inspect endpoint is read-only but
+# still admin-only — the operator's data layout is sensitive.
+
+
+class StorageExportRequest(BaseModel):
+    """Explicit confirmation + options for the export endpoint.
+
+    ``mode`` defaults to the safe ``data-only`` option. The
+    ``workspace`` mode is reserved for a follow-up PR and rejected
+    today.
+    """
+
+    confirm: bool = False
+    mode: str = _data_export.MODE_DATA_ONLY
+
+    model_config = {"extra": "forbid"}
+
+
+class StorageInspectRequest(BaseModel):
+    """Inspect an archive by its basename under the exports directory.
+
+    To prevent path traversal via the API, the admin selects an
+    archive by its filename (not by absolute path). The server
+    resolves it against ``core.paths.exports_dir()`` and refuses any
+    name that contains a path separator, an absolute path, or a
+    ``..`` component.
+    """
+
+    name: str = Field(min_length=1, max_length=255)
+
+    model_config = {"extra": "forbid"}
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("name must not be empty")
+        if "/" in v or "\\" in v or ".." in v or v.startswith("."):
+            raise ValueError("name must be a plain filename, not a path")
+        return v
+
+
+@app.get("/admin/storage/status")
+def storage_status_endpoint(_: CurrentUser = Depends(require_admin)):
+    """Calm read-only snapshot of Nova's storage layout.
+
+    Returns the data directory, the resolved database path, the
+    reserved subdirectories, free disk space (best effort), and any
+    warnings — for example when ``NOVA_DATA_DIR`` is unset or when
+    the configured path is on a transient mount such as
+    ``/run/media/...``.
+    """
+    return _storage_status.get_storage_status().as_dict()
+
+
+@app.post("/admin/storage/export")
+def storage_export_endpoint(
+    req: StorageExportRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Build a portable data-only export package.
+
+    Returns 400 when ``confirm`` is not True or when an unknown mode
+    is requested. The underlying helper writes the archive to
+    ``NOVA_DATA_DIR/exports`` (or the legacy ``./exports``) and
+    returns the absolute path along with a manifest summary so the
+    UI can render a "download / inspect" panel.
+    """
+    _require_confirm(req)
+    try:
+        result = _data_export.create_data_export(mode=req.mode)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return result.as_dict()
+
+
+@app.post("/admin/storage/inspect-export")
+def storage_inspect_endpoint(
+    req: StorageInspectRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Inspect an existing export archive under the exports directory.
+
+    Reads the manifest, validates the archive structure (no path
+    traversal, no symlink escape, format / version match), and
+    returns a structured report. Never writes to disk. The body
+    selects the archive by its plain filename — absolute paths are
+    rejected at the validation layer.
+    """
+    from core import paths as _paths_mod
+    exports_root = _paths_mod.effective_data_root() / _paths_mod.EXPORTS_SUBDIR
+    target = exports_root / req.name
+    try:
+        target_resolved = target.resolve(strict=False)
+        exports_resolved = exports_root.resolve(strict=False)
+        target_resolved.relative_to(exports_resolved)
+    except (OSError, ValueError):
+        raise HTTPException(
+            status_code=400,
+            detail="Archive name does not resolve inside the exports directory.",
+        )
+    if not target.is_file():
+        raise HTTPException(
+            status_code=404, detail="Archive not found.",
+        )
+    return _data_export.inspect_export(str(target)).as_dict()
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

Phase 1 of the Nova **Storage & Migration Center** — the backend +
docs foundation that lets an operator see where Nova stores its
data, build a portable export package, and inspect that package
before restoring on another machine. Nothing in this PR moves data
automatically, overwrites memory, or runs a wizard. The Phase 1
boundary is deliberate: backend + docs first, UI wizard later.

## What's in this PR

### New modules

* **`core/storage_status.py`** — read-only health snapshot of every
  Nova-owned path. Reports `NOVA_DATA_DIR`, the resolved
  `nova.db`, `backups/`, `exports/`, `memory-packs/`, `logs/`, and
  (informational) the Ollama models directory. Surfaces:
  * mount classification (`stable` / `transient` / `tmp` /
    `user_home` / `other`)
  * existence + writability per path
  * free-disk space (memoised by `st_dev` so a 7-row report makes
    one statvfs call, not seven)
  * top-level warnings: `NOVA_DATA_DIR` unset, data dir sitting
    inside a Git checkout, runtime data on `/run/media/...` or
    `/tmp/...`
  * a static recommendations block aligned with
    `docs/data-directory.md`

* **`core/data_export.py`** — portable tar.gz export builder,
  archive inspector, and dry-run restore planner. Phase 1 ships
  `mode="data-only"`; `workspace` is reserved for a follow-up PR
  and currently rejected.

* **`core/paths.py`** — adds `effective_data_root()` so the status
  reporter, export builder, and admin endpoint all share a single
  "where does Nova live?" fallback instead of re-deriving it.

### New endpoints (all admin-only, all `require_admin`-gated)

* `GET /admin/storage/status` — read-only snapshot.
* `POST /admin/storage/export` — confirmation-gated
  (`{"confirm": true}` or 400). Returns archive path, size,
  SHA-256, manifest, and lists of included / excluded entries.
* `POST /admin/storage/inspect-export` — selects an archive by
  plain filename (validator rejects `/`, `\`, `..`, leading dots,
  absolute paths). Validates structure, refuses path traversal /
  symlink escape / disallowed top-level entries / wrong format
  identifier / oversize manifest. Read-only.

### Docs

* **`docs/storage-and-migration.md`** — operator walkthrough
  (recommended layouts, the full safety contract, manual restore
  procedure, Ollama-models rationale, "GitHub is for source code
  only").
* `docs/data-directory.md` — cross-links the new doc.
* `README.md` — brief feature card (matches the shape of the
  Maintenance Center section).

### Tests

* `tests/test_storage_status.py` (30 tests) — mount classifier,
  unconfigured warnings, configured paths, missing /
  unwritable directory, transient mount + `/tmp` warnings, Ollama
  fallback, recommendations, read-only contract.
* `tests/test_data_export.py` (35 tests) — happy path; allowlist
  exclusions for `.env`, `.git`, `.venv`, caches, SSH keys, secret
  suffixes; symlink-escape vs symlink-inside-data-root; legacy
  mode warning; tarfile validation rejecting traversal, absolute
  member names, hardlinks, missing manifest, wrong format ID;
  restore plan refusing overwrite + traversal + unconfigured
  target; verifies plan_restore writes zero files.
* `tests/test_storage_endpoints.py` (19 tests) — admin-only auth
  gating (non-admin / restricted / unauthenticated all 403/401),
  status shape, export confirm-required, inspect filename
  validation (`../`, `/`, dotfile, 404 for missing), full
  export → inspect round-trip.

## Safety boundaries pinned by this PR

* **Read-only by default.** `/admin/storage/status` and
  `/admin/storage/inspect-export` never write.
* **Confirmation-gated export.** Missing `confirm: true` → 400.
* **Allowlist-only export.** Only `nova.db`, `nova.db.*` sidecars,
  and the four reserved subdirectories are eligible. Everything
  else is silently skipped (records the reason in the manifest).
* **No symlink escape.** `os.walk(followlinks=False)` + per-file
  resolve-and-contain check. Symlinks inside the data root are
  dereferenced into the archive so the restored copy doesn't
  depend on the target host's symlink layout.
* **No path traversal.** Lexical (`..`, leading `/`, drive
  letters, control chars) + post-resolution containment.
  Hostile archives are refused, never extracted.
* **No automatic restore.** Phase 1 plans + inspects only.
  Restore is the documented manual operator step.
* **No overwrite without explicit operator action.** Restore plan
  refuses when the target already has `nova.db`.
* **No shell, no subprocess, no privilege escalation.** Pure
  stdlib (`tarfile`, `hashlib`, `os.walk`, `shutil`).
* **No cloud sync. No background scheduler. No model file
  movement.** Ollama is reported for context and never touched.
* **No secret leakage.** Manifests never echo `.env` or token
  contents. Responses never include env vars.

## Out of scope (explicitly Phase 2 or later)

* Admin-UI wizard for migration.
* `workspace` export mode (the full Nova Portable Workspace as
  one archive).
* Automated restore.
* Encrypted-at-rest packages.
* Background scheduled exports.
* Editing `NOVA_DATA_DIR` from the UI.
* Moving Ollama models.

## Test plan

- [x] `python3 -m pytest tests/test_storage_status.py tests/test_data_export.py tests/test_storage_endpoints.py` → 84 passed (1 skipped on root for the unwritable-dir test that needs a non-root user)
- [x] Full regression run against the existing tests directly
  exercised by these changes: `tests/test_paths.py
  tests/test_maintenance.py tests/test_memory.py
  tests/test_feedback.py tests/test_auth.py
  tests/test_admin_users.py tests/test_storage_status.py
  tests/test_data_export.py tests/test_storage_endpoints.py` →
  316 passed, 2 skipped, 0 failures.
- [x] Confirmed the 33 pre-existing failures in
  `test_natural_memory`, `test_router`, `test_model_pulls`,
  `test_model_registry`, `test_model_download_warnings` are
  caused by the test environment stubbing `ollama` with a
  MagicMock (these fail on the parent commit before my changes
  too, with the same `TypeError: catching classes that do not
  inherit from BaseException`).

https://claude.ai/code/session_012ESyoJzFgqBStkv83SCX5E

---
_Generated by [Claude Code](https://claude.ai/code/session_012ESyoJzFgqBStkv83SCX5E)_