### PR TITLE
feat(model-providers): read-only provider settings/status admin surface (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Model provider settings (Phase 1, read-only): a small admin-only
+  surface to *see and validate* which model backend Nova is using,
+  without adding a runtime. A new `core/provider_status.py` reports the
+  configured provider, the default (always Ollama), the resolved active
+  backend, the selectable providers, and the redacted Ollama host —
+  calmly and read-only, never raising (an unknown configured provider
+  is an `error` string, not a 500). Two admin endpoints expose it:
+  `GET /admin/provider/status` and `POST /admin/provider/test-connection`
+  (a cheap, read-only liveness probe — `client.list()` for Ollama,
+  never a pull or a generation). The admin panel gains a **Provider**
+  tab that renders the snapshot and a **Test provider connection**
+  button surfacing health/errors clearly. **Ollama stays the default**
+  and provider selection stays env-driven (`NOVA_MODEL_PROVIDER`) —
+  nothing is written, migrated, pulled, or restarted. `MockProvider`
+  stays test-only: it is never advertised as selectable, but a
+  configured `mock` is reported truthfully with a clear warning so the
+  state can never hide. No llama.cpp, no Ollama removal, no
+  memory/projects/storage changes. New suites
+  `tests/test_provider_status.py` / `tests/test_provider_endpoints.py`;
+  see [`docs/model-providers.md`](docs/model-providers.md).
 - Model-provider abstraction (Phase: provider abstraction only): Nova
   is no longer architecturally hardwired to Ollama. A new
   `core/model_providers` package introduces a backend-agnostic

--- a/core/provider_status.py
+++ b/core/provider_status.py
@@ -1,0 +1,303 @@
+"""Read-only model-provider status reporter (Phase 1 of provider settings).
+
+This module answers, calmly and read-only, the two questions an operator
+asks about Nova's model backend:
+
+* **"Which provider is Nova configured to use, and is that configuration
+  coherent?"** — :func:`get_provider_status`. No network I/O, never
+  raises into the caller. An unknown / unregistered configured provider
+  is reported as an ``error`` string, never as an exception.
+* **"Does that backend actually answer right now?"** —
+  :func:`probe_provider_health`. Delegates to the provider's own cheap,
+  read-only ``health()`` probe (``client.list()`` for Ollama — never a
+  model pull, never a generation). ``health()`` never raises by
+  contract; an unreachable backend is surfaced as ``ok=False`` with a
+  short, non-sensitive detail.
+
+Scope / safety contract (Phase 1):
+
+* **Read-only.** Nothing here writes settings, mutates the registry,
+  triggers a model download, or restarts anything. Provider selection
+  stays env-driven (``NOVA_MODEL_PROVIDER``); this module only reports
+  the resolved state and probes liveness.
+* **Ollama stays the default.** :data:`DEFAULT_PROVIDER` is ``"ollama"``
+  and the status flags whether the configured provider differs so a
+  non-default backend is never silent.
+* **MockProvider stays test-only.** ``mock`` is never advertised as a
+  selectable production backend (:data:`TEST_ONLY_PROVIDERS`). If Nova
+  is *configured* to use it the status still reports that truthfully —
+  with a clear warning — so a stray test setting can never hide.
+* **No secrets.** The only env-derived string surfaced is the Ollama
+  host, with any ``user:pass@`` userinfo redacted before display.
+
+It is the read-only foundation under the admin-only
+``/admin/provider/status`` and ``/admin/provider/test-connection``
+endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
+
+logger = logging.getLogger(__name__)
+
+
+#: Nova's default model provider. Deployments that never set
+#: ``NOVA_MODEL_PROVIDER`` keep using this; the status surface flags any
+#: deviation so a non-default backend is never silent.
+DEFAULT_PROVIDER = "ollama"
+
+#: Providers that exist for tests / offline development only and must
+#: never be advertised to operators as a production choice. They are
+#: still reported *if explicitly configured* (with a warning) so the
+#: state is never hidden — they are only filtered out of the
+#: "selectable" list.
+TEST_ONLY_PROVIDERS: frozenset[str] = frozenset({"mock"})
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _redact_userinfo(url: str) -> str:
+    """Return ``url`` with any ``user:pass@`` userinfo removed.
+
+    ``OLLAMA_HOST`` is normally a plain ``http://localhost:11434`` and
+    safe to show, but a host *can* embed credentials in the netloc. We
+    strip those before surfacing so the status endpoint never leaks a
+    secret. Best-effort and never raises: an unparseable value is
+    masked conservatively rather than echoed back.
+    """
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+        netloc = parts.netloc
+        if "@" not in netloc:
+            return url
+        host = parts.hostname or ""
+        try:
+            port = parts.port
+        except ValueError:
+            port = None
+        if port is not None:
+            host = f"{host}:{port}"
+        return urlunsplit(
+            (parts.scheme, host, parts.path, parts.query, parts.fragment)
+        )
+    except ValueError:
+        return "<host redacted>"
+
+
+# ── Dataclass ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProviderStatus:
+    """Calm, read-only snapshot of Nova's model-provider configuration.
+
+    Every attribute is JSON-serialisable so the admin endpoint can hand
+    it to FastAPI without bespoke encoders.
+
+    * ``configured_provider`` — the provider name Nova is configured to
+      use (``config.MODEL_PROVIDER`` / ``NOVA_MODEL_PROVIDER``,
+      normalised, default ``"ollama"``).
+    * ``default_provider`` — always :data:`DEFAULT_PROVIDER`; surfaced
+      so the UI never hard-codes the word "ollama".
+    * ``active_provider`` — the resolved provider's backend label, or
+      ``None`` when the configured provider cannot be resolved (see
+      ``error``).
+    * ``is_default`` — whether the configured provider is the default.
+    * ``selectable_providers`` — registered providers an operator may
+      choose, with test-only backends filtered out.
+    * ``test_only_providers`` — registered test-only backends, surfaced
+      for transparency so the UI can label them clearly.
+    * ``ollama_host`` — the configured Ollama host with any userinfo
+      redacted (informational; Ollama is the default backend).
+    * ``error`` — a short message when the configured provider is not
+      registered, else ``""``.
+    * ``warnings`` — human-readable messages the UI renders verbatim.
+    """
+
+    configured_provider: str
+    default_provider: str
+    active_provider: Optional[str]
+    is_default: bool
+    selectable_providers: tuple[str, ...]
+    test_only_providers: tuple[str, ...]
+    ollama_host: str
+    error: str = ""
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "configured_provider": self.configured_provider,
+            "default_provider": self.default_provider,
+            "active_provider": self.active_provider,
+            "is_default": self.is_default,
+            "selectable_providers": list(self.selectable_providers),
+            "test_only_providers": list(self.test_only_providers),
+            "ollama_host": self.ollama_host,
+            "error": self.error,
+            "warnings": list(self.warnings),
+        }
+
+
+# ── Public entry points ─────────────────────────────────────────────
+
+
+def get_provider_status() -> ProviderStatus:
+    """Return a calm, read-only snapshot of the provider configuration.
+
+    Safe to call at any time and from any thread; never raises into the
+    caller and never reaches the network. An unknown configured provider
+    surfaces as a populated ``error`` / ``warnings`` pair with
+    ``active_provider=None`` rather than as an exception — the same
+    "report it, don't crash" stance as ``core.storage_status``.
+
+    Imports are deferred so the module has no import-time ``config``
+    dependency and tests can monkeypatch ``config.MODEL_PROVIDER`` /
+    the registry before the first call.
+    """
+    from config import MODEL_PROVIDER, OLLAMA_HOST
+    from core.model_providers import (
+        ModelProviderError,
+        available_providers,
+        get_provider,
+    )
+
+    configured = (
+        (MODEL_PROVIDER or DEFAULT_PROVIDER).strip().lower()
+        or DEFAULT_PROVIDER
+    )
+    is_default = configured == DEFAULT_PROVIDER
+
+    try:
+        names = list(available_providers())
+    except Exception as exc:  # pragma: no cover - registry is in-memory
+        logger.warning("provider status: available_providers failed: %s", exc)
+        names = [DEFAULT_PROVIDER]
+
+    selectable = tuple(n for n in names if n not in TEST_ONLY_PROVIDERS)
+    test_only = tuple(n for n in names if n in TEST_ONLY_PROVIDERS)
+
+    error = ""
+    active: Optional[str] = None
+    try:
+        active = get_provider().name
+    except ModelProviderError as exc:
+        error = str(exc) or f"unknown model provider {configured!r}"
+    except Exception as exc:  # never raise into the caller
+        logger.warning("provider status: unexpected resolve failure: %s", exc)
+        error = "provider could not be resolved"
+
+    warnings: list[str] = []
+    if error:
+        warnings.append(
+            f"Nova is configured to use the {configured!r} model "
+            f"provider, but it is not registered. Nova cannot generate "
+            f"text until this is fixed — set NOVA_MODEL_PROVIDER="
+            f"{DEFAULT_PROVIDER} (the default) or register the provider."
+        )
+    elif configured in TEST_ONLY_PROVIDERS:
+        warnings.append(
+            f"Nova is configured to use the test-only {configured!r} "
+            f"provider. It returns canned text and never talks to a real "
+            f"model — intended for tests / offline development only. Set "
+            f"NOVA_MODEL_PROVIDER={DEFAULT_PROVIDER} for normal use."
+        )
+    elif not is_default:
+        warnings.append(
+            f"Nova is using the {configured!r} provider instead of the "
+            f"default {DEFAULT_PROVIDER!r}. This is supported; Ollama "
+            f"remains the default and recommended local backend."
+        )
+
+    return ProviderStatus(
+        configured_provider=configured,
+        default_provider=DEFAULT_PROVIDER,
+        active_provider=active,
+        is_default=is_default,
+        selectable_providers=selectable,
+        test_only_providers=test_only,
+        ollama_host=_redact_userinfo((OLLAMA_HOST or "").strip()),
+        error=error,
+        warnings=tuple(warnings),
+    )
+
+
+def probe_provider_health(name: Optional[str] = None) -> dict:
+    """Live, read-only liveness probe for the configured provider.
+
+    Resolves the provider (the configured one unless ``name`` is given)
+    and delegates to its ``health()`` — a cheap read-only call
+    (``client.list()`` for Ollama; never a pull, never a generation).
+    ``health()`` never raises by contract, and an unknown / unregistered
+    provider is mapped to a clean ``ok=False`` result here instead of an
+    exception, so the endpoint always returns one stable JSON shape:
+
+        ``{"ok": bool, "provider": str, "detail": str, "models": [str]}``
+
+    Never raises into the caller — a misbehaving third-party provider
+    that breaks the "health never raises" contract is still contained.
+    """
+    from core.model_providers import ModelProviderError, get_provider
+
+    try:
+        provider = get_provider(name)
+    except ModelProviderError as exc:
+        requested = (name or "").strip().lower()
+        if not requested:
+            # No explicit name → fall back to the *configured*
+            # provider so the result is self-describing ("backend:
+            # does-not-exist — not registered") instead of a bare
+            # "unknown". Read calmly; never let this raise.
+            try:
+                from config import MODEL_PROVIDER
+
+                requested = (MODEL_PROVIDER or "").strip().lower()
+            except Exception:  # pragma: no cover - config import is stable
+                requested = ""
+        return {
+            "ok": False,
+            "provider": requested or "unknown",
+            "detail": str(exc) or "unknown model provider",
+            "models": [],
+        }
+    except Exception as exc:  # never raise into the endpoint
+        logger.warning("provider health: unexpected resolve failure: %s", exc)
+        return {
+            "ok": False,
+            "provider": (name or "unknown"),
+            "detail": "provider could not be resolved",
+            "models": [],
+        }
+
+    try:
+        health = provider.health()
+    except Exception as exc:  # base contract says never; stay calm anyway
+        logger.warning("provider health: probe raised: %s", exc)
+        return {
+            "ok": False,
+            "provider": getattr(provider, "name", name or "unknown"),
+            "detail": "health probe failed unexpectedly",
+            "models": [],
+        }
+
+    return {
+        "ok": bool(health.ok),
+        "provider": health.provider,
+        "detail": health.detail,
+        "models": list(health.models),
+    }
+
+
+__all__ = [
+    "DEFAULT_PROVIDER",
+    "TEST_ONLY_PROVIDERS",
+    "ProviderStatus",
+    "get_provider_status",
+    "probe_provider_health",
+]

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -1,13 +1,17 @@
 # Nova Model Providers
 
-> **Status: shipped (Phase: provider abstraction only), local-first.**
+> **Status: shipped (Phases: provider abstraction + read-only provider
+> settings), local-first.**
 > This document describes the seam that lets Nova's model backend be
-> replaced without rewriting Nova. It lives inside the boundaries set by
+> replaced without rewriting Nova, and the admin-only surface for
+> *seeing and validating* which backend is active. It lives inside the
+> boundaries set by
 > [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md).
 > Nothing here grants Nova new powers, adds a new model runtime, performs
 > model downloads, runs shell, touches a Docker socket, integrates a
-> cloud provider, or migrates settings. **Ollama remains the default and
-> is fully supported.**
+> cloud provider, or migrates settings. The settings surface is
+> **read-only**: provider selection stays env-driven and **Ollama
+> remains the default and is fully supported.**
 
 ## Why Nova has model providers
 
@@ -80,6 +84,53 @@ existing tests that patch that client keep working. Nothing about the
 default deployment changes: leave `NOVA_MODEL_PROVIDER` unset and Nova
 behaves exactly as before.
 
+## Seeing & validating the active provider (admin, read-only)
+
+Phase 1 of provider *settings* adds a small admin-only surface so an
+operator can answer two questions without reading logs or env files —
+**which backend is Nova configured to use**, and **does it actually
+answer right now**. It changes nothing: provider selection stays
+env-driven (`NOVA_MODEL_PROVIDER`), Ollama stays the default, and
+nothing is written, migrated, pulled, or restarted.
+
+`core/provider_status.py` is the calm, read-only foundation, mirroring
+`core/storage_status.py`:
+
+| Function | Role |
+| --- | --- |
+| `get_provider_status()` | Configured provider, the default (always `ollama`), the resolved active backend, the selectable providers, the redacted Ollama host, and warnings. Never reaches the network; never raises — an unknown configured provider is an `error` string, not an exception. |
+| `probe_provider_health(name=None)` | A live but cheap, read-only liveness probe. Delegates to the provider's own `health()` (`client.list()` for Ollama — never a pull, never a generation) and always returns the stable `{ok, provider, detail, models}` shape, even for an unreachable or unknown backend. |
+
+Two admin-only endpoints expose it (both `require_admin`; the provider
+name and host are operator-sensitive):
+
+- `GET /admin/provider/status` — the read-only snapshot.
+- `POST /admin/provider/test-connection` — runs the liveness probe now.
+  It is `POST` so it reads as an explicit "probe now" action and is
+  never cached; it needs no confirmation because it cannot modify
+  anything (mirrors `/admin/maintenance/fetch`).
+
+The admin panel gains a **Provider** tab rendering the snapshot, the
+redacted host, the registered providers, and a **Test provider
+connection** button that surfaces health and errors clearly.
+
+Guardrails baked into this surface:
+
+- **Read-only.** No endpoint mutates the registry, writes settings,
+  triggers a download, or restarts anything. An unreachable backend or
+  an unknown configured provider is reported as data (HTTP 200 with
+  `ok=false` / `error`), never a 500 — the same calm stance as the
+  maintenance / storage endpoints.
+- **Ollama stays the default.** `DEFAULT_PROVIDER` is `"ollama"`; a
+  non-default but registered provider is reported calmly with a "not
+  the default" note, never an error.
+- **MockProvider stays test-only.** `mock` is never advertised in
+  `selectable_providers`. If Nova is *configured* to use it the status
+  still reports that truthfully, with a clear warning, so a stray test
+  setting can never hide.
+- **No secrets.** The only env-derived string surfaced is the Ollama
+  host, with any `user:pass@` userinfo redacted before display.
+
 ## Future providers
 
 New **local** runtimes can be added cleanly in later phases — for
@@ -120,3 +171,13 @@ failure mapping, clean health-failure handling, registry resolution, and
 that `chat` / `chat_stream` route through the interface. The existing
 chat / memory / project / storage suites continue to pass against the
 real `OllamaProvider` path.
+
+The read-only settings surface has its own suites:
+`tests/test_provider_status.py` pins the reporter contract (Ollama is
+the default and unset deployments warn-free; `mock` is never selectable
+but is reported truthfully with a warning if configured; an unknown
+provider is an `error`, not an exception; the host is redacted; the
+liveness probe always returns the stable shape, even when the provider
+breaks the "health never raises" contract). `tests/test_provider_endpoints.py`
+pins the wire contract (`require_admin` gating, the status / probe JSON
+shapes, and that an unreachable or unknown backend stays a calm 200).

--- a/static/index.html
+++ b/static/index.html
@@ -2735,6 +2735,8 @@
         }
         .admin-warning.warning { border-color: rgba(212, 160, 23, 0.3); background: rgba(212, 160, 23, 0.05); }
         .admin-warning.warning .admin-warning-level { color: #d4a017; }
+        .admin-warning.error { border-color: rgba(224, 136, 129, 0.35); background: rgba(224, 136, 129, 0.06); }
+        .admin-warning.error .admin-warning-level { color: var(--danger); }
         .admin-warning.info .admin-warning-level { color: var(--text-dim); }
         .admin-warning-level {
             font-weight: 600;
@@ -2971,6 +2973,7 @@
                 <button class="admin-tab-btn active" data-tab="users" onclick="switchAdminTab('users')">⚑ Users</button>
                 <button class="admin-tab-btn" data-tab="models" onclick="switchAdminTab('models')">⬢ Models</button>
                 <button class="admin-tab-btn" data-tab="storage" onclick="switchAdminTab('storage')">⚇ Storage</button>
+                <button class="admin-tab-btn" data-tab="provider" onclick="switchAdminTab('provider')">◆ Provider</button>
             </div>
             <button id="admin-close" onclick="closeAdmin()">✕</button>
         </div>
@@ -3110,6 +3113,45 @@
                     </div>
                     <div id="storage-restore-result"></div>
                 </div>
+            </div>
+
+            <!-- PROVIDER TAB -->
+            <div id="admin-tab-provider" class="admin-tab-pane">
+                <div class="admin-section-title" style="display:flex;align-items:center;justify-content:space-between;">
+                    <span>Model provider</span>
+                    <button class="admin-btn" onclick="loadProviderStatus()">refresh</button>
+                </div>
+                <div class="admin-warning-summary">
+                    Read-only view of which model backend Nova is configured
+                    to use. <strong>Ollama is the default and recommended
+                    local backend</strong>; the provider is selected with the
+                    <code>NOVA_MODEL_PROVIDER</code> environment variable and
+                    is never changed from this screen. Per-mode model
+                    selection lives under the <strong>Models</strong> tab.
+                </div>
+                <div id="provider-status-list">
+                    <div class="admin-empty">Loading…</div>
+                </div>
+
+                <div class="admin-section-title">Test provider connection</div>
+                <div id="provider-test-form">
+                    <div class="admin-warning-summary">
+                        Runs a cheap, read-only liveness probe against the
+                        configured backend (for Ollama: lists installed
+                        models — never pulls a model and never generates
+                        text). Use it to confirm Nova can reach the backend.
+                    </div>
+                    <div class="row" style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;">
+                        <button class="admin-btn primary" onclick="testProviderConnection()" id="provider-test-btn">
+                            Test provider connection
+                        </button>
+                        <span class="admin-warning-summary" style="padding:0;">
+                            Read-only · admin-only · never pulls or generates
+                        </span>
+                    </div>
+                    <div id="provider-test-error" style="color:var(--danger);font-size:0.82rem;min-height:0;"></div>
+                </div>
+                <div id="provider-test-result"></div>
             </div>
         </div>
     </div>
@@ -8364,6 +8406,9 @@
         } else if (tab === "storage") {
             stopAdminPullsPolling();
             loadStorageStatus();
+        } else if (tab === "provider") {
+            stopAdminPullsPolling();
+            loadProviderStatus();
         }
     }
 
@@ -9371,6 +9416,176 @@
             `</div>` +
             restartLine +
             warnings;
+    }
+
+    // ── MODEL PROVIDER (read-only status + live liveness probe) ──
+    // Mirrors the storage tab: a calm read-only snapshot, plus an
+    // explicit "test connection" action. Nothing here changes the
+    // provider — selection stays env-driven and Ollama is the default.
+
+    async function loadProviderStatus() {
+        const list = document.getElementById("provider-status-list");
+        if (!list) return;
+        list.innerHTML = '<div class="admin-empty">Loading…</div>';
+        try {
+            const res = await fetch("/admin/provider/status", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                list.innerHTML = '<div class="admin-empty" style="color:var(--danger);">Access denied.</div>';
+                return;
+            }
+            if (!res.ok) {
+                list.innerHTML = '<div class="admin-empty">Failed to load provider status.</div>';
+                return;
+            }
+            renderProviderStatus(await res.json());
+        } catch (e) {
+            list.innerHTML = '<div class="admin-empty">Failed to load provider status.</div>';
+        }
+    }
+
+    function renderProviderStatus(status) {
+        const list = document.getElementById("provider-status-list");
+        if (!list) return;
+        const parts = [];
+        const configured = status.configured_provider || "ollama";
+        const stateTag = status.error
+            ? `<span class="admin-tag error">not registered</span>`
+            : (status.is_default
+                ? `<span class="admin-tag installed">default</span>`
+                : `<span class="admin-tag">non-default</span>`);
+        const activeLine = status.active_provider
+            ? `<div class="admin-progress-meta">active backend: <code>${escapeHtml(status.active_provider)}</code></div>`
+            : `<div class="admin-progress-meta">active backend: <code>unavailable</code></div>`;
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">configured provider</span>` +
+            `${stateTag}` +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(configured)}</div>` +
+            activeLine +
+            `<div class="admin-progress-meta">default: <code>${escapeHtml(status.default_provider || "ollama")}</code></div>` +
+            `</div>`
+        );
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">Ollama host</span>` +
+            `<span class="admin-tag">informational</span>` +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(status.ollama_host || "—")}</div>` +
+            `</div>`
+        );
+        const selectable = Array.isArray(status.selectable_providers) ? status.selectable_providers : [];
+        const testOnly = Array.isArray(status.test_only_providers) ? status.test_only_providers : [];
+        const selBody = selectable.length
+            ? selectable.map(p => `<code>${escapeHtml(p)}</code>`).join(" · ")
+            : "<code>none</code>";
+        let testOnlyLine = "";
+        if (testOnly.length) {
+            testOnlyLine =
+                `<div class="admin-progress-meta">test-only (never a production choice): ` +
+                testOnly.map(p => `<code>${escapeHtml(p)}</code>`).join(" · ") +
+                `</div>`;
+        }
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">registered providers</span>` +
+            `</div>` +
+            `<div class="admin-progress-meta">selectable: ${selBody}</div>` +
+            testOnlyLine +
+            `</div>`
+        );
+        if (status.error) {
+            parts.push(
+                `<div class="admin-warning error">` +
+                `<span class="admin-warning-level">error</span>` +
+                `<span class="admin-warning-msg">${escapeHtml(status.error)}</span>` +
+                `</div>`
+            );
+        }
+        const warnings = Array.isArray(status.warnings) ? status.warnings : [];
+        for (const w of warnings) {
+            parts.push(
+                `<div class="admin-warning warning">` +
+                `<span class="admin-warning-level">warning</span>` +
+                `<span class="admin-warning-msg">${escapeHtml(w)}</span>` +
+                `</div>`
+            );
+        }
+        list.innerHTML = parts.join("");
+    }
+
+    async function testProviderConnection() {
+        const btn = document.getElementById("provider-test-btn");
+        const errEl = document.getElementById("provider-test-error");
+        const resultEl = document.getElementById("provider-test-result");
+        if (errEl) errEl.textContent = "";
+        if (resultEl) resultEl.innerHTML = "";
+        if (!btn) return;
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Testing…";
+        try {
+            const res = await fetch("/admin/provider/test-connection", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: "{}",
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                if (errEl) errEl.textContent = "Access denied.";
+                return;
+            }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const body = await res.json();
+                    if (body && body.detail) detail = body.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            renderProviderHealth(await res.json());
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while testing the provider connection.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    }
+
+    function renderProviderHealth(body) {
+        const el = document.getElementById("provider-test-result");
+        if (!el) return;
+        const ok = body && body.ok === true;
+        const tag = ok
+            ? `<span class="admin-tag installed">reachable</span>`
+            : `<span class="admin-tag error">unreachable</span>`;
+        const models = Array.isArray(body.models) ? body.models : [];
+        const modelsLine = models.length
+            ? `<div class="admin-progress-meta">installed models: ${models.map(m => `<code>${escapeHtml(m)}</code>`).join(" · ")}</div>`
+            : `<div class="admin-progress-meta">installed models: <code>none reported</code></div>`;
+        const detailLine = body.detail
+            ? `<div class="admin-warning ${ok ? "info" : "error"}"><span class="admin-warning-level">${ok ? "info" : "error"}</span><span class="admin-warning-msg">${escapeHtml(body.detail)}</span></div>`
+            : "";
+        el.innerHTML =
+            `<div class="admin-section-title">Connection test result</div>` +
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">backend: ${escapeHtml(body.provider || "unknown")}</span>` +
+            tag +
+            `</div>` +
+            modelsLine +
+            `</div>` +
+            detailLine;
     }
 
     // ── UTILS ──

--- a/tests/test_provider_endpoints.py
+++ b/tests/test_provider_endpoints.py
@@ -1,0 +1,254 @@
+"""Tests for the admin-only ``/admin/provider/*`` endpoints.
+
+These pin the wire-level contract of the Phase-1 provider settings
+surface: who can call, who can't, and the JSON shape the admin UI
+renders.
+
+* Non-admin and restricted users get 403; unauthenticated callers get
+  401 / 403 (FastAPI's HTTPBearer default).
+* ``GET /admin/provider/status`` returns the configured provider, the
+  default (always ``ollama``), the selectable providers (test-only
+  ``mock`` filtered out), the redacted Ollama host, and warnings — and
+  reports an unknown configured provider as a calm 200 + ``error``,
+  never a 500.
+* ``POST /admin/provider/test-connection`` returns the stable
+  ``{ok, provider, detail, models}`` liveness shape with status 200,
+  including when the backend is unreachable or unknown.
+* The endpoints are read-only: they never mutate the provider and
+  Ollama stays the default.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core import memory as core_memory, users  # noqa: E402
+from core.model_providers import (  # noqa: E402
+    MockProvider,
+    reset as reset_registry,
+    set_override,
+)
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """A registry override / cached instance never leaks between tests."""
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post(
+        "/login", json={"username": username, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+# ── Auth gating ─────────────────────────────────────────────────────
+
+
+_ENDPOINTS = [
+    ("GET", "/admin/provider/status", None),
+    ("POST", "/admin/provider/test-connection", {}),
+]
+
+
+class TestProviderEndpointsAuth:
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_non_admin_forbidden(
+        self, web_client, user_token, method, path, body,
+    ):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(user_token))
+        else:
+            resp = web_client.post(path, headers=_h(user_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_restricted_forbidden(
+        self, web_client, restricted_token, method, path, body,
+    ):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(restricted_token))
+        else:
+            resp = web_client.post(
+                path, headers=_h(restricted_token), json=body,
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_unauthenticated_blocked(self, web_client, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path)
+        else:
+            resp = web_client.post(path, json=body)
+        assert resp.status_code in (401, 403)
+
+
+# ── /admin/provider/status ──────────────────────────────────────────
+
+
+class TestStatusEndpoint:
+    def test_status_shape_defaults_to_ollama(
+        self, web_client, admin_token, monkeypatch,
+    ):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        resp = web_client.get(
+            "/admin/provider/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["default_provider"] == "ollama"
+        assert body["configured_provider"] == "ollama"
+        assert body["is_default"] is True
+        assert isinstance(body["selectable_providers"], list)
+        # MockProvider stays test-only — never advertised as selectable.
+        assert "mock" not in body["selectable_providers"]
+        assert "mock" in body["test_only_providers"]
+        assert "ollama" in body["selectable_providers"]
+        assert isinstance(body["warnings"], list)
+        assert body["error"] == ""
+
+    def test_status_unknown_provider_is_calm_200(
+        self, web_client, admin_token, monkeypatch,
+    ):
+        # An unknown configured provider must surface as a calm 200 +
+        # error/warning, never a 500.
+        monkeypatch.setattr("config.MODEL_PROVIDER", "does-not-exist")
+        resp = web_client.get(
+            "/admin/provider/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["active_provider"] is None
+        assert body["error"]
+        assert any("not registered" in w for w in body["warnings"])
+
+    def test_status_redacts_ollama_host(
+        self, web_client, admin_token, monkeypatch,
+    ):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr(
+            "config.OLLAMA_HOST", "http://bob:hunter2@ollama.lan:11434",
+        )
+        resp = web_client.get(
+            "/admin/provider/status", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert "hunter2" not in resp.json()["ollama_host"]
+
+
+# ── /admin/provider/test-connection ─────────────────────────────────
+
+
+class TestTestConnectionEndpoint:
+    def test_reachable_backend_reports_ok(
+        self, web_client, admin_token,
+    ):
+        set_override(MockProvider(healthy=True))
+        resp = web_client.post(
+            "/admin/provider/test-connection", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["provider"] == "mock"
+        assert isinstance(body["models"], list)
+
+    def test_unreachable_backend_reports_clean_failure(
+        self, web_client, admin_token,
+    ):
+        set_override(MockProvider(healthy=False))
+        resp = web_client.post(
+            "/admin/provider/test-connection", headers=_h(admin_token),
+        )
+        # Still a 200 — an unreachable backend is data, not a server
+        # error (mirrors the maintenance / storage endpoints).
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["detail"]
+
+    def test_unknown_provider_reports_clean_failure(
+        self, web_client, admin_token, monkeypatch,
+    ):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "does-not-exist")
+        resp = web_client.post(
+            "/admin/provider/test-connection", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["provider"] == "does-not-exist"
+        assert body["models"] == []

--- a/tests/test_provider_status.py
+++ b/tests/test_provider_status.py
@@ -1,0 +1,282 @@
+"""Tests for the read-only model-provider status reporter.
+
+Pinned contracts (see ``core/provider_status.py``):
+
+* the reporter is read-only and never raises into the caller — an
+  unknown configured provider is an ``error`` string, not an
+  exception;
+* Ollama is the default and existing (unset) deployments report it
+  with ``is_default=True`` and no warnings;
+* MockProvider stays test-only: ``mock`` is never in
+  ``selectable_providers``, but if it is *configured* the status
+  reports it truthfully with a clear warning;
+* a non-default but registered provider is reported calmly with a
+  "not the default" warning, never an error;
+* the Ollama host is surfaced with any ``user:pass@`` userinfo
+  redacted;
+* ``probe_provider_health`` delegates to the provider's ``health()``
+  and always returns the stable ``{ok, provider, detail, models}``
+  shape, even for an unknown provider or a provider that breaks the
+  "health never raises" contract;
+* every response field is JSON-serialisable.
+
+The tests never assume a reachable Ollama daemon — the live-probe
+tests drive a registry override / MockProvider.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import provider_status as ps  # noqa: E402
+from core.model_providers import (  # noqa: E402
+    MockProvider,
+    register_provider,
+    reset,
+)
+from core.model_providers import registry as registry_mod  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """No override / cached instance / extra factory leaks between tests."""
+    reset()
+    yield
+    reset()
+
+
+# ── _redact_userinfo ────────────────────────────────────────────────
+
+
+class TestRedactUserinfo:
+    def test_plain_host_is_unchanged(self):
+        assert (
+            ps._redact_userinfo("http://localhost:11434")
+            == "http://localhost:11434"
+        )
+
+    def test_empty_is_empty(self):
+        assert ps._redact_userinfo("") == ""
+
+    def test_userinfo_is_stripped(self):
+        out = ps._redact_userinfo("http://user:secret@ollama.internal:11434")
+        assert "secret" not in out
+        assert "user" not in out
+        assert "ollama.internal" in out
+        assert "11434" in out
+
+    def test_unparseable_value_with_at_is_masked(self):
+        # A bizarre value still must not echo a potential secret back.
+        out = ps._redact_userinfo("http://u:p@[bad")
+        assert "p@" not in out
+
+
+# ── get_provider_status: default (Ollama) ───────────────────────────
+
+
+class TestStatusDefault:
+    def test_unset_defaults_to_ollama_no_warnings(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr("config.OLLAMA_HOST", "http://localhost:11434")
+        status = ps.get_provider_status()
+        assert status.configured_provider == "ollama"
+        assert status.default_provider == "ollama"
+        assert status.is_default is True
+        assert status.active_provider == "ollama"
+        assert status.error == ""
+        assert status.warnings == ()
+
+    def test_blank_provider_falls_back_to_ollama(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "   ")
+        status = ps.get_provider_status()
+        assert status.configured_provider == "ollama"
+        assert status.is_default is True
+
+    def test_mock_is_never_selectable_but_listed_as_test_only(
+        self, monkeypatch,
+    ):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        status = ps.get_provider_status()
+        assert "mock" not in status.selectable_providers
+        assert "ollama" in status.selectable_providers
+        assert "mock" in status.test_only_providers
+
+    def test_ollama_host_is_redacted(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr(
+            "config.OLLAMA_HOST", "http://bob:hunter2@10.0.0.5:11434",
+        )
+        status = ps.get_provider_status()
+        assert "hunter2" not in status.ollama_host
+        assert "10.0.0.5" in status.ollama_host
+
+    def test_status_is_json_serialisable(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        body = ps.get_provider_status().as_dict()
+        parsed = json.loads(json.dumps(body))
+        assert parsed["default_provider"] == "ollama"
+        assert isinstance(parsed["selectable_providers"], list)
+        assert isinstance(parsed["warnings"], list)
+
+
+# ── get_provider_status: test-only mock configured ──────────────────
+
+
+class TestStatusMockConfigured:
+    def test_configured_mock_is_reported_with_warning(self, monkeypatch):
+        # The state is never hidden: if someone sets the test provider
+        # in production the status must say so, loudly but calmly.
+        monkeypatch.setattr("config.MODEL_PROVIDER", "mock")
+        status = ps.get_provider_status()
+        assert status.configured_provider == "mock"
+        assert status.is_default is False
+        assert status.active_provider == "mock"
+        assert status.error == ""
+        joined = " ".join(status.warnings)
+        assert "test-only" in joined
+        assert "NOVA_MODEL_PROVIDER=ollama" in joined
+
+
+# ── get_provider_status: unknown provider ───────────────────────────
+
+
+class TestStatusUnknownProvider:
+    def test_unknown_provider_is_error_not_exception(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "does-not-exist")
+        status = ps.get_provider_status()
+        assert status.active_provider is None
+        assert status.error  # populated, non-empty
+        assert status.is_default is False
+        joined = " ".join(status.warnings)
+        assert "not registered" in joined
+        assert "NOVA_MODEL_PROVIDER=ollama" in joined
+
+
+# ── get_provider_status: non-default registered provider ────────────
+
+
+class _FutureProvider(MockProvider):
+    """A registered, non-test, non-default provider for status tests."""
+
+    name = "future"
+
+
+class TestStatusNonDefaultProvider:
+    def test_non_default_registered_provider_warns_calmly(self, monkeypatch):
+        register_provider("future", _FutureProvider)
+        try:
+            monkeypatch.setattr("config.MODEL_PROVIDER", "future")
+            status = ps.get_provider_status()
+            assert status.configured_provider == "future"
+            assert status.active_provider == "future"
+            assert status.is_default is False
+            assert status.error == ""
+            assert "future" in status.selectable_providers
+            joined = " ".join(status.warnings)
+            assert "default" in joined
+            assert "supported" in joined
+        finally:
+            registry_mod._factories.pop("future", None)
+            registry_mod._instances.pop("future", None)
+
+
+# ── probe_provider_health ───────────────────────────────────────────
+
+
+class TestProbeProviderHealth:
+    def test_healthy_override_reports_ok(self):
+        from core.model_providers import set_override
+
+        set_override(MockProvider(healthy=True))
+        out = ps.probe_provider_health()
+        assert out["ok"] is True
+        assert out["provider"] == "mock"
+        assert isinstance(out["models"], list)
+
+    def test_unhealthy_override_reports_clean_failure(self):
+        from core.model_providers import set_override
+
+        set_override(MockProvider(healthy=False))
+        out = ps.probe_provider_health()
+        assert out["ok"] is False
+        assert out["detail"]  # short, non-empty reason
+
+    def test_unknown_provider_maps_to_clean_failure(self):
+        out = ps.probe_provider_health("does-not-exist")
+        assert out["ok"] is False
+        assert out["provider"] == "does-not-exist"
+        assert out["detail"]
+        assert out["models"] == []
+
+    def test_health_contract_violation_is_contained(self):
+        # A misbehaving third-party provider that *raises* from
+        # health() (against the base contract) must still not blow up
+        # the endpoint.
+        class _Rogue(MockProvider):
+            name = "rogue"
+
+            def health(self):
+                raise RuntimeError("provider exploded")
+
+        from core.model_providers import set_override
+
+        set_override(_Rogue())
+        out = ps.probe_provider_health()
+        assert out["ok"] is False
+        assert out["models"] == []
+
+    def test_health_models_are_passed_through(self):
+        from core.model_providers import set_override
+        from core.model_providers import ProviderHealth
+
+        class _WithModels(MockProvider):
+            name = "withmodels"
+
+            def health(self):
+                return ProviderHealth(
+                    ok=True,
+                    provider=self.name,
+                    models=["gemma4", "qwen2.5:32b"],
+                )
+
+        set_override(_WithModels())
+        out = ps.probe_provider_health()
+        assert out["ok"] is True
+        assert set(out["models"]) == {"gemma4", "qwen2.5:32b"}
+
+
+# ── never raises ────────────────────────────────────────────────────
+
+
+class TestNeverRaises:
+    def test_status_never_raises_even_if_registry_breaks(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+
+        def _boom():
+            raise RuntimeError("registry on fire")
+
+        monkeypatch.setattr(
+            "core.model_providers.available_providers", _boom,
+        )
+        # Must not propagate — falls back to a sane default list.
+        status = ps.get_provider_status()
+        assert status.default_provider == "ollama"
+
+    def test_probe_never_raises_on_unexpected_resolve_error(
+        self, monkeypatch,
+    ):
+        def _boom(_name=None):
+            raise ValueError("not a ModelProviderError")
+
+        monkeypatch.setattr("core.model_providers.get_provider", _boom)
+        out = ps.probe_provider_health()
+        assert out["ok"] is False
+        assert out["models"] == []

--- a/web.py
+++ b/web.py
@@ -70,6 +70,7 @@ from core.security import lifecycle as _silentguard_lifecycle
 from core.security import SilentGuardProvider as _SilentGuardProvider
 from core import maintenance as _maintenance
 from core import storage_status as _storage_status
+from core import provider_status as _provider_status
 from core import data_export as _data_export
 from core import voice as _voice
 import sqlite3 as _sqlite3
@@ -2914,6 +2915,60 @@ def storage_restore_endpoint(
         dry_run=False,
     )
     return result.as_dict()
+
+
+# ── ADMIN: MODEL PROVIDER SETTINGS ────────────────────────────────
+# Phase 1 admin-only window onto Nova's model-provider configuration.
+# Both endpoints are wrapped with ``require_admin`` (the provider name
+# and host are operator-sensitive). The underlying module
+# (``core.provider_status``) enforces:
+#
+#   * read-only reporting — nothing here writes settings, mutates the
+#     provider registry, triggers a model download, or restarts
+#     anything. Provider selection stays env-driven
+#     (``NOVA_MODEL_PROVIDER``); Ollama remains the default.
+#   * MockProvider stays test-only — it is never advertised as a
+#     selectable production backend (only reported, with a warning, if
+#     explicitly configured).
+#   * no secrets — the Ollama host is surfaced with any ``user:pass@``
+#     userinfo redacted.
+#
+# ``test-connection`` performs a live but cheap, read-only liveness
+# probe (the provider's ``health()`` — ``client.list()`` for Ollama,
+# never a pull or a generation). It is POST so it reads as an explicit
+# "probe now" action and is never cached; it needs no confirmation
+# because it cannot modify anything (mirrors
+# ``/admin/maintenance/fetch``).
+
+
+@app.get("/admin/provider/status")
+def provider_status_endpoint(_: CurrentUser = Depends(require_admin)):
+    """Calm read-only snapshot of Nova's model-provider configuration.
+
+    Returns the configured provider, the default (always Ollama),
+    whether they match, the selectable providers (test-only backends
+    filtered out), the redacted Ollama host, and any warnings — for
+    example when the configured provider is unknown or is the
+    test-only mock. Never reaches the network.
+    """
+    return _provider_status.get_provider_status().as_dict()
+
+
+@app.post("/admin/provider/test-connection")
+def provider_test_connection_endpoint(
+    _: CurrentUser = Depends(require_admin),
+):
+    """Probe the configured provider's liveness, read-only.
+
+    Delegates to the provider's own ``health()`` (``client.list()``
+    for Ollama — never a model pull or a generation). Always returns
+    a stable ``{"ok", "provider", "detail", "models"}`` shape with
+    status 200; an unreachable backend or an unknown configured
+    provider is reported as ``ok=False`` with a short, non-sensitive
+    detail rather than a 500 — the same calm stance as the
+    maintenance / storage endpoints.
+    """
+    return _provider_status.probe_provider_health()
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

Nova Model Provider Settings **Phase 1**. The model-provider abstraction (#194) made the backend replaceable, but operators still had no way to *see* which provider Nova was using or *validate* that it was reachable without reading logs/env. This adds a small, **read-only** admin surface — no new runtime, no settings migration.

- **`core/provider_status.py`** — calm, read-only reporter mirroring `core/storage_status.py`:
  - `get_provider_status()` → configured provider, default (always `ollama`), resolved active backend, selectable providers (test-only `mock` filtered out), redacted Ollama host, warnings. Never reaches the network; never raises (an unknown configured provider is an `error` string, not a 500).
  - `probe_provider_health()` → delegates to the provider's own `health()` (`client.list()` for Ollama — never a pull or a generation); always returns a stable `{ok, provider, detail, models}` shape.
- **`web.py`** — `GET /admin/provider/status` and `POST /admin/provider/test-connection`, both `require_admin` and read-only.
- **`static/index.html`** — a new **Provider** admin tab rendering the snapshot + a **Test provider connection** button surfacing health/errors clearly (adds an `admin-warning.error` style).
- **Docs** — `docs/model-providers.md` + `CHANGELOG.md`.

## Scope guarantees

- ✅ Ollama stays the **default**; selection stays env-driven (`NOVA_MODEL_PROVIDER`) — nothing written, migrated, pulled, or restarted.
- ✅ `MockProvider` stays **test-only**: never advertised as selectable, but a configured `mock` is reported truthfully with a clear warning so the state can't hide.
- ✅ No llama.cpp, no Ollama removal, no memory/projects/storage changes.
- ✅ Secrets safe: the only env-derived string surfaced is the Ollama host, with `user:pass@` userinfo redacted.

## Test plan

- [x] `tests/test_provider_status.py` — reporter contract (default Ollama warn-free; `mock` never selectable but reported-with-warning if configured; unknown provider → `error` not exception; host redaction; probe always stable, even on a health-contract violation).
- [x] `tests/test_provider_endpoints.py` — `require_admin` gating (non-admin/restricted 403, unauth 401/403); status & probe JSON shapes; unreachable/unknown backend stays a calm HTTP 200.
- [x] Focused regression run green: **172 passed** across the new suites + `test_model_providers`, `test_chat_stream`, `test_storage_endpoints`, `test_settings_scoping`, `test_admin_users`.
- [x] `flake8 .` clean repo-wide.
- [ ] Manual: open admin → **Provider** tab, confirm snapshot renders and **Test provider connection** surfaces health/errors.

https://claude.ai/code/session_01LZfn9JfTCxogecVSkzxe83

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZfn9JfTCxogecVSkzxe83)_