### PR TITLE
feat(model-providers): introduce replaceable model-provider abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Model-provider abstraction (Phase: provider abstraction only): Nova
+  is no longer architecturally hardwired to Ollama. A new
+  `core/model_providers` package introduces a backend-agnostic
+  `ModelProvider` interface (`ModelRequest` / `ModelResponse` /
+  `ModelChunk` / `ProviderHealth` / `ModelProviderError`), a registry,
+  and an `OllamaProvider` that preserves the existing Ollama request,
+  streaming, fallback, and unreachable-error behaviour exactly. The
+  `chat` / `chat_stream` paths now talk to the provider interface
+  instead of calling the Ollama client directly; the Ollama-specific
+  stream duck-typing moved behind the provider. A deterministic
+  `MockProvider` replaces ad-hoc client stubs in tests. **Ollama
+  remains the default and fully supported** (`NOVA_MODEL_PROVIDER`,
+  default `ollama`); future *local* runtimes (llama.cpp, transformers,
+  a Nova-owned runtime) can register cleanly. No new runtime, no model
+  downloads, no shell/Docker/cloud/API-key, and no settings migration
+  in this phase. Nova identity / context / memory / safety stay owned
+  by Nova and always above any provider. See
+  [`docs/model-providers.md`](docs/model-providers.md).
 - Nova Projects / Workspaces (Phase 1): a local-first, per-user
   foundation for organising conversations and memory by project (e.g.
   `Nova`, `Auryn`, `SilentGuard`, `Home Lab`, `Personal`). Adds an

--- a/config.py
+++ b/config.py
@@ -5,6 +5,14 @@ load_dotenv()
 
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 
+# Which model-provider backend Nova talks to. Ollama remains the default
+# so existing deployments are unaffected; the value only selects which
+# `core.model_providers` implementation `get_provider()` returns. This is
+# a non-destructive runtime switch — it never touches the settings DB and
+# never triggers a download. Future local runtimes register their own
+# name here without Nova core changing.
+MODEL_PROVIDER = os.getenv("NOVA_MODEL_PROVIDER", "ollama").strip() or "ollama"
+
 _raw_channel = os.getenv("NOVA_CHANNEL", "stable").lower()
 NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else "stable"
 NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,9 +1,11 @@
 import logging
 from typing import Iterator
-import httpx
-import ollama
 from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
-from core.ollama_client import client
+from core.model_providers import (
+    ModelProviderError,
+    ModelRequest,
+    get_provider,
+)
 from core.memory import format_memories_for_prompt, parse_and_save
 from core.identity import IDENTITY_CONTRACT
 from core.nova_contract import build_personalization_block
@@ -45,49 +47,20 @@ def _reply_is_uncertain(reply: str) -> bool:
     return any(trigger in lowered for trigger in UNCERTAINTY_TRIGGERS)
 
 
-def _iter_content_chunks(stream) -> Iterator[str]:
-    """Yield non-empty `message.content` strings from an Ollama stream.
+def _generate(model: str, messages: list[dict]) -> str:
+    """One non-streamed generation through the active model provider.
 
-    Ollama's chat-stream generator yields events shaped like
-    ``{"message": {"content": "..."}, "done": bool}`` — but the concrete
-    type depends on the installed ollama-python client. ``ollama>=0.4``
-    streams ``ChatResponse`` Pydantic models (subscriptable but **not**
-    ``dict`` instances); older releases and our tests yield plain dicts.
-    We duck-type on the ``.get`` API both shapes expose so neither one
-    is silently dropped — an ``isinstance(event, dict)`` filter here was
-    the source of empty-reply regressions in production. Some
-    intermediate events have empty content (e.g. metadata frames) and
-    the final ``done`` event also carries a synthetic empty content —
-    skipping empties keeps the wire format tidy without affecting
-    correctness.
+    Nova core no longer talks to any concrete client library: it asks the
+    provider registry for the configured backend (Ollama by default) and
+    works in terms of the backend-agnostic :class:`ModelRequest` /
+    :class:`ModelResponse`. The provider is responsible for mapping its
+    own transport failures to :class:`ModelProviderError`, which the chat
+    entrypoints translate to the existing user-facing "unreachable" reply.
     """
-    for event in stream:
-        if event is None:
-            continue
-        msg = _safe_get(event, "message") or {}
-        chunk = _safe_get(msg, "content") or ""
-        if isinstance(chunk, str) and chunk:
-            yield chunk
-
-
-def _safe_get(obj, key: str):
-    """Read ``key`` from a dict-like or Pydantic ``SubscriptableBaseModel``.
-
-    Both shapes expose ``.get`` with the same contract, but a non-dict,
-    non-Pydantic object (e.g. an unexpected string event) would raise on
-    subscript. Falling back to ``getattr`` keeps the streaming loop
-    robust without re-introducing an ``isinstance(dict)`` filter that
-    silently drops valid ``ChatResponse`` events.
-    """
-    if obj is None:
-        return None
-    getter = getattr(obj, "get", None)
-    if callable(getter):
-        try:
-            return getter(key)
-        except TypeError:
-            pass
-    return getattr(obj, key, None)
+    response = get_provider().generate(
+        ModelRequest(model=model, messages=messages)
+    )
+    return response.content
 
 
 MEMORY_EXTRACTION_PROMPT = """Analyse cette conversation et extrait UNIQUEMENT les informations personnelles importantes sur l'utilisateur.
@@ -162,13 +135,12 @@ def extract_and_save_memory(
         assistant_response=assistant_response
     )
     try:
-        response = client.chat(
-            model=MODELS["default"],
-            messages=[{"role": "user", "content": prompt}]
-        )
-    except (ollama.ResponseError, ConnectionError, httpx.HTTPError):
+        result = _generate(
+            MODELS["default"],
+            [{"role": "user", "content": prompt}],
+        ).strip()
+    except ModelProviderError:
         return
-    result = response["message"]["content"].strip()
     parse_and_save(result, user_id, project_id)
 
 
@@ -273,8 +245,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
         if image:
             logger.debug("Processing image request, encoded length=%d", len(image))
             messages = build_image_messages(user_input, image)
-            response = client.chat(model=MODELS["default"], messages=messages)
-            reply = response["message"]["content"]
+            reply = _generate(MODELS["default"], messages)
             if policy.memory_save_enabled:
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
@@ -309,8 +280,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                     personalization=personalization,
                     feedback_preferences=feedback_prefs,
                 )
-                response = client.chat(model=model, messages=messages)
-                reply = response["message"]["content"]
+                reply = _generate(model, messages)
                 return reply, model
 
             if weather_result in ("no_city", "multiple"):
@@ -330,8 +300,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                     personalization=personalization,
                     feedback_preferences=feedback_prefs,
                 )
-                response = client.chat(model=model, messages=messages)
-                reply = response["message"]["content"]
+                reply = _generate(model, messages)
                 return reply, model
 
         # Web search — both the explicit `force_search` flag and the
@@ -343,8 +312,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 personalization=personalization,
                 feedback_preferences=feedback_prefs,
             )
-            response = client.chat(model=model, messages=messages)
-            reply = response["message"]["content"]
+            reply = _generate(model, messages)
             return reply, model
 
         # Chat normal — inject relevant natural memories into context
@@ -354,8 +322,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             personalization=personalization,
             feedback_preferences=feedback_prefs,
         )
-        response = client.chat(model=model, messages=messages)
-        reply = response["message"]["content"]
+        reply = _generate(model, messages)
 
         # Si Nova sait pas → cherche sur le web automatiquement
         if policy.web_search_enabled and _reply_is_uncertain(reply):
@@ -366,8 +333,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                     personalization=personalization,
                     feedback_preferences=feedback_prefs,
                 )
-                response = client.chat(model=model, messages=messages)
-                reply = response["message"]["content"]
+                reply = _generate(model, messages)
 
         if policy.memory_save_enabled:
             extract_and_save_memory(user_input, reply, user_id, project_id)
@@ -376,8 +342,8 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             )
         return reply, model
 
-    except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
-        logger.warning("Ollama unreachable during chat: %s", e)
+    except ModelProviderError as e:
+        logger.warning("Model provider unavailable during chat: %s", e)
         return OLLAMA_UNAVAILABLE, MODELS["default"]
 
 
@@ -422,8 +388,7 @@ def chat_stream(
         if image:
             logger.debug("Processing streaming-image request, encoded length=%d", len(image))
             messages = build_image_messages(user_input, image)
-            response = client.chat(model=MODELS["default"], messages=messages)
-            reply = response["message"]["content"]
+            reply = _generate(MODELS["default"], messages)
             if policy.memory_save_enabled:
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
@@ -532,38 +497,32 @@ def chat_stream(
 
         yield {"type": "done", "reply": reply, "model": model}
 
-    except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
-        logger.warning("Ollama unreachable during chat stream: %s", e)
+    except ModelProviderError as e:
+        logger.warning("Model provider unavailable during chat stream: %s", e)
         yield {"type": "error", "detail": OLLAMA_UNAVAILABLE}
 
 
 def _stream_and_accumulate(model: str, messages: list[dict]) -> Iterator[dict]:
-    """Stream a single Ollama chat call and re-emit each token as `delta`.
+    """Stream one generation through the provider, re-emitting each token.
 
     The generator behaves as a coroutine: ``reply = yield from
     _stream_and_accumulate(...)`` lets the caller inspect the full
-    concatenated text once the upstream stream is exhausted, while the
-    intermediate events propagate to whoever is iterating chat_stream.
+    concatenated text once the stream is exhausted, while the intermediate
+    `delta` events propagate to whoever is iterating chat_stream.
 
-    Falls back gracefully if the installed Ollama client predates the
-    streaming kwarg — the request degrades to a single-shot reply
-    surfaced as one `delta`.
+    Backend specifics — the legacy single-shot fallback for old clients
+    and the streamed-event duck-typing — live in the provider now; this
+    function only knows about :class:`ModelChunk`. A backend failure
+    surfaces as :class:`ModelProviderError`, which the ``chat_stream``
+    wrapper turns into the existing `error` event.
     """
     parts: list[str] = []
-    try:
-        stream = client.chat(model=model, messages=messages, stream=True)
-    except TypeError:
-        # Older ollama clients lacked the streaming kwarg. Fall back to a
-        # single, non-streaming call so the endpoint still works.
-        response = client.chat(model=model, messages=messages)
-        reply = response["message"]["content"]
-        if reply:
-            yield {"type": "delta", "content": reply}
-        return reply
-
-    for chunk in _iter_content_chunks(stream):
-        parts.append(chunk)
-        yield {"type": "delta", "content": chunk}
+    request = ModelRequest(model=model, messages=messages, stream=True)
+    for chunk in get_provider().stream(request):
+        if not chunk.content:
+            continue
+        parts.append(chunk.content)
+        yield {"type": "delta", "content": chunk.content}
     return "".join(parts)
 
 

--- a/core/model_providers/__init__.py
+++ b/core/model_providers/__init__.py
@@ -1,0 +1,48 @@
+"""Model-provider abstraction.
+
+Nova core depends on :class:`ModelProvider` and the small data objects in
+:mod:`core.model_providers.base` — never on a concrete client library.
+Ollama is the default provider; :class:`MockProvider` serves tests and
+offline development; future local runtimes register through
+:func:`register_provider`.
+
+See ``docs/model-providers.md`` for the rationale and the rule that a
+provider's identity is never Nova's identity.
+"""
+
+from .base import (
+    ModelChunk,
+    ModelProvider,
+    ModelProviderError,
+    ModelRequest,
+    ModelResponse,
+    ProviderHealth,
+)
+from .mock import MockProvider
+from .ollama import OllamaProvider, get_ollama_provider
+from .registry import (
+    available_providers,
+    get_provider,
+    register_provider,
+    reset,
+    set_override,
+    use_provider,
+)
+
+__all__ = [
+    "ModelProvider",
+    "ModelProviderError",
+    "ModelRequest",
+    "ModelResponse",
+    "ModelChunk",
+    "ProviderHealth",
+    "OllamaProvider",
+    "get_ollama_provider",
+    "MockProvider",
+    "get_provider",
+    "register_provider",
+    "available_providers",
+    "use_provider",
+    "set_override",
+    "reset",
+]

--- a/core/model_providers/base.py
+++ b/core/model_providers/base.py
@@ -1,0 +1,123 @@
+"""Model-provider interface — the seam between Nova core and a backend.
+
+Nova owns identity, memory, projects, context construction, safety/trust
+rules, tool routing, settings, and export/restore. The thing that turns a
+prompt into tokens is *replaceable*. This module defines the small,
+backend-agnostic contract every provider implements so Ollama becomes one
+provider among others (mock/test today; llama.cpp, transformers, or a
+Nova-owned runtime later) without Nova core depending on any concrete
+client library or its exception types.
+
+Hard rules baked into this boundary:
+
+  * A provider only turns ``messages`` into text. It never builds the
+    system prompt, so it can never reorder or override Nova's
+    identity/safety contract — that ordering is owned upstream in
+    :func:`core.chat.build_messages` and stays there.
+  * ``provider.name`` is a backend label (``"ollama"``, ``"mock"``). It
+    is **not** Nova's identity and must never be surfaced to the user as
+    such.
+  * Transport/availability failures surface as :class:`ModelProviderError`
+    only, so callers handle one exception type regardless of backend.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Iterator, Mapping, Optional
+
+
+class ModelProviderError(Exception):
+    """A model provider could not fulfil a request.
+
+    Providers wrap their backend-specific transport/availability errors
+    (e.g. ``ollama.ResponseError``, ``ConnectionError``, ``httpx.HTTPError``)
+    in this type so Nova core never imports or catches a concrete client
+    library's exceptions. Callers map it to a controlled, user-facing
+    message (the chat path turns it into the existing "Ollama is
+    unreachable" reply / stream ``error`` event).
+    """
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    """One generation request.
+
+    ``messages`` is the already-assembled chat history (system prompt
+    first, built by Nova core — providers never touch its ordering).
+    Vision requests carry their image inline on a message via the
+    backend's own ``images`` key, exactly as before; providers pass
+    ``messages`` through untouched. ``options`` is an opaque, optional
+    per-request hint bag for future backends; the Ollama path ignores it
+    today so current behaviour is unchanged.
+    """
+
+    model: str
+    messages: list[dict]
+    stream: bool = False
+    options: Optional[Mapping[str, object]] = None
+
+
+@dataclass(frozen=True)
+class ModelResponse:
+    """A complete, non-streamed reply."""
+
+    content: str
+    model: str
+
+
+@dataclass(frozen=True)
+class ModelChunk:
+    """One incremental text fragment from a streaming generation.
+
+    Empty fragments are legal on the wire (metadata/done frames) but the
+    chat layer already skips empties when accumulating, so providers may
+    forward or drop them as convenient.
+    """
+
+    content: str
+
+
+@dataclass(frozen=True)
+class ProviderHealth:
+    """Result of a cheap, read-only liveness probe.
+
+    ``health()`` never raises — an unreachable backend is reported as
+    ``ok=False`` with a short, non-sensitive ``detail`` so status surfaces
+    can render it without leaking transport internals.
+    """
+
+    ok: bool
+    provider: str
+    detail: str = ""
+    models: list[str] = field(default_factory=list)
+
+
+class ModelProvider(ABC):
+    """The contract Nova core depends on instead of a concrete client.
+
+    Implementations must be safe to construct cheaply and repeatedly, and
+    must not perform any network I/O at construction time (no model
+    downloads, ever — that is out of scope for this layer).
+    """
+
+    #: Stable backend label. NOT Nova's identity.
+    name: str = "base"
+
+    @abstractmethod
+    def generate(self, request: ModelRequest) -> ModelResponse:
+        """Return the full reply, or raise :class:`ModelProviderError`."""
+
+    @abstractmethod
+    def stream(self, request: ModelRequest) -> Iterator[ModelChunk]:
+        """Yield :class:`ModelChunk` fragments in order.
+
+        Raises :class:`ModelProviderError` if the backend is unreachable —
+        either when starting the stream or partway through iteration, so
+        callers wrap the whole consumption in one ``except``.
+        """
+
+    @abstractmethod
+    def health(self) -> ProviderHealth:
+        """Cheap read-only probe. Never raises; never triggers a pull."""

--- a/core/model_providers/mock.py
+++ b/core/model_providers/mock.py
@@ -1,0 +1,87 @@
+"""Deterministic in-process provider for tests and offline development.
+
+Same input always yields the same output, so suites that exercise the
+chat/streaming paths no longer need to stub a concrete client library or
+mimic Ollama's event shapes. It is intentionally tiny and never touches
+the network, the filesystem, or any model runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional, Sequence
+
+from .base import (
+    ModelChunk,
+    ModelProvider,
+    ModelProviderError,
+    ModelRequest,
+    ModelResponse,
+    ProviderHealth,
+)
+
+
+class MockProvider(ModelProvider):
+    """Canned, deterministic responses.
+
+    * ``response`` — the full text returned by :meth:`generate` and, when
+      ``chunks`` is not given, the single fragment streamed.
+    * ``chunks`` — explicit ordered fragments for :meth:`stream`; their
+      concatenation is also what :meth:`generate` returns when
+      ``response`` is left at its default so the two paths stay
+      consistent for a given configuration.
+    * ``healthy`` — what :meth:`health` reports.
+    * ``error`` — if set, every :meth:`generate` / :meth:`stream` call
+      raises it (use a :class:`ModelProviderError` to simulate an
+      unreachable backend cleanly).
+
+    Every request is recorded on :attr:`requests` so tests can assert
+    that Nova core routed through the provider with the expected model
+    and messages.
+    """
+
+    name = "mock"
+
+    _DEFAULT = "mock response"
+
+    def __init__(
+        self,
+        response: Optional[str] = None,
+        chunks: Optional[Sequence[str]] = None,
+        healthy: bool = True,
+        error: Optional[Exception] = None,
+    ):
+        self._chunks: list[str] = list(chunks) if chunks is not None else []
+        if response is not None:
+            self._response = response
+        elif self._chunks:
+            self._response = "".join(self._chunks)
+        else:
+            self._response = self._DEFAULT
+        if not self._chunks:
+            self._chunks = [self._response] if self._response else []
+        self._healthy = healthy
+        self._error = error
+        self.requests: list[ModelRequest] = []
+
+    def generate(self, request: ModelRequest) -> ModelResponse:
+        self.requests.append(request)
+        if self._error is not None:
+            raise self._error
+        return ModelResponse(content=self._response, model=request.model)
+
+    def stream(self, request: ModelRequest) -> Iterator[ModelChunk]:
+        self.requests.append(request)
+        if self._error is not None:
+            raise self._error
+        for fragment in self._chunks:
+            yield ModelChunk(content=fragment)
+
+    def health(self) -> ProviderHealth:
+        return ProviderHealth(
+            ok=self._healthy,
+            provider=self.name,
+            detail="" if self._healthy else "mock provider marked unhealthy",
+        )
+
+
+__all__ = ["MockProvider", "ModelProviderError"]

--- a/core/model_providers/ollama.py
+++ b/core/model_providers/ollama.py
@@ -1,0 +1,207 @@
+"""Ollama-backed model provider.
+
+This is the default provider — it preserves Nova's pre-refactor Ollama
+behaviour exactly. All the Ollama-specific knowledge that used to live in
+``core.chat`` now lives here behind the :class:`ModelProvider` contract:
+
+  * the exact ``client.chat(model=..., messages=...)`` call shape,
+  * the streaming chunk duck-typing (``ollama>=0.4`` streams
+    ``ChatResponse`` Pydantic objects — subscriptable but **not** ``dict``
+    — older clients/tests yield plain dicts; both must work),
+  * the legacy-client ``TypeError`` fallback when the installed
+    ollama-python predates the ``stream=`` kwarg,
+  * mapping ``(ollama.ResponseError, ConnectionError, httpx.HTTPError)``
+    to :class:`ModelProviderError`.
+
+The shared ``core.ollama_client.client`` singleton is resolved lazily on
+every call rather than captured at construction, so existing tests that
+``patch`` either ``core.ollama_client.client`` or its ``.chat`` attribute
+keep working unchanged, and so a host can swap ``OLLAMA_HOST`` without a
+process restart.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+import httpx
+import ollama
+
+from .base import (
+    ModelChunk,
+    ModelProvider,
+    ModelProviderError,
+    ModelRequest,
+    ModelResponse,
+    ProviderHealth,
+)
+
+# Backend transport/availability errors. Resolved via the ``ollama``
+# module object at raise/except time (not bound at import) so a test that
+# monkeypatches ``ollama.ResponseError`` is still matched — this mirrors
+# the pre-refactor behaviour in ``core.chat``.
+_TRANSPORT_ERRORS = (ConnectionError, OSError, httpx.HTTPError)
+
+
+def _safe_get(obj, key: str):
+    """Read ``key`` from a dict-like or Pydantic ``SubscriptableBaseModel``.
+
+    Both shapes expose ``.get`` with the same contract, but a non-dict,
+    non-Pydantic object (e.g. an unexpected string event) would raise on
+    subscript. Falling back to ``getattr`` keeps the streaming loop
+    robust without re-introducing an ``isinstance(dict)`` filter that
+    silently drops valid ``ChatResponse`` events.
+    """
+    if obj is None:
+        return None
+    getter = getattr(obj, "get", None)
+    if callable(getter):
+        try:
+            return getter(key)
+        except TypeError:
+            pass
+    return getattr(obj, key, None)
+
+
+def _iter_content_chunks(stream) -> Iterator[str]:
+    """Yield non-empty ``message.content`` strings from an Ollama stream.
+
+    Ollama's chat-stream generator yields events shaped like
+    ``{"message": {"content": "..."}, "done": bool}`` — but the concrete
+    type depends on the installed ollama-python client. ``ollama>=0.4``
+    streams ``ChatResponse`` Pydantic models (subscriptable but **not**
+    ``dict`` instances); older releases and our tests yield plain dicts.
+    We duck-type on the ``.get`` API both shapes expose so neither one is
+    silently dropped — an ``isinstance(event, dict)`` filter here was the
+    source of empty-reply regressions in production. Some intermediate
+    events have empty content (e.g. metadata frames) and the final
+    ``done`` event also carries a synthetic empty content — skipping
+    empties keeps the wire format tidy without affecting correctness.
+    """
+    for event in stream:
+        if event is None:
+            continue
+        msg = _safe_get(event, "message") or {}
+        chunk = _safe_get(msg, "content") or ""
+        if isinstance(chunk, str) and chunk:
+            yield chunk
+
+
+def _is_response_error(exc: BaseException) -> bool:
+    """True if ``exc`` is Ollama's ``ResponseError``.
+
+    Looked up off the live ``ollama`` module so a monkeypatched
+    ``ollama.ResponseError`` (used by the unreachable-backend tests) is
+    still recognised. ``ResponseError`` may be absent when the optional
+    ``ollama`` wheel is stubbed in CI — guard with ``getattr``.
+    """
+    response_error = getattr(ollama, "ResponseError", None)
+    return isinstance(response_error, type) and isinstance(exc, response_error)
+
+
+class OllamaProvider(ModelProvider):
+    """Default provider. Talks to a local Ollama daemon."""
+
+    name = "ollama"
+
+    def __init__(self, client=None):
+        # ``None`` => resolve the shared singleton lazily on every call
+        # (see module docstring). An explicit client is only injected by
+        # tests that want a fully isolated double.
+        self._client_override = client
+
+    def _client(self):
+        if self._client_override is not None:
+            return self._client_override
+        # Late import + late attribute read: keeps `patch`-ability and
+        # avoids an import cycle (core.ollama_client pulls in config).
+        from core import ollama_client
+
+        return ollama_client.client
+
+    def generate(self, request: ModelRequest) -> ModelResponse:
+        try:
+            response = self._client().chat(
+                model=request.model, messages=request.messages
+            )
+        except _TRANSPORT_ERRORS as exc:
+            raise ModelProviderError(str(exc) or "Ollama unreachable") from exc
+        except Exception as exc:  # noqa: BLE001 — narrowed below
+            if _is_response_error(exc):
+                raise ModelProviderError(
+                    str(exc) or "Ollama error"
+                ) from exc
+            raise
+        content = _safe_get(_safe_get(response, "message") or {}, "content")
+        return ModelResponse(content=content or "", model=request.model)
+
+    def stream(self, request: ModelRequest) -> Iterator[ModelChunk]:
+        client = self._client()
+        try:
+            try:
+                upstream = client.chat(
+                    model=request.model,
+                    messages=request.messages,
+                    stream=True,
+                )
+            except TypeError:
+                # Older ollama clients lacked the streaming kwarg. Fall
+                # back to a single, non-streaming call so the path still
+                # works — surfaced as one chunk.
+                response = client.chat(
+                    model=request.model, messages=request.messages
+                )
+                content = _safe_get(
+                    _safe_get(response, "message") or {}, "content"
+                )
+                if content:
+                    yield ModelChunk(content=content)
+                return
+            for chunk in _iter_content_chunks(upstream):
+                yield ModelChunk(content=chunk)
+        except _TRANSPORT_ERRORS as exc:
+            raise ModelProviderError(str(exc) or "Ollama unreachable") from exc
+        except Exception as exc:  # noqa: BLE001 — narrowed below
+            if _is_response_error(exc):
+                raise ModelProviderError(str(exc) or "Ollama error") from exc
+            raise
+
+    def health(self) -> ProviderHealth:
+        """Read-only ``client.list()`` probe. Never raises, never pulls."""
+        try:
+            payload = self._client().list()
+        except _TRANSPORT_ERRORS as exc:
+            return ProviderHealth(
+                ok=False, provider=self.name, detail=str(exc) or "unreachable"
+            )
+        except Exception as exc:  # noqa: BLE001 — narrowed below
+            if _is_response_error(exc):
+                return ProviderHealth(
+                    ok=False,
+                    provider=self.name,
+                    detail=str(exc) or "error",
+                )
+            raise
+        models: list[str] = []
+        raw = _safe_get(payload, "models") or []
+        try:
+            for entry in raw:
+                name = _safe_get(entry, "name") or _safe_get(entry, "model")
+                if isinstance(name, str) and name:
+                    models.append(name)
+        except TypeError:
+            # Unexpected payload shape — still healthy (Ollama answered),
+            # just no parseable model list.
+            models = []
+        return ProviderHealth(ok=True, provider=self.name, models=models)
+
+
+_default: Optional[OllamaProvider] = None
+
+
+def get_ollama_provider() -> OllamaProvider:
+    """Process-wide singleton. Cheap; holds no captured client."""
+    global _default
+    if _default is None:
+        _default = OllamaProvider()
+    return _default

--- a/core/model_providers/registry.py
+++ b/core/model_providers/registry.py
@@ -1,0 +1,124 @@
+"""Provider registry — the one place Nova core asks "who generates text?".
+
+``get_provider()`` returns the configured backend (Ollama by default, so
+existing deployments are unaffected). New local runtimes register a
+factory under a name; nothing in Nova core changes when they do. There is
+no network I/O here and no model download — registering or resolving a
+provider is cheap and side-effect free.
+
+Selection precedence:
+
+  1. an explicit test override (:func:`use_provider` / :func:`set_override`),
+  2. an explicit ``name`` argument to :func:`get_provider`,
+  3. ``config.MODEL_PROVIDER`` (env ``NOVA_MODEL_PROVIDER``, default
+     ``"ollama"``).
+
+Instances are cached per name so the Ollama provider stays a process-wide
+singleton; :func:`reset` clears the cache and override for test isolation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from typing import Callable, Dict, Iterator, Optional
+
+from .base import ModelProvider, ModelProviderError
+from .mock import MockProvider
+from .ollama import get_ollama_provider
+
+ProviderFactory = Callable[[], ModelProvider]
+
+_lock = threading.Lock()
+_factories: Dict[str, ProviderFactory] = {
+    "ollama": get_ollama_provider,
+    "mock": MockProvider,
+}
+_instances: Dict[str, ModelProvider] = {}
+_override: Optional[ModelProvider] = None
+
+
+def register_provider(name: str, factory: ProviderFactory) -> None:
+    """Register (or replace) a provider factory under ``name``.
+
+    A future ``LlamaCppProvider`` / ``TransformersProvider`` /
+    ``NovaModelProvider`` plugs in here without touching call sites. Any
+    cached instance for ``name`` is dropped so the new factory takes
+    effect on the next :func:`get_provider`.
+    """
+    key = (name or "").strip().lower()
+    if not key:
+        raise ValueError("provider name must be a non-empty string")
+    with _lock:
+        _factories[key] = factory
+        _instances.pop(key, None)
+
+
+def available_providers() -> list[str]:
+    """Names that can currently be resolved (sorted, for stable output)."""
+    with _lock:
+        return sorted(_factories)
+
+
+def _default_name() -> str:
+    # Imported lazily so the registry has no import-time config dependency
+    # and tests can monkeypatch config.MODEL_PROVIDER before first use.
+    from config import MODEL_PROVIDER
+
+    return (MODEL_PROVIDER or "ollama").strip().lower() or "ollama"
+
+
+def get_provider(name: Optional[str] = None) -> ModelProvider:
+    """Resolve a provider following the precedence in the module docstring.
+
+    Raises :class:`ModelProviderError` for an unknown name rather than a
+    bare ``KeyError`` so callers handle one exception type. An unknown
+    *configured default* is treated the same way — misconfiguration is
+    surfaced loudly instead of silently falling back.
+    """
+    if _override is not None:
+        return _override
+
+    key = (name or "").strip().lower() or _default_name()
+    with _lock:
+        cached = _instances.get(key)
+        if cached is not None:
+            return cached
+        factory = _factories.get(key)
+        if factory is None:
+            raise ModelProviderError(
+                f"unknown model provider {key!r}; "
+                f"known: {sorted(_factories)}"
+            )
+        instance = factory()
+        _instances[key] = instance
+        return instance
+
+
+def set_override(provider: Optional[ModelProvider]) -> None:
+    """Force :func:`get_provider` to return ``provider`` (tests only).
+
+    Passing ``None`` clears the override.
+    """
+    global _override
+    _override = provider
+
+
+@contextlib.contextmanager
+def use_provider(provider: ModelProvider) -> Iterator[ModelProvider]:
+    """Scope an override to a ``with`` block (tests only)."""
+    global _override
+    prev = _override
+    _override = provider
+    try:
+        yield provider
+    finally:
+        _override = prev
+
+
+def reset() -> None:
+    """Drop cached instances and any override (test isolation)."""
+    global _override
+    with _lock:
+        _instances.clear()
+    _override = None

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -1,0 +1,122 @@
+# Nova Model Providers
+
+> **Status: shipped (Phase: provider abstraction only), local-first.**
+> This document describes the seam that lets Nova's model backend be
+> replaced without rewriting Nova. It lives inside the boundaries set by
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md).
+> Nothing here grants Nova new powers, adds a new model runtime, performs
+> model downloads, runs shell, touches a Docker socket, integrates a
+> cloud provider, or migrates settings. **Ollama remains the default and
+> is fully supported.**
+
+## Why Nova has model providers
+
+Nova is not a chat wrapper around Ollama. Nova owns the parts that make
+it *Nova*:
+
+- **identity** and the safety / trust contract,
+- **memory** (global and per-project),
+- **projects / workspaces**,
+- **context construction** (the system prompt, ordered so identity and
+  safety always win),
+- **tool routing**, **settings**, and **export / restore**.
+
+The component that turns an assembled prompt into tokens — the *model
+backend* — is an implementation detail. Before this change Nova called
+the Ollama client directly from the chat path, so the backend could not
+be swapped, tested without mimicking Ollama's wire shapes, or evolved
+toward a Nova-owned runtime. The provider abstraction makes the backend
+*replaceable* while everything above stays exactly as it was.
+
+```text
+Nova Core  (identity · memory · projects · context · safety · routing · settings · export)
+   │
+   ▼
+Model Provider Interface          core/model_providers/base.py
+   ├── OllamaProvider   (default)  core/model_providers/ollama.py
+   ├── MockProvider     (tests)    core/model_providers/mock.py
+   ├── future LlamaCppProvider
+   ├── future TransformersProvider
+   └── future NovaModelProvider
+```
+
+## The contract
+
+`core/model_providers/base.py` defines small, backend-agnostic objects so
+Nova core never imports a concrete client library or its exceptions:
+
+| Object | Role |
+| --- | --- |
+| `ModelRequest` | `model`, `messages` (already assembled by Nova — system/identity prompt first), `stream`, optional opaque `options`. |
+| `ModelResponse` | A complete reply (`content`, `model`). |
+| `ModelChunk` | One streamed text fragment. |
+| `ProviderHealth` | Result of a cheap, read-only liveness probe. |
+| `ModelProviderError` | The **only** failure type callers handle, regardless of backend. |
+| `ModelProvider` | ABC: `generate()`, `stream()`, `health()`. |
+
+`core/model_providers/registry.py` is the one place Nova core asks "who
+generates text?". Selection precedence: a test override → an explicit
+name → `config.MODEL_PROVIDER` (env `NOVA_MODEL_PROVIDER`, default
+`"ollama"`). A future runtime registers a factory via
+`register_provider("name", factory)` and nothing in Nova core changes.
+
+## Ollama remains supported (and default)
+
+`OllamaProvider` preserves the pre-refactor behaviour exactly:
+
+- the same `client.chat(model=…, messages=…)` call shape,
+- the streaming chunk duck-typing (`ollama>=0.4` streams `ChatResponse`
+  Pydantic objects — subscriptable but not `dict`; older clients/tests
+  yield dicts — both must work),
+- the legacy single-shot fallback when an old ollama-python lacks the
+  `stream=` kwarg,
+- mapping `(ollama.ResponseError, ConnectionError, httpx.HTTPError, …)`
+  to `ModelProviderError`, which the chat path still turns into the
+  existing "Ollama is unreachable" reply / stream `error` event.
+
+It resolves the shared `core.ollama_client.client` singleton lazily on
+every call, so changing `OLLAMA_HOST` needs no process restart and
+existing tests that patch that client keep working. Nothing about the
+default deployment changes: leave `NOVA_MODEL_PROVIDER` unset and Nova
+behaves exactly as before.
+
+## Future providers
+
+New **local** runtimes can be added cleanly in later phases — for
+example a `LlamaCppProvider` (GGUF via llama.cpp), a
+`TransformersProvider` (Hugging Face Transformers), or a Nova-owned
+runtime (`NovaModelProvider`). Each only implements `generate()`,
+`stream()`, and `health()` and registers a name. **This phase adds none
+of them**, performs no model downloads, and adds no cloud providers and
+no API keys — those are explicitly out of scope.
+
+## Nova identity is above provider identity
+
+This is a hard rule, enforced by where the boundary sits:
+
+- A provider only turns `messages` into text. It never builds or reorders
+  the system prompt — that ordering is owned by
+  `core.chat.build_messages`, where the identity / safety contract,
+  personalization, and feedback blocks are layered so **safety and
+  identity always win**. A provider cannot move itself above them.
+- `provider.name` (`"ollama"`, `"mock"`, …) is a backend label for
+  diagnostics. It is **not** Nova's identity and is never surfaced to the
+  user as such. Whatever a model emits about "who it is" does not change
+  who Nova is.
+- Global memory and per-project memory remain owned by Nova. Providers
+  receive only the messages Nova chose to send and never read or write
+  memory, projects, settings, or export data.
+- Backend failures degrade to a calm, controlled message — a provider
+  can make Nova briefly unable to answer, never able to override its
+  rules.
+
+## Testing
+
+`MockProvider` gives deterministic, offline replies so suites no longer
+stub a concrete client or mimic Ollama's event shapes. The provider
+suite (`tests/test_model_providers.py`) covers request-shape
+preservation, stream duck-typing, the legacy `TypeError` fallback,
+failure mapping, clean health-failure handling, registry resolution, and
+that `chat` / `chat_stream` route through the interface. The existing
+chat / memory / project / storage suites continue to pass against the
+real `OllamaProvider` path.

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -29,7 +29,7 @@ for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
         sys.modules[_mod] = MagicMock()
 
 from core import chat as chat_module  # noqa: E402
-from core import memory as core_memory, users  # noqa: E402
+from core import memory as core_memory, ollama_client, users  # noqa: E402
 from core.chat import chat_stream  # noqa: E402
 from memory import store as natural_store  # noqa: E402
 
@@ -130,7 +130,10 @@ def stub_chat_stream_runtime(chunks, *, event_shape="dict"):
         # Non-streaming fallback (e.g. memory extractor) — return single shot.
         return {"message": {"content": "".join(chunks)}}
 
-    with patch.object(chat_module.client, "chat", side_effect=fake_chat), \
+    # OllamaProvider talks to the shared core.ollama_client.client
+    # singleton; patching its .chat drives the real chat→provider→Ollama
+    # path end-to-end (the provider owns the chunk duck-typing now).
+    with patch.object(ollama_client.client, "chat", side_effect=fake_chat), \
             patch.object(chat_module, "route", lambda _msg: "default"), \
             patch.object(chat_module, "should_search", lambda _msg: False), \
             patch.object(chat_module, "is_security_query", lambda _msg: False), \
@@ -199,7 +202,7 @@ class TestChatStreamGenerator:
             pass
         with patch.object(_ollama, "ResponseError", _FakeResponseError), \
                 patch.object(
-                    chat_module.client, "chat",
+                    ollama_client.client, "chat",
                     side_effect=_FakeResponseError("nope"),
                 ), \
                 patch.object(chat_module, "route", lambda _msg: "default"), \
@@ -478,7 +481,7 @@ class TestChatStreamEndpoint:
 
         with patch.object(_ollama, "ResponseError", _FakeResponseError), \
                 patch.object(
-                    chat_module.client, "chat",
+                    ollama_client.client, "chat",
                     side_effect=_FakeResponseError("nope"),
                 ), \
                 patch.object(chat_module, "route", lambda _msg: "default"), \

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -31,7 +31,7 @@ for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
         sys.modules[_mod] = MagicMock()
 
 from core import chat as chat_module  # noqa: E402
-from core import memory as core_memory, users  # noqa: E402
+from core import memory as core_memory, ollama_client, users  # noqa: E402
 from core.chat import build_messages, chat  # noqa: E402
 from core.feedback import (  # noqa: E402
     REASON_MAX_LEN,
@@ -260,7 +260,9 @@ class TestPreferenceBlock:
 def _stub_chat_runtime(reply: str = "ok"):
     """Stub the network bits so chat() exercises only prompt-shaping."""
     fake_client_chat = MagicMock(return_value={"message": {"content": reply}})
-    with patch.object(chat_module.client, "chat", fake_client_chat), \
+    # OllamaProvider talks to the shared core.ollama_client.client
+    # singleton; patching its .chat exercises the real chat→provider path.
+    with patch.object(ollama_client.client, "chat", fake_client_chat), \
          patch.object(chat_module, "route", lambda _msg: "default"), \
          patch.object(chat_module, "should_search", lambda _msg: False), \
          patch.object(chat_module, "is_security_query", lambda _msg: False), \

--- a/tests/test_feedback_endpoints.py
+++ b/tests/test_feedback_endpoints.py
@@ -28,7 +28,7 @@ for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
         sys.modules[_mod] = MagicMock()
 
 from core import chat as chat_module  # noqa: E402
-from core import memory as core_memory, users  # noqa: E402
+from core import memory as core_memory, ollama_client, users  # noqa: E402
 from memory import store as natural_store  # noqa: E402
 
 
@@ -83,7 +83,7 @@ def _stub_chat_stream_runtime(chunks):
             return gen()
         return {"message": {"content": "".join(chunks)}}
 
-    with patch.object(chat_module.client, "chat", side_effect=fake_chat), \
+    with patch.object(ollama_client.client, "chat", side_effect=fake_chat), \
             patch.object(chat_module, "route", lambda _msg: "default"), \
             patch.object(chat_module, "should_search", lambda _msg: False), \
             patch.object(chat_module, "is_security_query", lambda _msg: False), \
@@ -267,7 +267,7 @@ class TestNonStreamingExposesMessageId:
         _make_user(db_path, "alice")
         token = _login(web_client, "alice")
         fake = MagicMock(return_value={"message": {"content": "hello"}})
-        with patch.object(chat_module.client, "chat", fake), \
+        with patch.object(ollama_client.client, "chat", fake), \
                 patch.object(chat_module, "route", lambda _msg: "default"), \
                 patch.object(
                     chat_module, "should_search", lambda _msg: False,

--- a/tests/test_model_providers.py
+++ b/tests/test_model_providers.py
@@ -1,0 +1,367 @@
+"""Tests for the model-provider abstraction (Nova ↔ backend seam).
+
+Covers:
+  * OllamaProvider preserves the exact pre-refactor request behaviour
+    (same ``client.chat(model=, messages=)`` shape, same response
+    mapping, same stream chunk duck-typing + legacy ``TypeError``
+    fallback) and maps backend failures to ``ModelProviderError``.
+  * OllamaProvider.health() is a clean read-only probe that never raises.
+  * MockProvider is deterministic and records requests.
+  * The registry resolves Ollama by default, supports overrides, and
+    raises a typed error for unknown providers.
+  * core.chat.chat / chat_stream route through the provider interface
+    rather than a concrete client, and a provider-health/availability
+    failure is surfaced cleanly (no regression to the existing
+    "Ollama unreachable" reply / stream `error` event).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Match the rest of the suite: stub optional wheels if absent so this
+# file collects on a minimal host. ``ollama`` is real in CI (the
+# transport-error tests monkeypatch ``ollama.ResponseError`` exactly the
+# way ``test_chat_stream`` already does).
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import ollama  # noqa: E402
+
+from core import chat as chat_module  # noqa: E402
+from core import memory as core_memory, ollama_client, users  # noqa: E402
+from core.chat import chat, chat_stream  # noqa: E402
+from core.model_providers import (  # noqa: E402
+    MockProvider,
+    ModelProviderError,
+    ModelRequest,
+    ModelResponse,
+    OllamaProvider,
+    ProviderHealth,
+    available_providers,
+    get_provider,
+    register_provider,
+    reset,
+    use_provider,
+)
+from core.model_providers import registry as registry_mod  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """No override / no cached instances leaks between tests."""
+    reset()
+    yield
+    reset()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username="alice"):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, "pw", role=users.ROLE_USER)
+
+
+class _SubscriptableEvent:
+    """Mirror of ``ollama.ChatResponse`` — subscriptable, not a ``dict``."""
+
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def get(self, key, default=None):
+        return self._fields.get(key, default)
+
+    def __getitem__(self, key):
+        return self._fields[key]
+
+
+# ── OllamaProvider: request behaviour ───────────────────────────────────────
+
+
+class TestOllamaProviderRequestBehaviour:
+    def test_generate_uses_exact_legacy_call_shape(self):
+        fake = MagicMock(return_value={"message": {"content": "hi there"}})
+        provider = OllamaProvider(client=MagicMock(chat=fake))
+
+        out = provider.generate(
+            ModelRequest(model="gemma4", messages=[{"role": "user", "content": "yo"}])
+        )
+
+        assert isinstance(out, ModelResponse)
+        assert out.content == "hi there"
+        assert out.model == "gemma4"
+        fake.assert_called_once_with(
+            model="gemma4", messages=[{"role": "user", "content": "yo"}]
+        )
+
+    def test_generate_handles_subscriptable_chatresponse(self):
+        resp = _SubscriptableEvent(
+            message=_SubscriptableEvent(content="pong")
+        )
+        provider = OllamaProvider(client=MagicMock(chat=MagicMock(return_value=resp)))
+        assert provider.generate(ModelRequest("m", [])).content == "pong"
+
+    def test_stream_yields_chunks_and_skips_empty_metadata_frames(self):
+        events = [
+            {"message": {"content": "Hel"}, "done": False},
+            {"message": {"content": ""}, "done": False},  # metadata frame
+            {"message": {"content": "lo"}, "done": False},
+            {"message": {"content": ""}, "done": True},  # synthetic done
+        ]
+        client = MagicMock()
+        client.chat.return_value = iter(events)
+        provider = OllamaProvider(client=client)
+
+        chunks = list(provider.stream(ModelRequest("m", [], stream=True)))
+
+        assert [c.content for c in chunks] == ["Hel", "lo"]
+        client.chat.assert_called_once_with(model="m", messages=[], stream=True)
+
+    def test_stream_handles_subscriptable_chatresponse_shape(self):
+        # Regression: ``ollama>=0.4`` streams Pydantic objects, not dicts.
+        events = [
+            _SubscriptableEvent(
+                message=_SubscriptableEvent(content="bon"), done=False
+            ),
+            _SubscriptableEvent(
+                message=_SubscriptableEvent(content="jour"), done=False
+            ),
+            _SubscriptableEvent(
+                message=_SubscriptableEvent(content=""), done=True
+            ),
+        ]
+        client = MagicMock()
+        client.chat.return_value = iter(events)
+        provider = OllamaProvider(client=client)
+
+        chunks = list(provider.stream(ModelRequest("m", [], stream=True)))
+        assert "".join(c.content for c in chunks) == "bonjour"
+
+    def test_stream_falls_back_when_client_lacks_stream_kwarg(self):
+        # An old ollama-python without the stream= kwarg raises TypeError;
+        # the provider degrades to a single non-streamed reply.
+        def chat(*args, **kwargs):
+            if kwargs.get("stream"):
+                raise TypeError("unexpected keyword argument 'stream'")
+            return {"message": {"content": "single shot"}}
+
+        provider = OllamaProvider(client=MagicMock(chat=chat))
+        chunks = list(provider.stream(ModelRequest("m", [], stream=True)))
+        assert [c.content for c in chunks] == ["single shot"]
+
+    def test_default_resolves_shared_singleton(self):
+        # No injected client → the shared core.ollama_client.client, so a
+        # patch on its .chat is seen (this is the test seam the existing
+        # chat suites rely on).
+        provider = OllamaProvider()
+        with patch.object(
+            ollama_client.client, "chat",
+            return_value={"message": {"content": "shared"}},
+        ):
+            assert provider.generate(ModelRequest("m", [])).content == "shared"
+
+
+# ── OllamaProvider: failure mapping ─────────────────────────────────────────
+
+
+class TestOllamaProviderFailureMapping:
+    @pytest.mark.parametrize(
+        "exc",
+        [ConnectionError("down"), OSError("refused")],
+    )
+    def test_generate_maps_transport_errors(self, exc):
+        provider = OllamaProvider(client=MagicMock(chat=MagicMock(side_effect=exc)))
+        with pytest.raises(ModelProviderError):
+            provider.generate(ModelRequest("m", []))
+
+    def test_generate_maps_ollama_response_error(self):
+        class _FakeResponseError(Exception):
+            pass
+
+        with patch.object(ollama, "ResponseError", _FakeResponseError):
+            provider = OllamaProvider(
+                client=MagicMock(chat=MagicMock(side_effect=_FakeResponseError("x")))
+            )
+            with pytest.raises(ModelProviderError):
+                provider.generate(ModelRequest("m", []))
+
+    def test_stream_maps_transport_error_during_iteration(self):
+        def gen():
+            yield {"message": {"content": "partial"}}
+            raise ConnectionError("dropped mid-stream")
+
+        provider = OllamaProvider(client=MagicMock(chat=MagicMock(return_value=gen())))
+        with pytest.raises(ModelProviderError):
+            list(provider.stream(ModelRequest("m", [], stream=True)))
+
+
+# ── OllamaProvider: health ──────────────────────────────────────────────────
+
+
+class TestOllamaProviderHealth:
+    def test_health_ok_lists_models(self):
+        client = MagicMock()
+        client.list.return_value = {
+            "models": [{"name": "gemma4"}, {"model": "qwen2.5:32b"}]
+        }
+        health = OllamaProvider(client=client).health()
+        assert health.ok is True
+        assert health.provider == "ollama"
+        assert set(health.models) == {"gemma4", "qwen2.5:32b"}
+
+    def test_health_failure_is_clean_never_raises(self):
+        client = MagicMock()
+        client.list.side_effect = ConnectionError("no daemon")
+        health = OllamaProvider(client=client).health()
+        assert isinstance(health, ProviderHealth)
+        assert health.ok is False
+        assert health.provider == "ollama"
+        assert health.detail  # short, non-empty reason
+
+
+# ── MockProvider ────────────────────────────────────────────────────────────
+
+
+class TestMockProvider:
+    def test_generate_is_deterministic_and_records_requests(self):
+        mp = MockProvider(response="always this")
+        req = ModelRequest("m", [{"role": "user", "content": "q"}])
+        assert mp.generate(req).content == "always this"
+        assert mp.generate(req).content == "always this"
+        assert mp.requests == [req, req]
+
+    def test_stream_chunks_concat_matches_generate(self):
+        mp = MockProvider(chunks=["a", "b", "c"])
+        streamed = "".join(c.content for c in mp.stream(ModelRequest("m", [])))
+        assert streamed == "abc"
+        assert mp.generate(ModelRequest("m", [])).content == "abc"
+
+    def test_error_injection_raises_for_both_paths(self):
+        mp = MockProvider(error=ModelProviderError("simulated outage"))
+        with pytest.raises(ModelProviderError):
+            mp.generate(ModelRequest("m", []))
+        with pytest.raises(ModelProviderError):
+            list(mp.stream(ModelRequest("m", [])))
+
+    def test_health_reflects_configuration(self):
+        assert MockProvider().health().ok is True
+        unhealthy = MockProvider(healthy=False).health()
+        assert unhealthy.ok is False
+        assert unhealthy.detail
+
+
+# ── Registry ────────────────────────────────────────────────────────────────
+
+
+class TestRegistry:
+    def test_default_is_ollama(self):
+        assert isinstance(get_provider(), OllamaProvider)
+
+    def test_named_lookup_and_singleton_caching(self):
+        a = get_provider("ollama")
+        b = get_provider("ollama")
+        assert a is b
+        assert isinstance(get_provider("mock"), MockProvider)
+
+    def test_unknown_provider_raises_typed_error(self):
+        with pytest.raises(ModelProviderError):
+            get_provider("does-not-exist")
+
+    def test_config_default_is_honoured(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "mock")
+        reset()
+        assert isinstance(get_provider(), MockProvider)
+
+    def test_register_provider_plugs_in_a_new_backend(self):
+        sentinel = MockProvider(response="future-runtime")
+        register_provider("future", lambda: sentinel)
+        try:
+            assert "future" in available_providers()
+            assert get_provider("future") is sentinel
+        finally:
+            registry_mod._factories.pop("future", None)
+            registry_mod._instances.pop("future", None)
+
+    def test_use_provider_override_scopes_to_block(self):
+        mock = MockProvider(response="overridden")
+        with use_provider(mock):
+            assert get_provider() is mock
+            assert get_provider("ollama") is mock  # override wins
+        assert isinstance(get_provider(), OllamaProvider)
+
+
+# ── core.chat routes through the provider interface ─────────────────────────
+
+
+@contextlib.contextmanager
+def _neutralise_chat_side_effects():
+    with patch.object(chat_module, "route", lambda _m: "default"), \
+         patch.object(chat_module, "should_search", lambda _m: False), \
+         patch.object(chat_module, "is_security_query", lambda _m: False), \
+         patch.object(chat_module, "detect_weather_city", lambda _m: None), \
+         patch.object(chat_module, "get_relevant_memories", lambda *_a, **_k: []), \
+         patch.object(chat_module, "extract_and_save_memory", lambda *_a, **_k: None), \
+         patch.object(
+             chat_module, "_extract_and_save_natural_memories",
+             lambda *_a, **_k: None,
+         ):
+        yield
+
+
+class TestChatUsesProviderInterface:
+    def test_chat_returns_provider_output(self, db_path):
+        alice = _make_user(db_path)
+        mock = MockProvider(response="from the provider")
+        with use_provider(mock), _neutralise_chat_side_effects():
+            reply, model = chat([], "hello", [], alice)
+        assert reply == "from the provider"
+        assert model == "default"
+        # Nova core handed the assembled messages to the provider, with
+        # the system/identity prompt first — provider never reorders it.
+        assert mock.requests
+        sent = mock.requests[-1]
+        assert isinstance(sent, ModelRequest)
+        assert sent.messages[0]["role"] == "system"
+
+    def test_chat_stream_streams_provider_chunks(self, db_path):
+        alice = _make_user(db_path)
+        mock = MockProvider(chunks=["Hel", "lo", "!"])
+        with use_provider(mock), _neutralise_chat_side_effects():
+            events = list(chat_stream([], "hi", [], alice))
+        assert events[0]["type"] == "meta"
+        deltas = [e["content"] for e in events if e["type"] == "delta"]
+        assert deltas == ["Hel", "lo", "!"]
+        done = events[-1]
+        assert done["type"] == "done"
+        assert done["reply"] == "Hello!"
+
+    def test_chat_provider_failure_maps_to_unreachable_reply(self, db_path):
+        alice = _make_user(db_path)
+        broken = MockProvider(error=ModelProviderError("backend down"))
+        with use_provider(broken), _neutralise_chat_side_effects():
+            reply, model = chat([], "hi", [], alice)
+        assert reply == chat_module.OLLAMA_UNAVAILABLE
+
+    def test_chat_stream_provider_failure_yields_clean_error(self, db_path):
+        alice = _make_user(db_path)
+        broken = MockProvider(error=ModelProviderError("backend down"))
+        with use_provider(broken), _neutralise_chat_side_effects():
+            events = list(chat_stream([], "hi", [], alice))
+        assert any(e["type"] == "error" for e in events)
+        assert not any(e["type"] == "done" for e in events)
+        err = next(e for e in events if e["type"] == "error")
+        assert err["detail"] == chat_module.OLLAMA_UNAVAILABLE

--- a/tests/test_personalization_chat_wiring.py
+++ b/tests/test_personalization_chat_wiring.py
@@ -31,7 +31,12 @@ for _mod in ("ddgs", "ollama"):
         sys.modules[_mod] = MagicMock()
 
 from core import chat as chat_module  # noqa: E402
-from core import memory as core_memory, settings as core_settings, users  # noqa: E402
+from core import (  # noqa: E402
+    memory as core_memory,
+    ollama_client,
+    settings as core_settings,
+    users,
+)
 from core.chat import build_messages, chat  # noqa: E402
 from core.identity import IDENTITY_CONTRACT  # noqa: E402
 from memory import store as natural_store  # noqa: E402
@@ -69,7 +74,9 @@ def stub_chat_runtime(reply: str = "ok"):
     `call_args` (which only ever holds the *last* call).
     """
     fake_client_chat = MagicMock(return_value={"message": {"content": reply}})
-    with patch.object(chat_module.client, "chat", fake_client_chat), \
+    # OllamaProvider talks to the shared core.ollama_client.client
+    # singleton; patching its .chat exercises the real chat→provider path.
+    with patch.object(ollama_client.client, "chat", fake_client_chat), \
          patch.object(chat_module, "route", lambda _msg: "default"), \
          patch.object(chat_module, "should_search", lambda _msg: False), \
          patch.object(chat_module, "is_security_query", lambda _msg: False), \


### PR DESCRIPTION
## Summary

Nova was architecturally hardwired to Ollama: the chat path called the Ollama client directly, so the model backend could not be swapped, tested without mimicking Ollama's wire shapes, or evolved toward a Nova‑owned runtime. This PR introduces a backend‑agnostic seam so **Ollama becomes one provider among others, with no behaviour change**. Scope is *provider abstraction only* — no new runtime.

```text
Nova Core  (identity · memory · projects · context · safety · routing · settings · export)
   └─> Model Provider Interface
        ├─ OllamaProvider   (default)
        ├─ MockProvider     (tests)
        └─ future LlamaCppProvider / TransformersProvider / NovaModelProvider
```

- **`core/model_providers/`** — `ModelProvider` ABC + `ModelRequest` / `ModelResponse` / `ModelChunk` / `ProviderHealth` / `ModelProviderError`; a registry (`get_provider` / `register_provider`, default `"ollama"`); `OllamaProvider` preserving the exact `client.chat(model=, messages=)` shape, the stream chunk duck‑typing, the legacy `TypeError` fallback and the unreachable‑error mapping; a deterministic `MockProvider`.
- **`core/chat.py`** — `chat` / `chat_stream` / `extract_and_save_memory` now talk to the provider interface instead of the Ollama client; the Ollama‑specific stream duck‑typing moved behind `OllamaProvider`. Public signatures, event shapes and the `OLLAMA_UNAVAILABLE` behaviour are unchanged.
- **`config.py`** — non‑destructive `NOVA_MODEL_PROVIDER` env (default `"ollama"`).
- **Tests** — chat suites now patch the real transport seam (`core.ollama_client.client`) so `OllamaProvider` is exercised end‑to‑end; new `tests/test_model_providers.py`.
- **Docs** — `docs/model-providers.md` + CHANGELOG: rationale, Ollama stays default & supported, future *local* runtimes, and the rule that Nova identity/context/safety stay above any provider.

### Safety / scope

Provider output never reorders the identity/safety system prompt (`build_messages` untouched); `provider.name` is a backend label, not Nova's identity; memory/projects stay owned by Nova. **No** new runtime, model downloads, shell, Docker socket, cloud provider, API keys, or settings migration. Ollama is **not** removed and remains the default.

## Test plan

- [x] New `tests/test_model_providers.py` — 26 tests: OllamaProvider request‑shape preservation, stream duck‑typing (dict + `SubscriptableBaseModel`), `TypeError` fallback, transport/`ResponseError`→`ModelProviderError` mapping, clean health‑failure handling, registry resolution/override, and `chat`/`chat_stream` routing through the interface.
- [x] Regression sweep (486 passed / 1 skipped): chat, streaming, feedback, personalization, router, model_registry, local_models, memory, projects, identity, data_export, storage.
- [x] flake8 clean on `core/`, `config.py`, changed tests.
- [ ] Full repository test suite (running at time of PR open — result to be confirmed in a follow‑up comment).

> Draft: opened for review before the full‑suite result is confirmed; nothing merges from a draft.

https://claude.ai/code/session_01Xo892P3KkcdufgcJ4YGk5z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo892P3KkcdufgcJ4YGk5z)_