### PR TITLE
feat(storage): add safe guided restore (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Safe guided restore for Nova data export packages (Storage &
+  Migration Phase 3). The Storage tab now exposes a four-step flow —
+  inspect, dry-run, confirm, restore — backed by a new
+  `apply_restore` helper in `core/data_export.py`, two admin
+  endpoints (`POST /admin/storage/restore-dry-run` and
+  `POST /admin/storage/restore`), and a `python -m core.data_export
+  restore <archive> --confirm` CLI subcommand. Every real restore
+  writes an automatic pre-restore backup of the current data under
+  `NOVA_DATA_DIR/backups/pre-restore/`, refuses to proceed if the
+  backup cannot be written, stages the archive into a private
+  `.restore-staging/` directory inside the data root, validates
+  every extracted member against path traversal / symlink escape,
+  and only then replaces files atomically per-file. Failed restores
+  leave existing data bit-for-bit identical; the pre-restore backup
+  is preserved on success so an operator can roll back. The admin UI
+  keeps the restore button disabled until inspection and dry-run
+  both succeed and the operator ticks an explicit "I understand"
+  checkbox. No cloud sync, no automatic restart, no shell, no model
+  files; secrets, `.env`, `.git`, and Ollama models stay out by
+  construction. See `docs/storage-and-migration.md` for the full
+  walkthrough.
 - Smoother streamed chat experience: the streaming bubble now coalesces
   incoming Ollama tokens on a short flush window (~28 ms) and only
   paints once per cycle, so single-character chunks no longer cause

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -2307,8 +2307,8 @@ def apply_restore(
         )
     if not target_has_data:
         final_warnings.append(
-            "Target data directory was empty before restore; no "
-            "pre-restore backup was needed."
+            "Target data directory contained no canonical Nova data; "
+            "no pre-restore backup was needed."
         )
 
     return RestoreResult(
@@ -2329,36 +2329,27 @@ def apply_restore(
 
 
 def _target_has_canonical_data(target_root: Path) -> bool:
-    """Return True when the target already contains canonical Nova data.
+    """Return True when the target contains a file the backup would pack.
 
-    "Canonical" mirrors the export allowlist: ``nova.db``, any
-    ``nova.db.*`` sidecar, or any file inside the four reserved
-    subdirectories. The function is intentionally cheap — it returns
-    on the first match so we don't walk the entire tree.
+    The decision must match :func:`_create_pre_restore_backup`'s
+    allowlist — otherwise ``apply_restore`` will demand a backup,
+    the backup builder will skip every entry, and the restore is
+    refused with a spurious ``outcome=backup_failed``. That false
+    positive shows up on installations where a reserved
+    subdirectory holds only excluded files (a stray
+    ``backups/.env``, a ``logs/__pycache__/foo.pyc`` left behind by
+    tooling, …): the directory is non-empty but contains nothing
+    the backup builder would actually preserve.
+
+    The check therefore reuses :func:`_walk_allowlisted` (the same
+    walk the backup builder uses) and returns ``True`` only when
+    that walk would pack at least one file. The walk is cheap for
+    typical Nova installs and never raises into the caller.
     """
-    db = target_root / _paths.DB_FILENAME
-    if db.exists():
-        return True
-    try:
-        for entry in target_root.iterdir():
-            if entry.is_file() and entry.name.startswith(
-                _paths.DB_FILENAME + "."
-            ):
-                return True
-            if entry.is_dir() and entry.name in (
-                _paths.BACKUPS_SUBDIR,
-                _paths.EXPORTS_SUBDIR,
-                _paths.MEMORY_PACKS_SUBDIR,
-                _paths.LOGS_SUBDIR,
-            ):
-                try:
-                    next(entry.iterdir())
-                    return True
-                except (StopIteration, OSError):
-                    continue
-    except OSError:
+    if not target_root.exists():
         return False
-    return False
+    included_pairs, _ = _walk_allowlisted(target_root)
+    return bool(included_pairs)
 
 
 def _dry_run_warnings(

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -982,19 +982,23 @@ def inspect_export(archive_path: str | os.PathLike[str]) -> InspectionResult:
                         f"Disallowed member type for {member.name!r}."
                     )
                     continue
-                # Symlinks must point at a name still inside the
-                # archive — not an absolute path, no ``..``.
+                # Symlinks are refused outright. Nova exports use
+                # ``tarfile.open(..., dereference=True)`` so a
+                # Nova-built archive never contains a symlink entry
+                # — every link is resolved at build time. An archive
+                # with a symlink is therefore anomalous, and
+                # ``_extract_to_staging`` would silently skip it,
+                # which would make the dry-run plan (built from
+                # ``inspection.files``) disagree with the actual
+                # restore. Refuse it at inspection time so all three
+                # surfaces (inspect, dry-run, real restore) agree.
                 if member.issym():
-                    target = member.linkname or ""
-                    if (
-                        not target
-                        or target.startswith("/")
-                        or ".." in PurePosixPath(target).parts
-                    ):
-                        errors.append(
-                            f"Unsafe symlink target for {member.name!r}."
-                        )
-                        continue
+                    errors.append(
+                        f"Archive contains a symlink member "
+                        f"({member.name!r}). Nova exports never "
+                        "contain symlinks."
+                    )
+                    continue
                 parts = PurePosixPath(member.name).parts
                 if not parts:
                     continue
@@ -1760,6 +1764,50 @@ def _extract_to_staging(
     return extracted, skipped, None
 
 
+def _newly_created_parents(
+    dst: Path, target_root: Path,
+) -> list[Path]:
+    """Return the parent directories that would be newly created.
+
+    Walks from ``dst.parent`` upward, collecting every component
+    that does not yet exist on disk, and stops at ``target_root``
+    (or at the filesystem root). The returned list is in
+    outer-most-first order, which is the order
+    ``Path.mkdir(parents=True)`` would create them. Callers reverse
+    the list for deepest-first removal during rollback.
+
+    The function never raises; OS errors during stat short-circuit
+    and return whatever was collected so far.
+    """
+    target_resolved = target_root.resolve()
+    needed: list[Path] = []
+    p = dst.parent
+    while True:
+        try:
+            if p.exists():
+                break
+        except OSError:
+            break
+        try:
+            p_resolved = p.resolve(strict=False)
+        except OSError:
+            break
+        if p_resolved == target_resolved:
+            break
+        # Defence in depth: stop if we have walked above the target
+        # root somehow (only possible with symlink trickery).
+        try:
+            p_resolved.relative_to(target_resolved)
+        except ValueError:
+            break
+        needed.append(p)
+        new_parent = p.parent
+        if new_parent == p:
+            break
+        p = new_parent
+    return list(reversed(needed))
+
+
 def _copy_into_target(
     staging: Path,
     target_root: Path,
@@ -1785,8 +1833,11 @@ def _copy_into_target(
     On any failure the function walks back over the successful
     moves: each ``.replaced-originals`` file is moved back to its
     original target path; files that did not exist before are
-    deleted. The pre-restore backup (created earlier by
-    :func:`_create_pre_restore_backup`) remains as the second
+    deleted. Newly-created parent directories (created by
+    ``dst.parent.mkdir(parents=True)``) are also rmdir'd in
+    deepest-first order so the target tree returns bit-for-bit to
+    its pre-restore shape. The pre-restore backup (created earlier
+    by :func:`_create_pre_restore_backup`) remains as the second
     line of defence if even the rollback fails.
 
     The returned ``restored`` / ``conflicts`` lists are intentionally
@@ -1807,24 +1858,49 @@ def _copy_into_target(
         )
 
     # Successfully-committed moves so a later failure can roll back.
-    # Each entry is ``(dst, stash_path | None)``. ``stash_path is
-    # None`` means "the file did not exist before; rollback should
-    # delete it".
-    committed: list[tuple[Path, Optional[Path]]] = []
+    # Each entry is ``(dst, stash_path | None, created_dirs)``.
+    # ``stash_path is None`` means "the file did not exist before;
+    # rollback should delete it". ``created_dirs`` is the (possibly
+    # empty) list of parent directories ``dst.parent.mkdir`` brought
+    # into existence for this commit; rollback rmdirs them in
+    # deepest-first order.
+    committed: list[tuple[Path, Optional[Path], list[Path]]] = []
+    # Parents that the *in-flight* iteration brought into existence
+    # but haven't yet been committed. The rollback path consumes
+    # this list too so a failure between mkdir and the final
+    # ``os.replace`` doesn't leave empty directories behind.
+    in_flight_dirs: list[Path] = []
 
     def _rollback() -> None:
         # Walk in reverse so a newly-created directory tree unwinds
         # in the right order. Best-effort: a failure here leaves
         # the pre-restore backup as the operator-facing recovery.
-        for dst_path, stash in reversed(committed):
+        for dst_path, stash, created_dirs in reversed(committed):
             if stash is None:
                 try:
                     dst_path.unlink(missing_ok=True)
                 except OSError:
                     pass
-                continue
+            else:
+                try:
+                    os.replace(str(stash), str(dst_path))
+                except OSError:
+                    pass
+            # Remove parent directories we created for this commit,
+            # deepest first. ``rmdir`` only succeeds on empty
+            # directories so a parent that picked up another
+            # committed file in the same run is left alone.
+            for new_dir in reversed(created_dirs):
+                try:
+                    new_dir.rmdir()
+                except OSError:
+                    pass
+        # Mop up any in-flight directories that were created for
+        # the failing iteration but never made it into
+        # ``committed``.
+        for new_dir in reversed(in_flight_dirs):
             try:
-                os.replace(str(stash), str(dst_path))
+                new_dir.rmdir()
             except OSError:
                 pass
 
@@ -1841,6 +1917,13 @@ def _copy_into_target(
                 f"Refusing to write {rel!r}: it would land outside "
                 "the target data directory."
             )
+        # Snapshot which parent directories don't yet exist so
+        # rollback can rmdir them. Must be computed *before* the
+        # mkdir call below — afterwards every parent exists. The
+        # in-flight tracker holds them until either the iteration
+        # commits (they move to ``committed``) or fails (rollback
+        # rmdirs them).
+        in_flight_dirs = _newly_created_parents(dst, target_root)
         try:
             dst.parent.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
@@ -1917,7 +2000,11 @@ def _copy_into_target(
         restored.append(rel)
         if existed:
             conflicts.append(rel)
-        committed.append((dst, stash_path))
+        # Promote the in-flight parents into the committed record so
+        # they roll back together with the file move. Reset the
+        # in-flight tracker for the next iteration.
+        committed.append((dst, stash_path, in_flight_dirs))
+        in_flight_dirs = []
     return restored, conflicts, None
 
 

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -62,6 +62,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import tarfile
 import time
 from dataclasses import dataclass, field
@@ -1260,6 +1261,953 @@ def plan_restore(
     )
 
 
+# ── Safe guided restore (Phase 3) ───────────────────────────────────
+#
+# Phase 3 layers an opt-in "actually copy the data into the target"
+# step on top of Phase 2's dry-run plan. The restore is **only ever**
+# performed when:
+#
+#   1. The archive inspects clean (manifest, format, no path
+#      traversal, no symlink escape, no disallowed entry types).
+#   2. The dry-run plan returns ``allowed=True`` *or* the caller
+#      passed an explicit confirmation that they understand a
+#      ``nova.db`` will be replaced.
+#   3. A pre-restore backup of the current target data directory was
+#      created successfully and lives under
+#      ``<target>/backups/pre-restore/`` — refusing the restore if
+#      the backup step fails.
+#   4. Every archive member was extracted into a private staging
+#      directory under ``<target>/.restore-staging/`` and re-validated
+#      against path traversal post-extraction.
+#
+# Only after all of the above does the engine copy the staged files
+# into the target. Existing target files that would be replaced were
+# already copied into the pre-restore backup, so the operator can roll
+# back at any time.
+
+#: Subdirectory under the target ``NOVA_DATA_DIR/backups/`` that holds
+#: automatic pre-restore backups. Kept stable so an operator can find
+#: previous backups via the filesystem alone.
+PRE_RESTORE_BACKUP_SUBDIR = "pre-restore"
+
+#: Directory under the target data root that stages extracted archive
+#: contents during a restore. Lives **inside** the data root so the
+#: extraction never lands on a different filesystem (an `os.replace`
+#: across filesystems would otherwise fail or fall back to a copy +
+#: delete that is not atomic).
+RESTORE_STAGING_DIRNAME = ".restore-staging"
+
+
+#: Wire-format strings for ``RestoreResult.outcome``. Stable enough
+#: for the UI to switch on and for tests to pin.
+RESTORE_OUTCOME_DRY_RUN = "dry_run"
+RESTORE_OUTCOME_RESTORED = "restored"
+RESTORE_OUTCOME_REFUSED = "refused"
+RESTORE_OUTCOME_BACKUP_FAILED = "backup_failed"
+RESTORE_OUTCOME_EXTRACT_FAILED = "extract_failed"
+RESTORE_OUTCOME_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    """Outcome of a real (or dry-run) restore call.
+
+    The structure mirrors :class:`RestorePlan` so the UI can render
+    a single result panel for either flow.
+
+    * ``outcome`` — short stable identifier (``dry_run``, ``restored``,
+      ``refused``, ``backup_failed``, ``extract_failed``, ``failed``).
+    * ``refuse_reason`` — non-empty when ``outcome`` is anything other
+      than ``restored`` or ``dry_run``; short, frontend-safe.
+    * ``restored_files`` — list of POSIX-relative paths actually copied
+      into the target on a successful restore. Empty for refusals and
+      dry-runs.
+    * ``skipped_files`` — files present in the archive that were not
+      copied (for example, a stray entry that did not exist in the
+      manifest's allowlist).
+    * ``conflicts`` — files at the target that were overwritten by
+      the restore. Each one is mirrored inside the pre-restore backup.
+    * ``backup_path`` — absolute path of the pre-restore backup
+      archive, or ``""`` when no backup was created (e.g. dry-run or
+      pre-validation refusal).
+    * ``restart_recommended`` — ``True`` when restoring a ``nova.db``
+      (the database is open by the running process; a calm restart
+      ensures the new file is observed).
+    * ``warnings`` — soft issues the UI should surface but that did
+      not abort the restore.
+    """
+
+    archive_path: str
+    target_data_dir: str
+    outcome: str
+    refuse_reason: str
+    confirmed: bool
+    restored_files: tuple[str, ...]
+    skipped_files: tuple[ExcludedEntry, ...]
+    conflicts: tuple[str, ...]
+    backup_path: str
+    backup_size: int
+    restart_recommended: bool
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    manifest: Optional[dict] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "archive_path": self.archive_path,
+            "target_data_dir": self.target_data_dir,
+            "outcome": self.outcome,
+            "refuse_reason": self.refuse_reason,
+            "confirmed": self.confirmed,
+            "restored_files": list(self.restored_files),
+            "skipped_files": [e.as_dict() for e in self.skipped_files],
+            "conflicts": list(self.conflicts),
+            "backup_path": self.backup_path,
+            "backup_size": self.backup_size,
+            "restart_recommended": self.restart_recommended,
+            "warnings": list(self.warnings),
+            "manifest": self.manifest,
+        }
+
+
+def _manifest_id(manifest: Optional[dict]) -> str:
+    """Return a short identifier for ``manifest`` (best effort).
+
+    Phase 3 uses the manifest's ``created_at`` timestamp as a
+    lightweight "confirm you really mean this archive" token. The CLI
+    and API accept an optional ``confirmed_manifest_id`` field; when
+    present it must match this value.
+    """
+    if not isinstance(manifest, dict):
+        return ""
+    val = manifest.get("created_at")
+    if isinstance(val, str):
+        return val
+    return ""
+
+
+def _resolve_target_root(
+    target_data_dir: Optional[str | os.PathLike[str]],
+) -> Optional[Path]:
+    """Resolve the target data root from arg / env, or ``None``.
+
+    Mirrors :func:`plan_restore`: the explicit argument wins; without
+    one we fall back to ``NOVA_DATA_DIR``. Returns ``None`` when
+    nothing usable is configured — the caller surfaces that as a
+    refusal so the operator gets a clear error.
+    """
+    if target_data_dir is not None:
+        return Path(os.fspath(target_data_dir)).expanduser()
+    configured = _paths.configured_data_dir()
+    if configured is None:
+        return None
+    return configured
+
+
+def _create_pre_restore_backup(
+    target_root: Path,
+) -> tuple[Optional[Path], int, list[str]]:
+    """Build a pre-restore backup archive of the current target dir.
+
+    Returns ``(archive_path, size, warnings)``. ``archive_path`` is
+    ``None`` when no backup was needed (the target was empty / had
+    no canonical Nova data files) or when the backup failed. The
+    caller refuses the restore if the backup was *required* (a
+    ``nova.db`` was present) and ``archive_path`` is ``None``.
+
+    The archive is written under
+    ``<target_root>/backups/pre-restore/`` using the same data export
+    format as the manual export, so an operator can reuse the inspect
+    / restore-dry-run flow to verify it. The backup filename is
+    namespaced (``nova-pre-restore-<UTC timestamp>.tar.gz``) so it
+    can't collide with normal exports.
+
+    The function never overwrites an existing backup file: a name
+    clash falls back to appending ``-N`` to the stem until a free
+    name is found, or fails with a returned warning if it cannot.
+    """
+    warnings: list[str] = []
+    backup_dir = (
+        target_root / _paths.BACKUPS_SUBDIR / PRE_RESTORE_BACKUP_SUBDIR
+    )
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        warnings.append(
+            f"Could not create pre-restore backup directory: "
+            f"{exc.strerror or 'OS error'}"
+        )
+        return None, 0, warnings
+
+    # Compose a unique stem so the new backup never collides with an
+    # existing file. Phase 3 explicitly forbids overwriting backups.
+    timestamp = _now_iso_utc()
+    stem = f"nova-pre-restore-{timestamp}"
+    candidate = backup_dir / f"{stem}.tar.gz"
+    counter = 1
+    while candidate.exists():
+        candidate = backup_dir / f"{stem}-{counter}.tar.gz"
+        counter += 1
+        if counter > 50:  # pragma: no cover - extreme paranoia
+            warnings.append(
+                "Could not find a free filename for the pre-restore "
+                "backup after 50 attempts."
+            )
+            return None, 0, warnings
+
+    # Run the export builder against the *target* data root. We
+    # cannot rely on the running process's NOVA_DATA_DIR here because
+    # the operator may be restoring into a target that is **not** the
+    # configured data dir. Temporarily redirect by passing the
+    # explicit destination directory and walking the target_root
+    # directly.
+    included_pairs, excluded_entries = _walk_allowlisted(target_root)
+    if not included_pairs:
+        # Nothing to back up — return cleanly. The caller can decide
+        # whether that is acceptable.
+        return None, 0, warnings
+
+    included_entries: list[IncludedEntry] = []
+    archive_files: list[tuple[Path, str]] = []
+    for file_p, rel_parts in included_pairs:
+        try:
+            size = int(file_p.stat().st_size)
+            digest = _sha256_file(file_p)
+        except OSError:
+            excluded_entries.append(ExcludedEntry(
+                "/".join(rel_parts), REASON_UNREADABLE,
+            ))
+            continue
+        rel_posix = "/".join(rel_parts)
+        included_entries.append(IncludedEntry(
+            path=rel_posix, size=size, sha256=digest,
+        ))
+        archive_files.append((file_p, rel_posix))
+
+    manifest = _build_manifest(
+        mode=MODE_DATA_ONLY,
+        timestamp=timestamp,
+        source_root=target_root,
+        included=included_entries,
+        excluded=excluded_entries,
+    )
+    manifest["pre_restore_backup"] = True
+
+    partial = backup_dir / (candidate.name + ".partial")
+    try:
+        with tarfile.open(partial, mode="w:gz", dereference=True) as tar:
+            manifest_bytes = json.dumps(
+                manifest, indent=2, sort_keys=True,
+            ).encode("utf-8")
+            _add_bytes_to_tar(
+                tar, ARCHIVE_MANIFEST_NAME, manifest_bytes,
+            )
+            restore_doc = _build_restore_doc(manifest).encode("utf-8")
+            _add_bytes_to_tar(
+                tar, ARCHIVE_RESTORE_DOC_NAME, restore_doc,
+            )
+            for file_p, rel_posix in archive_files:
+                arcname = f"{ARCHIVE_DATA_PREFIX}/{rel_posix}"
+                if not _is_safe_member_name(arcname):
+                    continue
+                tar.add(
+                    str(file_p),
+                    arcname=arcname,
+                    recursive=False,
+                    filter=_tar_filter,
+                )
+        partial.replace(candidate)
+    except OSError as exc:
+        try:
+            partial.unlink(missing_ok=True)
+        except OSError:
+            pass
+        warnings.append(
+            f"Pre-restore backup could not be written: "
+            f"{exc.strerror or 'OS error'}"
+        )
+        return None, 0, warnings
+
+    try:
+        size = int(candidate.stat().st_size)
+    except OSError:
+        size = 0
+    return candidate, size, warnings
+
+
+def _safe_extract_member(
+    tar: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    staging: Path,
+) -> Optional[Path]:
+    """Extract a single archive member into ``staging`` safely.
+
+    Returns the resolved destination path on success, or ``None``
+    when the member must be skipped (a non-regular file or a path
+    that resolves outside the staging tree). The function uses
+    explicit byte-stream copying instead of ``tar.extract`` so we
+    fully control the destination path; tarfile's own filter
+    (``data_filter``) is also applied where available to refuse the
+    historical CVE-2007-4559-style escapes.
+
+    Symlinks within the archive are deliberately **not** materialised
+    on disk: the export builder dereferences them at build time, so a
+    well-formed Nova archive never contains a symlink in the first
+    place. A symlink in a hostile archive is therefore rejected.
+    """
+    name = member.name
+    if not _is_safe_member_name(name):
+        return None
+    if member.isdir():
+        # Just create the directory; tar entries are recreated
+        # implicitly by writing files below.
+        rel = PurePosixPath(name)
+        if not rel.parts or rel.parts[0] != ARCHIVE_DATA_PREFIX:
+            return None
+        dest = staging / Path(*rel.parts[1:]) if len(rel.parts) > 1 else None
+        if dest is None:
+            return None
+        dest.mkdir(parents=True, exist_ok=True)
+        return dest
+    if not member.isfile():
+        # Symlinks, devices, hardlinks, fifos — all forbidden.
+        return None
+
+    rel = PurePosixPath(name)
+    if not rel.parts or rel.parts[0] != ARCHIVE_DATA_PREFIX:
+        return None
+    if len(rel.parts) == 1:
+        return None
+    dest = staging / Path(*rel.parts[1:])
+    # Post-resolution containment check.
+    try:
+        dest_resolved = dest.resolve(strict=False)
+        staging_resolved = staging.resolve(strict=False)
+        dest_resolved.relative_to(staging_resolved)
+    except (OSError, ValueError):
+        return None
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    extracted = tar.extractfile(member)
+    if extracted is None:
+        return None
+    try:
+        with open(dest, "wb") as out:
+            shutil.copyfileobj(extracted, out, length=_HASH_CHUNK_BYTES)
+    finally:
+        extracted.close()
+    try:
+        os.chmod(dest, 0o600)
+    except OSError:
+        pass
+    return dest
+
+
+def _extract_to_staging(
+    archive_path: Path,
+    staging: Path,
+) -> tuple[list[str], list[ExcludedEntry], Optional[str]]:
+    """Extract ``archive_path`` into ``staging``.
+
+    Returns ``(extracted_files, skipped, error)``. ``extracted_files``
+    is the list of POSIX-relative file paths under ``staging/data``
+    that were materialised. ``skipped`` records members that were
+    intentionally not extracted (symlinks, hardlinks, devices, or
+    names that would resolve outside the staging tree). ``error`` is
+    ``None`` on success or a short, frontend-safe string describing
+    a fatal extraction error.
+    """
+    extracted: list[str] = []
+    skipped: list[ExcludedEntry] = []
+    try:
+        with tarfile.open(archive_path, mode="r:*") as tar:
+            for member in tar:
+                if member.name in (
+                    ARCHIVE_MANIFEST_NAME, ARCHIVE_RESTORE_DOC_NAME
+                ):
+                    continue
+                if not _is_safe_member_name(member.name):
+                    skipped.append(ExcludedEntry(
+                        member.name, REASON_PATH_TRAVERSAL,
+                    ))
+                    continue
+                if member.islnk() or member.isdev() or member.isfifo():
+                    skipped.append(ExcludedEntry(
+                        member.name, REASON_DEVICE_OR_OTHER,
+                    ))
+                    continue
+                if member.issym():
+                    skipped.append(ExcludedEntry(
+                        member.name, REASON_SYMLINK_ESCAPE,
+                    ))
+                    continue
+                dest = _safe_extract_member(tar, member, staging)
+                if dest is None:
+                    if member.isfile():
+                        skipped.append(ExcludedEntry(
+                            member.name, REASON_PATH_TRAVERSAL,
+                        ))
+                    continue
+                if member.isfile():
+                    rel = PurePosixPath(member.name)
+                    posix_rel = "/".join(rel.parts[1:])
+                    extracted.append(posix_rel)
+    except tarfile.TarError as exc:
+        return [], skipped, f"Archive could not be extracted: {exc.__class__.__name__}."
+    except OSError as exc:
+        return [], skipped, (
+            f"Archive could not be extracted: "
+            f"{exc.strerror or 'OS error'}."
+        )
+    return extracted, skipped, None
+
+
+def _copy_into_target(
+    staging: Path,
+    target_root: Path,
+    relative_files: list[str],
+) -> tuple[list[str], list[str], Optional[str]]:
+    """Copy staged files into ``target_root``.
+
+    Returns ``(restored, conflicts, error)``. ``restored`` is the
+    list of POSIX-relative paths actually copied; ``conflicts`` lists
+    target paths that already existed and were replaced (those files
+    were already captured by the pre-restore backup). ``error`` is
+    ``None`` on success.
+
+    The copy is done file-by-file with ``os.replace`` so each
+    individual destination flips atomically. We do not attempt a
+    whole-tree rename because the target directory contains files
+    Nova did not bring in (other backups, prior exports, etc.) and
+    the safety contract forbids deleting them.
+    """
+    restored: list[str] = []
+    conflicts: list[str] = []
+    target_resolved = target_root.resolve()
+    for rel in relative_files:
+        src = staging / Path(*rel.split("/"))
+        dst = target_root / Path(*rel.split("/"))
+        # Post-resolution containment check on the destination.
+        try:
+            dst_resolved = dst.resolve(strict=False)
+            dst_resolved.relative_to(target_resolved)
+        except (OSError, ValueError):
+            return restored, conflicts, (
+                f"Refusing to write {rel!r}: it would land outside "
+                "the target data directory."
+            )
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            existed = dst.exists()
+            # ``os.replace`` is atomic on the same filesystem. The
+            # staging directory lives **inside** the target root by
+            # construction so this never falls back to a cross-FS
+            # copy.
+            os.replace(str(src), str(dst))
+        except OSError as exc:
+            return restored, conflicts, (
+                f"Could not write {rel!r}: {exc.strerror or 'OS error'}."
+            )
+        try:
+            os.chmod(dst, 0o600)
+        except OSError:
+            pass
+        restored.append(rel)
+        if existed:
+            conflicts.append(rel)
+    return restored, conflicts, None
+
+
+def _cleanup_staging(staging: Path) -> None:
+    """Remove ``staging`` recursively, swallowing OS errors.
+
+    The staging directory always lives inside the target data root,
+    so the recursive delete cannot escape it even if something
+    upstream had failed.
+    """
+    if not staging.exists():
+        return
+    try:
+        shutil.rmtree(str(staging), ignore_errors=True)
+    except OSError:
+        pass
+
+
+def apply_restore(
+    archive_path: str | os.PathLike[str],
+    *,
+    target_data_dir: Optional[str | os.PathLike[str]] = None,
+    confirm: bool = False,
+    confirmed_manifest_id: Optional[str] = None,
+    dry_run: bool = False,
+) -> RestoreResult:
+    """Restore ``archive_path`` into the target data directory.
+
+    The function never writes anything unless **all** of the following
+    are true:
+
+    * ``dry_run`` is ``False``,
+    * ``confirm`` is ``True``,
+    * the archive inspects clean,
+    * a pre-restore backup of the current target was created
+      successfully (or none was needed — empty target).
+
+    Any failure short-circuits to a :class:`RestoreResult` with an
+    explanatory ``refuse_reason``, leaves the target data directory
+    bit-for-bit identical, and cleans up staging on a best-effort
+    basis. Failed restores **must not** corrupt current data — this
+    contract is exercised by tests.
+
+    ``confirmed_manifest_id`` lets the caller pin the archive they
+    inspected. When provided, it must match the manifest's
+    ``created_at`` field — a mismatch refuses the restore so a
+    different archive cannot slip in between the inspect step and
+    the restore step.
+    """
+    archive_path_s = str(archive_path)
+    archive_p = Path(archive_path_s)
+    if not archive_p.is_file():
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir="",
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason="Archive does not exist or is not a regular file.",
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=(),
+            conflicts=(),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=False,
+            warnings=(),
+            manifest=None,
+        )
+
+    # Phase 1: inspection (no writes, no staging).
+    inspection = inspect_export(archive_path_s)
+    if not inspection.valid:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir="",
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason=(
+                "Archive is not valid: " + "; ".join(inspection.errors)
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=(),
+            conflicts=(),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=False,
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    # Optional pinning of the archive identity.
+    if confirmed_manifest_id is not None:
+        actual = _manifest_id(inspection.manifest)
+        if confirmed_manifest_id and actual and confirmed_manifest_id != actual:
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir="",
+                outcome=RESTORE_OUTCOME_REFUSED,
+                refuse_reason=(
+                    "Confirmed manifest id does not match the archive's "
+                    "manifest. Re-inspect the package before confirming."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=(),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=False,
+                warnings=inspection.warnings,
+                manifest=inspection.manifest,
+            )
+
+    # Resolve the target root.
+    target_root = _resolve_target_root(target_data_dir)
+    if target_root is None:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir="",
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason=(
+                "NOVA_DATA_DIR is not set. Configure a target data "
+                "directory before restoring."
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=(),
+            conflicts=(),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=False,
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    try:
+        target_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_root),
+            outcome=RESTORE_OUTCOME_FAILED,
+            refuse_reason=(
+                f"Target data directory could not be prepared: "
+                f"{exc.strerror or 'OS error'}"
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=(),
+            conflicts=(),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=False,
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    target_resolved = target_root.resolve()
+
+    # Phase 2: compute the "would restore" file list (also checks
+    # post-resolution containment of each archive member against the
+    # target root — we do **not** rely on the dry-run plan refusing
+    # an existing nova.db because Phase 3's real restore is allowed
+    # to replace it under explicit confirmation).
+    would_restore: list[str] = []
+    conflicts_seen: list[str] = []
+    has_nova_db_in_archive = False
+    for member_name in inspection.files:
+        if member_name in (ARCHIVE_MANIFEST_NAME, ARCHIVE_RESTORE_DOC_NAME):
+            continue
+        parts = PurePosixPath(member_name).parts
+        if not parts or parts[0] != ARCHIVE_DATA_PREFIX:
+            continue
+        relative = PurePosixPath(*parts[1:])
+        if not str(relative):
+            continue
+        if ".." in relative.parts or relative.is_absolute():
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir=str(target_resolved),
+                outcome=RESTORE_OUTCOME_REFUSED,
+                refuse_reason=(
+                    "Archive contains an unsafe path "
+                    f"({member_name!r}). Refusing to restore."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=(),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=False,
+                warnings=inspection.warnings,
+                manifest=inspection.manifest,
+            )
+        candidate = target_resolved / Path(*relative.parts)
+        try:
+            candidate_abs = candidate.resolve(strict=False)
+            candidate_abs.relative_to(target_resolved)
+        except (OSError, ValueError):
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir=str(target_resolved),
+                outcome=RESTORE_OUTCOME_REFUSED,
+                refuse_reason=(
+                    f"Archive member {member_name!r} would land outside "
+                    "the target data directory."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=(),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=False,
+                warnings=inspection.warnings,
+                manifest=inspection.manifest,
+            )
+        would_restore.append(str(relative))
+        if relative.parts and relative.parts[0] == _paths.DB_FILENAME:
+            has_nova_db_in_archive = True
+        if candidate.exists():
+            conflicts_seen.append(str(relative))
+
+    # Existing target nova.db is the most-sensitive overwrite. Phase
+    # 2's plan_restore refuses unconditionally; Phase 3's real
+    # restore allows it iff the caller explicitly confirms.
+    target_nova_db = target_resolved / _paths.DB_FILENAME
+    target_has_db = target_nova_db.exists()
+    if dry_run:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_DRY_RUN,
+            refuse_reason="",
+            confirmed=bool(confirm),
+            restored_files=tuple(would_restore),
+            skipped_files=(),
+            conflicts=tuple(conflicts_seen),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=tuple(_dry_run_warnings(
+                target_has_db, has_nova_db_in_archive, conflicts_seen,
+                inspection.warnings,
+            )),
+            manifest=inspection.manifest,
+        )
+
+    # Real restore: every gate from here on must succeed.
+    if not confirm:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason=(
+                "Restore requires explicit confirmation. Re-run with "
+                "confirm=true after reviewing the dry-run plan."
+            ),
+            confirmed=False,
+            restored_files=(),
+            skipped_files=(),
+            conflicts=tuple(conflicts_seen),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    # Pre-restore backup. Required when the target has any canonical
+    # Nova data on disk; skipped (with a warning) when the target is
+    # empty — there is literally nothing to back up.
+    backup_archive_path = ""
+    backup_size = 0
+    backup_warnings: list[str] = []
+    target_has_data = _target_has_canonical_data(target_resolved)
+    if target_has_data:
+        backup, size, backup_warnings = _create_pre_restore_backup(
+            target_resolved,
+        )
+        if backup is None:
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir=str(target_resolved),
+                outcome=RESTORE_OUTCOME_BACKUP_FAILED,
+                refuse_reason=(
+                    "Pre-restore backup could not be created — "
+                    "refusing to overwrite current data. See warnings."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=tuple(conflicts_seen),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=has_nova_db_in_archive,
+                warnings=tuple(
+                    list(inspection.warnings) + backup_warnings
+                ),
+                manifest=inspection.manifest,
+            )
+        backup_archive_path = str(backup)
+        backup_size = size
+
+    # Extract into staging.
+    staging = target_resolved / RESTORE_STAGING_DIRNAME
+    _cleanup_staging(staging)
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_FAILED,
+            refuse_reason=(
+                f"Could not create staging directory: "
+                f"{exc.strerror or 'OS error'}"
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=(),
+            conflicts=tuple(conflicts_seen),
+            backup_path=backup_archive_path,
+            backup_size=backup_size,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=tuple(
+                list(inspection.warnings) + backup_warnings
+            ),
+            manifest=inspection.manifest,
+        )
+
+    extracted, skipped, extract_err = _extract_to_staging(archive_p, staging)
+    if extract_err is not None:
+        _cleanup_staging(staging)
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_EXTRACT_FAILED,
+            refuse_reason=extract_err,
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=tuple(skipped),
+            conflicts=tuple(conflicts_seen),
+            backup_path=backup_archive_path,
+            backup_size=backup_size,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=tuple(
+                list(inspection.warnings) + backup_warnings
+            ),
+            manifest=inspection.manifest,
+        )
+
+    if not extracted:
+        _cleanup_staging(staging)
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason=(
+                "Archive contained no extractable Nova data files."
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=tuple(skipped),
+            conflicts=tuple(conflicts_seen),
+            backup_path=backup_archive_path,
+            backup_size=backup_size,
+            restart_recommended=False,
+            warnings=tuple(
+                list(inspection.warnings) + backup_warnings
+            ),
+            manifest=inspection.manifest,
+        )
+
+    restored, conflicts, copy_err = _copy_into_target(
+        staging, target_resolved, extracted,
+    )
+    if copy_err is not None:
+        _cleanup_staging(staging)
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_FAILED,
+            refuse_reason=copy_err,
+            confirmed=bool(confirm),
+            restored_files=tuple(restored),
+            skipped_files=tuple(skipped),
+            conflicts=tuple(conflicts),
+            backup_path=backup_archive_path,
+            backup_size=backup_size,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=tuple(
+                list(inspection.warnings) + backup_warnings
+            ),
+            manifest=inspection.manifest,
+        )
+    _cleanup_staging(staging)
+
+    final_warnings: list[str] = list(inspection.warnings) + backup_warnings
+    if has_nova_db_in_archive:
+        final_warnings.append(
+            "Restart Nova so the new nova.db is picked up by the "
+            "running process. The previous database is preserved in "
+            "the pre-restore backup."
+        )
+    if not target_has_data:
+        final_warnings.append(
+            "Target data directory was empty before restore; no "
+            "pre-restore backup was needed."
+        )
+
+    return RestoreResult(
+        archive_path=archive_path_s,
+        target_data_dir=str(target_resolved),
+        outcome=RESTORE_OUTCOME_RESTORED,
+        refuse_reason="",
+        confirmed=True,
+        restored_files=tuple(restored),
+        skipped_files=tuple(skipped),
+        conflicts=tuple(conflicts),
+        backup_path=backup_archive_path,
+        backup_size=backup_size,
+        restart_recommended=has_nova_db_in_archive,
+        warnings=tuple(final_warnings),
+        manifest=inspection.manifest,
+    )
+
+
+def _target_has_canonical_data(target_root: Path) -> bool:
+    """Return True when the target already contains canonical Nova data.
+
+    "Canonical" mirrors the export allowlist: ``nova.db``, any
+    ``nova.db.*`` sidecar, or any file inside the four reserved
+    subdirectories. The function is intentionally cheap — it returns
+    on the first match so we don't walk the entire tree.
+    """
+    db = target_root / _paths.DB_FILENAME
+    if db.exists():
+        return True
+    try:
+        for entry in target_root.iterdir():
+            if entry.is_file() and entry.name.startswith(
+                _paths.DB_FILENAME + "."
+            ):
+                return True
+            if entry.is_dir() and entry.name in (
+                _paths.BACKUPS_SUBDIR,
+                _paths.EXPORTS_SUBDIR,
+                _paths.MEMORY_PACKS_SUBDIR,
+                _paths.LOGS_SUBDIR,
+            ):
+                try:
+                    next(entry.iterdir())
+                    return True
+                except (StopIteration, OSError):
+                    continue
+    except OSError:
+        return False
+    return False
+
+
+def _dry_run_warnings(
+    target_has_db: bool,
+    has_nova_db_in_archive: bool,
+    conflicts: list[str],
+    inspection_warnings: tuple[str, ...],
+) -> list[str]:
+    """Compose the warning list rendered by a dry-run restore.
+
+    The dry-run is informational — Phase 3 surfaces every "would
+    happen" caveat the operator should see before flipping
+    ``confirm=true``.
+    """
+    warnings: list[str] = list(inspection_warnings)
+    if target_has_db and has_nova_db_in_archive:
+        warnings.append(
+            "Target already contains nova.db. The real restore will "
+            "create an automatic pre-restore backup, then replace the "
+            "database. The previous nova.db will live inside the "
+            "pre-restore backup so you can roll back."
+        )
+    if conflicts:
+        warnings.append(
+            f"{len(conflicts)} file(s) at the target would be replaced. "
+            "Each replaced file is preserved inside the pre-restore "
+            "backup."
+        )
+    warnings.append(
+        "Stop Nova before running the real restore. The dry-run is "
+        "safe to run while Nova is running."
+    )
+    return warnings
+
+
 # ── CLI ─────────────────────────────────────────────────────────────
 #
 # ``python -m core.data_export <command> [...]`` exposes the three
@@ -1407,6 +2355,56 @@ def _format_restore_plan(plan: RestorePlan) -> str:
     return "\n".join(lines)
 
 
+def _format_restore_result(result: RestoreResult) -> str:
+    """Render a short human summary of a :class:`RestoreResult`.
+
+    Used by both the ``restore`` and ``restore-dry-run`` (Phase 3)
+    subcommands so the CLI text-format stays consistent between
+    flows. The dry-run form omits the backup line because no backup
+    was written.
+    """
+    lines = [f"Restore {result.outcome} for {result.archive_path}"]
+    lines.append(f"  target data dir   : {result.target_data_dir}")
+    lines.append(f"  confirmed         : {result.confirmed}")
+    if result.refuse_reason:
+        lines.append(f"  refuse reason     : {result.refuse_reason}")
+    lines.append(
+        f"  restored files    : {len(result.restored_files)}"
+    )
+    if result.conflicts:
+        lines.append(
+            f"  replaced existing : {len(result.conflicts)} file(s)"
+        )
+        for path in result.conflicts[:10]:
+            lines.append(f"    ~ {path}")
+        if len(result.conflicts) > 10:
+            lines.append(
+                f"    ... and {len(result.conflicts) - 10} more"
+            )
+    if result.skipped_files:
+        lines.append(
+            f"  skipped from archive: {len(result.skipped_files)} entry(ies)"
+        )
+        for entry in result.skipped_files[:10]:
+            lines.append(f"    ! {entry.path} ({entry.reason})")
+    if result.backup_path:
+        lines.append(
+            f"  pre-restore backup: {result.backup_path}"
+        )
+        lines.append(
+            f"  backup size       : {_format_bytes(result.backup_size)}"
+        )
+    if result.restart_recommended:
+        lines.append(
+            "  restart Nova so the new nova.db is picked up."
+        )
+    if result.warnings:
+        lines.append("  warnings:")
+        for warning in result.warnings:
+            lines.append(f"    - {warning}")
+    return "\n".join(lines)
+
+
 def _stderr():  # pragma: no cover - trivial helper for monkeypatching
     """Return ``sys.stderr`` indirectly so tests can swap it out."""
     import sys
@@ -1502,6 +2500,45 @@ def _cli(argv: list[str]) -> int:
         ),
     )
 
+    apply_parser = subparsers.add_parser(
+        "restore",
+        help=(
+            "Restore an archive into the target data directory. "
+            "Requires --confirm. Creates an automatic pre-restore "
+            "backup before replacing any file."
+        ),
+    )
+    apply_parser.add_argument(
+        "archive",
+        help="Path to a Nova data export archive (.tar.gz).",
+    )
+    apply_parser.add_argument(
+        "--data-dir",
+        default=None,
+        help=(
+            "Target data directory. Defaults to the configured "
+            "NOVA_DATA_DIR; failing that, the command refuses."
+        ),
+    )
+    apply_parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help=(
+            "Confirm the restore explicitly. Without this flag the "
+            "command refuses. Pair with --confirmed-manifest-id to "
+            "pin the archive identity to the one you inspected."
+        ),
+    )
+    apply_parser.add_argument(
+        "--confirmed-manifest-id",
+        default=None,
+        help=(
+            "Optional manifest identifier (the archive's 'created_at' "
+            "timestamp from inspect output). When set, the restore "
+            "refuses unless the archive's manifest matches."
+        ),
+    )
+
     if not argv:
         parser.print_help(file=_stderr())
         return 2
@@ -1541,6 +2578,30 @@ def _cli(argv: list[str]) -> int:
         # exit-1 reserved for unexpected errors. Tests pin this.
         return 0
 
+    if args.command == "restore":
+        if not args.confirm:
+            print(
+                "error: restore requires --confirm. Re-run with "
+                "--confirm after reviewing the dry-run plan with "
+                "`python -m core.data_export restore-dry-run`.",
+                file=_stderr(),
+            )
+            return 1
+        result = apply_restore(
+            args.archive,
+            target_data_dir=args.data_dir,
+            confirm=True,
+            confirmed_manifest_id=args.confirmed_manifest_id,
+            dry_run=False,
+        )
+        print(_format_restore_result(result))
+        if result.outcome == RESTORE_OUTCOME_RESTORED:
+            return 0
+        # A refused / failed restore is a CLI-level failure: the
+        # operator typed `restore` and the data did not move. Tests
+        # pin this so shell scripts can branch on it.
+        return 1
+
     parser.print_help(file=_stderr())
     return 2
 
@@ -1564,6 +2625,7 @@ __all__ = [
     "InspectionResult",
     "MODE_DATA_ONLY",
     "MODE_WORKSPACE",
+    "PRE_RESTORE_BACKUP_SUBDIR",
     "REASON_CACHE",
     "REASON_NODE_MODULES",
     "REASON_NOT_ALLOWLISTED",
@@ -1573,7 +2635,16 @@ __all__ = [
     "REASON_SYMLINK_ESCAPE",
     "REASON_VCS",
     "REASON_VENV",
+    "RESTORE_OUTCOME_BACKUP_FAILED",
+    "RESTORE_OUTCOME_DRY_RUN",
+    "RESTORE_OUTCOME_EXTRACT_FAILED",
+    "RESTORE_OUTCOME_FAILED",
+    "RESTORE_OUTCOME_REFUSED",
+    "RESTORE_OUTCOME_RESTORED",
+    "RESTORE_STAGING_DIRNAME",
     "RestorePlan",
+    "RestoreResult",
+    "apply_restore",
     "create_data_export",
     "inspect_export",
     "plan_restore",

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -2188,6 +2188,17 @@ def apply_restore(
     # ``data/.ssh/id_rsa`` that the exporter would have refused.
     would_restore: list[str] = []
     would_restore_seen: set[str] = set()
+    # Path-type collision detection. ``file_paths`` lists every
+    # would-be file destination as a POSIX string; ``dir_paths``
+    # lists every ancestor directory implied by those files. A
+    # crafted archive that contains both ``data/foo`` (file) and
+    # ``data/foo/bar`` (file) would deterministically fail at
+    # extraction (``mkdir`` cannot create ``foo/`` when ``foo`` is
+    # already a file). Detecting the collision here keeps inspect
+    # / dry-run / real restore consistent: any ancestor-vs-descendant
+    # clash refuses the whole restore upfront.
+    file_paths_seen: set[str] = set()
+    dir_paths_seen: set[str] = set()
     conflicts_seen: list[str] = []
     skipped_in_archive: list[ExcludedEntry] = []
     has_nova_db_in_archive = False
@@ -2258,6 +2269,62 @@ def apply_restore(
         if rel_str in would_restore_seen:
             continue
         would_restore_seen.add(rel_str)
+        # Path-type collision: refuse if this file's path is
+        # already in use as someone else's ancestor directory
+        # (a previously-added file would require it to be a
+        # directory), or if any ancestor of this path was already
+        # added as a file (we'd have to ``mkdir`` over an
+        # existing file). Either way the real restore would
+        # deterministically fail at extraction time, so the
+        # preflight refuses upfront.
+        if rel_str in dir_paths_seen:
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir=str(target_resolved),
+                outcome=RESTORE_OUTCOME_REFUSED,
+                refuse_reason=(
+                    f"Archive contains a path-type collision: "
+                    f"{rel_str!r} is a file in this archive but also "
+                    "the parent of another archive entry. Restore "
+                    "cannot resolve both."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=(),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=False,
+                warnings=inspection.warnings,
+                manifest=inspection.manifest,
+            )
+        ancestor_components: list[str] = []
+        for part in relative.parts[:-1]:
+            ancestor_components.append(part)
+            anc = "/".join(ancestor_components)
+            if anc in file_paths_seen:
+                return RestoreResult(
+                    archive_path=archive_path_s,
+                    target_data_dir=str(target_resolved),
+                    outcome=RESTORE_OUTCOME_REFUSED,
+                    refuse_reason=(
+                        f"Archive contains a path-type collision: "
+                        f"{anc!r} is both a file and a parent "
+                        f"directory of {rel_str!r}. Restore cannot "
+                        "resolve both."
+                    ),
+                    confirmed=bool(confirm),
+                    restored_files=(),
+                    skipped_files=(),
+                    conflicts=(),
+                    backup_path="",
+                    backup_size=0,
+                    restart_recommended=False,
+                    warnings=inspection.warnings,
+                    manifest=inspection.manifest,
+                )
+            dir_paths_seen.add(anc)
+        file_paths_seen.add(rel_str)
         # Preflight type-gate on the existing destination so the
         # dry-run reports the same outcome the real restore would
         # produce. ``_copy_into_target`` refuses to stash a symlink

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -947,6 +947,14 @@ def inspect_export(archive_path: str | os.PathLike[str]) -> InspectionResult:
     file_names: list[str] = []
     total_size = 0
     manifest: Optional[dict] = None
+    # Track file vs directory members by their normalised (no
+    # trailing slash) path so we can refuse archives that list the
+    # same path as both a file and a directory. Such archives
+    # deterministically fail at extraction (``open(dest, "wb")``
+    # on a directory raises ``IsADirectoryError``); refusing at
+    # inspection keeps dry-run and real-restore consistent.
+    file_member_paths: set[str] = set()
+    dir_member_paths: set[str] = set()
 
     if not os.path.isfile(archive_path):
         return InspectionResult(
@@ -1031,7 +1039,33 @@ def inspect_export(archive_path: str | os.PathLike[str]) -> InspectionResult:
                 # while the real restore refused with "no
                 # extractable Nova data files", breaking the
                 # inspect → dry-run → confirm contract.
-                if member.isfile():
+                #
+                # We also track each member's normalised path on the
+                # side so we can refuse an archive that lists the
+                # same path as both a file and a directory (e.g.
+                # ``data/backups/a`` and ``data/backups/a/``). That
+                # combination is deterministically unrestorable —
+                # extraction creates the directory first and then
+                # ``open(file_dst, "wb")`` raises
+                # ``IsADirectoryError`` — so refusing here keeps
+                # inspect / dry-run / real restore in lockstep.
+                normalised_name = member.name.rstrip("/")
+                if member.isdir():
+                    if normalised_name in file_member_paths:
+                        errors.append(
+                            f"Archive contains {normalised_name!r} "
+                            "as both a file and a directory member."
+                        )
+                        continue
+                    dir_member_paths.add(normalised_name)
+                elif member.isfile():
+                    if normalised_name in dir_member_paths:
+                        errors.append(
+                            f"Archive contains {normalised_name!r} "
+                            "as both a file and a directory member."
+                        )
+                        continue
+                    file_member_paths.add(normalised_name)
                     file_names.append(member.name)
                     total_size += int(member.size)
 

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -2486,11 +2486,47 @@ def apply_restore(
         backup_archive_path = str(backup)
         backup_size = size
 
-    # Extract into staging.
+    # Extract into staging. The staging directory holds (a) the
+    # extracted archive contents and (b) the rollback stash of any
+    # files we displaced during the copy phase. It is **never
+    # blindly cleaned up at startup**: doing so used to silently
+    # delete a concurrent restore's in-flight stash, breaking the
+    # "failed restore leaves data intact" guarantee for the other
+    # caller. ``mkdir(exist_ok=False)`` atomically creates the
+    # directory, so two concurrent restores deterministically lose
+    # one: the loser sees ``FileExistsError`` and returns
+    # ``outcome=refused`` with a clear message. A staging directory
+    # left behind by a crashed restore also triggers the same
+    # refusal; the operator can investigate and remove it by hand
+    # once they have confirmed no other restore is running.
     staging = target_resolved / RESTORE_STAGING_DIRNAME
-    _cleanup_staging(staging)
     try:
         staging.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason=(
+                f"Staging directory {RESTORE_STAGING_DIRNAME!r} "
+                "already exists in the target. Another restore may "
+                "be in progress, or a previous restore was "
+                "interrupted. Confirm no other restore is running, "
+                "then remove the staging directory by hand and "
+                "retry."
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=(),
+            conflicts=tuple(conflicts_seen),
+            backup_path=backup_archive_path,
+            backup_size=backup_size,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=tuple(
+                list(inspection.warnings) + backup_warnings
+            ),
+            manifest=inspection.manifest,
+        )
     except OSError as exc:
         return RestoreResult(
             archive_path=archive_path_s,

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1465,6 +1465,28 @@ def _create_pre_restore_backup(
     # explicit destination directory and walking the target_root
     # directly.
     included_pairs, excluded_entries = _walk_allowlisted(target_root)
+    # Filter out any previously-written pre-restore archives. They
+    # live under ``backups/pre-restore/`` (the destination of this
+    # very function), so without this filter every restore would
+    # pack the previous restore's backup into the next backup —
+    # producing "backups of backups" that grow on each restore and
+    # eventually trigger spurious ``backup_failed`` outcomes from
+    # storage pressure. The operator-facing rollback flow still
+    # works: previous pre-restore archives remain on disk
+    # untouched; they're just not duplicated into the new one.
+    filtered_pairs: list[tuple[Path, tuple[str, ...]]] = []
+    for file_p, rel_parts in included_pairs:
+        if (
+            len(rel_parts) >= 2
+            and rel_parts[0] == _paths.BACKUPS_SUBDIR
+            and rel_parts[1] == PRE_RESTORE_BACKUP_SUBDIR
+        ):
+            excluded_entries.append(ExcludedEntry(
+                "/".join(rel_parts), REASON_NOT_ALLOWLISTED,
+            ))
+            continue
+        filtered_pairs.append((file_p, rel_parts))
+    included_pairs = filtered_pairs
     if not included_pairs:
         # Nothing to back up — return cleanly. The caller can decide
         # whether that is acceptable.
@@ -2236,6 +2258,54 @@ def apply_restore(
         if rel_str in would_restore_seen:
             continue
         would_restore_seen.add(rel_str)
+        # Preflight type-gate on the existing destination so the
+        # dry-run reports the same outcome the real restore would
+        # produce. ``_copy_into_target`` refuses to stash a symlink
+        # or a non-regular file at ``dst``; mirror that decision
+        # here so a target whose ``nova.db`` is a symlink doesn't
+        # show ``outcome=dry_run`` and then deterministically fail
+        # at execution time. Refusal is structural, not per-file:
+        # any non-regular destination invalidates the whole
+        # restore.
+        if candidate.is_symlink():
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir=str(target_resolved),
+                outcome=RESTORE_OUTCOME_REFUSED,
+                refuse_reason=(
+                    f"Existing target {rel_str!r} is a symlink. "
+                    "Restore never follows symlinks at the destination."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=(),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=False,
+                warnings=inspection.warnings,
+                manifest=inspection.manifest,
+            )
+        if candidate.exists() and not candidate.is_file():
+            return RestoreResult(
+                archive_path=archive_path_s,
+                target_data_dir=str(target_resolved),
+                outcome=RESTORE_OUTCOME_REFUSED,
+                refuse_reason=(
+                    f"Existing target {rel_str!r} is not a regular "
+                    "file (directory or special node). Restore would "
+                    "be unable to replace it safely."
+                ),
+                confirmed=bool(confirm),
+                restored_files=(),
+                skipped_files=(),
+                conflicts=(),
+                backup_path="",
+                backup_size=0,
+                restart_recommended=False,
+                warnings=inspection.warnings,
+                manifest=inspection.manifest,
+            )
         would_restore.append(rel_str)
         if relative.parts and relative.parts[0] == _paths.DB_FILENAME:
             has_nova_db_in_archive = True
@@ -2494,15 +2564,32 @@ def _target_has_canonical_data(target_root: Path) -> bool:
     tooling, …): the directory is non-empty but contains nothing
     the backup builder would actually preserve.
 
-    The check therefore reuses :func:`_walk_allowlisted` (the same
-    walk the backup builder uses) and returns ``True`` only when
-    that walk would pack at least one file. The walk is cheap for
-    typical Nova installs and never raises into the caller.
+    The check also excludes the pre-restore backup subtree so a
+    target whose only "canonical" content is previous pre-restore
+    archives doesn't trigger a backup-of-backups loop on
+    follow-up restores.
+
+    The walk is cheap for typical Nova installs and never raises
+    into the caller.
     """
     if not target_root.exists():
         return False
     included_pairs, _ = _walk_allowlisted(target_root)
-    return bool(included_pairs)
+    # Mirror the pre-restore-archive filter in
+    # :func:`_create_pre_restore_backup`: a target that contains
+    # *only* previous pre-restore archives is treated as having no
+    # canonical data, so we skip the backup step (there's nothing
+    # the operator hasn't already preserved via the previous
+    # pre-restore backup).
+    for _file_p, rel_parts in included_pairs:
+        if (
+            len(rel_parts) >= 2
+            and rel_parts[0] == _paths.BACKUPS_SUBDIR
+            and rel_parts[1] == PRE_RESTORE_BACKUP_SUBDIR
+        ):
+            continue
+        return True
+    return False
 
 
 def _dry_run_warnings(

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1469,15 +1469,32 @@ def _create_pre_restore_backup(
     included_entries: list[IncludedEntry] = []
     archive_files: list[tuple[Path, str]] = []
     for file_p, rel_parts in included_pairs:
+        rel_posix = "/".join(rel_parts)
+        # Read failures here are not a "skip and continue" — the
+        # whole point of the pre-restore backup is to give the
+        # operator a recoverable copy of every canonical file
+        # before any file is replaced. If we cannot stat or hash a
+        # file, we cannot include it in the backup, and the
+        # subsequent restore could overwrite it without a fallback.
+        # Abort the backup so ``apply_restore`` refuses the restore
+        # with ``outcome=backup_failed`` and the operator can
+        # investigate the unreadable file.
         try:
             size = int(file_p.stat().st_size)
+        except OSError as exc:
+            warnings.append(
+                f"Could not stat {rel_posix!r} for pre-restore "
+                f"backup: {exc.strerror or 'OS error'}"
+            )
+            return None, 0, warnings
+        try:
             digest = _sha256_file(file_p)
-        except OSError:
-            excluded_entries.append(ExcludedEntry(
-                "/".join(rel_parts), REASON_UNREADABLE,
-            ))
-            continue
-        rel_posix = "/".join(rel_parts)
+        except OSError as exc:
+            warnings.append(
+                f"Could not read {rel_posix!r} for pre-restore "
+                f"backup: {exc.strerror or 'OS error'}"
+            )
+            return None, 0, warnings
         included_entries.append(IncludedEntry(
             path=rel_posix, size=size, sha256=digest,
         ))

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1885,10 +1885,16 @@ def apply_restore(
             manifest=inspection.manifest,
         )
 
-    # Optional pinning of the archive identity.
-    if confirmed_manifest_id is not None:
+    # Optional pinning of the archive identity. A non-empty
+    # ``confirmed_manifest_id`` is a deliberate "I inspected
+    # exactly this archive" assertion — it must match the
+    # archive's manifest id exactly, including when the archive
+    # has no usable id of its own. ``None`` and ``""`` both mean
+    # "no pin requested" (the CLI omits the flag, the UI sends
+    # ``null`` when it has no id to pin against).
+    if confirmed_manifest_id:
         actual = _manifest_id(inspection.manifest)
-        if confirmed_manifest_id and actual and confirmed_manifest_id != actual:
+        if actual != confirmed_manifest_id:
             return RestoreResult(
                 archive_path=archive_path_s,
                 target_data_dir="",

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1818,7 +1818,30 @@ def _copy_into_target(
                 f"{exc.strerror or 'OS error'}."
             )
 
-        existed = dst.exists()
+        # Type-gate the destination before any move. A directory,
+        # symlink, fifo, or other special node at ``dst`` would be
+        # accepted by ``os.replace`` for the stash step, but the
+        # rollback path can't put it back over a regular file —
+        # ``os.replace(dir, file)`` errors out, the staging cleanup
+        # then deletes the stash, and the original target data is
+        # permanently lost. Refuse those upfront and unwind whatever
+        # we have committed so far.
+        dst_is_symlink = dst.is_symlink()
+        existed = dst.exists() or dst_is_symlink
+        if existed:
+            if dst_is_symlink:
+                _rollback()
+                return [], [], (
+                    f"Refusing to replace {rel!r}: existing target "
+                    "is a symlink."
+                )
+            if not dst.is_file():
+                _rollback()
+                return [], [], (
+                    f"Refusing to replace {rel!r}: existing target "
+                    "is not a regular file (directory or special "
+                    "node)."
+                )
         stash_path: Optional[Path] = None
         if existed:
             stash_path = stash_dir / Path(*rel.split("/"))

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1020,8 +1020,19 @@ def inspect_export(archive_path: str | os.PathLike[str]) -> InspectionResult:
                         "a directory."
                     )
                     continue
-                file_names.append(member.name)
+                # Only regular files become entries in
+                # ``InspectionResult.files``. Directory members are
+                # structural — they validate (no traversal, no
+                # disallowed top-level) but they are not restorable
+                # in their own right and ``_extract_to_staging``
+                # never adds them to ``extracted``. Including them
+                # here used to let the dry-run preview report an
+                # ``outcome=dry_run`` for a directory-only archive
+                # while the real restore refused with "no
+                # extractable Nova data files", breaking the
+                # inspect → dry-run → confirm contract.
                 if member.isfile():
+                    file_names.append(member.name)
                     total_size += int(member.size)
 
                 if member.name == ARCHIVE_MANIFEST_NAME and member.isfile():
@@ -2384,6 +2395,34 @@ def apply_restore(
     # restore allows it iff the caller explicitly confirms.
     target_nova_db = target_resolved / _paths.DB_FILENAME
     target_has_db = target_nova_db.exists()
+
+    # Refuse upfront when there is nothing to restore. This keeps
+    # dry-run and real-restore in lockstep: the real-restore path
+    # would later hit ``if not extracted:`` inside
+    # ``_extract_to_staging`` and refuse with the same reason;
+    # surfacing the refusal here means the dry-run preview never
+    # says "would proceed" for an archive that holds only
+    # directory members or whose only files were filtered by the
+    # restore allowlist.
+    if not would_restore:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_REFUSED,
+            refuse_reason=(
+                "Archive contains no extractable Nova data files."
+            ),
+            confirmed=bool(confirm),
+            restored_files=(),
+            skipped_files=tuple(skipped_in_archive),
+            conflicts=(),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=False,
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
     if dry_run:
         return RestoreResult(
             archive_path=archive_path_s,

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1667,6 +1667,7 @@ def _extract_to_staging(
     extraction error.
     """
     extracted: list[str] = []
+    seen_extracted: set[str] = set()
     skipped: list[ExcludedEntry] = []
     try:
         with tarfile.open(archive_path, mode="r:*") as tar:
@@ -1717,6 +1718,20 @@ def _extract_to_staging(
                 if member.isfile():
                     rel = PurePosixPath(member.name)
                     posix_rel = "/".join(rel.parts[1:])
+                    # Duplicate archive members would queue the same
+                    # staging path more than once. The first copy in
+                    # ``_copy_into_target`` succeeds — the second one
+                    # then hits ENOENT because the staged source has
+                    # already been moved into the target. Tar
+                    # semantics already make the last write win at
+                    # extraction time, so we record one entry per
+                    # POSIX-relative path. A well-formed Nova export
+                    # never produces duplicates; the dedup is
+                    # defence-in-depth against externally-generated
+                    # tarballs.
+                    if posix_rel in seen_extracted:
+                        continue
+                    seen_extracted.add(posix_rel)
                     extracted.append(posix_rel)
     except tarfile.TarError as exc:
         return [], skipped, f"Archive could not be extracted: {exc.__class__.__name__}."
@@ -2046,6 +2061,7 @@ def apply_restore(
     # so a crafted archive cannot smuggle in a ``data/.env`` or a
     # ``data/.ssh/id_rsa`` that the exporter would have refused.
     would_restore: list[str] = []
+    would_restore_seen: set[str] = set()
     conflicts_seen: list[str] = []
     skipped_in_archive: list[ExcludedEntry] = []
     has_nova_db_in_archive = False
@@ -2106,11 +2122,21 @@ def apply_restore(
                 warnings=inspection.warnings,
                 manifest=inspection.manifest,
             )
-        would_restore.append(str(relative))
+        rel_str = str(relative)
+        # Deduplicate so a tarball with duplicate members (an
+        # externally-generated archive, defence in depth) reports a
+        # single entry per POSIX path in the dry-run preview. This
+        # matches the extraction-time dedup in
+        # ``_extract_to_staging`` so dry-run and real-restore stay
+        # consistent.
+        if rel_str in would_restore_seen:
+            continue
+        would_restore_seen.add(rel_str)
+        would_restore.append(rel_str)
         if relative.parts and relative.parts[0] == _paths.DB_FILENAME:
             has_nova_db_in_archive = True
         if candidate.exists():
-            conflicts_seen.append(str(relative))
+            conflicts_seen.append(rel_str)
 
     # Existing target nova.db is the most-sensitive overwrite. Phase
     # 2's plan_restore refuses unconditionally; Phase 3's real

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1666,23 +1666,69 @@ def _copy_into_target(
     target_root: Path,
     relative_files: list[str],
 ) -> tuple[list[str], list[str], Optional[str]]:
-    """Copy staged files into ``target_root``.
+    """Copy staged files into ``target_root`` with rollback on failure.
 
     Returns ``(restored, conflicts, error)``. ``restored`` is the
-    list of POSIX-relative paths actually copied; ``conflicts`` lists
-    target paths that already existed and were replaced (those files
-    were already captured by the pre-restore backup). ``error`` is
+    list of POSIX-relative paths actually copied; ``conflicts``
+    lists target paths that already existed and were replaced
+    (those files were also captured by the pre-restore backup, plus
+    stashed in-staging for per-restore rollback). ``error`` is
     ``None`` on success.
 
-    The copy is done file-by-file with ``os.replace`` so each
-    individual destination flips atomically. We do not attempt a
-    whole-tree rename because the target directory contains files
-    Nova did not bring in (other backups, prior exports, etc.) and
-    the safety contract forbids deleting them.
+    Each per-file copy is staged in two steps so a mid-run failure
+    can be rolled back atomically:
+
+      1. If the target file already exists, move it to
+         ``<staging>/.replaced-originals/<rel>``.
+      2. Move the staged source file into the target via
+         ``os.replace`` (atomic on the same filesystem).
+
+    On any failure the function walks back over the successful
+    moves: each ``.replaced-originals`` file is moved back to its
+    original target path; files that did not exist before are
+    deleted. The pre-restore backup (created earlier by
+    :func:`_create_pre_restore_backup`) remains as the second
+    line of defence if even the rollback fails.
+
+    The returned ``restored`` / ``conflicts`` lists are intentionally
+    empty on a failure path so the caller does not report files as
+    "restored" when the rollback returned them to their previous
+    state.
     """
     restored: list[str] = []
     conflicts: list[str] = []
     target_resolved = target_root.resolve()
+    stash_dir = staging / ".replaced-originals"
+    try:
+        stash_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return [], [], (
+            f"Could not create rollback stash: "
+            f"{exc.strerror or 'OS error'}."
+        )
+
+    # Successfully-committed moves so a later failure can roll back.
+    # Each entry is ``(dst, stash_path | None)``. ``stash_path is
+    # None`` means "the file did not exist before; rollback should
+    # delete it".
+    committed: list[tuple[Path, Optional[Path]]] = []
+
+    def _rollback() -> None:
+        # Walk in reverse so a newly-created directory tree unwinds
+        # in the right order. Best-effort: a failure here leaves
+        # the pre-restore backup as the operator-facing recovery.
+        for dst_path, stash in reversed(committed):
+            if stash is None:
+                try:
+                    dst_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                continue
+            try:
+                os.replace(str(stash), str(dst_path))
+            except OSError:
+                pass
+
     for rel in relative_files:
         src = staging / Path(*rel.split("/"))
         dst = target_root / Path(*rel.split("/"))
@@ -1691,21 +1737,56 @@ def _copy_into_target(
             dst_resolved = dst.resolve(strict=False)
             dst_resolved.relative_to(target_resolved)
         except (OSError, ValueError):
-            return restored, conflicts, (
+            _rollback()
+            return [], [], (
                 f"Refusing to write {rel!r}: it would land outside "
                 "the target data directory."
             )
         try:
             dst.parent.mkdir(parents=True, exist_ok=True)
-            existed = dst.exists()
+        except OSError as exc:
+            _rollback()
+            return [], [], (
+                f"Could not prepare {rel!r}: "
+                f"{exc.strerror or 'OS error'}."
+            )
+
+        existed = dst.exists()
+        stash_path: Optional[Path] = None
+        if existed:
+            stash_path = stash_dir / Path(*rel.split("/"))
+            try:
+                stash_path.parent.mkdir(parents=True, exist_ok=True)
+                # Move existing file aside. ``os.replace`` is atomic
+                # on the same filesystem; staging lives inside the
+                # data root by construction.
+                os.replace(str(dst), str(stash_path))
+            except OSError as exc:
+                _rollback()
+                return [], [], (
+                    f"Could not stash existing {rel!r}: "
+                    f"{exc.strerror or 'OS error'}."
+                )
+
+        try:
             # ``os.replace`` is atomic on the same filesystem. The
             # staging directory lives **inside** the target root by
             # construction so this never falls back to a cross-FS
             # copy.
             os.replace(str(src), str(dst))
         except OSError as exc:
-            return restored, conflicts, (
-                f"Could not write {rel!r}: {exc.strerror or 'OS error'}."
+            # Best-effort recovery for *this* file before unwinding
+            # the rest: move the stash back into place if we just
+            # bumped a pre-existing file out of the way.
+            if stash_path is not None and stash_path.exists():
+                try:
+                    os.replace(str(stash_path), str(dst))
+                except OSError:
+                    pass
+            _rollback()
+            return [], [], (
+                f"Could not write {rel!r}: "
+                f"{exc.strerror or 'OS error'}."
             )
         try:
             os.chmod(dst, 0o600)
@@ -1714,6 +1795,7 @@ def _copy_into_target(
         restored.append(rel)
         if existed:
             conflicts.append(rel)
+        committed.append((dst, stash_path))
     return restored, conflicts, None
 
 
@@ -1848,28 +1930,12 @@ def apply_restore(
             manifest=inspection.manifest,
         )
 
-    try:
-        target_root.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        return RestoreResult(
-            archive_path=archive_path_s,
-            target_data_dir=str(target_root),
-            outcome=RESTORE_OUTCOME_FAILED,
-            refuse_reason=(
-                f"Target data directory could not be prepared: "
-                f"{exc.strerror or 'OS error'}"
-            ),
-            confirmed=bool(confirm),
-            restored_files=(),
-            skipped_files=(),
-            conflicts=(),
-            backup_path="",
-            backup_size=0,
-            restart_recommended=False,
-            warnings=inspection.warnings,
-            manifest=inspection.manifest,
-        )
-
+    # Resolve the target lexically. ``Path.resolve(strict=False)``
+    # does not require the directory to exist, so the dry-run path
+    # below stays strictly read-only — no mkdir, no statvfs, no
+    # touch. The actual ``mkdir`` is deferred until after the
+    # dry-run early return so a dry-run against a missing target
+    # never creates a directory on disk.
     target_resolved = target_root.resolve()
 
     # Phase 2: compute the "would restore" file list (also checks
@@ -1973,6 +2039,32 @@ def apply_restore(
                 "confirm=true after reviewing the dry-run plan."
             ),
             confirmed=False,
+            restored_files=(),
+            skipped_files=(),
+            conflicts=tuple(conflicts_seen),
+            backup_path="",
+            backup_size=0,
+            restart_recommended=has_nova_db_in_archive,
+            warnings=inspection.warnings,
+            manifest=inspection.manifest,
+        )
+
+    # Confirmation has cleared. Now (and only now) is it safe to
+    # create the target data directory on disk — the dry-run path
+    # never reaches this point so a dry-run against a missing
+    # target leaves the filesystem untouched.
+    try:
+        target_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return RestoreResult(
+            archive_path=archive_path_s,
+            target_data_dir=str(target_resolved),
+            outcome=RESTORE_OUTCOME_FAILED,
+            refuse_reason=(
+                f"Target data directory could not be prepared: "
+                f"{exc.strerror or 'OS error'}"
+            ),
+            confirmed=bool(confirm),
             restored_files=(),
             skipped_files=(),
             conflicts=tuple(conflicts_seen),

--- a/core/data_export.py
+++ b/core/data_export.py
@@ -1534,6 +1534,54 @@ def _create_pre_restore_backup(
     return candidate, size, warnings
 
 
+def _restore_allowlist_reason(
+    rel_parts: tuple[str, ...],
+) -> Optional[str]:
+    """Return an exclusion reason for an archive-relative path, or ``None``.
+
+    Mirrors the export builder's allowlist so a crafted package
+    cannot restore files the exporter would never have packed in
+    the first place. The rejection vocabulary uses the existing
+    ``REASON_*`` wire strings so the UI can render mixed export /
+    restore exclusion lists uniformly.
+
+    A relative path is **allowed** when every component clears the
+    secret / VCS / cache / venv / Ollama checks (see
+    :func:`_classify_exclusion`) **and** the top-level component is
+    one of:
+
+      * ``nova.db`` (single-component path), or
+      * a name starting with ``nova.db.`` (sidecar / preupgrade
+        backup, single-component path), or
+      * one of the four reserved subdirectories (``backups``,
+        ``exports``, ``memory-packs``, ``logs``) when the path has
+        more than one component.
+
+    Anything else — a bare ``.env`` under ``data/``, a hostile
+    ``data/.ssh/id_rsa``, a stray ``data/README.txt``, even
+    ``data/notabackup/file`` — is refused with the most specific
+    reason available.
+    """
+    if not rel_parts:
+        return REASON_NOT_ALLOWLISTED
+    # First pass: per-component secret / forbidden-dir / cache /
+    # Ollama checks. This catches ``data/.env``, ``data/.ssh/...``,
+    # ``data/backups/.git/...``, ``data/logs/leaked.pem``, etc.
+    reason = _classify_exclusion(rel_parts)
+    if reason is not None:
+        return reason
+    top = rel_parts[0]
+    if len(rel_parts) == 1:
+        if top in _ALLOWED_TOP_FILES:
+            return None
+        if any(top.startswith(p) for p in _ALLOWED_TOP_FILE_PREFIXES):
+            return None
+        return REASON_NOT_ALLOWLISTED
+    if top in _ALLOWED_TOP_DIRS:
+        return None
+    return REASON_NOT_ALLOWLISTED
+
+
 def _safe_extract_member(
     tar: tarfile.TarFile,
     member: tarfile.TarInfo,
@@ -1611,10 +1659,12 @@ def _extract_to_staging(
     Returns ``(extracted_files, skipped, error)``. ``extracted_files``
     is the list of POSIX-relative file paths under ``staging/data``
     that were materialised. ``skipped`` records members that were
-    intentionally not extracted (symlinks, hardlinks, devices, or
-    names that would resolve outside the staging tree). ``error`` is
-    ``None`` on success or a short, frontend-safe string describing
-    a fatal extraction error.
+    intentionally not extracted (symlinks, hardlinks, devices,
+    names that would resolve outside the staging tree, **or
+    entries that fail the export-side allowlist** — e.g. a hostile
+    ``data/.env`` or ``data/.ssh/id_rsa``). ``error`` is ``None`` on
+    success or a short, frontend-safe string describing a fatal
+    extraction error.
     """
     extracted: list[str] = []
     skipped: list[ExcludedEntry] = []
@@ -1640,6 +1690,23 @@ def _extract_to_staging(
                         member.name, REASON_SYMLINK_ESCAPE,
                     ))
                     continue
+                # Restore-side allowlist gate. A crafted archive may
+                # ship entries the exporter would have refused (the
+                # ``.env`` family, ``.ssh/...``, ``.git/...``,
+                # arbitrary non-canonical names). They are never
+                # extracted into staging.
+                parts = PurePosixPath(member.name).parts
+                if (
+                    parts
+                    and parts[0] == ARCHIVE_DATA_PREFIX
+                    and len(parts) > 1
+                ):
+                    allow_reason = _restore_allowlist_reason(parts[1:])
+                    if allow_reason is not None:
+                        skipped.append(ExcludedEntry(
+                            member.name, allow_reason,
+                        ))
+                        continue
                 dest = _safe_extract_member(tar, member, staging)
                 if dest is None:
                     if member.isfile():
@@ -1949,8 +2016,15 @@ def apply_restore(
     # target root — we do **not** rely on the dry-run plan refusing
     # an existing nova.db because Phase 3's real restore is allowed
     # to replace it under explicit confirmation).
+    #
+    # The same export-side allowlist that prevents secrets / VCS /
+    # caches / Ollama blobs / arbitrary non-canonical files from
+    # being *exported* is applied here on the *restore* side too,
+    # so a crafted archive cannot smuggle in a ``data/.env`` or a
+    # ``data/.ssh/id_rsa`` that the exporter would have refused.
     would_restore: list[str] = []
     conflicts_seen: list[str] = []
+    skipped_in_archive: list[ExcludedEntry] = []
     has_nova_db_in_archive = False
     for member_name in inspection.files:
         if member_name in (ARCHIVE_MANIFEST_NAME, ARCHIVE_RESTORE_DOC_NAME):
@@ -1980,6 +2054,12 @@ def apply_restore(
                 warnings=inspection.warnings,
                 manifest=inspection.manifest,
             )
+        allow_reason = _restore_allowlist_reason(relative.parts)
+        if allow_reason is not None:
+            skipped_in_archive.append(
+                ExcludedEntry(str(relative), allow_reason)
+            )
+            continue
         candidate = target_resolved / Path(*relative.parts)
         try:
             candidate_abs = candidate.resolve(strict=False)
@@ -2022,7 +2102,7 @@ def apply_restore(
             refuse_reason="",
             confirmed=bool(confirm),
             restored_files=tuple(would_restore),
-            skipped_files=(),
+            skipped_files=tuple(skipped_in_archive),
             conflicts=tuple(conflicts_seen),
             backup_path="",
             backup_size=0,
@@ -2143,7 +2223,15 @@ def apply_restore(
             manifest=inspection.manifest,
         )
 
-    extracted, skipped, extract_err = _extract_to_staging(archive_p, staging)
+    extracted, _extract_skipped, extract_err = _extract_to_staging(
+        archive_p, staging,
+    )
+    # ``_extract_skipped`` is a defence-in-depth sibling of
+    # ``skipped_in_archive`` — both gates run the same allowlist
+    # check on each member, so they should agree in well-formed
+    # cases. We surface ``skipped_in_archive`` as the wire-format
+    # ``skipped_files`` so dry-run and real-restore consumers see
+    # the same path shape (POSIX-relative, no ``data/`` prefix).
     if extract_err is not None:
         _cleanup_staging(staging)
         return RestoreResult(
@@ -2153,7 +2241,7 @@ def apply_restore(
             refuse_reason=extract_err,
             confirmed=bool(confirm),
             restored_files=(),
-            skipped_files=tuple(skipped),
+            skipped_files=tuple(skipped_in_archive),
             conflicts=tuple(conflicts_seen),
             backup_path=backup_archive_path,
             backup_size=backup_size,
@@ -2175,7 +2263,7 @@ def apply_restore(
             ),
             confirmed=bool(confirm),
             restored_files=(),
-            skipped_files=tuple(skipped),
+            skipped_files=tuple(skipped_in_archive),
             conflicts=tuple(conflicts_seen),
             backup_path=backup_archive_path,
             backup_size=backup_size,
@@ -2198,7 +2286,7 @@ def apply_restore(
             refuse_reason=copy_err,
             confirmed=bool(confirm),
             restored_files=tuple(restored),
-            skipped_files=tuple(skipped),
+            skipped_files=tuple(skipped_in_archive),
             conflicts=tuple(conflicts),
             backup_path=backup_archive_path,
             backup_size=backup_size,
@@ -2230,7 +2318,7 @@ def apply_restore(
         refuse_reason="",
         confirmed=True,
         restored_files=tuple(restored),
-        skipped_files=tuple(skipped),
+        skipped_files=tuple(skipped_in_archive),
         conflicts=tuple(conflicts),
         backup_path=backup_archive_path,
         backup_size=backup_size,

--- a/docs/storage-and-migration.md
+++ b/docs/storage-and-migration.md
@@ -1,13 +1,15 @@
 # Nova Storage & Migration Center
 
-> **Status: Phase 2 — admin UI + CLI on top of Phase 1's backend.**
+> **Status: Phase 3 — safe guided restore on top of Phase 1 + 2.**
 > Nova ships a small, admin-only surface that reports where Nova
 > stores its data, builds a portable data export package, lets you
-> inspect an existing package, and produces a dry-run restore plan
-> before you touch the target. Every action is opt-in,
-> confirmation-gated, and safe by default. No data is ever moved,
-> overwritten, or deleted by Nova itself. Restore stays a manual
-> operator step — the dry-run plan is the most Phase 2 will do.
+> inspect an existing package, produces a dry-run restore plan, and
+> — new in Phase 3 — performs the actual restore after an explicit
+> confirmation and an automatic pre-restore backup. Every action is
+> opt-in, confirmation-gated, and safe by default. No data is ever
+> moved, overwritten, or deleted by Nova without first writing a
+> recoverable backup; a failed restore leaves the current data
+> bit-for-bit identical to before.
 
 This document is the operator-facing companion to
 [`docs/data-directory.md`](data-directory.md) and
@@ -31,7 +33,7 @@ If you are setting up Nova for the first time, start with
 
 ## What the Storage & Migration Center covers
 
-Nova exposes four things to the admin:
+Nova exposes five things to the admin:
 
 1. **Storage status** — a read-only report on Nova's path layout:
    `NOVA_DATA_DIR`, the resolved `nova.db` path, the four reserved
@@ -53,23 +55,32 @@ Nova exposes four things to the admin:
    any conflicts (e.g. an existing `nova.db`), and refuses to
    proceed automatically. The plan is purely informational: nothing
    is written, moved, or deleted.
+5. **Guided restore (Phase 3)** — given an archive and an explicit
+   confirmation, Nova creates an automatic pre-restore backup of
+   the current data, stages the archive into a private directory,
+   validates every extracted file, and only then replaces files
+   inside `NOVA_DATA_DIR`. Failed restores leave the current data
+   intact; the pre-restore backup is preserved on success so the
+   operator can roll back at any time.
 
 Surfaces:
 
 * **Admin overlay → ⚇ Storage tab** — confirmation-gated UI
-  wrapper around the three endpoints. Shows the status report,
-  builds an export package, and renders the latest export summary.
+  wrapper around all five flows. Shows the status report, builds an
+  export package, and (Phase 3) walks the operator through inspect
+  → dry-run → confirm → restore.
 * **HTTP endpoints** — `/admin/storage/status`,
-  `/admin/storage/export`, `/admin/storage/inspect-export`. All
-  three require an admin bearer token.
-* **CLI** — `python -m core.data_export {export,inspect,restore-dry-run}`
+  `/admin/storage/export`, `/admin/storage/inspect-export`,
+  `/admin/storage/restore-dry-run`, `/admin/storage/restore`. All
+  five require an admin bearer token.
+* **CLI** — `python -m core.data_export {export,inspect,restore-dry-run,restore}`
   so an operator can run the same flows from a shell on either host,
   including the target machine before any data is copied.
 
-Restore itself stays a **manual operator step**. The dry-run plan
-is the most Phase 2 will do: Nova never overwrites a `nova.db`
-automatically, and the actual file-copy step is a documented
-`rsync` (or equivalent) you run yourself.
+Restore is now **safe and reversible**: the dry-run still exists
+(default for the cautious operator) and the real restore writes a
+pre-restore backup *before* any file is replaced. A failed restore
+never corrupts current data.
 
 ---
 
@@ -419,51 +430,151 @@ this phase. Inspection and dry-run restore are CLI-only on
 purpose — they are the steps you take on the target machine, often
 before Nova is even running there.
 
-## Restoring on the target machine (manual, Phase 2)
+## Guided restore (Phase 3)
 
-1. On the target machine, set `NOVA_DATA_DIR` to the new data
-   directory (`/mnt/fastdata/NovaData` is the recommended default).
-2. Stop Nova: `sudo systemctl stop nova`.
-3. If the target already has a `nova.db`, **back it up** by hand
-   before continuing. Nova refuses to overwrite an existing
-   database; do not work around this by deleting the file blindly.
-4. Inspect the package and review the dry-run plan:
+Nova can now restore a valid data export package into the active
+`NOVA_DATA_DIR` directly — safely, with an automatic pre-restore
+backup and explicit confirmation. The flow is the same whether you
+use the CLI or the admin UI, and the safety contract is identical:
 
-   ```bash
-   python -m core.data_export inspect \
-       /path/to/nova-data-export-<stamp>.tar.gz
+1. **Inspect** the package.
+2. **Dry-run** the restore. Read the file list and warnings.
+3. **Confirm** explicitly.
+4. Nova **backs up** the current data automatically.
+5. Nova **stages** the archive into a private directory inside
+   `NOVA_DATA_DIR`.
+6. Nova **replaces** matched files atomically per-file.
+7. Nova **cleans up** staging on success or failure.
 
-   python -m core.data_export restore-dry-run \
-       /path/to/nova-data-export-<stamp>.tar.gz \
-       --data-dir /mnt/fastdata/NovaData
-   ```
+The pre-restore backup lives under
+`NOVA_DATA_DIR/backups/pre-restore/` as a Nova export package of
+its own (same `tar.gz` format, same manifest). You can inspect it
+or use it as the source for a follow-up restore — that is how you
+roll back.
 
-   The dry-run plan refuses (`allowed: false`) if the target
-   directory already contains a `nova.db`. Move or rename the
-   existing file by hand before retrying.
+### Restoring from the CLI
 
-5. Extract the package somewhere staging:
+```bash
+# Stop Nova so the running process does not hold the database open.
+sudo systemctl stop nova
 
-   ```bash
-   tar -xzf nova-data-export-<stamp>.tar.gz -C /tmp/nova-restore
-   ```
+# Inspect first. The CLI prints the manifest, the file count, the
+# uncompressed size, and any structural issues.
+python -m core.data_export inspect \
+    /mnt/archive/Backups/Nova/nova-data-export-<stamp>.tar.gz
 
-6. Copy the contents of `/tmp/nova-restore/data/` into
-   `NOVA_DATA_DIR` and fix ownership:
+# Dry-run the restore against the active data directory. Never
+# writes a file. The output lists the would-be files and conflicts.
+python -m core.data_export restore-dry-run \
+    /mnt/archive/Backups/Nova/nova-data-export-<stamp>.tar.gz \
+    --data-dir /mnt/fastdata/NovaData
 
-   ```bash
-   sudo -u nova rsync -aH /tmp/nova-restore/data/ /mnt/fastdata/NovaData/
-   ```
+# Real restore. The --confirm flag is required; without it the
+# command refuses. The optional --confirmed-manifest-id pins the
+# archive identity so another archive cannot slip in between the
+# inspect and restore calls.
+python -m core.data_export restore \
+    /mnt/archive/Backups/Nova/nova-data-export-<stamp>.tar.gz \
+    --data-dir /mnt/fastdata/NovaData \
+    --confirm
 
-7. Start Nova: `sudo systemctl start nova` and confirm the web UI
-   shows your memories, conversations, and settings.
-8. Re-pull any Ollama models you had configured on the source host.
+# Start Nova back up.
+sudo systemctl start nova
+```
 
-Nova's **automated restore is future work**. Today step 5–6 is
-something you do, deliberately, with the database file in your hand.
-The dry-run plan is the safety net — it tells you what *would*
-happen, so you can sanity-check the package and the target before
-you copy anything.
+The restore CLI exits `0` on success and `1` on a refusal or
+failure — so shell scripts can branch on it. The output includes:
+
+* the restored file count,
+* the absolute path of the pre-restore backup,
+* any warnings (e.g. "restart Nova so the new nova.db is picked
+  up"),
+* and the manifest summary.
+
+### Restoring from the admin UI
+
+The **⚇ Storage** tab gains a **Restore from export package**
+section in Phase 3. The flow:
+
+1. Type the filename of the package as it sits under
+   `NOVA_DATA_DIR/exports/` (the admin UI never reads arbitrary
+   filesystem paths — the file must already be under the configured
+   exports directory). Move the archive there with `rsync` or `cp`
+   first if it is not.
+2. Click **Inspect**. The UI renders the manifest, the format /
+   version, the member count, the uncompressed size, and whether
+   `nova.db` is in the package. Errors and warnings are listed
+   verbatim.
+3. Click **Dry-run**. The UI renders what *would* be restored and
+   surfaces a `would proceed` / `refused` tag. The restore button
+   appears below.
+4. Tick the confirmation checkbox:
+   *"I understand this will replace Nova's current data after
+   creating a backup."*
+5. Click **Restore package and backup current data first**. The UI
+   reports the restored files count, the pre-restore backup path,
+   any warnings, and a clear "restart Nova" hint when `nova.db`
+   was in the package.
+
+The restore button stays **disabled** until inspection and dry-run
+have both succeeded *and* the confirmation checkbox is ticked. Each
+gate is enforced on both sides: client-side (so the UI never offers
+the destructive action before the operator has reviewed) and
+server-side (so a misbehaving client cannot bypass the gates).
+
+### Verifying after a restore
+
+1. **Restart Nova** if `nova.db` was in the package: `sudo
+   systemctl restart nova`.
+2. **Open Nova** and confirm:
+   - your conversations are present,
+   - your memories are restored,
+   - your per-user preferences look correct,
+   - `/admin/storage/status` reports the data directory as healthy.
+3. **Re-pull Ollama models** you had configured on the source host
+   (`ollama pull <name>`). Ollama models are owned by Ollama, not
+   by Nova, and never live inside an export package.
+
+### Rolling back using the pre-restore backup
+
+The pre-restore backup is a Nova export package. To roll back:
+
+```bash
+# The pre-restore backup lives under NOVA_DATA_DIR/backups/pre-restore/.
+ls -lh /mnt/fastdata/NovaData/backups/pre-restore/
+
+# Inspect it as you would any other export.
+python -m core.data_export inspect \
+    /mnt/fastdata/NovaData/backups/pre-restore/nova-pre-restore-<stamp>.tar.gz
+
+# Restore from the backup. The current data is itself backed up
+# *again* automatically before the rollback proceeds, so multiple
+# rollbacks are possible.
+sudo systemctl stop nova
+python -m core.data_export restore \
+    /mnt/fastdata/NovaData/backups/pre-restore/nova-pre-restore-<stamp>.tar.gz \
+    --data-dir /mnt/fastdata/NovaData \
+    --confirm
+sudo systemctl start nova
+```
+
+Pre-restore backup files are **never overwritten**: a name clash
+falls back to `-<n>` until a free name is found. Operators are
+expected to clean up old pre-restore backups by hand when they no
+longer need them.
+
+### What stays out of scope (still)
+
+* **Ollama models.** Re-pull on the target machine.
+* **`.env` and other secrets.** Configure them on the target
+  machine, not in the export.
+* **Media libraries (Jellyfin, Plex, …).** Those services own
+  their own data directories.
+* **Automatic restart of Nova.** Nova never restarts itself after
+  a restore — even though the maintenance center has a calm
+  systemd-user restart facility, the restore flow surfaces a
+  "restart Nova" *hint* rather than performing it, so the operator
+  remains in charge of when the new database starts being served.
 
 ---
 
@@ -495,8 +606,11 @@ contain one.
 
 These are firm boundaries of the Storage & Migration Center:
 
-* **Read-only by default.** `/admin/storage/status` and
-  `/admin/storage/inspect-export` never write to disk.
+* **Local-only.** No outbound calls, no cloud sync, no scheduled
+  background restore.
+* **Read-only by default.** `/admin/storage/status`,
+  `/admin/storage/inspect-export`, and `/admin/storage/restore-dry-run`
+  never write to disk.
 * **Admin-only.** Every endpoint is wrapped with `require_admin`;
   non-admin and restricted users see a 403.
 * **Confirmation-gated export.** `/admin/storage/export` requires
@@ -516,12 +630,33 @@ These are firm boundaries of the Storage & Migration Center:
   letter) and re-checked against the intended root after
   resolution. Hostile archives are refused with a clear error,
   never extracted.
-* **No automatic restore.** Phase 1 plans and inspects only. No
-  file is written, moved, or deleted by Nova during a restore.
-* **No overwrite without explicit confirmation.** A restore plan
-  refuses when the target data directory already contains a
-  `nova.db`. The operator removes or renames the existing file by
-  hand, deliberately, before continuing.
+* **No restore without explicit confirmation.** Phase 3's real
+  restore endpoint refuses unless the request body carries
+  `confirm: true`. The CLI's `restore` subcommand refuses without
+  `--confirm`. The admin UI keeps the restore button disabled until
+  inspection succeeds, the dry-run plan reports "would proceed", and
+  the operator ticks the "I understand" checkbox.
+* **Automatic pre-restore backup.** The real restore writes a Nova
+  export package of the *current* data directory under
+  `NOVA_DATA_DIR/backups/pre-restore/` **before** any file is
+  replaced. The restore refuses if that backup cannot be created.
+  Pre-restore backups are never overwritten — a name clash falls
+  back to `-<n>` until a free name is found.
+* **Staging-first extraction.** The archive is extracted into a
+  private staging directory under
+  `NOVA_DATA_DIR/.restore-staging/`. Files are validated against
+  path traversal post-resolution and only then moved into the
+  target tree, one file at a time. The staging directory is
+  cleaned up after success or failure.
+* **Atomic per-file replace.** Each restored file lands via
+  `os.replace` inside the same filesystem — no half-written
+  partials, no torn writes. The staging directory lives **inside**
+  the target data root by construction so the rename never falls
+  back to a cross-filesystem copy.
+* **Failed restores leave current data intact.** A failure after
+  the backup step but before all files have been copied keeps the
+  remaining target files untouched; rolling back via the
+  pre-restore backup recovers the prior state in one step.
 * **No automatic data move.** Nova never copies its data root to a
   different disk for you. Use `rsync` or the operator's preferred
   tool, then update `NOVA_DATA_DIR`.

--- a/docs/storage-and-migration.md
+++ b/docs/storage-and-migration.md
@@ -630,6 +630,17 @@ These are firm boundaries of the Storage & Migration Center:
   letter) and re-checked against the intended root after
   resolution. Hostile archives are refused with a clear error,
   never extracted.
+* **Same allowlist on restore as on export.** A crafted archive
+  cannot smuggle in files the exporter would never have produced.
+  The restore path applies the same secret / VCS / cache / venv /
+  Ollama / non-canonical filters as the export builder, with
+  identical wire-format reasons. ``data/.env``, ``data/.ssh/...``,
+  ``data/backups/.git/...``, ``data/*.gguf``, and bare
+  ``data/README.txt``-style stray files are skipped during restore
+  with a reason in ``skipped_files`` even when the rest of the
+  archive inspects clean. Only the canonical Nova entries
+  (``nova.db``, ``nova.db.*`` sidecars, and contents of the four
+  reserved subdirectories) actually land on disk.
 * **No restore without explicit confirmation.** Phase 3's real
   restore endpoint refuses unless the request body carries
   `confirm: true`. The CLI's `restore` subcommand refuses without

--- a/static/index.html
+++ b/static/index.html
@@ -3016,6 +3016,57 @@
                     <div id="storage-export-error" style="color:var(--danger);font-size:0.82rem;min-height:0;"></div>
                 </div>
                 <div id="storage-export-result"></div>
+
+                <!-- Phase 3 — safe guided restore. Inspect first,
+                     then dry-run, then explicitly confirm. The
+                     restore button stays disabled until inspection
+                     and dry-run both succeed. -->
+                <div class="admin-section-title">Restore from export package</div>
+                <div id="storage-restore-form">
+                    <div class="admin-warning-summary">
+                        Restores a Nova data export package <strong>into the
+                        active data directory</strong>. A pre-restore backup of
+                        the current data is created automatically before any
+                        file is replaced. The package must already live under
+                        <code>NOVA_DATA_DIR/exports/</code> — Nova never reads
+                        arbitrary filesystem paths.
+                    </div>
+                    <div class="row" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+                        <input id="storage-restore-name" type="text"
+                            placeholder="nova-data-export-…tar.gz"
+                            oninput="resetRestoreState(true)"
+                            style="flex:1;min-width:260px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:monospace;font-size:0.82rem;padding:6px 10px;outline:none;" />
+                        <button class="admin-btn" id="storage-restore-inspect-btn" onclick="inspectRestorePackage()">Inspect</button>
+                        <button class="admin-btn" id="storage-restore-dryrun-btn" onclick="dryRunRestorePackage()" disabled>Dry-run</button>
+                    </div>
+                    <div id="storage-restore-error" style="color:var(--danger);font-size:0.82rem;min-height:0;"></div>
+                    <div id="storage-restore-inspect-result"></div>
+                    <div id="storage-restore-dryrun-result"></div>
+                    <div id="storage-restore-confirm" style="display:none;">
+                        <div class="admin-warning warning">
+                            <span class="admin-warning-level">warning</span>
+                            <span class="admin-warning-msg">
+                                The restore replaces files inside
+                                <code>NOVA_DATA_DIR</code>. A pre-restore
+                                backup is created first so you can roll back.
+                                Stop Nova before continuing if it is running.
+                            </span>
+                        </div>
+                        <label style="display:flex;gap:8px;align-items:flex-start;font-size:0.82rem;margin:8px 0;">
+                            <input type="checkbox" id="storage-restore-checkbox" onchange="updateRestoreButtonState()" />
+                            <span>I understand this will replace Nova's current data after creating a backup.</span>
+                        </label>
+                        <div class="row" style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;">
+                            <button class="admin-btn primary" id="storage-restore-btn" onclick="applyRestorePackage()" disabled>
+                                Restore package and backup current data first
+                            </button>
+                            <span class="admin-warning-summary" style="padding:0;">
+                                Confirmation-gated · admin-only · creates backup first
+                            </span>
+                        </div>
+                    </div>
+                    <div id="storage-restore-result"></div>
+                </div>
             </div>
         </div>
     </div>
@@ -8799,6 +8850,291 @@
             `${warnings}` +
             `</div>` +
             `<div class="admin-warning-summary">Inspect or dry-run the package on the target machine with <code>python -m core.data_export inspect &lt;archive&gt;</code>. Phase 2 does not perform an automated restore — see <code>docs/storage-and-migration.md</code>.</div>`;
+    }
+
+    // ── PHASE 3: Safe guided restore ──
+    //
+    // The flow is enforced client-side:
+    //   1. Inspect the package by basename (sits under exports/).
+    //   2. Dry-run, which lists what would be restored.
+    //   3. Toggle the "I understand" checkbox.
+    //   4. Click the explicit restore button.
+    //
+    // Each step unlocks the next. The server enforces the same
+    // ordering: the restore endpoint requires confirm=true and the
+    // helper creates a pre-restore backup before any file is moved.
+
+    let restoreState = {
+        inspected: false,
+        dryRunPassed: false,
+        manifestId: "",
+        archiveName: "",
+    };
+
+    function updateRestoreButtonState() {
+        const checkbox = document.getElementById("storage-restore-checkbox");
+        const btn = document.getElementById("storage-restore-btn");
+        if (!btn) return;
+        btn.disabled = !(
+            restoreState.dryRunPassed &&
+            checkbox && checkbox.checked
+        );
+    }
+
+    function resetRestoreState(keepName) {
+        restoreState = {
+            inspected: false,
+            dryRunPassed: false,
+            manifestId: "",
+            archiveName: keepName ? restoreState.archiveName : "",
+        };
+        const dryBtn = document.getElementById("storage-restore-dryrun-btn");
+        if (dryBtn) dryBtn.disabled = true;
+        const confirmEl = document.getElementById("storage-restore-confirm");
+        if (confirmEl) confirmEl.style.display = "none";
+        const checkbox = document.getElementById("storage-restore-checkbox");
+        if (checkbox) checkbox.checked = false;
+        const dryEl = document.getElementById("storage-restore-dryrun-result");
+        if (dryEl) dryEl.innerHTML = "";
+        const resultEl = document.getElementById("storage-restore-result");
+        if (resultEl) resultEl.innerHTML = "";
+        updateRestoreButtonState();
+    }
+
+    function getRestoreName() {
+        const input = document.getElementById("storage-restore-name");
+        return input ? input.value.trim() : "";
+    }
+
+    async function inspectRestorePackage() {
+        const name = getRestoreName();
+        const errEl = document.getElementById("storage-restore-error");
+        const inspEl = document.getElementById("storage-restore-inspect-result");
+        if (errEl) errEl.textContent = "";
+        if (inspEl) inspEl.innerHTML = "";
+        resetRestoreState(false);
+        if (!name) {
+            if (errEl) errEl.textContent = "Enter an archive filename first.";
+            return;
+        }
+        try {
+            const res = await fetch("/admin/storage/inspect-export", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ name }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const body = await res.json();
+                    if (body && body.detail) detail = body.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            restoreState.archiveName = name;
+            renderInspectResult(body);
+            if (body.valid) {
+                restoreState.inspected = true;
+                restoreState.manifestId =
+                    (body.manifest && body.manifest.created_at) || "";
+                const dryBtn = document.getElementById("storage-restore-dryrun-btn");
+                if (dryBtn) dryBtn.disabled = false;
+            }
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while inspecting package.";
+        }
+    }
+
+    function renderInspectResult(body) {
+        const el = document.getElementById("storage-restore-inspect-result");
+        if (!el) return;
+        const manifest = body.manifest || {};
+        const errors = (body.errors || []).map(e =>
+            `<div class="admin-warning error"><span class="admin-warning-level">error</span><span class="admin-warning-msg">${escapeHtml(e)}</span></div>`
+        ).join("");
+        const warnings = (body.warnings || []).map(w =>
+            `<div class="admin-warning warning"><span class="admin-warning-level">warning</span><span class="admin-warning-msg">${escapeHtml(w)}</span></div>`
+        ).join("");
+        const okTag = body.valid
+            ? `<span class="admin-tag installed">valid</span>`
+            : `<span class="admin-tag error">invalid</span>`;
+        const hasDb = (body.files || []).indexOf("data/nova.db") >= 0;
+        el.innerHTML =
+            `<div class="admin-section-title">Package inspection</div>` +
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">${escapeHtml(manifest.format || "?")} v${escapeHtml(String(manifest.format_version || ""))}</span>` +
+            okTag +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(body.archive_path || "")}</div>` +
+            `<div class="admin-progress-meta">created (UTC): ${escapeHtml(manifest.created_at || "")}</div>` +
+            `<div class="admin-progress-meta">members: ${(body.files || []).length} · uncompressed: ${formatBytes(body.total_uncompressed_size || 0)}</div>` +
+            `<div class="admin-progress-meta">nova.db present in package: ${hasDb ? "yes" : "no"}</div>` +
+            errors + warnings +
+            `</div>`;
+    }
+
+    async function dryRunRestorePackage() {
+        if (!restoreState.inspected) return;
+        const errEl = document.getElementById("storage-restore-error");
+        const dryEl = document.getElementById("storage-restore-dryrun-result");
+        const confirmEl = document.getElementById("storage-restore-confirm");
+        if (errEl) errEl.textContent = "";
+        if (dryEl) dryEl.innerHTML = "";
+        if (confirmEl) confirmEl.style.display = "none";
+        restoreState.dryRunPassed = false;
+        updateRestoreButtonState();
+        try {
+            const res = await fetch("/admin/storage/restore-dry-run", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    name: restoreState.archiveName,
+                    confirm: false,
+                    confirmed_manifest_id: restoreState.manifestId || null,
+                }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const body = await res.json();
+                    if (body && body.detail) detail = body.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            renderDryRunResult(body);
+            if (body.outcome === "dry_run") {
+                restoreState.dryRunPassed = true;
+                if (confirmEl) confirmEl.style.display = "";
+            }
+            updateRestoreButtonState();
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while running dry-run.";
+        }
+    }
+
+    function renderDryRunResult(body) {
+        const el = document.getElementById("storage-restore-dryrun-result");
+        if (!el) return;
+        const warnings = (body.warnings || []).map(w =>
+            `<div class="admin-warning warning"><span class="admin-warning-level">warning</span><span class="admin-warning-msg">${escapeHtml(w)}</span></div>`
+        ).join("");
+        const allowed = body.outcome === "dry_run";
+        const okTag = allowed
+            ? `<span class="admin-tag installed">would proceed</span>`
+            : `<span class="admin-tag error">refused</span>`;
+        const refuseLine = body.refuse_reason
+            ? `<div class="admin-progress-meta">refuse reason: ${escapeHtml(body.refuse_reason)}</div>`
+            : "";
+        const restartLine = body.restart_recommended
+            ? `<div class="admin-progress-meta">restart Nova after restore (nova.db will be replaced)</div>`
+            : "";
+        el.innerHTML =
+            `<div class="admin-section-title">Dry-run plan</div>` +
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">target: ${escapeHtml(body.target_data_dir || "")}</span>` +
+            okTag +
+            `</div>` +
+            `<div class="admin-progress-meta">would restore: ${(body.restored_files || []).length} file(s)</div>` +
+            `<div class="admin-progress-meta">would replace existing: ${(body.conflicts || []).length} file(s)</div>` +
+            restartLine +
+            refuseLine +
+            warnings +
+            `</div>`;
+    }
+
+    async function applyRestorePackage() {
+        if (!restoreState.dryRunPassed) return;
+        const checkbox = document.getElementById("storage-restore-checkbox");
+        if (!checkbox || !checkbox.checked) return;
+        const btn = document.getElementById("storage-restore-btn");
+        const errEl = document.getElementById("storage-restore-error");
+        const resultEl = document.getElementById("storage-restore-result");
+        if (errEl) errEl.textContent = "";
+        if (resultEl) resultEl.innerHTML = "";
+        if (!btn) return;
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Restoring…";
+        try {
+            const res = await fetch("/admin/storage/restore", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    name: restoreState.archiveName,
+                    confirm: true,
+                    confirmed_manifest_id: restoreState.manifestId || null,
+                }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const body = await res.json();
+                    if (body && body.detail) detail = body.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            renderRestoreResult(body);
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while restoring.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    }
+
+    function renderRestoreResult(body) {
+        const el = document.getElementById("storage-restore-result");
+        if (!el) return;
+        const warnings = (body.warnings || []).map(w =>
+            `<div class="admin-warning warning"><span class="admin-warning-level">warning</span><span class="admin-warning-msg">${escapeHtml(w)}</span></div>`
+        ).join("");
+        const ok = body.outcome === "restored";
+        const tag = ok
+            ? `<span class="admin-tag installed">restored</span>`
+            : `<span class="admin-tag error">${escapeHtml(body.outcome || "failed")}</span>`;
+        const refuseLine = body.refuse_reason
+            ? `<div class="admin-progress-meta">reason: ${escapeHtml(body.refuse_reason)}</div>`
+            : "";
+        const backupLine = body.backup_path
+            ? `<div class="admin-progress-meta">pre-restore backup: <code>${escapeHtml(body.backup_path)}</code> (${formatBytes(body.backup_size || 0)})</div>`
+            : "";
+        const restartLine = body.restart_recommended
+            ? `<div class="admin-warning warning"><span class="admin-warning-level">action</span><span class="admin-warning-msg">Restart Nova so the new database is picked up. The previous data is preserved inside the pre-restore backup.</span></div>`
+            : "";
+        el.innerHTML =
+            `<div class="admin-section-title">Restore result</div>` +
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">target: ${escapeHtml(body.target_data_dir || "")}</span>` +
+            tag +
+            `</div>` +
+            `<div class="admin-progress-meta">restored files: ${(body.restored_files || []).length}</div>` +
+            `<div class="admin-progress-meta">replaced existing: ${(body.conflicts || []).length}</div>` +
+            backupLine +
+            refuseLine +
+            `</div>` +
+            restartLine +
+            warnings;
     }
 
     // ── UTILS ──

--- a/static/index.html
+++ b/static/index.html
@@ -8870,6 +8870,13 @@
         manifestId: "",
         archiveName: "",
     };
+    // Monotonic generation counters so stale in-flight requests
+    // can't overwrite a newer selection. An older inspect (or
+    // dry-run) that comes back after the operator re-clicks must
+    // be silently dropped — otherwise it would prime the
+    // restore button for the wrong archive.
+    let restoreInspectGeneration = 0;
+    let restoreDryRunGeneration = 0;
 
     function updateRestoreButtonState() {
         const checkbox = document.getElementById("storage-restore-checkbox");
@@ -8888,6 +8895,11 @@
             manifestId: "",
             archiveName: keepName ? restoreState.archiveName : "",
         };
+        // Bump both generations so any in-flight inspect / dry-run
+        // request observes a mismatch on return and bails out
+        // before touching the freshly-reset state.
+        restoreInspectGeneration++;
+        restoreDryRunGeneration++;
         const dryBtn = document.getElementById("storage-restore-dryrun-btn");
         if (dryBtn) dryBtn.disabled = true;
         const confirmEl = document.getElementById("storage-restore-confirm");
@@ -8917,6 +8929,10 @@
             if (errEl) errEl.textContent = "Enter an archive filename first.";
             return;
         }
+        // Tag this request with a generation. A response that comes
+        // back after a newer click (or a filename edit + re-click)
+        // must not be allowed to overwrite the live state.
+        const generation = ++restoreInspectGeneration;
         try {
             const res = await fetch("/admin/storage/inspect-export", {
                 method: "POST",
@@ -8926,6 +8942,7 @@
                 },
                 body: JSON.stringify({ name }),
             });
+            if (generation !== restoreInspectGeneration) return;
             if (res.status === 401) { logout(); return; }
             if (!res.ok) {
                 let detail = `Failed (${res.status})`;
@@ -8933,10 +8950,12 @@
                     const body = await res.json();
                     if (body && body.detail) detail = body.detail;
                 } catch (_) { /* ignore */ }
+                if (generation !== restoreInspectGeneration) return;
                 if (errEl) errEl.textContent = detail;
                 return;
             }
             const body = await res.json();
+            if (generation !== restoreInspectGeneration) return;
             restoreState.archiveName = name;
             renderInspectResult(body);
             if (body.valid) {
@@ -8947,6 +8966,7 @@
                 if (dryBtn) dryBtn.disabled = false;
             }
         } catch (e) {
+            if (generation !== restoreInspectGeneration) return;
             if (errEl) errEl.textContent = "Network error while inspecting package.";
         }
     }
@@ -8990,6 +9010,11 @@
         if (confirmEl) confirmEl.style.display = "none";
         restoreState.dryRunPassed = false;
         updateRestoreButtonState();
+        // Mirror the inspect-side generation guard: a slower
+        // in-flight dry-run must not flip the restore button to
+        // "ready" for a stale archive selection.
+        const generation = ++restoreDryRunGeneration;
+        const targetedArchive = restoreState.archiveName;
         try {
             const res = await fetch("/admin/storage/restore-dry-run", {
                 method: "POST",
@@ -9003,6 +9028,10 @@
                     confirmed_manifest_id: restoreState.manifestId || null,
                 }),
             });
+            if (
+                generation !== restoreDryRunGeneration
+                || targetedArchive !== restoreState.archiveName
+            ) return;
             if (res.status === 401) { logout(); return; }
             if (!res.ok) {
                 let detail = `Failed (${res.status})`;
@@ -9010,10 +9039,18 @@
                     const body = await res.json();
                     if (body && body.detail) detail = body.detail;
                 } catch (_) { /* ignore */ }
+                if (
+                    generation !== restoreDryRunGeneration
+                    || targetedArchive !== restoreState.archiveName
+                ) return;
                 if (errEl) errEl.textContent = detail;
                 return;
             }
             const body = await res.json();
+            if (
+                generation !== restoreDryRunGeneration
+                || targetedArchive !== restoreState.archiveName
+            ) return;
             renderDryRunResult(body);
             if (body.outcome === "dry_run") {
                 restoreState.dryRunPassed = true;
@@ -9021,6 +9058,10 @@
             }
             updateRestoreButtonState();
         } catch (e) {
+            if (
+                generation !== restoreDryRunGeneration
+                || targetedArchive !== restoreState.archiveName
+            ) return;
             if (errEl) errEl.textContent = "Network error while running dry-run.";
         }
     }

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -755,6 +755,32 @@ class TestApplyRestoreDryRun:
         )
         assert out.outcome == de.RESTORE_OUTCOME_REFUSED
 
+    def test_dry_run_does_not_create_missing_target(
+        self, configured_data_dir, tmp_path,
+    ):
+        """A dry-run must be strictly read-only on the filesystem.
+
+        Earlier implementations called ``target_root.mkdir(...)``
+        before the dry-run early return, which created
+        ``NOVA_DATA_DIR`` on disk whenever the configured target did
+        not yet exist. The dry-run path is now deferred to *after*
+        the early return so a dry-run against a missing target
+        leaves the filesystem untouched.
+        """
+        result = de.create_data_export()
+        missing_target = tmp_path / "DoesNotExist"
+        assert not missing_target.exists()
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=missing_target,
+            dry_run=True,
+        )
+        # The plan was computed against the would-be target path.
+        assert out.outcome == de.RESTORE_OUTCOME_DRY_RUN
+        assert "nova.db" in out.restored_files
+        # Critical: the dry-run did NOT create the target directory.
+        assert not missing_target.exists()
+
 
 class TestApplyRestoreConfirmation:
     """The real restore refuses without explicit confirmation."""
@@ -1083,6 +1109,64 @@ class TestApplyRestoreSafety:
         assert out2.backup_path != out1.backup_path
         assert Path(out1.backup_path).is_file()
         assert Path(out2.backup_path).is_file()
+
+    def test_partial_copy_failure_rolls_back_earlier_files(
+        self, configured_data_dir, tmp_path, monkeypatch,
+    ):
+        """A mid-run copy failure must roll back every earlier replacement.
+
+        Without rollback, the per-file ``os.replace`` loop would
+        leave the target in a mixed state (files 1..N-1 from the
+        archive, file N original, files N+1.. original). The
+        rollback path moves the stashed originals back into place
+        so the target stays bit-for-bit identical to its pre-restore
+        state when any file fails to copy.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        # Seed the target with two distinct canonical files so we
+        # can verify both survive a partial-failure rollback.
+        marker_db = b"-- original nova.db --"
+        marker_pack = b'{"old": "pack"}'
+        (target / "nova.db").write_bytes(marker_db)
+        (target / "memory-packs").mkdir()
+        (target / "memory-packs" / "trip-2026.json").write_bytes(marker_pack)
+
+        # Fail the third os.replace call. The first two are:
+        #   1. stash existing nova.db → .replaced-originals/nova.db
+        #   2. move staged nova.db → nova.db (commits file 1)
+        # The third is then either stash for file 2 or its copy. By
+        # the time it fires at least one file has been "committed"
+        # so rollback has work to do.
+        original_replace = os.replace
+        call_count = {"n": 0}
+
+        def flaky_replace(src, dst):
+            call_count["n"] += 1
+            if call_count["n"] == 3:
+                raise OSError("synthetic mid-run failure")
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(de.os, "replace", flaky_replace)
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        monkeypatch.setattr(de.os, "replace", original_replace)
+        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        # Both target files are bit-for-bit identical to the original.
+        assert (target / "nova.db").read_bytes() == marker_db
+        assert (
+            (target / "memory-packs" / "trip-2026.json").read_bytes()
+            == marker_pack
+        )
+        # The failure path reports no restored files (rollback).
+        assert out.restored_files == ()
+        assert out.conflicts == ()
+        # Staging cleaned up.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
 
 
 class TestApplyRestoreExcludedContent:

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1152,6 +1152,103 @@ class TestApplyRestoreSafety:
         )
         assert out.outcome == de.RESTORE_OUTCOME_REFUSED
 
+    def test_refuses_path_type_collision_file_then_subfile(
+        self, tmp_path,
+    ):
+        """An archive with both ``data/backups/a`` (file) and
+        ``data/backups/a/b.txt`` (file) is structurally unrestorable
+        — ``mkdir`` cannot create ``backups/a/`` when ``backups/a``
+        is already a file. The preflight refuses upfront so the
+        operator gets a single clear refusal instead of a
+        ``FAILED`` outcome mid-extraction.
+        """
+        # Ordering matters for the test of the "ancestor was added
+        # as a file" branch: file ``backups/a`` is added first,
+        # then ``backups/a/b.txt`` tries to walk ``backups/a`` as
+        # an ancestor and finds it in ``file_paths_seen``.
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                "backups/a": b"file-at-collision",
+                "backups/a/b.txt": b"inner content",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "collision" in out.refuse_reason.lower()
+        # Target untouched — no backup, no staging.
+        assert list(target.iterdir()) == []
+        assert out.backup_path == ""
+
+    def test_refuses_path_type_collision_subfile_then_file(
+        self, tmp_path,
+    ):
+        """The opposite ordering (``backups/a/b.txt`` first, then
+        ``backups/a`` as a file) must also be refused: when the
+        later file is processed, its name already lives in
+        ``dir_paths_seen`` from the earlier file's ancestor walk.
+        """
+        archive = tmp_path / "collide-reverse.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "created_at": "20260514T120000Z",
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(archive, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            # Reverse order: deeper entry first.
+            for path, payload in (
+                ("data/nova.db", b"-- db --"),
+                ("data/backups/a/b.txt", b"inner content"),
+                ("data/backups/a", b"file-at-collision"),
+            ):
+                ti = tarfile.TarInfo(name=path)
+                ti.size = len(payload)
+                ti.mtime = 0
+                tar.addfile(ti, io.BytesIO(payload))
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "collision" in out.refuse_reason.lower()
+        assert list(target.iterdir()) == []
+        assert out.backup_path == ""
+
+    def test_dry_run_refuses_path_type_collision(self, tmp_path):
+        """The dry-run preview must refuse path-type collisions too
+        so inspect / dry-run / real restore stay consistent.
+        """
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                "backups/a": b"file-at-collision",
+                "backups/a/b.txt": b"inner",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, dry_run=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "collision" in out.refuse_reason.lower()
+        # Dry-run never writes anything.
+        assert list(target.iterdir()) == []
+
     def test_failed_restore_leaves_existing_data_intact(
         self, configured_data_dir, tmp_path, monkeypatch,
     ):

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -829,6 +829,59 @@ class TestApplyRestoreConfirmation:
         )
         assert out.outcome == de.RESTORE_OUTCOME_RESTORED
 
+    def test_pin_refuses_archive_with_missing_manifest_id(self, tmp_path):
+        """A pin must refuse even when the archive has no created_at.
+
+        Otherwise a hostile archive could omit ``created_at`` from
+        its manifest and bypass the pin check entirely (the previous
+        implementation only rejected when both strings were
+        non-empty). The pin is a deliberate "I inspected exactly
+        this archive" assertion — a missing archive id is not the
+        same identity as the operator's pin.
+        """
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {"nova.db": b"-- fake db --"},
+            manifest_overrides={"created_at": ""},
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive,
+            target_data_dir=target,
+            confirm=True,
+            confirmed_manifest_id="20260514T120000Z",
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "manifest" in out.refuse_reason.lower()
+        # Target untouched.
+        assert list(target.iterdir()) == []
+
+    def test_empty_pin_is_treated_as_no_pin(self, tmp_path):
+        """An empty ``confirmed_manifest_id`` is "no pin requested"."""
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {"nova.db": b"-- fake db --"},
+            manifest_overrides={"created_at": ""},
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        # Empty string and None both mean "no pin". Verify both.
+        for pin in ("", None):
+            (target / "nova.db").unlink(missing_ok=True)
+            # Clear backups so the second pass starts fresh.
+            backups = target / "backups"
+            if backups.exists():
+                import shutil
+                shutil.rmtree(backups)
+            out = de.apply_restore(
+                archive,
+                target_data_dir=target,
+                confirm=True,
+                confirmed_manifest_id=pin,
+            )
+            assert out.outcome == de.RESTORE_OUTCOME_RESTORED, (pin, out.refuse_reason)
+
 
 class TestApplyRestoreSuccess:
     """A confirmed restore copies the archive's data files into target."""

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1368,6 +1368,54 @@ class TestApplyRestoreExcludedContent:
         assert "backups/llama-7b.gguf" in skipped_paths
         assert skipped_paths["backups/llama-7b.gguf"] == de.REASON_OLLAMA_MODEL
 
+    def test_stray_excluded_files_do_not_trigger_backup_failed(
+        self, tmp_path,
+    ):
+        """A target whose reserved subdir holds only excluded entries
+        must not produce a spurious ``backup_failed`` outcome.
+
+        ``_target_has_canonical_data`` used to flag any non-empty
+        reserved subdirectory as "canonical data", but
+        ``_create_pre_restore_backup`` filters through the same
+        allowlist used by ``_walk_allowlisted``. A target like
+        ``backups/.env`` (a stray secret left behind by tooling) is
+        non-empty but contains nothing the backup builder would
+        actually pack — flagging it as needing a backup would force
+        the backup builder to produce an empty archive and the
+        restore would refuse with ``outcome=backup_failed``. The
+        detection now matches the allowlist, so this scenario
+        succeeds as a normal restore.
+        """
+        # Build an archive with a real nova.db payload.
+        archive = _make_archive_with_payload(
+            tmp_path, {"nova.db": b"-- db --"},
+        )
+        # Seed the target with ONLY excluded entries — a stray
+        # .env inside backups/ and a __pycache__ under logs/.
+        target = tmp_path / "Target"
+        target.mkdir()
+        (target / "backups").mkdir()
+        (target / "backups" / ".env").write_text("SECRET=x\n")
+        (target / "logs").mkdir()
+        (target / "logs" / "__pycache__").mkdir()
+        (target / "logs" / "__pycache__" / "stale.pyc").write_bytes(b"\x00")
+
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        # Restore succeeds because the target has nothing canonical
+        # to back up — no spurious backup_failed.
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED, (
+            out.outcome, out.refuse_reason
+        )
+        assert out.backup_path == ""
+        # The new database lands at the target.
+        assert (target / "nova.db").is_file()
+        # The stray excluded files are still where they were —
+        # restore never touches them.
+        assert (target / "backups" / ".env").is_file()
+        assert (target / "logs" / "__pycache__" / "stale.pyc").is_file()
+
     def test_dry_run_surfaces_allowlist_skips(self, tmp_path):
         """The dry-run preview lists disallowed entries up front."""
         archive = _make_archive_with_payload(

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1136,6 +1136,45 @@ class TestApplyRestoreSafety:
         # No staging directory left behind.
         assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
 
+    def test_backup_read_failure_aborts_restore(
+        self, configured_data_dir, tmp_path, monkeypatch,
+    ):
+        """An unreadable canonical file in the target must abort the
+        restore, not be silently skipped.
+
+        Treating a read failure as "exclude this file from the
+        backup and continue" would let ``apply_restore`` proceed to
+        replace a file the operator has no recoverable copy of.
+        The backup builder now returns failure on the first OSError
+        from ``stat()`` / ``_sha256_file`` so ``apply_restore``
+        surfaces ``outcome=backup_failed`` and leaves the target
+        intact.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        marker = b"-- precious --"
+        (target / "nova.db").write_bytes(marker)
+
+        def boom(path):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(de, "_sha256_file", boom)
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_BACKUP_FAILED
+        # Existing data untouched even though the backup failed.
+        assert (target / "nova.db").read_bytes() == marker
+        # The warning identifies the unreadable file.
+        assert any(
+            "nova.db" in w for w in out.warnings
+        ), out.warnings
+        # No staging directory left behind.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
     def test_backup_never_overwrites_existing_file(
         self, configured_data_dir, tmp_path,
     ):

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1293,6 +1293,65 @@ class TestApplyRestoreSafety:
         assert stash.is_dir()
         assert (stash / "nova.db").read_bytes() == b"in-flight-stash-payload"
 
+    def test_directory_only_archive_dry_run_and_restore_agree(
+        self, tmp_path,
+    ):
+        """An archive with only directory members must produce the
+        same outcome from dry-run and real restore.
+
+        ``inspect_export`` used to add directory members to
+        ``InspectionResult.files``; the preview loop then treated
+        them as restorable, so ``apply_restore(dry_run=True)``
+        reported ``outcome=dry_run`` while the real restore later
+        refused with ``"Archive contained no extractable Nova data
+        files."``. The fix excludes directory members from
+        ``file_names`` so both paths agree.
+        """
+        # Build an archive with manifest + a single directory entry.
+        archive = tmp_path / "dirs-only.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "created_at": "20260514T120000Z",
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(archive, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            di = tarfile.TarInfo(name="data/backups/foo")
+            di.type = tarfile.DIRTYPE
+            di.mtime = 0
+            tar.addfile(di)
+
+        target = tmp_path / "Target"
+        target.mkdir()
+
+        dry = de.apply_restore(
+            archive, target_data_dir=target, dry_run=True,
+        )
+        real = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        # Both flows must converge to the same answer.
+        assert dry.outcome == real.outcome, (
+            f"dry-run reported {dry.outcome!r} but real restore "
+            f"reported {real.outcome!r}; inspect → dry-run → "
+            "confirm contract broken."
+        )
+        # Specifically, both should refuse — there's nothing to
+        # restore. Real restore says "no extractable files"; the
+        # dry-run should not be misleadingly "would proceed".
+        assert real.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert dry.outcome == de.RESTORE_OUTCOME_REFUSED
+        # No staging or backup state was produced.
+        assert dry.backup_path == ""
+        assert real.backup_path == ""
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
     def test_failed_restore_leaves_existing_data_intact(
         self, configured_data_dir, tmp_path, monkeypatch,
     ):

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -817,6 +817,44 @@ class TestApplyRestoreDryRun:
         # Critical: the dry-run did NOT create the target directory.
         assert not missing_target.exists()
 
+    def test_dry_run_refuses_when_target_has_symlink_destination(
+        self, configured_data_dir, tmp_path,
+    ):
+        """The dry-run must mirror the real-restore type-gate.
+
+        If ``NOVA_DATA_DIR/nova.db`` is a symlink, the real restore
+        will refuse in ``_copy_into_target``. The dry-run preflight
+        therefore needs to refuse too — otherwise ``inspect →
+        dry-run → confirm`` would report ``outcome=dry_run`` and
+        the real restore would deterministically fail at execution
+        time, breaking the contract.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        real = target / "actual.txt"
+        real.write_text("real", encoding="utf-8")
+        link = target / "nova.db"
+        try:
+            link.symlink_to(real)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this host")
+
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            dry_run=True,
+        )
+        # Dry-run reports REFUSED — and never wrote a thing.
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "symlink" in out.refuse_reason.lower()
+        assert out.backup_path == ""
+        # No staging or partial state.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+        # Link + target both intact.
+        assert link.is_symlink()
+        assert real.read_text(encoding="utf-8") == "real"
+
 
 class TestApplyRestoreConfirmation:
     """The real restore refuses without explicit confirmation."""
@@ -1238,6 +1276,102 @@ class TestApplyRestoreSafety:
         assert Path(out1.backup_path).is_file()
         assert Path(out2.backup_path).is_file()
 
+    def test_pre_restore_backup_excludes_earlier_pre_restore_archives(
+        self, configured_data_dir, tmp_path,
+    ):
+        """A new pre-restore backup must not contain earlier ones.
+
+        Without filtering, every restore would walk the entire
+        ``backups/`` tree — including the previous restore's
+        pre-restore archive — and pack it into the new backup.
+        Repeated restores would therefore stack "backups of
+        backups" and grow on each run, eventually triggering
+        spurious ``backup_failed`` outcomes from disk pressure.
+        The filter in ``_create_pre_restore_backup`` excludes the
+        ``backups/pre-restore/`` subtree from its own walk so each
+        backup stays roughly the size of the live data dir.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        (target / "nova.db").write_bytes(b"first")
+
+        out1 = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out1.outcome == de.RESTORE_OUTCOME_RESTORED
+        backup1 = Path(out1.backup_path)
+        assert backup1.is_file()
+        size1 = backup1.stat().st_size
+
+        # Run a second restore so the backup builder has a real
+        # ``backups/pre-restore/`` subtree to walk past.
+        (target / "nova.db").write_bytes(b"second")
+        out2 = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out2.outcome == de.RESTORE_OUTCOME_RESTORED
+        backup2 = Path(out2.backup_path)
+        assert backup2.is_file()
+
+        # The second backup must not contain any pre-restore entry
+        # — otherwise we'd be packing backup1 inside backup2.
+        with tarfile.open(backup2, mode="r:*") as tar:
+            names = set(tar.getnames())
+        nested = [
+            n for n in names
+            if "pre-restore" in n or "nova-pre-restore" in n
+        ]
+        assert nested == [], (
+            "pre-restore archives leaked into the new backup: "
+            f"{nested}"
+        )
+        # And the second backup is the same order of magnitude as
+        # the first (not exponentially larger).
+        size2 = backup2.stat().st_size
+        assert size2 < size1 * 5
+
+    def test_target_with_only_pre_restore_backups_skips_backup_step(
+        self, configured_data_dir, tmp_path,
+    ):
+        """A target whose only canonical content is previous
+        pre-restore archives must not retrigger a backup attempt.
+
+        Without aligning ``_target_has_canonical_data`` with the
+        new backup filter, a target that's just been wiped except
+        for ``backups/pre-restore/`` would still be flagged as
+        "has canonical data", causing the next restore to try
+        backing up an effectively-empty set and either looping
+        the backups-of-backups problem or refusing the restore
+        spuriously.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        # Seed an "old" pre-restore backup as the only content.
+        pre_dir = target / "backups" / de.PRE_RESTORE_BACKUP_SUBDIR
+        pre_dir.mkdir(parents=True)
+        (pre_dir / "old-pre-restore.tar.gz").write_bytes(b"opaque blob")
+        # No nova.db, no other canonical files.
+        assert not (target / "nova.db").exists()
+
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        # Restore proceeds, no backup step (nothing canonical to
+        # back up), nova.db lands as expected.
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert out.backup_path == ""
+        assert (target / "nova.db").is_file()
+        # The old pre-restore archive is left alone.
+        assert (pre_dir / "old-pre-restore.tar.gz").is_file()
+
     def test_partial_copy_failure_rolls_back_earlier_files(
         self, configured_data_dir, tmp_path, monkeypatch,
     ):
@@ -1412,8 +1546,11 @@ class TestApplyRestoreSafety:
         the rollback path cannot put a directory back over a regular
         file (``os.replace(dir, file)`` raises) and the staging
         cleanup would then permanently delete the stashed
-        directory. Refusing before the first move keeps operator
-        data intact.
+        directory. The preview-loop preflight catches this before
+        any backup or staging work happens — the outcome is
+        ``REFUSED`` (we never started), not ``FAILED`` (we tried
+        and stopped mid-way), and the target is byte-for-byte
+        untouched.
         """
         result = de.create_data_export()
         target = tmp_path / "Target"
@@ -1429,13 +1566,14 @@ class TestApplyRestoreSafety:
             target_data_dir=target,
             confirm=True,
         )
-        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
         assert "regular file" in out.refuse_reason.lower()
         # The weird directory and its contents are untouched.
         assert weird_dir.is_dir()
         assert weird_payload.read_text(encoding="utf-8") == "operator data"
-        # Staging cleaned up — no leftover state.
+        # No staging directory or backup work happened.
         assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+        assert out.backup_path == ""
 
     def test_refuses_to_replace_symlink_at_target(
         self, configured_data_dir, tmp_path,
@@ -1444,13 +1582,14 @@ class TestApplyRestoreSafety:
 
         ``os.replace`` on top of a symlink replaces the symlink
         itself, not the file it points at — which would silently
-        relink whatever lives at the link target. The restore
-        engine therefore refuses to touch any symlink and unwinds
-        whatever it had committed so far.
+        relink whatever lives at the link target. The preview-loop
+        preflight refuses upfront so the outcome is ``REFUSED``
+        (no backup, no staging, no copy) rather than ``FAILED``.
 
         The symlink resolves *inside* the target so the earlier
-        containment check in ``apply_restore`` passes — this is the
-        test that pins ``_copy_into_target``'s own type-gate.
+        containment check in ``apply_restore`` passes — this test
+        pins the preview-loop type-gate that mirrors
+        ``_copy_into_target``'s own check.
         """
         result = de.create_data_export()
         target = tmp_path / "Target"
@@ -1468,8 +1607,10 @@ class TestApplyRestoreSafety:
             target_data_dir=target,
             confirm=True,
         )
-        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
         assert "symlink" in out.refuse_reason.lower()
+        # No backup work — preview loop refused before that step.
+        assert out.backup_path == ""
         # Link and its target are both intact.
         assert link.is_symlink()
         assert real.read_text(encoding="utf-8") == "inside content"

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -655,3 +655,532 @@ class TestCli:
         assert rc == 1
         err = capsys.readouterr().err
         assert "error" in err.lower()
+
+
+# ── apply_restore (Phase 3, real restore) ──────────────────────────
+
+
+def _make_archive_with_payload(
+    tmp_path: Path,
+    files: dict[str, bytes],
+    *,
+    manifest_overrides: dict | None = None,
+) -> Path:
+    """Build a synthetic Nova export archive at ``tmp_path/test.tar.gz``.
+
+    ``files`` maps POSIX-relative paths (under ``data/``) to bytes. The
+    helper writes a well-formed manifest so the resulting archive
+    inspects clean; tests that probe rejection paths build their own
+    archive directly via ``tarfile``.
+    """
+    archive = tmp_path / "test.tar.gz"
+    file_entries = []
+    for rel, body in files.items():
+        file_entries.append({
+            "path": rel,
+            "size": len(body),
+            "sha256": hashlib.sha256(body).hexdigest(),
+        })
+    manifest = {
+        "format": de.FORMAT_ID,
+        "format_version": de.FORMAT_VERSION,
+        "mode": de.MODE_DATA_ONLY,
+        "created_at": "20260514T120000Z",
+        "nova_version": "0.0.0",
+        "source_data_dir": "/source",
+        "files": file_entries,
+        "excluded": [],
+        "warnings": [],
+    }
+    if manifest_overrides:
+        manifest.update(manifest_overrides)
+    with tarfile.open(archive, mode="w:gz") as tar:
+        body = json.dumps(manifest, sort_keys=True).encode("utf-8")
+        info = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+        info.size = len(body)
+        info.mtime = 0
+        tar.addfile(info, io.BytesIO(body))
+        for rel, payload in files.items():
+            info = tarfile.TarInfo(name=f"data/{rel}")
+            info.size = len(payload)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(payload))
+    return archive
+
+
+class TestApplyRestoreDryRun:
+    """Dry-run mode never writes and surfaces what would happen."""
+
+    def test_dry_run_does_not_write(self, configured_data_dir, tmp_path):
+        result = de.create_data_export()
+        target = tmp_path / "FreshTarget"
+        target.mkdir()
+        before = sorted(target.rglob("*"))
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            dry_run=True,
+        )
+        after = sorted(target.rglob("*"))
+        assert before == after
+        assert out.outcome == de.RESTORE_OUTCOME_DRY_RUN
+        assert "nova.db" in out.restored_files
+        assert out.backup_path == ""
+
+    def test_dry_run_flags_existing_nova_db(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "TargetData"
+        target.mkdir()
+        (target / "nova.db").write_bytes(b"existing")
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            dry_run=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_DRY_RUN
+        assert out.restart_recommended is True
+        assert "nova.db" in out.conflicts
+        # Target file untouched.
+        assert (target / "nova.db").read_bytes() == b"existing"
+
+    def test_dry_run_refuses_invalid_archive(self, tmp_path):
+        bogus = tmp_path / "broken.tar.gz"
+        bogus.write_text("not a tar", encoding="utf-8")
+        target = tmp_path / "T"
+        target.mkdir()
+        out = de.apply_restore(
+            bogus, target_data_dir=target, dry_run=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+
+
+class TestApplyRestoreConfirmation:
+    """The real restore refuses without explicit confirmation."""
+
+    def test_refuses_without_confirm(self, configured_data_dir, tmp_path):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=False,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "confirmation" in out.refuse_reason.lower()
+        # Target untouched.
+        assert list(target.iterdir()) == []
+
+    def test_refuses_unknown_manifest_id(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+            confirmed_manifest_id="not-the-right-id",
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "manifest" in out.refuse_reason.lower()
+
+    def test_accepts_matching_manifest_id(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        manifest_id = result.manifest["created_at"]
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+            confirmed_manifest_id=manifest_id,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+
+
+class TestApplyRestoreSuccess:
+    """A confirmed restore copies the archive's data files into target."""
+
+    def test_restores_nova_db_into_empty_target(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "FreshTarget"
+        target.mkdir()
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert (target / "nova.db").is_file()
+        # Content matches what the source nova.db had.
+        assert (target / "nova.db").read_bytes() == (
+            configured_data_dir / "nova.db"
+        ).read_bytes()
+        # restart hint surfaces because nova.db was in the archive.
+        assert out.restart_recommended is True
+
+    def test_replaces_existing_nova_db_after_backup(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "TargetData"
+        target.mkdir()
+        old_db = b"-- old database --"
+        (target / "nova.db").write_bytes(old_db)
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert out.backup_path != ""
+        backup = Path(out.backup_path)
+        assert backup.is_file()
+        # Backup contains the previous nova.db.
+        with tarfile.open(backup, mode="r:*") as tar:
+            names = set(tar.getnames())
+        assert "data/nova.db" in names
+        # The new database lives at target.
+        assert (target / "nova.db").read_bytes() != old_db
+        # The conflict is recorded.
+        assert "nova.db" in out.conflicts
+
+    def test_staging_directory_cleaned_after_success(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        staging = target / de.RESTORE_STAGING_DIRNAME
+        assert not staging.exists()
+
+    def test_restore_writes_backup_under_pre_restore_subdir(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        (target / "nova.db").write_bytes(b"orig")
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        backup_dir = (
+            target / "backups" / de.PRE_RESTORE_BACKUP_SUBDIR
+        )
+        assert backup_dir.is_dir()
+        archives = list(backup_dir.glob("nova-pre-restore-*.tar.gz"))
+        assert len(archives) >= 1
+
+
+class TestApplyRestoreSafety:
+    """Hostile archives are refused — current data is never corrupted."""
+
+    def test_refuses_path_traversal_archive(self, tmp_path):
+        bad = tmp_path / "evil.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            payload = b"hostile"
+            ei = tarfile.TarInfo(name="data/../escape.txt")
+            ei.size = len(payload)
+            ei.mtime = 0
+            tar.addfile(ei, io.BytesIO(payload))
+        target = tmp_path / "Target"
+        target.mkdir()
+        original = target / "nova.db"
+        original.write_bytes(b"keep me")
+        out = de.apply_restore(
+            bad, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        # Existing data untouched.
+        assert original.read_bytes() == b"keep me"
+        # The bad escape file did not land outside the target.
+        assert not (target.parent / "escape.txt").exists()
+
+    def test_refuses_absolute_archive_entry(self, tmp_path):
+        bad = tmp_path / "abs.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            payload = b"x"
+            ei = tarfile.TarInfo(name="/etc/passwd")
+            ei.size = len(payload)
+            ei.mtime = 0
+            tar.addfile(ei, io.BytesIO(payload))
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            bad, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+
+    def test_refuses_symlink_archive_member(self, tmp_path):
+        bad = tmp_path / "link.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            # Insert a symlink-type entry pointing outside the target.
+            li = tarfile.TarInfo(name="data/escape")
+            li.type = tarfile.SYMTYPE
+            li.linkname = "/etc/passwd"
+            li.mtime = 0
+            tar.addfile(li)
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            bad, target_data_dir=target, confirm=True,
+        )
+        # inspect_export refuses the symlink up-front.
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+
+    def test_refuses_unsupported_manifest_version(self, tmp_path):
+        bad = tmp_path / "futureproof.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": 999,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            bad, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+
+    def test_failed_restore_leaves_existing_data_intact(
+        self, configured_data_dir, tmp_path, monkeypatch,
+    ):
+        """If the copy phase fails halfway, the target keeps its files."""
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        marker = b"-- precious original --"
+        (target / "nova.db").write_bytes(marker)
+
+        # Force the copy step to fail. ``_copy_into_target`` is the
+        # only place where the staged files migrate into the target;
+        # patching it returns a controlled failure without disturbing
+        # the backup-write path (which uses the same OS primitives).
+        def fake_copy(staging, target_root, files):
+            return [], [], "synthetic failure during restore copy"
+
+        monkeypatch.setattr(de, "_copy_into_target", fake_copy)
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        # Restore was aborted.
+        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        # Original database survived intact (it was also captured
+        # inside the pre-restore backup before any copy attempt).
+        assert (target / "nova.db").read_bytes() == marker
+        # Backup was created before the failure.
+        assert out.backup_path != ""
+        # Staging directory cleaned.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
+    def test_backup_failure_aborts_restore(
+        self, configured_data_dir, tmp_path, monkeypatch,
+    ):
+        """When the backup step fails the restore must abort cleanly."""
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        marker = b"-- keep me --"
+        (target / "nova.db").write_bytes(marker)
+
+        def fake_backup(target_root):
+            return None, 0, ["Synthetic failure during backup"]
+
+        monkeypatch.setattr(de, "_create_pre_restore_backup", fake_backup)
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_BACKUP_FAILED
+        # Existing data untouched.
+        assert (target / "nova.db").read_bytes() == marker
+        # No staging directory left behind.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
+    def test_backup_never_overwrites_existing_file(
+        self, configured_data_dir, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        (target / "nova.db").write_bytes(b"v1")
+        out1 = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out1.outcome == de.RESTORE_OUTCOME_RESTORED
+        # Now run the restore again — the previous backup file should
+        # still exist and a *new* backup file should be created with a
+        # distinct name.
+        (target / "nova.db").write_bytes(b"v2")
+        out2 = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out2.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert out2.backup_path != out1.backup_path
+        assert Path(out1.backup_path).is_file()
+        assert Path(out2.backup_path).is_file()
+
+
+class TestApplyRestoreExcludedContent:
+    """Hostile-extra entries in the archive are skipped, not extracted."""
+
+    def test_secret_files_in_archive_are_skipped(self, tmp_path):
+        archive = tmp_path / "evil.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(archive, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            # A regular nova.db entry — should be restored.
+            payload = b"db"
+            di = tarfile.TarInfo(name="data/nova.db")
+            di.size = len(payload)
+            di.mtime = 0
+            tar.addfile(di, io.BytesIO(payload))
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert (target / "nova.db").is_file()
+        # No surprise files at the target root.
+        files = sorted(
+            p.name for p in target.iterdir() if p.is_file()
+        )
+        assert files == ["nova.db"]
+
+
+# ── CLI: restore subcommand ─────────────────────────────────────────
+
+
+class TestRestoreCli:
+    """The ``restore`` subcommand exposes apply_restore via the CLI."""
+
+    def test_restore_requires_confirm_flag(
+        self, configured_data_dir, capsys, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        rc = de._cli([
+            "restore", result.archive_path,
+            "--data-dir", str(target),
+        ])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "confirm" in err.lower()
+        # Nothing was written.
+        assert list(target.iterdir()) == []
+
+    def test_restore_with_confirm_writes_data(
+        self, configured_data_dir, capsys, tmp_path,
+    ):
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        rc = de._cli([
+            "restore", result.archive_path,
+            "--data-dir", str(target),
+            "--confirm",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "restored" in out.lower()
+        assert (target / "nova.db").is_file()
+
+    def test_restore_refusal_exits_nonzero(
+        self, configured_data_dir, capsys, tmp_path,
+    ):
+        # Pin a manifest id that does not match → refusal.
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        rc = de._cli([
+            "restore", result.archive_path,
+            "--data-dir", str(target),
+            "--confirm",
+            "--confirmed-manifest-id", "not-the-right-id",
+        ])
+        assert rc == 1
+        # Target was not touched.
+        assert list(target.iterdir()) == []
+
+    def test_unknown_command_still_prints_restore_in_usage(
+        self, capsys,
+    ):
+        rc = de._cli([])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "restore" in err

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1249,6 +1249,50 @@ class TestApplyRestoreSafety:
         # Dry-run never writes anything.
         assert list(target.iterdir()) == []
 
+    def test_refuses_when_staging_directory_already_exists(
+        self, configured_data_dir, tmp_path,
+    ):
+        """Two restores against the same target must not interfere.
+
+        The previous implementation unconditionally cleaned up the
+        staging directory at startup. A second restore launched
+        while the first was still running would therefore delete
+        the first restore's rollback stash, breaking the "failed
+        restore leaves data intact" guarantee for the original
+        caller. The fix uses ``mkdir(exist_ok=False)`` atomically
+        and refuses when the staging directory is already present,
+        whether from a concurrent restore or from a previous run
+        that crashed before cleanup.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        marker = b"original-db"
+        (target / "nova.db").write_bytes(marker)
+        # Simulate a concurrent (or crashed) restore's staging:
+        # the directory exists with in-flight state inside.
+        staging = target / de.RESTORE_STAGING_DIRNAME
+        staging.mkdir()
+        stash = staging / ".replaced-originals"
+        stash.mkdir()
+        (stash / "nova.db").write_bytes(b"in-flight-stash-payload")
+
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_REFUSED
+        assert "staging" in out.refuse_reason.lower()
+        # Existing target file untouched.
+        assert (target / "nova.db").read_bytes() == marker
+        # The "in-flight" staging area was not clobbered — the
+        # stash file inside it is still intact, so the other
+        # (hypothetical) restore can still roll back if it needs
+        # to.
+        assert stash.is_dir()
+        assert (stash / "nova.db").read_bytes() == b"in-flight-stash-payload"
+
     def test_failed_restore_leaves_existing_data_intact(
         self, configured_data_dir, tmp_path, monkeypatch,
     ):

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -417,6 +417,42 @@ class TestInspectExportRejections:
         assert inspection.valid is False
         assert any("format" in e.lower() for e in inspection.errors)
 
+    def test_archive_with_symlink_member_is_invalid(self, tmp_path):
+        """A symlink entry of any kind invalidates the archive.
+
+        Nova builds tarballs with ``dereference=True`` so a
+        Nova-built archive never contains a symlink. An archive
+        with a symlink is therefore anomalous; refusing it at
+        inspection keeps the dry-run plan honest (the real restore
+        would also drop the symlink) and gives the operator a
+        clear "this is not a Nova archive" signal.
+        """
+        bad = tmp_path / "symlinks.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            # A "safe" symlink (relative, no ..). Previously this
+            # passed inspect but was silently dropped by extract.
+            li = tarfile.TarInfo(name="data/alias.json")
+            li.type = tarfile.SYMTYPE
+            li.linkname = "real.json"
+            li.mtime = 0
+            tar.addfile(li)
+        inspection = de.inspect_export(bad)
+        assert inspection.valid is False
+        assert any(
+            "symlink" in e.lower() for e in inspection.errors
+        )
+
 
 # ── plan_restore ───────────────────────────────────────────────────
 
@@ -1258,6 +1294,112 @@ class TestApplyRestoreSafety:
         assert out.restored_files == ()
         assert out.conflicts == ()
         # Staging cleaned up.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
+    def test_failed_restore_removes_newly_created_parent_dirs(
+        self, tmp_path, monkeypatch,
+    ):
+        """A failed restore must clean up parent directories it created.
+
+        The previous rollback unwound the file moves but left
+        empty parent directories behind (the ones materialised by
+        ``dst.parent.mkdir(parents=True)``), so a failed restore
+        still mutated the target tree. The fix tracks newly-
+        created parents per commit and rmdirs them in
+        deepest-first order — only empty directories are removed,
+        so a parent that picked up another committed file in the
+        same restore is left alone.
+        """
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "memory-packs/trip-2026.json": b'{"ok": true}',
+                "logs/import.log": b"loaded\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        # No pre-existing memory-packs or logs dir — those will
+        # be created by the restore.
+
+        original_replace = os.replace
+        call_count = {"n": 0}
+
+        def flaky_replace(src, dst):
+            call_count["n"] += 1
+            # Let the first file commit (one os.replace call for a
+            # fresh, non-existing destination). Fail on the second
+            # file's commit attempt.
+            if call_count["n"] == 2:
+                raise OSError("synthetic mid-run failure")
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(de.os, "replace", flaky_replace)
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        monkeypatch.setattr(de.os, "replace", original_replace)
+        assert out.outcome == de.RESTORE_OUTCOME_FAILED, (
+            out.outcome, out.refuse_reason
+        )
+        # Both the first file *and* its newly-created parent dir
+        # are gone — the target is bit-for-bit back to its
+        # pre-restore state.
+        assert not (target / "memory-packs").exists()
+        assert not (target / "logs").exists()
+        # No staging directory left behind.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+        # And the target itself contains nothing.
+        assert list(target.iterdir()) == []
+
+    def test_failed_restore_preserves_pre_existing_parent_dirs(
+        self, tmp_path, monkeypatch,
+    ):
+        """Rollback must not delete parent dirs the target already had.
+
+        If ``memory-packs/`` existed before the restore (with
+        unrelated content), a rollback must leave that directory
+        and its contents in place — only directories created **by
+        this restore call** should be removed.
+        """
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "memory-packs/trip-2026.json": b'{"ok": true}',
+                "logs/import.log": b"loaded\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        # Pre-existing memory-packs/ with an unrelated (allow-listed)
+        # file inside.
+        (target / "memory-packs").mkdir()
+        (target / "memory-packs" / "earlier.json").write_text(
+            '{"keep": true}', encoding="utf-8"
+        )
+
+        original_replace = os.replace
+        call_count = {"n": 0}
+
+        def flaky_replace(src, dst):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise OSError("synthetic mid-run failure")
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(de.os, "replace", flaky_replace)
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        monkeypatch.setattr(de.os, "replace", original_replace)
+        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        # The pre-existing directory and its content survived.
+        assert (target / "memory-packs").is_dir()
+        assert (
+            (target / "memory-packs" / "earlier.json").read_text(encoding="utf-8")
+            == '{"keep": true}'
+        )
+        # No staging directory left behind.
         assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
 
     def test_refuses_to_replace_directory_at_target(

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -453,6 +453,111 @@ class TestInspectExportRejections:
             "symlink" in e.lower() for e in inspection.errors
         )
 
+    def test_archive_with_same_path_as_file_and_dir_is_invalid(
+        self, tmp_path,
+    ):
+        """An archive that lists the same path as both a file and
+        a directory is unrestorable: extraction creates the
+        directory first, then ``open(file_dst, "wb")`` raises
+        ``IsADirectoryError``. The previous dry-run would have
+        said ``outcome=dry_run`` because it iterated only files;
+        the real restore deterministically failed at extraction.
+        Inspect now refuses such archives so dry-run and real
+        restore agree.
+
+        Both orderings (dir-first / file-first) are detected by
+        the two-set tracker.
+        """
+        for order, members in (
+            ("dir-first", [
+                ("data/backups/a/", tarfile.DIRTYPE, b""),
+                ("data/backups/a", tarfile.REGTYPE, b"file payload"),
+            ]),
+            ("file-first", [
+                ("data/backups/a", tarfile.REGTYPE, b"file payload"),
+                ("data/backups/a/", tarfile.DIRTYPE, b""),
+            ]),
+        ):
+            bad = tmp_path / f"collide-{order}.tar.gz"
+            manifest = json.dumps({
+                "format": de.FORMAT_ID,
+                "format_version": de.FORMAT_VERSION,
+                "mode": de.MODE_DATA_ONLY,
+                "files": [],
+                "excluded": [],
+            }).encode()
+            with tarfile.open(bad, mode="w:gz") as tar:
+                mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+                mi.size = len(manifest)
+                mi.mtime = 0
+                tar.addfile(mi, io.BytesIO(manifest))
+                for name, mtype, payload in members:
+                    ti = tarfile.TarInfo(name=name)
+                    ti.type = mtype
+                    ti.size = len(payload)
+                    ti.mtime = 0
+                    if payload:
+                        tar.addfile(ti, io.BytesIO(payload))
+                    else:
+                        tar.addfile(ti)
+            inspection = de.inspect_export(bad)
+            assert inspection.valid is False, (
+                f"{order}: expected invalid, got {inspection.errors!r}"
+            )
+            assert any(
+                "both" in e.lower() and (
+                    "file" in e.lower() and "directory" in e.lower()
+                )
+                for e in inspection.errors
+            ), (order, inspection.errors)
+
+    def test_dry_run_and_restore_agree_on_file_dir_collision(
+        self, tmp_path,
+    ):
+        """The dry-run and real-restore outcomes must match for an
+        archive that has a file/directory same-path collision.
+        Both should refuse via ``inspect_export``'s validation —
+        not "dry_run" from preview vs "extract_failed" from real.
+        """
+        bad = tmp_path / "collision.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+        }).encode()
+        with tarfile.open(bad, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            di = tarfile.TarInfo(name="data/backups/a/")
+            di.type = tarfile.DIRTYPE
+            di.mtime = 0
+            tar.addfile(di)
+            fi = tarfile.TarInfo(name="data/backups/a")
+            fi.size = 7
+            fi.mtime = 0
+            tar.addfile(fi, io.BytesIO(b"payload"))
+
+        target = tmp_path / "Target"
+        target.mkdir()
+        dry = de.apply_restore(
+            bad, target_data_dir=target, dry_run=True,
+        )
+        real = de.apply_restore(
+            bad, target_data_dir=target, confirm=True,
+        )
+        assert dry.outcome == real.outcome, (
+            f"dry-run = {dry.outcome!r}, real = {real.outcome!r}"
+        )
+        assert dry.outcome == de.RESTORE_OUTCOME_REFUSED
+        # No backup or staging side effects from either flow.
+        assert dry.backup_path == ""
+        assert real.backup_path == ""
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
 
 # ── plan_restore ───────────────────────────────────────────────────
 

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1514,6 +1514,82 @@ class TestApplyRestoreExcludedContent:
         # Dry-run must never write anything.
         assert list(target.iterdir()) == []
 
+    def test_duplicate_archive_members_are_deduped(self, tmp_path):
+        """An archive with duplicate ``data/nova.db`` entries restores
+        cleanly instead of hitting ENOENT on the second copy attempt.
+
+        Tar files can carry duplicate member names; at extraction
+        time the filesystem keeps the *last* write. The restore
+        engine deduplicates ``extracted`` (and ``would_restore``)
+        accordingly so dry-run and real-restore both report one
+        entry per POSIX-relative path and the copy phase never
+        tries to move the same staging file twice.
+        """
+        archive = tmp_path / "dup.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+            "created_at": "20260514T120000Z",
+        }).encode()
+        with tarfile.open(archive, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            # Two entries with the same archive name. Last write wins.
+            for payload in (b"-- v1 --", b"-- v2 --"):
+                di = tarfile.TarInfo(name="data/nova.db")
+                di.size = len(payload)
+                di.mtime = 0
+                tar.addfile(di, io.BytesIO(payload))
+
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED, (
+            out.outcome, out.refuse_reason
+        )
+        # Exactly one entry reported, despite the duplicate.
+        assert out.restored_files == ("nova.db",)
+        # The restored content is the last-written payload (tar
+        # semantics: last entry with a given name wins).
+        assert (target / "nova.db").read_bytes() == b"-- v2 --"
+
+    def test_dry_run_dedupes_duplicate_archive_members(self, tmp_path):
+        archive = tmp_path / "dup.tar.gz"
+        manifest = json.dumps({
+            "format": de.FORMAT_ID,
+            "format_version": de.FORMAT_VERSION,
+            "mode": de.MODE_DATA_ONLY,
+            "files": [],
+            "excluded": [],
+            "created_at": "20260514T120000Z",
+        }).encode()
+        with tarfile.open(archive, mode="w:gz") as tar:
+            mi = tarfile.TarInfo(name=de.ARCHIVE_MANIFEST_NAME)
+            mi.size = len(manifest)
+            mi.mtime = 0
+            tar.addfile(mi, io.BytesIO(manifest))
+            for payload in (b"-- a --", b"-- b --"):
+                di = tarfile.TarInfo(name="data/nova.db")
+                di.size = len(payload)
+                di.mtime = 0
+                tar.addfile(di, io.BytesIO(payload))
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, dry_run=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_DRY_RUN
+        # Dry-run preview reports one entry, matching what the real
+        # restore would produce.
+        assert out.restored_files == ("nova.db",)
+
 
 # ── CLI: restore subcommand ─────────────────────────────────────────
 

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1258,6 +1258,140 @@ class TestApplyRestoreExcludedContent:
         )
         assert files == ["nova.db"]
 
+    def test_restore_refuses_to_materialise_dot_env(self, tmp_path):
+        """A crafted archive cannot smuggle in ``data/.env``.
+
+        The export builder refuses to *pack* a ``.env`` file. The
+        restore path must mirror that allowlist — otherwise a
+        crafted archive could write secrets into ``NOVA_DATA_DIR``
+        that the exporter would never have produced.
+        """
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                ".env": b"SECRET_KEY=topsecret\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        # nova.db lands fine.
+        assert (target / "nova.db").is_file()
+        # The .env is never created.
+        assert not (target / ".env").exists()
+        # And it is surfaced as skipped with the secret reason.
+        skipped_paths = {e.path: e.reason for e in out.skipped_files}
+        assert ".env" in skipped_paths
+        assert skipped_paths[".env"] == de.REASON_SECRET
+
+    def test_restore_refuses_ssh_key_inside_archive(self, tmp_path):
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                ".ssh/id_rsa": b"PRIVATE KEY\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert not (target / ".ssh").exists()
+        assert not (target / ".ssh" / "id_rsa").exists()
+        skipped_paths = {e.path: e.reason for e in out.skipped_files}
+        assert ".ssh/id_rsa" in skipped_paths
+        assert skipped_paths[".ssh/id_rsa"] == de.REASON_SECRET
+
+    def test_restore_refuses_non_canonical_top_level_file(self, tmp_path):
+        """A bare ``data/README.txt`` is not in the allowlist."""
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                "README.txt": b"Surprise!\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert not (target / "README.txt").exists()
+        skipped_paths = {e.path: e.reason for e in out.skipped_files}
+        assert "README.txt" in skipped_paths
+        assert skipped_paths["README.txt"] == de.REASON_NOT_ALLOWLISTED
+
+    def test_restore_refuses_non_canonical_subdir(self, tmp_path):
+        """Anything outside the four reserved subdirs is refused."""
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                "notabackup/foo.txt": b"leaked\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert not (target / "notabackup").exists()
+        skipped_paths = {e.path: e.reason for e in out.skipped_files}
+        assert "notabackup/foo.txt" in skipped_paths
+        assert skipped_paths["notabackup/foo.txt"] == de.REASON_NOT_ALLOWLISTED
+
+    def test_restore_refuses_ollama_gguf_blob(self, tmp_path):
+        """Ollama model files inside ``backups/`` are refused."""
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                "backups/llama-7b.gguf": b"weights\n",
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_RESTORED
+        assert not (target / "backups" / "llama-7b.gguf").exists()
+        skipped_paths = {e.path: e.reason for e in out.skipped_files}
+        assert "backups/llama-7b.gguf" in skipped_paths
+        assert skipped_paths["backups/llama-7b.gguf"] == de.REASON_OLLAMA_MODEL
+
+    def test_dry_run_surfaces_allowlist_skips(self, tmp_path):
+        """The dry-run preview lists disallowed entries up front."""
+        archive = _make_archive_with_payload(
+            tmp_path,
+            {
+                "nova.db": b"-- db --",
+                ".env": b"SECRET=x\n",
+                "memory-packs/trip.json": b'{"ok": true}',
+            },
+        )
+        target = tmp_path / "Target"
+        target.mkdir()
+        out = de.apply_restore(
+            archive, target_data_dir=target, dry_run=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_DRY_RUN
+        assert "nova.db" in out.restored_files
+        assert "memory-packs/trip.json" in out.restored_files
+        assert ".env" not in out.restored_files
+        skipped_paths = {e.path: e.reason for e in out.skipped_files}
+        assert ".env" in skipped_paths
+        # Dry-run must never write anything.
+        assert list(target.iterdir()) == []
+
 
 # ── CLI: restore subcommand ─────────────────────────────────────────
 

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1221,6 +1221,80 @@ class TestApplyRestoreSafety:
         # Staging cleaned up.
         assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
 
+    def test_refuses_to_replace_directory_at_target(
+        self, configured_data_dir, tmp_path,
+    ):
+        """A target directory where the archive has a regular file
+        must refuse the restore upfront — never stash the directory.
+
+        ``os.replace`` happily moves a directory into the stash, but
+        the rollback path cannot put a directory back over a regular
+        file (``os.replace(dir, file)`` raises) and the staging
+        cleanup would then permanently delete the stashed
+        directory. Refusing before the first move keeps operator
+        data intact.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        # Plant a directory at the path where nova.db should land.
+        weird_dir = target / "nova.db"
+        weird_dir.mkdir()
+        weird_payload = weird_dir / "inside.txt"
+        weird_payload.write_text("operator data", encoding="utf-8")
+
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        assert "regular file" in out.refuse_reason.lower()
+        # The weird directory and its contents are untouched.
+        assert weird_dir.is_dir()
+        assert weird_payload.read_text(encoding="utf-8") == "operator data"
+        # Staging cleaned up — no leftover state.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
+    def test_refuses_to_replace_symlink_at_target(
+        self, configured_data_dir, tmp_path,
+    ):
+        """A symlink at the target path must refuse the restore.
+
+        ``os.replace`` on top of a symlink replaces the symlink
+        itself, not the file it points at — which would silently
+        relink whatever lives at the link target. The restore
+        engine therefore refuses to touch any symlink and unwinds
+        whatever it had committed so far.
+
+        The symlink resolves *inside* the target so the earlier
+        containment check in ``apply_restore`` passes — this is the
+        test that pins ``_copy_into_target``'s own type-gate.
+        """
+        result = de.create_data_export()
+        target = tmp_path / "Target"
+        target.mkdir()
+        real = target / "actual-content.txt"
+        real.write_text("inside content", encoding="utf-8")
+        link = target / "nova.db"
+        try:
+            link.symlink_to(real)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this host")
+
+        out = de.apply_restore(
+            result.archive_path,
+            target_data_dir=target,
+            confirm=True,
+        )
+        assert out.outcome == de.RESTORE_OUTCOME_FAILED
+        assert "symlink" in out.refuse_reason.lower()
+        # Link and its target are both intact.
+        assert link.is_symlink()
+        assert real.read_text(encoding="utf-8") == "inside content"
+        # Staging cleaned up.
+        assert not (target / de.RESTORE_STAGING_DIRNAME).exists()
+
 
 class TestApplyRestoreExcludedContent:
     """Hostile-extra entries in the archive are skipped, not extracted."""

--- a/tests/test_storage_endpoints.py
+++ b/tests/test_storage_endpoints.py
@@ -115,9 +115,11 @@ def configured_data_root(monkeypatch, tmp_path):
 
 class TestStorageEndpointsAuth:
     @pytest.mark.parametrize("method,path,body", [
-        ("GET",  "/admin/storage/status",          None),
-        ("POST", "/admin/storage/export",          {"confirm": True}),
-        ("POST", "/admin/storage/inspect-export",  {"name": "x.tar.gz"}),
+        ("GET",  "/admin/storage/status",            None),
+        ("POST", "/admin/storage/export",            {"confirm": True}),
+        ("POST", "/admin/storage/inspect-export",    {"name": "x.tar.gz"}),
+        ("POST", "/admin/storage/restore-dry-run",   {"name": "x.tar.gz"}),
+        ("POST", "/admin/storage/restore",           {"name": "x.tar.gz", "confirm": True}),
     ])
     def test_non_admin_forbidden(
         self, web_client, user_token, method, path, body,
@@ -129,9 +131,11 @@ class TestStorageEndpointsAuth:
         assert resp.status_code == 403
 
     @pytest.mark.parametrize("method,path,body", [
-        ("GET",  "/admin/storage/status",          None),
-        ("POST", "/admin/storage/export",          {"confirm": True}),
-        ("POST", "/admin/storage/inspect-export",  {"name": "x.tar.gz"}),
+        ("GET",  "/admin/storage/status",            None),
+        ("POST", "/admin/storage/export",            {"confirm": True}),
+        ("POST", "/admin/storage/inspect-export",    {"name": "x.tar.gz"}),
+        ("POST", "/admin/storage/restore-dry-run",   {"name": "x.tar.gz"}),
+        ("POST", "/admin/storage/restore",           {"name": "x.tar.gz", "confirm": True}),
     ])
     def test_restricted_forbidden(
         self, web_client, restricted_token, method, path, body,
@@ -145,9 +149,11 @@ class TestStorageEndpointsAuth:
         assert resp.status_code == 403
 
     @pytest.mark.parametrize("method,path,body", [
-        ("GET",  "/admin/storage/status",          None),
-        ("POST", "/admin/storage/export",          {"confirm": True}),
-        ("POST", "/admin/storage/inspect-export",  {"name": "x.tar.gz"}),
+        ("GET",  "/admin/storage/status",            None),
+        ("POST", "/admin/storage/export",            {"confirm": True}),
+        ("POST", "/admin/storage/inspect-export",    {"name": "x.tar.gz"}),
+        ("POST", "/admin/storage/restore-dry-run",   {"name": "x.tar.gz"}),
+        ("POST", "/admin/storage/restore",           {"name": "x.tar.gz", "confirm": True}),
     ])
     def test_unauthenticated_blocked(self, web_client, method, path, body):
         if method == "GET":
@@ -292,3 +298,136 @@ class TestInspectEndpoint:
         body = resp.json()
         assert body["valid"] is True
         assert body["manifest"]["format"] == "nova-data-export"
+
+
+# ── /admin/storage/restore-dry-run ─────────────────────────────────
+
+
+class TestRestoreDryRunEndpoint:
+    """The dry-run endpoint mirrors the apply_restore helper safely."""
+
+    def test_rejects_traversal_name(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/restore-dry-run",
+            headers=_h(admin_token),
+            json={"name": "../etc/passwd"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_rejects_absolute_path(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/restore-dry-run",
+            headers=_h(admin_token),
+            json={"name": "/tmp/something.tar.gz"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_missing_archive_returns_404(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/restore-dry-run",
+            headers=_h(admin_token),
+            json={"name": "missing.tar.gz"},
+        )
+        assert resp.status_code == 404
+
+    def test_dry_run_returns_plan_for_real_archive(
+        self, web_client, admin_token, configured_data_root, tmp_path,
+        monkeypatch,
+    ):
+        # Build an export, but redirect NOVA_DATA_DIR so the dry-run
+        # targets a fresh empty directory after the export was built.
+        export = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token), json={"confirm": True},
+        )
+        assert export.status_code == 200, export.text
+        archive_path = Path(export.json()["archive_path"])
+
+        # Move the archive to a new exports/ dir.
+        new_root = tmp_path / "NovaFresh"
+        new_root.mkdir()
+        (new_root / "exports").mkdir()
+        moved = new_root / "exports" / archive_path.name
+        moved.write_bytes(archive_path.read_bytes())
+        monkeypatch.setenv(core_paths.ENV_VAR, str(new_root))
+
+        resp = web_client.post(
+            "/admin/storage/restore-dry-run",
+            headers=_h(admin_token),
+            json={"name": archive_path.name},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["outcome"] == "dry_run"
+        # Dry-run never writes anything.
+        assert body["backup_path"] == ""
+
+
+# ── /admin/storage/restore ─────────────────────────────────────────
+
+
+class TestRestoreEndpoint:
+    """The real restore endpoint is admin-only and confirmation-gated."""
+
+    def test_restore_requires_confirm(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/restore",
+            headers=_h(admin_token),
+            json={"name": "anything.tar.gz", "confirm": False},
+        )
+        assert resp.status_code == 400
+
+    def test_restore_rejects_traversal_name(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/restore",
+            headers=_h(admin_token),
+            json={"name": "../etc/passwd", "confirm": True},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_restore_missing_archive_returns_404(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        resp = web_client.post(
+            "/admin/storage/restore",
+            headers=_h(admin_token),
+            json={"name": "missing.tar.gz", "confirm": True},
+        )
+        assert resp.status_code == 404
+
+    def test_restore_happy_path_creates_backup_and_replaces_db(
+        self, web_client, admin_token, configured_data_root,
+    ):
+        # Build an export from the configured data root.
+        export = web_client.post(
+            "/admin/storage/export",
+            headers=_h(admin_token), json={"confirm": True},
+        )
+        assert export.status_code == 200, export.text
+        archive_name = Path(export.json()["archive_path"]).name
+        original = (configured_data_root / "nova.db").read_bytes()
+        # Mutate the on-disk db so the restore has something to roll
+        # back to — the archive holds the *previous* content.
+        (configured_data_root / "nova.db").write_bytes(b"-- mutated --")
+
+        resp = web_client.post(
+            "/admin/storage/restore",
+            headers=_h(admin_token),
+            json={"name": archive_name, "confirm": True},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["outcome"] == "restored"
+        assert body["backup_path"] != ""
+        # The original archive content is restored.
+        assert (configured_data_root / "nova.db").read_bytes() == original

--- a/web.py
+++ b/web.py
@@ -2606,9 +2606,52 @@ def storage_inspect_endpoint(
     selects the archive by its plain filename — absolute paths are
     rejected at the validation layer.
     """
+    target = _resolve_storage_archive(req.name)
+    return _data_export.inspect_export(str(target)).as_dict()
+
+
+class StorageRestoreRequest(BaseModel):
+    """Body shape for ``/admin/storage/restore[-dry-run]``.
+
+    ``name`` selects an archive sitting under the configured exports
+    directory by its plain basename — the same convention the inspect
+    endpoint uses. ``confirm`` is required to be ``True`` for the
+    real restore endpoint; the dry-run endpoint accepts either value
+    and never writes a file. ``confirmed_manifest_id`` is an
+    optional pin: when provided, the archive's ``created_at``
+    timestamp (returned by inspect) must match or the restore is
+    refused.
+    """
+
+    name: str = Field(min_length=1, max_length=255)
+    confirm: bool = False
+    confirmed_manifest_id: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("name must not be empty")
+        if "/" in v or "\\" in v or ".." in v or v.startswith("."):
+            raise ValueError("name must be a plain filename, not a path")
+        return v
+
+
+def _resolve_storage_archive(name: str):
+    """Return the absolute path of an archive name under the exports dir.
+
+    Centralises the path-traversal guard used by inspect / restore /
+    restore-dry-run so the three endpoints stay consistent. Raises
+    ``HTTPException(400)`` for any name that resolves outside the
+    exports directory and ``HTTPException(404)`` when the file does
+    not exist.
+    """
     from core import paths as _paths_mod
     exports_root = _paths_mod.effective_data_root() / _paths_mod.EXPORTS_SUBDIR
-    target = exports_root / req.name
+    target = exports_root / name
     try:
         target_resolved = target.resolve(strict=False)
         exports_resolved = exports_root.resolve(strict=False)
@@ -2622,7 +2665,74 @@ def storage_inspect_endpoint(
         raise HTTPException(
             status_code=404, detail="Archive not found.",
         )
-    return _data_export.inspect_export(str(target)).as_dict()
+    return target
+
+
+@app.post("/admin/storage/restore-dry-run")
+def storage_restore_dry_run_endpoint(
+    req: StorageRestoreRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Dry-run a restore for an archive under the exports directory.
+
+    Reads the archive, validates every member, and returns the file
+    list the real restore would produce, along with conflicts,
+    warnings, and a flag for whether a restart is recommended. Does
+    **not** write to disk, does **not** create a backup, and does
+    **not** stage anything.
+
+    Confirmation is irrelevant for the dry-run flow (the body field
+    is accepted for symmetry with the real endpoint but ignored).
+    """
+    archive = _resolve_storage_archive(req.name)
+    result = _data_export.apply_restore(
+        str(archive),
+        target_data_dir=None,
+        confirm=False,
+        confirmed_manifest_id=req.confirmed_manifest_id,
+        dry_run=True,
+    )
+    return result.as_dict()
+
+
+@app.post("/admin/storage/restore")
+def storage_restore_endpoint(
+    req: StorageRestoreRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Restore an archive into ``NOVA_DATA_DIR`` after explicit confirm.
+
+    Refuses with 400 when ``confirm`` is not True. The underlying
+    helper:
+
+    * re-inspects the archive (manifest, traversal, symlink escape);
+    * creates a pre-restore backup under
+      ``NOVA_DATA_DIR/backups/pre-restore/`` and refuses if the
+      backup cannot be written;
+    * extracts into a staging directory inside the data root;
+    * atomically replaces canonical Nova files only;
+    * cleans up staging on success or failure;
+    * returns a structured result the UI can render verbatim.
+
+    On a refused or failed restore the response still has status
+    200 — the body's ``outcome`` and ``refuse_reason`` describe what
+    happened. This mirrors the maintenance endpoints, which surface
+    a ``"refused"`` outcome instead of a 500.
+    """
+    if not req.confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Restore requires explicit confirmation.",
+        )
+    archive = _resolve_storage_archive(req.name)
+    result = _data_export.apply_restore(
+        str(archive),
+        target_data_dir=None,
+        confirm=True,
+        confirmed_manifest_id=req.confirmed_manifest_id,
+        dry_run=False,
+    )
+    return result.as_dict()
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

Phase 3 of the Storage & Migration Center adds an opt-in,
admin-only **safe guided restore** flow on top of Phase 2's
inspect / dry-run plan. Nova can now restore a previously
exported Nova data package into the active `NOVA_DATA_DIR`, but
only after package inspection, dry-run validation, explicit
confirmation, and an automatic pre-restore backup of the current
data. Failed restores leave existing data bit-for-bit identical.

## Flow

1. **Inspect** the package (admin UI or CLI).
2. **Dry-run** the restore — Nova lists would-be files / conflicts.
3. **Confirm** explicitly (`--confirm` for CLI, "I understand"
   checkbox + `confirm: true` body for the API).
4. Nova **backs up** the current data automatically under
   `NOVA_DATA_DIR/backups/pre-restore/`. Restore aborts if the
   backup cannot be written.
5. Nova **stages** the archive into `NOVA_DATA_DIR/.restore-staging/`.
6. Every extracted member is **re-validated** against path
   traversal / symlink escape post-resolution.
7. Files are **atomically replaced** per-file via `os.replace`
   inside the same filesystem.
8. Staging is **cleaned up** on success or failure.

## Surfaces

* **Library** — `core.data_export.apply_restore(archive, *, target_data_dir, confirm, confirmed_manifest_id, dry_run)`
* **CLI** — `python -m core.data_export restore <archive> [--data-dir DIR] --confirm [--confirmed-manifest-id ID]`
* **API** — `POST /admin/storage/restore-dry-run` and `POST /admin/storage/restore` (both admin-only).
* **Admin UI** — Storage tab grows a "Restore from export package"
  panel (inspect → dry-run → checkbox → restore button stays
  disabled until all gates pass).

## Safety contract

* **Admin-only, local-only.** No cloud sync. No outbound calls.
  No background restore.
* **Explicit confirmation.** CLI refuses without `--confirm`; API
  returns 400 without `confirm: true`; UI keeps the restore
  button disabled until inspection, dry-run, and the
  "I understand" checkbox all pass.
* **Automatic pre-restore backup.** Aborts if the backup cannot
  be created; never overwrites an existing pre-restore backup
  file (name clash → `-<n>` suffix).
* **Hostile-archive defense.** Rejects path traversal, absolute
  archive paths, symlink members, hardlinks, devices, fifos,
  unsupported manifest versions, and unknown top-level entries.
* **Failed restores leave existing data intact.** A failure in
  the copy phase reports `outcome=failed` and the target keeps
  every file it had before. The pre-restore backup is preserved
  so the operator can roll back.
* **No model files, no secrets, no .env, no .git, no .venv, no
  caches** — same exclusions as the export builder.
* **No automatic Nova restart.** The restore surfaces a "restart
  Nova" hint when `nova.db` was in the package; the operator
  drives the restart.

## Test plan

- [x] `python -m pytest tests/test_data_export.py` — 65 passed
  (22 new tests in `TestApplyRestoreDryRun`, `TestApplyRestoreConfirmation`,
  `TestApplyRestoreSuccess`, `TestApplyRestoreSafety`,
  `TestApplyRestoreExcludedContent`, `TestRestoreCli`).
- [x] `python -m pytest tests/test_storage_endpoints.py` — 33
  passed (14 new tests for auth gating + dry-run / restore
  endpoint flows).
- [x] `python -m pytest tests/test_data_export.py tests/test_storage_endpoints.py tests/test_storage_status.py tests/test_paths.py tests/test_auth.py tests/test_admin_users.py tests/test_alpha_auth.py tests/test_feedback.py tests/test_feedback_endpoints.py tests/test_personalization_settings.py tests/test_memory.py tests/test_memory_command.py tests/test_memory_parsing.py tests/test_memory_scoping.py` — all green.
- [x] `python -m flake8 core/data_export.py web.py tests/test_data_export.py tests/test_storage_endpoints.py` — clean.
- [ ] Manual: build an export, mutate `nova.db`, restore via the
  admin UI, verify rollback through the pre-restore backup.
- [ ] Manual: confirm the CLI `restore` subcommand refuses
  without `--confirm` and runs cleanly with `--confirm`.

See `docs/storage-and-migration.md` for the full walkthrough,
including how to verify after a restore and how to roll back
using the pre-restore backup.

https://claude.ai/code/session_01W5EKdJZnoxthxusjzPphfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5EKdJZnoxthxusjzPphfs)_