### PR TITLE
feat(storage): CLI + admin UI for Nova data export packages (Phase 2)

### DIFF
--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1260,6 +1260,297 @@ def plan_restore(
     )
 
 
+# ── CLI ─────────────────────────────────────────────────────────────
+#
+# ``python -m core.data_export <command> [...]`` exposes the three
+# public helpers in a tiny argparse wrapper so an operator can build,
+# inspect, and dry-run a restore without going through the admin UI.
+# The CLI is the only surface here that talks to ``stdout`` / ``stderr``
+# — the library functions never print.
+#
+# Commands:
+#
+#   export                 Build a portable archive in the exports
+#                          directory (or under ``--output``).
+#   inspect <path>         Read-only structural check on an existing
+#                          archive — never writes anywhere.
+#   restore-dry-run <path> Dry-run plan only — never writes anywhere.
+#
+# Every command exits 0 on success, 1 on a user-visible failure, and
+# 2 for argparse usage errors. Exit codes are intentional so the CLI
+# composes cleanly with shell pipelines and CI checks.
+#
+# The CLI deliberately stays tiny: the heavy lifting lives in the
+# functions above so the unit tests can drive them without spawning a
+# subprocess (mirroring ``core/paths.py``'s ``_cli`` pattern).
+
+
+def _format_bytes(size: int) -> str:
+    """Render ``size`` as a short, human-readable string.
+
+    Used by the CLI summaries; tests pin the wire format only at the
+    program-output level, so the rendering is free to change as long
+    as the keywords ("MB", "GB") stay recognisable.
+    """
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    if size < 1024 * 1024 * 1024:
+        return f"{size / (1024 * 1024):.1f} MB"
+    return f"{size / (1024 * 1024 * 1024):.2f} GB"
+
+
+def _format_export_summary(result: ExportResult) -> str:
+    """Render a short human summary of an :class:`ExportResult`."""
+    manifest = result.manifest or {}
+    lines = [
+        f"Nova export package created at {result.archive_path}",
+        (
+            f"  format        : {manifest.get('format', '')} "
+            f"v{manifest.get('format_version', '')}"
+        ),
+        f"  mode          : {manifest.get('mode', '')}",
+        f"  created (UTC) : {manifest.get('created_at', '')}",
+        f"  source        : {manifest.get('source_data_dir', '')}",
+        f"  archive size  : {_format_bytes(result.archive_size)}",
+        f"  sha256        : {result.archive_sha256}",
+        f"  files included: {len(result.included)}",
+        f"  files excluded: {len(result.excluded)}",
+    ]
+    if result.warnings:
+        lines.append("  warnings:")
+        for warning in result.warnings:
+            lines.append(f"    - {warning}")
+    lines.append("")
+    lines.append(
+        "Move this file to your backup target (e.g. "
+        "/mnt/archive/Backups/Nova) via rsync or a removable disk."
+    )
+    lines.append(
+        "Inspect before restoring on the target machine with:"
+    )
+    lines.append(
+        f"    python -m core.data_export inspect {result.archive_path}"
+    )
+    return "\n".join(lines)
+
+
+def _format_inspect_summary(result: InspectionResult) -> str:
+    """Render a short human summary of an :class:`InspectionResult`."""
+    lines = [f"Inspecting {result.archive_path}"]
+    lines.append(f"  valid                  : {result.valid}")
+    if result.manifest:
+        lines.append(
+            f"  format                 : {result.manifest.get('format', '')} "
+            f"v{result.manifest.get('format_version', '')}"
+        )
+        lines.append(
+            f"  mode                   : {result.manifest.get('mode', '')}"
+        )
+        lines.append(
+            f"  created (UTC)          : "
+            f"{result.manifest.get('created_at', '')}"
+        )
+        lines.append(
+            f"  source data dir        : "
+            f"{result.manifest.get('source_data_dir', '')}"
+        )
+    has_nova_db = any(
+        f == f"{ARCHIVE_DATA_PREFIX}/{_paths.DB_FILENAME}"
+        for f in result.files
+    )
+    lines.append(f"  nova.db present        : {has_nova_db}")
+    lines.append(f"  total uncompressed size: "
+                 f"{_format_bytes(result.total_uncompressed_size)}")
+    lines.append(f"  member count           : {len(result.files)}")
+    if result.errors:
+        lines.append("  errors:")
+        for err in result.errors:
+            lines.append(f"    - {err}")
+    if result.warnings:
+        lines.append("  warnings:")
+        for warning in result.warnings:
+            lines.append(f"    - {warning}")
+    return "\n".join(lines)
+
+
+def _format_restore_plan(plan: RestorePlan) -> str:
+    """Render a short human summary of a :class:`RestorePlan`."""
+    lines = [f"Restore dry-run for {plan.archive_path}"]
+    lines.append(f"  target data dir : {plan.target_data_dir}")
+    lines.append(f"  allowed         : {plan.allowed}")
+    if plan.refuse_reason:
+        lines.append(f"  refuse reason   : {plan.refuse_reason}")
+    lines.append(f"  would restore   : {len(plan.would_restore)} file(s)")
+    if plan.conflicts:
+        lines.append(
+            f"  conflicts       : {len(plan.conflicts)} "
+            "existing file(s) would be overwritten"
+        )
+        for path in plan.conflicts[:10]:
+            lines.append(f"    ! {path}")
+        if len(plan.conflicts) > 10:
+            lines.append(
+                f"    ... and {len(plan.conflicts) - 10} more"
+            )
+    if plan.warnings:
+        lines.append("  warnings:")
+        for warning in plan.warnings:
+            lines.append(f"    - {warning}")
+    lines.append("")
+    lines.append(
+        "This is a dry-run plan only. Nothing was written. Phase 2 "
+        "does not perform an automated restore — follow the manual "
+        "steps in docs/storage-and-migration.md when you are ready."
+    )
+    return "\n".join(lines)
+
+
+def _stderr():  # pragma: no cover - trivial helper for monkeypatching
+    """Return ``sys.stderr`` indirectly so tests can swap it out."""
+    import sys
+
+    return sys.stderr
+
+
+def _cli(argv: list[str]) -> int:
+    """Parse ``argv`` and dispatch a data-export subcommand.
+
+    Returns a POSIX-style exit code:
+
+    * ``0`` — command succeeded.
+    * ``1`` — command failed for a user-visible reason (bad archive,
+      unwritable destination, refused restore, …). The CLI prints a
+      short error line to stderr; nothing else is touched on disk.
+    * ``2`` — argparse-style usage error. The CLI prints the usage
+      banner to stderr.
+
+    The function is split out so tests can drive the CLI without
+    spawning a subprocess, matching the pattern used by
+    ``core.paths._cli``.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m core.data_export",
+        description=(
+            "Build, inspect, and dry-run-restore Nova data export "
+            "packages. Read-only by default — only the export "
+            "subcommand writes anything, and only inside the "
+            "configured exports directory or an explicit --output."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    export_parser = subparsers.add_parser(
+        "export",
+        help="Build a portable Nova data export package.",
+    )
+    export_parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help=(
+            "Directory to write the archive into. Defaults to "
+            "NOVA_DATA_DIR/exports (or ./exports in legacy mode)."
+        ),
+    )
+    export_parser.add_argument(
+        "--mode",
+        default=MODE_DATA_ONLY,
+        help=(
+            "Export mode. Phase 2 supports 'data-only' only; "
+            "'workspace' is reserved for future work."
+        ),
+    )
+    export_parser.add_argument(
+        "--stem",
+        default=None,
+        help=(
+            "Override the default filename stem "
+            f"({DEFAULT_EXPORT_STEM!r}). Letters, digits, '.', '_', "
+            "'-' only."
+        ),
+    )
+
+    inspect_parser = subparsers.add_parser(
+        "inspect",
+        help="Read-only structural check on an existing archive.",
+    )
+    inspect_parser.add_argument(
+        "archive",
+        help="Path to a Nova data export archive (.tar.gz).",
+    )
+
+    restore_parser = subparsers.add_parser(
+        "restore-dry-run",
+        help=(
+            "Dry-run plan for restoring an archive. Never writes a "
+            "file."
+        ),
+    )
+    restore_parser.add_argument(
+        "archive",
+        help="Path to a Nova data export archive (.tar.gz).",
+    )
+    restore_parser.add_argument(
+        "--data-dir",
+        default=None,
+        help=(
+            "Target data directory. Defaults to the configured "
+            "NOVA_DATA_DIR; failing that, the command refuses."
+        ),
+    )
+
+    if not argv:
+        parser.print_help(file=_stderr())
+        return 2
+
+    args = parser.parse_args(argv)
+
+    if args.command == "export":
+        try:
+            result = create_data_export(
+                dest_dir=args.output,
+                mode=args.mode,
+                stem=args.stem,
+            )
+        except ValueError as exc:
+            print(f"error: {exc}", file=_stderr())
+            return 1
+        except RuntimeError as exc:
+            print(f"error: {exc}", file=_stderr())
+            return 1
+        print(_format_export_summary(result))
+        return 0
+
+    if args.command == "inspect":
+        result = inspect_export(args.archive)
+        print(_format_inspect_summary(result))
+        return 0 if result.valid else 1
+
+    if args.command == "restore-dry-run":
+        plan = plan_restore(
+            args.archive,
+            target_data_dir=args.data_dir,
+        )
+        print(_format_restore_plan(plan))
+        # A refused plan is a *result*, not a CLI failure — the
+        # operator asked us to plan, we did, the plan said "no".
+        # Return 0 so shell scripts can branch on the structured
+        # exit-1 reserved for unexpected errors. Tests pin this.
+        return 0
+
+    parser.print_help(file=_stderr())
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via tests
+    import sys
+
+    sys.exit(_cli(sys.argv[1:]))
+
+
 __all__ = [
     "ARCHIVE_DATA_PREFIX",
     "ARCHIVE_MANIFEST_NAME",

--- a/docs/storage-and-migration.md
+++ b/docs/storage-and-migration.md
@@ -1,11 +1,13 @@
 # Nova Storage & Migration Center
 
-> **Status: Phase 1 — backend + docs.** Nova ships a small, admin-only
-> surface that reports where Nova stores its data, builds a portable
-> data export package, and lets you inspect an existing package
-> before you restore. Every action is opt-in, confirmation-gated, and
-> safe by default. No data is ever moved, overwritten, or deleted by
-> Nova itself.
+> **Status: Phase 2 — admin UI + CLI on top of Phase 1's backend.**
+> Nova ships a small, admin-only surface that reports where Nova
+> stores its data, builds a portable data export package, lets you
+> inspect an existing package, and produces a dry-run restore plan
+> before you touch the target. Every action is opt-in,
+> confirmation-gated, and safe by default. No data is ever moved,
+> overwritten, or deleted by Nova itself. Restore stays a manual
+> operator step — the dry-run plan is the most Phase 2 will do.
 
 This document is the operator-facing companion to
 [`docs/data-directory.md`](data-directory.md) and
@@ -29,7 +31,7 @@ If you are setting up Nova for the first time, start with
 
 ## What the Storage & Migration Center covers
 
-Nova exposes three things to the admin in Phase 1:
+Nova exposes four things to the admin:
 
 1. **Storage status** — a read-only report on Nova's path layout:
    `NOVA_DATA_DIR`, the resolved `nova.db` path, the four reserved
@@ -46,11 +48,28 @@ Nova exposes three things to the admin in Phase 1:
    existing archive. The manifest is parsed, every member is
    validated against path traversal and symlink escape, and the
    result is returned in a structured form the admin UI can render.
+4. **Dry-run restore plan** — given an archive and a target data
+   directory, Nova lists the files that *would* be restored, flags
+   any conflicts (e.g. an existing `nova.db`), and refuses to
+   proceed automatically. The plan is purely informational: nothing
+   is written, moved, or deleted.
 
-Restore itself stays a **manual operator step** in Phase 1. The
-inspection result includes the dry-run plan (what files would land
-where) so you can review it before you copy anything. Nova never
-overwrites a `nova.db` automatically.
+Surfaces:
+
+* **Admin overlay → ⚇ Storage tab** — confirmation-gated UI
+  wrapper around the three endpoints. Shows the status report,
+  builds an export package, and renders the latest export summary.
+* **HTTP endpoints** — `/admin/storage/status`,
+  `/admin/storage/export`, `/admin/storage/inspect-export`. All
+  three require an admin bearer token.
+* **CLI** — `python -m core.data_export {export,inspect,restore-dry-run}`
+  so an operator can run the same flows from a shell on either host,
+  including the target machine before any data is copied.
+
+Restore itself stays a **manual operator step**. The dry-run plan
+is the most Phase 2 will do: Nova never overwrites a `nova.db`
+automatically, and the actual file-copy step is a documented
+`rsync` (or equivalent) you run yourself.
 
 ---
 
@@ -348,7 +367,59 @@ secrets.
 
 ---
 
-## Restoring on the target machine (manual, Phase 1)
+## Using the CLI
+
+The admin endpoints are also exposed through a small command-line
+wrapper so an operator can drive the same flows from a shell on
+either host. The CLI is part of the Nova checkout — no extra install
+required.
+
+```bash
+# Build an export package. By default it lands in NOVA_DATA_DIR/exports.
+python -m core.data_export export
+
+# Build into a specific output directory (must be writable).
+python -m core.data_export export --output /mnt/archive/Backups/Nova
+
+# Read-only inspection of an existing package.
+python -m core.data_export inspect \
+    /mnt/archive/Backups/Nova/nova-data-export-20260514T160000Z.tar.gz
+
+# Dry-run restore plan against an explicit target data directory.
+# Never writes anything; refuses if the target already has a nova.db.
+python -m core.data_export restore-dry-run \
+    /mnt/archive/Backups/Nova/nova-data-export-20260514T160000Z.tar.gz \
+    --data-dir /mnt/fastdata/NovaData
+```
+
+Exit codes:
+
+* `0` — the command succeeded (including a dry-run that returned
+  `allowed: false` — that is a *result*, not an error).
+* `1` — a user-visible failure (bad archive, unwritable destination,
+  workspace mode requested, malformed stem).
+* `2` — argparse usage error.
+
+The CLI never modifies anything outside the chosen output directory
+(for `export`), never extracts archives, and never restores data.
+
+## Using the admin UI
+
+When you sign in as an admin and open the admin overlay, a third
+tab — **⚇ Storage** — sits next to Users and Models. It renders the
+storage status report (path-by-path, with mount-class and free-space
+hints), and exposes a single **Create export package** button.
+
+The button calls `/admin/storage/export` with `confirm: true`. The
+response is rendered as a short summary: archive path, size, SHA-256,
+manifest format / version / timestamp, included vs excluded file
+counts, and any warnings (for example: "NOVA_DATA_DIR is not
+configured"). The UI does **not** offer a destructive restore in
+this phase. Inspection and dry-run restore are CLI-only on
+purpose — they are the steps you take on the target machine, often
+before Nova is even running there.
+
+## Restoring on the target machine (manual, Phase 2)
 
 1. On the target machine, set `NOVA_DATA_DIR` to the new data
    directory (`/mnt/fastdata/NovaData` is the recommended default).
@@ -356,10 +427,21 @@ secrets.
 3. If the target already has a `nova.db`, **back it up** by hand
    before continuing. Nova refuses to overwrite an existing
    database; do not work around this by deleting the file blindly.
-4. Inspect the package via `/admin/storage/inspect-export` (run it
-   on the target host after starting Nova once with an empty data
-   directory, or use `tar tvf` from the shell to read the file
-   list).
+4. Inspect the package and review the dry-run plan:
+
+   ```bash
+   python -m core.data_export inspect \
+       /path/to/nova-data-export-<stamp>.tar.gz
+
+   python -m core.data_export restore-dry-run \
+       /path/to/nova-data-export-<stamp>.tar.gz \
+       --data-dir /mnt/fastdata/NovaData
+   ```
+
+   The dry-run plan refuses (`allowed: false`) if the target
+   directory already contains a `nova.db`. Move or rename the
+   existing file by hand before retrying.
+
 5. Extract the package somewhere staging:
 
    ```bash
@@ -377,9 +459,11 @@ secrets.
    shows your memories, conversations, and settings.
 8. Re-pull any Ollama models you had configured on the source host.
 
-Nova's automated restore is **future work**. Today every step above
-is something you do, deliberately, with the database file in your
-hand.
+Nova's **automated restore is future work**. Today step 5–6 is
+something you do, deliberately, with the database file in your hand.
+The dry-run plan is the safety net — it tells you what *would*
+happen, so you can sanity-check the package and the target before
+you copy anything.
 
 ---
 
@@ -409,7 +493,7 @@ contain one.
 
 ## Safety guarantees
 
-These are firm boundaries of the Phase 1 Storage & Migration Center:
+These are firm boundaries of the Storage & Migration Center:
 
 * **Read-only by default.** `/admin/storage/status` and
   `/admin/storage/inspect-export` never write to disk.
@@ -461,7 +545,7 @@ boundaries above are firm.
 
 ## Future work
 
-These are explicitly **not** in Phase 1:
+These are explicitly **not** in Phase 2:
 
 * A full admin-UI wizard for migration between disks.
 * A `workspace` export mode that snapshots the entire Nova Portable
@@ -473,6 +557,6 @@ These are explicitly **not** in Phase 1:
   / Docker config updates).
 * Moving Ollama models.
 
-Each of those is a separate PR with its own review. The Phase 1
+Each of those is a separate PR with its own review. The current
 boundary keeps the surface area small, the safety contract clear,
 and the existing Nova install untouched.

--- a/static/index.html
+++ b/static/index.html
@@ -2927,6 +2927,7 @@
             <div id="admin-tabs">
                 <button class="admin-tab-btn active" data-tab="users" onclick="switchAdminTab('users')">⚑ Users</button>
                 <button class="admin-tab-btn" data-tab="models" onclick="switchAdminTab('models')">⬢ Models</button>
+                <button class="admin-tab-btn" data-tab="storage" onclick="switchAdminTab('storage')">⚇ Storage</button>
             </div>
             <button id="admin-close" onclick="closeAdmin()">✕</button>
         </div>
@@ -2977,6 +2978,44 @@
                     <button class="admin-btn" onclick="loadAdminPulls()">refresh</button>
                 </div>
                 <div id="admin-pulls-list"></div>
+            </div>
+
+            <!-- STORAGE TAB -->
+            <div id="admin-tab-storage" class="admin-tab-pane">
+                <div class="admin-section-title" style="display:flex;align-items:center;justify-content:space-between;">
+                    <span>Storage status</span>
+                    <button class="admin-btn" onclick="loadStorageStatus()">refresh</button>
+                </div>
+                <div class="admin-warning-summary">
+                    Read-only snapshot of Nova's data paths. Mount class warnings
+                    surface when data lives on transient mounts (e.g.
+                    <code>/run/media/...</code>) or in <code>/tmp</code>.
+                </div>
+                <div id="storage-status-list">
+                    <div class="admin-empty">Loading…</div>
+                </div>
+
+                <div class="admin-section-title">Create export package</div>
+                <div id="storage-export-form">
+                    <div class="admin-warning-summary">
+                        Builds a portable <code>.tar.gz</code> archive of Nova's
+                        data directory (database, backups, memory packs, logs).
+                        Secrets, <code>.git</code>, <code>.venv</code>, caches,
+                        and Ollama models are <strong>never</strong> included.
+                        The package is written to
+                        <code>NOVA_DATA_DIR/exports/</code>.
+                    </div>
+                    <div class="row" style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;">
+                        <button class="admin-btn primary" onclick="createStorageExport()" id="storage-export-btn">
+                            Create export package
+                        </button>
+                        <span class="admin-warning-summary" style="padding:0;">
+                            Confirmation-gated · admin-only · never uploads
+                        </span>
+                    </div>
+                    <div id="storage-export-error" style="color:var(--danger);font-size:0.82rem;min-height:0;"></div>
+                </div>
+                <div id="storage-export-result"></div>
             </div>
         </div>
     </div>
@@ -8076,6 +8115,9 @@
             loadAdminModels();
             loadAdminPulls();
             startAdminPullsPolling();
+        } else if (tab === "storage") {
+            stopAdminPullsPolling();
+            loadStorageStatus();
         }
     }
 
@@ -8602,6 +8644,161 @@
             clearInterval(adminPullsPollTimer);
             adminPullsPollTimer = null;
         }
+    }
+
+    // ── ADMIN: STORAGE & MIGRATION ──
+    //
+    // Read-only status + confirmation-gated export. No destructive
+    // restore UI in this phase. Inspection and dry-run restore live
+    // in the CLI (``python -m core.data_export``) so an operator can
+    // run them on the target machine before copying.
+
+    function formatBytes(bytes) {
+        if (bytes === null || bytes === undefined) return "—";
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+        if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+        return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
+    }
+
+    async function loadStorageStatus() {
+        const list = document.getElementById("storage-status-list");
+        if (!list) return;
+        list.innerHTML = '<div class="admin-empty">Loading…</div>';
+        try {
+            const res = await fetch("/admin/storage/status", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                list.innerHTML = '<div class="admin-empty" style="color:var(--danger);">Access denied.</div>';
+                return;
+            }
+            if (!res.ok) {
+                list.innerHTML = '<div class="admin-empty">Failed to load storage status.</div>';
+                return;
+            }
+            const status = await res.json();
+            renderStorageStatus(status);
+        } catch (e) {
+            list.innerHTML = '<div class="admin-empty">Failed to load storage status.</div>';
+        }
+    }
+
+    function renderStorageStatus(status) {
+        const list = document.getElementById("storage-status-list");
+        if (!list) return;
+        const parts = [];
+        if (status.warnings && status.warnings.length) {
+            for (const w of status.warnings) {
+                parts.push(
+                    `<div class="admin-warning warning">` +
+                    `<span class="admin-warning-level">warning</span>` +
+                    `<span class="admin-warning-msg">${escapeHtml(w)}</span>` +
+                    `</div>`
+                );
+            }
+        }
+        const paths = Array.isArray(status.paths) ? status.paths : [];
+        for (const p of paths) {
+            const mountTag = p.mount_class
+                ? `<span class="admin-tag">${escapeHtml(p.mount_class)}</span>`
+                : "";
+            const okTag = p.exists
+                ? `<span class="admin-tag installed">exists</span>`
+                : `<span class="admin-tag missing">missing</span>`;
+            const writable = p.writable === true
+                ? `<span class="admin-tag installed">writable</span>`
+                : (p.writable === false
+                    ? `<span class="admin-tag error">read-only</span>`
+                    : "");
+            const free = formatBytes(p.free_bytes);
+            const warnings = (p.warnings || []).map(w =>
+                `<div class="admin-warning warning"><span class="admin-warning-level">warning</span><span class="admin-warning-msg">${escapeHtml(w)}</span></div>`
+            ).join("");
+            parts.push(
+                `<div class="admin-model-row">` +
+                `<div class="admin-model-head">` +
+                `<span class="admin-model-display">${escapeHtml(p.label || p.name)}</span>` +
+                `${okTag}${writable}${mountTag}` +
+                `</div>` +
+                `<div class="admin-model-name">${escapeHtml(p.path)}</div>` +
+                `<div class="admin-progress-meta">free: ${free}</div>` +
+                `${warnings}` +
+                `</div>`
+            );
+        }
+        const recs = Array.isArray(status.recommendations) ? status.recommendations : [];
+        if (recs.length) {
+            parts.push('<div class="admin-section-title">Recommended layout</div>');
+            for (const r of recs) {
+                parts.push(`<div class="admin-warning info"><span class="admin-warning-level">info</span><span class="admin-warning-msg">${escapeHtml(r)}</span></div>`);
+            }
+        }
+        list.innerHTML = parts.join("") || '<div class="admin-empty">No storage paths reported.</div>';
+    }
+
+    async function createStorageExport() {
+        const btn = document.getElementById("storage-export-btn");
+        const errEl = document.getElementById("storage-export-error");
+        const resultEl = document.getElementById("storage-export-result");
+        if (errEl) errEl.textContent = "";
+        if (!btn) return;
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Building…";
+        try {
+            const res = await fetch("/admin/storage/export", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ confirm: true, mode: "data-only" }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const body = await res.json();
+                    if (body && body.detail) detail = body.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            renderStorageExportResult(body);
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while creating export.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    }
+
+    function renderStorageExportResult(result) {
+        const el = document.getElementById("storage-export-result");
+        if (!el) return;
+        const manifest = result.manifest || {};
+        const includedCount = (result.included || []).length;
+        const excludedCount = (result.excluded || []).length;
+        const warnings = (result.warnings || []).map(w =>
+            `<div class="admin-warning warning"><span class="admin-warning-level">warning</span><span class="admin-warning-msg">${escapeHtml(w)}</span></div>`
+        ).join("");
+        el.innerHTML =
+            `<div class="admin-section-title">Latest export</div>` +
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">${escapeHtml(manifest.format || "export")} v${escapeHtml(String(manifest.format_version || ""))}</span>` +
+            `<span class="admin-tag installed">${escapeHtml(manifest.mode || "data-only")}</span>` +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(result.archive_path || "")}</div>` +
+            `<div class="admin-progress-meta">size: ${formatBytes(result.archive_size || 0)} · sha256: ${escapeHtml((result.archive_sha256 || "").slice(0, 16))}…</div>` +
+            `<div class="admin-progress-meta">created (UTC): ${escapeHtml(manifest.created_at || "")}</div>` +
+            `<div class="admin-progress-meta">${includedCount} file(s) included · ${excludedCount} excluded with reason</div>` +
+            `${warnings}` +
+            `</div>` +
+            `<div class="admin-warning-summary">Inspect or dry-run the package on the target machine with <code>python -m core.data_export inspect &lt;archive&gt;</code>. Phase 2 does not perform an automated restore — see <code>docs/storage-and-migration.md</code>.</div>`;
     }
 
     // ── UTILS ──

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -546,3 +546,112 @@ class TestPublicSurface:
         ):
             assert reason == reason.lower()
             assert " " not in reason
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    """The ``python -m core.data_export`` entry point.
+
+    Driven through :func:`core.data_export._cli` so the assertions do
+    not have to spawn a subprocess (mirroring the ``core.paths`` CLI
+    test pattern). Each test verifies the exit code, the human-
+    readable summary, and the on-disk side effects (or lack thereof).
+    """
+
+    def test_export_subcommand_writes_archive(
+        self, configured_data_dir, capsys, tmp_path,
+    ):
+        dest = tmp_path / "out"
+        rc = de._cli(["export", "--output", str(dest)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Nova export package created" in out
+        # The archive file actually exists on disk.
+        archives = list(dest.glob("nova-data-export-*.tar.gz"))
+        assert len(archives) == 1
+
+    def test_export_subcommand_rejects_workspace_mode(
+        self, configured_data_dir, capsys,
+    ):
+        rc = de._cli(["export", "--mode", "workspace"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "error" in err.lower()
+
+    def test_inspect_subcommand_on_valid_archive(
+        self, configured_data_dir, capsys,
+    ):
+        # Build a real archive first.
+        result = de.create_data_export()
+        rc = de._cli(["inspect", result.archive_path])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "valid                  : True" in out
+        assert "nova.db present        : True" in out
+
+    def test_inspect_subcommand_on_invalid_archive(
+        self, capsys, tmp_path,
+    ):
+        bogus = tmp_path / "broken.tar.gz"
+        bogus.write_text("not a tar", encoding="utf-8")
+        rc = de._cli(["inspect", str(bogus)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "valid                  : False" in out
+
+    def test_restore_dry_run_refuses_when_target_has_nova_db(
+        self, configured_data_dir, tmp_path, capsys,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "TargetData"
+        target.mkdir()
+        (target / "nova.db").write_bytes(b"existing")
+        rc = de._cli([
+            "restore-dry-run", result.archive_path,
+            "--data-dir", str(target),
+        ])
+        # Refusal is a result, not a CLI error — exit 0 with the plan.
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "allowed         : False" in out
+        assert "already contains nova.db" in out
+        # The dry-run never touched the target.
+        assert (target / "nova.db").read_bytes() == b"existing"
+
+    def test_restore_dry_run_allows_clean_target(
+        self, configured_data_dir, tmp_path, capsys,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "FreshTarget"
+        target.mkdir()
+        rc = de._cli([
+            "restore-dry-run", result.archive_path,
+            "--data-dir", str(target),
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "allowed         : True" in out
+        # Even on a clean target, the dry-run never extracts anything.
+        assert list(target.iterdir()) == []
+
+    def test_unknown_command_prints_usage(self, capsys):
+        rc = de._cli([])
+        assert rc == 2
+        err = capsys.readouterr().err
+        # argparse prints the program description / available subcommands.
+        assert "export" in err
+        assert "inspect" in err
+        assert "restore-dry-run" in err
+
+    def test_export_subcommand_rejects_unsafe_stem(
+        self, configured_data_dir, capsys, tmp_path,
+    ):
+        dest = tmp_path / "out"
+        rc = de._cli([
+            "export", "--output", str(dest), "--stem", "../escape",
+        ])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "error" in err.lower()


### PR DESCRIPTION
## Summary

Phase 2 of the Storage & Migration Center wraps the existing admin-only
export / inspect / dry-run-restore backend in two calmer surfaces — a
small CLI and an admin overlay tab — without changing the Phase 1
safety contract.

- **`core/data_export.py`** — adds a tiny argparse CLI mirroring the
  `core.paths` pattern. `python -m core.data_export` exposes three
  subcommands:
  - `export [--output DIR] [--mode data-only] [--stem STEM]`
  - `inspect <archive>`
  - `restore-dry-run <archive> [--data-dir DIR]`

  Exit codes are deliberate: `0` on success (a refused dry-run plan
  is a *result*, not an error), `1` on a user-visible failure, `2`
  on argparse usage. The CLI never extracts archives and never
  restores data.

- **`static/index.html`** — admin overlay grows a third tab,
  **⚇ Storage**. It renders the read-only status report (path,
  mount class, writability, free disk, warnings) and exposes a single
  **Create export package** button wired to `POST /admin/storage/export`
  with the existing confirmation-gated request shape. No destructive
  restore UI; inspection and dry-run remain CLI-only on purpose, since
  they are the steps an operator runs on the target machine.

- **`tests/test_data_export.py`** — adds `TestCli` driving the new
  `_cli` entry point without spawning a subprocess: a real archive is
  built, then inspected and dry-run-planned against empty / occupied
  targets. The workspace-mode rejection and the unsafe-stem rejection
  are pinned at the CLI boundary too.

- **`docs/storage-and-migration.md`** — adds "Using the CLI" and
  "Using the admin UI" sections, refreshes the manual restore
  walkthrough to include the dry-run plan step, and re-titles the
  status block as Phase 2.

No new endpoints, no destructive restore, no automatic data move. The
Phase 1 safety contract (allowlist export, no symlink escape, dry-run
only restore, admin-only API) is unchanged.

## Test plan

- [x] `python -m pytest tests/test_data_export.py` — 43 passed
  (including new `TestCli` covering export, inspect, dry-run, refused
  overwrite, unsafe stem, workspace-mode rejection).
- [x] `python -m pytest tests/test_data_export.py tests/test_storage_endpoints.py tests/test_storage_status.py tests/test_paths.py tests/test_memory.py tests/test_feedback.py tests/test_chat_stream.py` — 199 passed, 2 pre-existing skips.
- [x] `python -m core.data_export` (no args) prints argparse usage banner.
- [x] `python -m core.data_export export --output /tmp/nova-out` builds a real archive in a tmp dir.
- [ ] Manual UI smoke: open admin overlay → ⚇ Storage tab → review paths → click "Create export package" → verify summary renders.

https://claude.ai/code/session_014jEqhN4QaRd7tpwKKFALAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014jEqhN4QaRd7tpwKKFALAZ)_