### PR TITLE
feat(model-providers): surface active provider in Settings → Models (Phase 1 UI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,23 @@
   memory/projects/storage changes. New suites
   `tests/test_provider_status.py` / `tests/test_provider_endpoints.py`;
   see [`docs/model-providers.md`](docs/model-providers.md).
+- Model provider in Settings → Models (Phase 1 UI, read-only,
+  admin-only): the active model provider is now visible and testable
+  where users actually look for model settings, not just in the deep
+  Admin → Provider tab. The status snapshot now also reports Nova's
+  default chat model (`config.MODELS["default"]` — host-level,
+  non-secret; a missing default degrades to `""`, never an error) and
+  whether the resolved backend supports streaming. A new admin-only
+  card in **Settings → Models** shows the active provider and its
+  state, the current/default model, the streaming flag, the redacted
+  Ollama host, and a **Test connection** button with a clear
+  success/failure message; the row is hidden entirely for non-admins
+  and the endpoints stay `require_admin`. Reuses the existing
+  `/admin/provider/status` and `/admin/provider/test-connection`
+  endpoints — nothing new is written, pulled, restarted, or
+  generated, Ollama stays the default, and `MockProvider` stays
+  test-only. No new runtime, no model downloads, no cloud provider,
+  no API keys; chat/memory/projects/storage behaviour is unchanged.
 - Model-provider abstraction (Phase: provider abstraction only): Nova
   is no longer architecturally hardwired to Ollama. A new
   `core/model_providers` package introduces a backend-agnostic

--- a/core/provider_status.py
+++ b/core/provider_status.py
@@ -116,6 +116,14 @@ class ProviderStatus:
       for transparency so the UI can label them clearly.
     * ``ollama_host`` — the configured Ollama host with any userinfo
       redacted (informational; Ollama is the default backend).
+    * ``current_model`` — Nova's default chat model (``config.MODELS
+      ["default"]``); the model the backend is asked for unless a
+      per-mode/route override applies. Host-level config, never a
+      secret. ``""`` if it cannot be read.
+    * ``supports_streaming`` — whether the resolved provider exposes a
+      streaming generation path. Every provider implements ``stream``
+      by contract, so this is ``True`` for any resolvable backend and
+      ``False`` only when the configured provider cannot be resolved.
     * ``error`` — a short message when the configured provider is not
       registered, else ``""``.
     * ``warnings`` — human-readable messages the UI renders verbatim.
@@ -128,6 +136,8 @@ class ProviderStatus:
     selectable_providers: tuple[str, ...]
     test_only_providers: tuple[str, ...]
     ollama_host: str
+    current_model: str = ""
+    supports_streaming: bool = False
     error: str = ""
     warnings: tuple[str, ...] = field(default_factory=tuple)
 
@@ -140,6 +150,8 @@ class ProviderStatus:
             "selectable_providers": list(self.selectable_providers),
             "test_only_providers": list(self.test_only_providers),
             "ollama_host": self.ollama_host,
+            "current_model": self.current_model,
+            "supports_streaming": self.supports_streaming,
             "error": self.error,
             "warnings": list(self.warnings),
         }
@@ -161,7 +173,7 @@ def get_provider_status() -> ProviderStatus:
     dependency and tests can monkeypatch ``config.MODEL_PROVIDER`` /
     the registry before the first call.
     """
-    from config import MODEL_PROVIDER, OLLAMA_HOST
+    from config import MODEL_PROVIDER, MODELS, OLLAMA_HOST
     from core.model_providers import (
         ModelProviderError,
         available_providers,
@@ -174,6 +186,16 @@ def get_provider_status() -> ProviderStatus:
     )
     is_default = configured == DEFAULT_PROVIDER
 
+    # Nova's default chat model. Host-level config (never per-user, never
+    # a secret); surfaced so the UI can show "what the backend is asked
+    # for" without the operator grepping config. Best-effort: a missing
+    # / oddly-shaped MODELS must not turn this read-only call into a 500.
+    try:
+        current_model = str((MODELS or {}).get("default", "") or "")
+    except Exception as exc:  # pragma: no cover - config is stable
+        logger.warning("provider status: default model lookup failed: %s", exc)
+        current_model = ""
+
     try:
         names = list(available_providers())
     except Exception as exc:  # pragma: no cover - registry is in-memory
@@ -185,8 +207,15 @@ def get_provider_status() -> ProviderStatus:
 
     error = ""
     active: Optional[str] = None
+    supports_streaming = False
     try:
-        active = get_provider().name
+        provider = get_provider()
+        active = provider.name
+        # Every ModelProvider implements ``stream`` by contract, so a
+        # resolvable backend always supports streaming. We duck-type
+        # rather than assume so a hypothetical non-conforming provider
+        # is reported honestly instead of optimistically.
+        supports_streaming = callable(getattr(provider, "stream", None))
     except ModelProviderError as exc:
         error = str(exc) or f"unknown model provider {configured!r}"
     except Exception as exc:  # never raise into the caller
@@ -223,6 +252,8 @@ def get_provider_status() -> ProviderStatus:
         selectable_providers=selectable,
         test_only_providers=test_only,
         ollama_host=_redact_userinfo((OLLAMA_HOST or "").strip()),
+        current_model=current_model,
+        supports_streaming=supports_streaming,
         error=error,
         warnings=tuple(warnings),
     )

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -88,17 +88,18 @@ behaves exactly as before.
 
 Phase 1 of provider *settings* adds a small admin-only surface so an
 operator can answer two questions without reading logs or env files —
-**which backend is Nova configured to use**, and **does it actually
-answer right now**. It changes nothing: provider selection stays
-env-driven (`NOVA_MODEL_PROVIDER`), Ollama stays the default, and
-nothing is written, migrated, pulled, or restarted.
+**which backend is Nova configured to use** (and which model it asks
+for), and **does it actually answer right now**. It changes nothing:
+provider selection stays env-driven (`NOVA_MODEL_PROVIDER`), Ollama
+stays the default, and nothing is written, migrated, pulled, or
+restarted.
 
 `core/provider_status.py` is the calm, read-only foundation, mirroring
 `core/storage_status.py`:
 
 | Function | Role |
 | --- | --- |
-| `get_provider_status()` | Configured provider, the default (always `ollama`), the resolved active backend, the selectable providers, the redacted Ollama host, and warnings. Never reaches the network; never raises — an unknown configured provider is an `error` string, not an exception. |
+| `get_provider_status()` | Configured provider, the default (always `ollama`), the resolved active backend, the selectable providers, the redacted Ollama host, Nova's default chat model (`config.MODELS["default"]`, host-level and non-secret), whether the backend supports streaming, and warnings. Never reaches the network; never raises — an unknown configured provider is an `error` string, not an exception, and a missing default model degrades to `""`, never a failure. |
 | `probe_provider_health(name=None)` | A live but cheap, read-only liveness probe. Delegates to the provider's own `health()` (`client.list()` for Ollama — never a pull, never a generation) and always returns the stable `{ok, provider, detail, models}` shape, even for an unreachable or unknown backend. |
 
 Two admin-only endpoints expose it (both `require_admin`; the provider
@@ -110,9 +111,24 @@ name and host are operator-sensitive):
   never cached; it needs no confirmation because it cannot modify
   anything (mirrors `/admin/maintenance/fetch`).
 
-The admin panel gains a **Provider** tab rendering the snapshot, the
-redacted host, the registered providers, and a **Test provider
-connection** button that surfaces health and errors clearly.
+Two places render this, both admin-only on the client *and* the server
+(the row/tab is hidden for non-admins and the endpoints are
+`require_admin`):
+
+- **Settings → Models** shows a calm summary an admin sees where they
+  already look for model settings: the active provider and its state
+  (default / non-default / not-registered), the current/default model,
+  whether streaming is supported, the redacted Ollama host, and a
+  **Test connection** button with a clear success/failure message. To
+  check provider health, open **Settings → Models** and click **Test
+  connection** — it runs the cheap, read-only liveness probe (for
+  Ollama: lists installed models; never a pull, never a generation).
+- **Admin → Provider** keeps the deeper view: the same snapshot plus
+  the registered/selectable providers, the test-only backends, every
+  warning, and its own **Test provider connection** button.
+
+Both reuse the same `/admin/provider/*` endpoints, so the success and
+failure language is identical wherever an admin runs the probe.
 
 Guardrails baked into this surface:
 

--- a/static/index.html
+++ b/static/index.html
@@ -3451,6 +3451,33 @@
                             <div style="font-size:0.7rem;color:var(--text-dim);" id="settings-novamodel-help">Ollama model name (e.g. nova-assistant, llama3:8b)</div>
                         </div>
                     </div>
+
+                    <!--
+                      Model provider (admin-only, read-only). Surfaces
+                      which backend Nova uses to turn prompts into text
+                      and lets an admin run a cheap liveness probe
+                      without leaving Settings. Provider selection stays
+                      env-driven (NOVA_MODEL_PROVIDER): nothing here
+                      writes settings, pulls a model, or generates text.
+                      The row is hidden entirely for non-admins — the
+                      endpoints are admin-only and would 403. The deeper
+                      view (registered providers, warnings) still lives
+                      under Admin → Provider; this is the calm summary.
+                    -->
+                    <div class="settings-row" id="settings-provider-row" style="display:none;">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-provider-title">Model provider</span>
+                                <span class="settings-row-hint" id="settings-provider-hint">Which backend Nova uses to generate text. Read-only · admin-only.</span>
+                            </div>
+                            <button class="memory-btn" id="settings-provider-test-btn" onclick="testModelsProviderConnection()" style="white-space:nowrap;">Test connection</button>
+                        </div>
+                        <div id="settings-provider-summary" style="margin-top:10px;">
+                            <div class="admin-empty">Loading…</div>
+                        </div>
+                        <div id="settings-provider-test-error" style="color:var(--danger);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
+                        <div id="settings-provider-test-result" style="margin-top:8px;"></div>
+                    </div>
                 </section>
 
                 <!-- ADMIN (admin-only) -->
@@ -7890,6 +7917,12 @@
         document.querySelectorAll(".settings-pane").forEach(p => {
             p.classList.toggle("active", p.id === "settings-pane-" + pane);
         });
+        // The provider summary is admin-only and read-only; refresh it
+        // when the Models pane is shown (the loader self-gates and hides
+        // the row for non-admins, so this is free in the common path).
+        if (pane === "models") {
+            loadModelsProviderCard().catch(() => {});
+        }
     }
 
     function applySettingsAdminVisibility() {
@@ -9467,7 +9500,17 @@
             `</div>` +
             `<div class="admin-model-name">${escapeHtml(configured)}</div>` +
             activeLine +
-            `<div class="admin-progress-meta">default: <code>${escapeHtml(status.default_provider || "ollama")}</code></div>` +
+            `<div class="admin-progress-meta">default: <code>${escapeHtml(status.default_provider || "ollama")}</code> · streaming: <code>${status.supports_streaming ? "yes" : "no"}</code></div>` +
+            `</div>`
+        );
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">current model</span>` +
+            `<span class="admin-tag">default chat</span>` +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(status.current_model || "—")}</div>` +
+            `<div class="admin-progress-meta">the model the backend is asked for unless a per-route override applies</div>` +
             `</div>`
         );
         parts.push(
@@ -9562,9 +9605,10 @@
         }
     }
 
-    function renderProviderHealth(body) {
-        const el = document.getElementById("provider-test-result");
-        if (!el) return;
+    // Shared between the admin Provider tab and the Settings → Models
+    // card so the success/failure language is identical wherever an
+    // admin runs the probe. Pure: returns HTML, touches no DOM.
+    function _providerHealthHtml(body) {
         const ok = body && body.ok === true;
         const tag = ok
             ? `<span class="admin-tag installed">reachable</span>`
@@ -9576,8 +9620,7 @@
         const detailLine = body.detail
             ? `<div class="admin-warning ${ok ? "info" : "error"}"><span class="admin-warning-level">${ok ? "info" : "error"}</span><span class="admin-warning-msg">${escapeHtml(body.detail)}</span></div>`
             : "";
-        el.innerHTML =
-            `<div class="admin-section-title">Connection test result</div>` +
+        return `<div class="admin-section-title">Connection test result</div>` +
             `<div class="admin-model-row">` +
             `<div class="admin-model-head">` +
             `<span class="admin-model-display">backend: ${escapeHtml(body.provider || "unknown")}</span>` +
@@ -9586,6 +9629,146 @@
             modelsLine +
             `</div>` +
             detailLine;
+    }
+
+    function renderProviderHealth(body) {
+        const el = document.getElementById("provider-test-result");
+        if (el) el.innerHTML = _providerHealthHtml(body);
+    }
+
+    // ── Settings → Models: model-provider summary (admin-only) ────
+    //
+    // A calm, read-only mirror of the admin Provider tab placed where
+    // users actually look for model settings. Admin-gated on the
+    // client (the row is hidden for non-admins) and on the server (the
+    // endpoints are require_admin). Reuses the existing
+    // /admin/provider/* endpoints — nothing new is written, pulled,
+    // restarted, or generated.
+    async function loadModelsProviderCard() {
+        const row = document.getElementById("settings-provider-row");
+        if (!row) return;
+        const isAdmin = !!(currentUser && currentUser.role === "admin");
+        if (!isAdmin) { row.style.display = "none"; return; }
+        row.style.display = "";
+        const summary = document.getElementById("settings-provider-summary");
+        const errEl = document.getElementById("settings-provider-test-error");
+        const resEl = document.getElementById("settings-provider-test-result");
+        if (errEl) errEl.textContent = "";
+        if (resEl) resEl.innerHTML = "";
+        if (summary) summary.innerHTML = '<div class="admin-empty">Loading…</div>';
+        try {
+            const res = await fetch("/admin/provider/status", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) { row.style.display = "none"; return; }
+            if (!res.ok) {
+                if (summary) summary.innerHTML = '<div class="admin-empty">Failed to load provider status.</div>';
+                return;
+            }
+            renderModelsProviderCard(await res.json());
+        } catch (e) {
+            if (summary) summary.innerHTML = '<div class="admin-empty">Failed to load provider status.</div>';
+        }
+    }
+
+    function renderModelsProviderCard(status) {
+        const summary = document.getElementById("settings-provider-summary");
+        if (!summary) return;
+        const configured = status.configured_provider || "ollama";
+        const stateTag = status.error
+            ? `<span class="admin-tag error">not registered</span>`
+            : (status.is_default
+                ? `<span class="admin-tag installed">default</span>`
+                : `<span class="admin-tag">non-default</span>`);
+        const active = status.active_provider
+            ? escapeHtml(status.active_provider) : "unavailable";
+        const model = status.current_model
+            ? escapeHtml(status.current_model) : "—";
+        const streaming = status.supports_streaming ? "yes" : "no";
+        const parts = [];
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">active provider</span>` +
+            stateTag +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(configured)}</div>` +
+            `<div class="admin-progress-meta">active backend: <code>${active}</code> · default: <code>${escapeHtml(status.default_provider || "ollama")}</code></div>` +
+            `<div class="admin-progress-meta">current model: <code>${model}</code> · streaming: <code>${streaming}</code></div>` +
+            `</div>`
+        );
+        if (status.ollama_host) {
+            parts.push(
+                `<div class="admin-model-row">` +
+                `<div class="admin-model-head">` +
+                `<span class="admin-model-display">Ollama host</span>` +
+                `<span class="admin-tag">informational</span>` +
+                `</div>` +
+                `<div class="admin-model-name">${escapeHtml(status.ollama_host)}</div>` +
+                `</div>`
+            );
+        }
+        if (status.error) {
+            parts.push(
+                `<div class="admin-warning error">` +
+                `<span class="admin-warning-level">error</span>` +
+                `<span class="admin-warning-msg">${escapeHtml(status.error)}</span>` +
+                `</div>`
+            );
+        }
+        const warnings = Array.isArray(status.warnings) ? status.warnings : [];
+        for (const w of warnings) {
+            parts.push(
+                `<div class="admin-warning warning">` +
+                `<span class="admin-warning-level">warning</span>` +
+                `<span class="admin-warning-msg">${escapeHtml(w)}</span>` +
+                `</div>`
+            );
+        }
+        summary.innerHTML = parts.join("");
+    }
+
+    async function testModelsProviderConnection() {
+        const btn = document.getElementById("settings-provider-test-btn");
+        const errEl = document.getElementById("settings-provider-test-error");
+        const resEl = document.getElementById("settings-provider-test-result");
+        if (errEl) errEl.textContent = "";
+        if (resEl) resEl.innerHTML = "";
+        if (!btn) return;
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Testing…";
+        try {
+            const res = await fetch("/admin/provider/test-connection", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: "{}",
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                if (errEl) errEl.textContent = "Access denied.";
+                return;
+            }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const b = await res.json();
+                    if (b && b.detail) detail = b.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            if (resEl) resEl.innerHTML = _providerHealthHtml(await res.json());
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while testing the provider connection.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
     }
 
     // ── UTILS ──

--- a/tests/test_provider_endpoints.py
+++ b/tests/test_provider_endpoints.py
@@ -179,6 +179,10 @@ class TestStatusEndpoint:
         assert "ollama" in body["selectable_providers"]
         assert isinstance(body["warnings"], list)
         assert body["error"] == ""
+        # Phase-1 settings UI fields: default chat model + streaming.
+        assert isinstance(body["current_model"], str)
+        assert isinstance(body["supports_streaming"], bool)
+        assert body["supports_streaming"] is True
 
     def test_status_unknown_provider_is_calm_200(
         self, web_client, admin_token, monkeypatch,

--- a/tests/test_provider_status.py
+++ b/tests/test_provider_status.py
@@ -125,6 +125,55 @@ class TestStatusDefault:
         assert parsed["default_provider"] == "ollama"
         assert isinstance(parsed["selectable_providers"], list)
         assert isinstance(parsed["warnings"], list)
+        assert isinstance(parsed["current_model"], str)
+        assert isinstance(parsed["supports_streaming"], bool)
+
+
+# ── current_model / supports_streaming ──────────────────────────────
+
+
+class TestStatusModelAndStreaming:
+    """The Phase-1 settings UI surfaces the default model and whether
+    the backend can stream. Both are read-only, host-level, non-secret
+    facts derived without touching the network."""
+
+    def test_current_model_is_the_configured_default(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr(
+            "config.MODELS", {"default": "test-model-x", "router": "r"},
+        )
+        status = ps.get_provider_status()
+        assert status.current_model == "test-model-x"
+
+    def test_missing_default_model_is_empty_not_an_error(self, monkeypatch):
+        # An absent "default" key must degrade to "" calmly — a model
+        # name is informational, never a reason to fail the status read.
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr("config.MODELS", {"router": "r"})
+        status = ps.get_provider_status()
+        assert status.current_model == ""
+        assert status.error == ""
+
+    def test_resolvable_provider_reports_streaming_true(self, monkeypatch):
+        # Ollama (the default) resolves without network I/O and
+        # implements ``stream`` by contract.
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        status = ps.get_provider_status()
+        assert status.active_provider == "ollama"
+        assert status.supports_streaming is True
+
+    def test_unknown_provider_does_not_claim_streaming(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "does-not-exist")
+        status = ps.get_provider_status()
+        assert status.active_provider is None
+        assert status.supports_streaming is False
+
+    def test_mock_override_supports_streaming(self):
+        from core.model_providers import set_override
+
+        set_override(MockProvider(healthy=True))
+        status = ps.get_provider_status()
+        assert status.supports_streaming is True
 
 
 # ── get_provider_status: test-only mock configured ──────────────────

--- a/web.py
+++ b/web.py
@@ -2947,8 +2947,9 @@ def provider_status_endpoint(_: CurrentUser = Depends(require_admin)):
 
     Returns the configured provider, the default (always Ollama),
     whether they match, the selectable providers (test-only backends
-    filtered out), the redacted Ollama host, and any warnings — for
-    example when the configured provider is unknown or is the
+    filtered out), the redacted Ollama host, Nova's default chat
+    model, whether the backend supports streaming, and any warnings —
+    for example when the configured provider is unknown or is the
     test-only mock. Never reaches the network.
     """
     return _provider_status.get_provider_status().as_dict()


### PR DESCRIPTION
## Summary

Phase 1 of the **Nova Model Provider Settings UI**. Builds directly on
the read-only provider status module + admin endpoints from #195 and
exposes the active model backend **where users actually look for model
settings** (Settings → Models), so they can *see and test* it without
opening logs or env files. **Ollama stays the default.**

> The branch also carries the already-reviewed phases #192–#195
> (paths Phase 4, projects, model-provider abstraction, read-only
> provider admin surface). This PR's own change set is the 7-file,
> ~319-line commit `feat(model-providers): surface active provider in
> Settings → Models (Phase 1 UI)`.

### Backend (`core/provider_status.py`)
- Added two read-only, non-secret fields to the status snapshot:
  - `current_model` — Nova's default chat model
    (`config.MODELS["default"]`); a missing/odd value degrades to `""`,
    never a 500.
  - `supports_streaming` — duck-typed from the resolved provider
    (`False` when the configured provider can't be resolved).
- The model-provider abstraction (#194) is **not** touched.

### Endpoints (`web.py`)
- Reuses the existing admin-only `GET /admin/provider/status` and
  `POST /admin/provider/test-connection` (docstring updated only). No
  new endpoints, no behaviour change.

### UI (`static/index.html`)
- New **admin-only, read-only** Model provider card in
  **Settings → Models**: active provider + state (default /
  non-default / not-registered), current/default model, streaming
  flag, redacted Ollama host, and a **Test connection** button with a
  clear success/failure message.
- Hidden entirely for non-admins (endpoints stay `require_admin`).
- Shared health-render helper so both surfaces use identical
  success/failure language; the existing **Admin → Provider** tab is
  preserved and also shows the two new fields.

### Tests / Docs
- `tests/test_provider_status.py` (+5) and
  `tests/test_provider_endpoints.py` cover `current_model`,
  `supports_streaming`, and admin-only gating.
- `docs/model-providers.md` + `CHANGELOG.md` document the Models-area
  surface, how to test provider health, and reiterate: no new runtimes
  (llama.cpp / transformers / cloud), no model downloads, no API keys.

### Safety / scope
- Admin-only, read-only. Nothing is written, migrated, pulled,
  restarted, or generated. Provider selection stays env-driven
  (`NOVA_MODEL_PROVIDER`). `MockProvider` stays test-only. Ollama host
  is surfaced with `user:pass@` userinfo redacted.
- No memory / projects / storage / chat behaviour changes.

## Test plan
- [x] `tests/test_provider_status.py` — pass (incl. new model/stream)
- [x] `tests/test_provider_endpoints.py` — pass (admin-only + shape)
- [x] `tests/test_model_providers.py`, `test_chat_stream.py`,
      `test_model_registry.py`, `test_local_models.py` — 113 pass
      (Ollama compatible, MockProvider test-only, streaming intact)
- [x] **Full suite green locally — 2003 passed, 2 skipped, 0 failed**
      (memory/projects/storage/auth/security unaffected; 4 pre-existing
      unrelated warnings)
- [x] `flake8 .` clean; inline JS validated with `node --check`
- [ ] Manual: Settings → Models shows the card for an admin, hidden for
      a non-admin; Test connection shows clear success/failure

https://claude.ai/code/session_01TYgL7UPWkL14XGar9ya8rH