### PR TITLE
feat(model-providers): admin-only default-model selection (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Model provider settings (Phase 2): admin-only **default-model
+  selection**. Admins can now see the models the active provider
+  actually reports and choose which one Nova uses by default, from the
+  UI, without adding a runtime or downloading anything. A new
+  `core/model_settings.py` resolves the default model — the
+  admin-selected one if safely persisted, else `config.MODELS["default"]`
+  — network-free and never raising, so the chat hot path and every
+  existing install (nothing persisted) behave exactly as before. Two
+  admin endpoints expose it: `GET /admin/provider/models` (read-only;
+  reuses the Phase-1 `health()` probe — `client.list()` for Ollama,
+  never a pull or a generation) and `POST /admin/provider/default-model`
+  (validates the chosen model against the active provider's reported
+  list *before* persisting a single host-wide `settings` row; an
+  unreachable provider, an empty/oversized string, or a not-installed
+  model is refused with a sanitised `400` and **nothing is written**).
+  **Settings → Models** gains a *Default model* card (current default,
+  installed-model picker, *Set as default*) next to the Phase-1
+  read-only provider summary. No provider name is ever accepted from
+  the client (`extra="forbid"`; the core never takes one) so provider
+  *selection* stays env-driven and **Ollama remains the default
+  provider**. `code`/`advanced` routing and the *Code*/*Deep* modes are
+  unchanged; `MockProvider` stays test-only. New suites
+  `tests/test_model_settings.py` /
+  `tests/test_provider_default_model_endpoints.py`; see
+  [`docs/model-providers.md`](docs/model-providers.md).
 - Model provider settings (Phase 1, read-only): a small admin-only
   surface to *see and validate* which model backend Nova is using,
   without adding a runtime. A new `core/provider_status.py` reports the

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,11 +1,12 @@
 import logging
 from typing import Iterator
-from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT, MODELS
+from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT
 from core.model_providers import (
     ModelProviderError,
     ModelRequest,
     get_provider,
 )
+from core.model_settings import resolve_default_model
 from core.memory import format_memories_for_prompt, parse_and_save
 from core.identity import IDENTITY_CONTRACT
 from core.nova_contract import build_personalization_block
@@ -136,7 +137,7 @@ def extract_and_save_memory(
     )
     try:
         result = _generate(
-            MODELS["default"],
+            resolve_default_model(),
             [{"role": "user", "content": prompt}],
         ).strip()
     except ModelProviderError:
@@ -245,12 +246,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
         if image:
             logger.debug("Processing image request, encoded length=%d", len(image))
             messages = build_image_messages(user_input, image)
-            reply = _generate(MODELS["default"], messages)
+            default_model = resolve_default_model()
+            reply = _generate(default_model, messages)
             if policy.memory_save_enabled:
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
                 )
-            return reply, MODELS["default"]
+            return reply, default_model
 
         model = forced_model if forced_model else route(user_input)
 
@@ -344,7 +346,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
 
     except ModelProviderError as e:
         logger.warning("Model provider unavailable during chat: %s", e)
-        return OLLAMA_UNAVAILABLE, MODELS["default"]
+        return OLLAMA_UNAVAILABLE, resolve_default_model()
 
 
 def chat_stream(
@@ -388,15 +390,16 @@ def chat_stream(
         if image:
             logger.debug("Processing streaming-image request, encoded length=%d", len(image))
             messages = build_image_messages(user_input, image)
-            reply = _generate(MODELS["default"], messages)
+            default_model = resolve_default_model()
+            reply = _generate(default_model, messages)
             if policy.memory_save_enabled:
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
                 )
-            yield {"type": "meta", "model": MODELS["default"]}
+            yield {"type": "meta", "model": default_model}
             if reply:
                 yield {"type": "delta", "content": reply}
-            yield {"type": "done", "reply": reply, "model": MODELS["default"]}
+            yield {"type": "done", "reply": reply, "model": default_model}
             return
 
         model = forced_model if forced_model else route(user_input)

--- a/core/model_providers/mock.py
+++ b/core/model_providers/mock.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 from typing import Iterator, Optional, Sequence
 
+# This provider is test/offline-only and is never advertised as a
+# selectable production backend (see ``core.provider_status``).
+
 from .base import (
     ModelChunk,
     ModelProvider,
@@ -29,7 +32,11 @@ class MockProvider(ModelProvider):
       concatenation is also what :meth:`generate` returns when
       ``response`` is left at its default so the two paths stay
       consistent for a given configuration.
-    * ``healthy`` — what :meth:`health` reports.
+    * ``healthy`` — the ``ok`` flag :meth:`health` reports.
+    * ``models`` — the model list :meth:`health` reports, so suites can
+      exercise the Phase-2 "validate the selected default against the
+      provider's reported models" path without a real backend. Defaults
+      to empty, matching the pre-Phase-2 behaviour.
     * ``error`` — if set, every :meth:`generate` / :meth:`stream` call
       raises it (use a :class:`ModelProviderError` to simulate an
       unreachable backend cleanly).
@@ -48,6 +55,7 @@ class MockProvider(ModelProvider):
         response: Optional[str] = None,
         chunks: Optional[Sequence[str]] = None,
         healthy: bool = True,
+        models: Optional[Sequence[str]] = None,
         error: Optional[Exception] = None,
     ):
         self._chunks: list[str] = list(chunks) if chunks is not None else []
@@ -60,6 +68,7 @@ class MockProvider(ModelProvider):
         if not self._chunks:
             self._chunks = [self._response] if self._response else []
         self._healthy = healthy
+        self._models: list[str] = list(models) if models is not None else []
         self._error = error
         self.requests: list[ModelRequest] = []
 
@@ -81,6 +90,7 @@ class MockProvider(ModelProvider):
             ok=self._healthy,
             provider=self.name,
             detail="" if self._healthy else "mock provider marked unhealthy",
+            models=list(self._models),
         )
 
 

--- a/core/model_settings.py
+++ b/core/model_settings.py
@@ -1,0 +1,234 @@
+"""Admin-selected default model (Phase 2 of provider settings).
+
+Phase 1 made the active provider *visible* and *probeable* (see
+``core/provider_status.py``). Phase 2 lets an admin choose **which model
+that provider is asked for by default**, picked from the models the
+provider actually reports — validated before it is ever persisted, never
+a free-text field, never a download trigger.
+
+Scope / safety contract (Phase 2):
+
+* **Validated, never arbitrary.** :func:`set_default_model` only persists
+  a model the *active* provider currently lists via its read-only
+  ``health()`` probe. An unreachable provider, an empty / oversized
+  string, or a model the provider does not report is refused with a
+  short, sanitised reason — nothing is written.
+* **The active provider only.** The provider is always the configured
+  one (``core.model_providers.get_provider()``); callers never pass a
+  provider name, so a stray/unknown backend can never be selected here.
+* **Host-level, not per-user.** The choice is a single row in the global
+  ``settings`` table via :func:`core.settings.save_system_setting` — the
+  same scope as ``config.MODELS``. It is an operator decision, not a
+  per-account preference (``nova_model_name`` stays a separate per-user
+  concern and is untouched).
+* **Read path is network-free and never raises.**
+  :func:`resolve_default_model` returns the persisted choice if one is
+  set, else ``config.MODELS["default"]``. It performs no network I/O and
+  swallows every error, so the chat hot path stays exactly as fast and
+  offline-safe as before — a missing/oddly-shaped config or DB degrades
+  to the config default, never an exception.
+* **No secrets, no downloads, no new runtime.** Model listing reuses the
+  Phase-1 ``probe_provider_health`` (``client.list()`` for Ollama —
+  never a pull or a generation); the only strings surfaced are model
+  names and the provider's own short, non-sensitive health detail.
+
+It is the foundation under the admin-only ``GET
+/admin/provider/models`` and ``POST /admin/provider/default-model``
+endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Host-wide ``settings`` key holding the admin-selected default model.
+#: Not in ``core.settings.USER_SETTING_KEYS`` on purpose — it is global,
+#: not per-user — and not in ``config.ALLOWED_SETTINGS`` so it can never
+#: be written through the generic ``/settings`` path that would bypass
+#: the provider-list validation below.
+DEFAULT_MODEL_SETTING_KEY = "default_model"
+
+#: Defensive cap on the persisted model id. Mirrors the admin model-pull
+#: request bound so a crafted client can never smuggle a large blob into
+#: the settings row even though the value is also validated against the
+#: provider's reported list.
+MAX_MODEL_NAME_LEN = 200
+
+
+def config_default_model() -> str:
+    """Nova's compiled-in default chat model (``config.MODELS["default"]``).
+
+    Best-effort and never raises: a missing / oddly-shaped ``MODELS``
+    degrades to ``""`` rather than turning a read into a failure.
+    """
+    try:
+        from config import MODELS
+
+        return str((MODELS or {}).get("default", "") or "")
+    except Exception as exc:  # pragma: no cover - config is stable
+        logger.warning("default model: config lookup failed: %s", exc)
+        return ""
+
+
+def resolve_default_model() -> str:
+    """The model Nova uses by default: persisted admin choice, else config.
+
+    Safe to call from the chat hot path and from any thread: it performs
+    **no network I/O** and never raises. The persisted value is only ever
+    written by :func:`set_default_model` after it has been validated
+    against the active provider's reported model list, so a non-empty
+    stored value is one the provider listed at the time it was chosen.
+    A missing / blank setting (the default for every existing install)
+    transparently falls back to ``config.MODELS["default"]`` — existing
+    deployments behave exactly as before.
+    """
+    config_default = config_default_model()
+    try:
+        from core.settings import get_system_setting
+
+        saved = (get_system_setting(DEFAULT_MODEL_SETTING_KEY, "") or "").strip()
+    except Exception as exc:  # never block chat on a settings read
+        logger.debug("default model: settings read failed: %s", exc)
+        return config_default
+    return saved or config_default
+
+
+def _provider_health() -> dict:
+    """Read-only liveness + model list for the active provider.
+
+    Delegates to the Phase-1 ``probe_provider_health`` so listing and
+    validation reuse exactly one read-only path (``client.list()`` for
+    Ollama — never a pull, never a generation) and one stable shape:
+    ``{"ok": bool, "provider": str, "detail": str, "models": [str]}``.
+    Never raises.
+    """
+    from core.provider_status import probe_provider_health
+
+    health = probe_provider_health()
+    models = health.get("models") or []
+    return {
+        "ok": bool(health.get("ok")),
+        "provider": str(health.get("provider") or "unknown"),
+        "detail": str(health.get("detail") or ""),
+        "models": [m for m in models if isinstance(m, str) and m],
+    }
+
+
+def list_available_models() -> dict:
+    """Read-only view: what models the active provider reports + the default.
+
+    Returns a JSON-serialisable dict the admin UI renders verbatim::
+
+        {
+          "ok": bool,                # provider reachable
+          "provider": str,           # active backend label
+          "detail": str,             # provider's short health detail
+          "models": [str],           # installed models (empty if down)
+          "default_model": str,      # what Nova uses by default now
+          "config_default_model": str,  # the compiled-in default
+          "is_custom": bool,         # default differs from config
+        }
+
+    Never raises and never reaches a model runtime — an unreachable
+    provider is reported as ``ok=False`` with an empty model list, not
+    an exception, the same calm stance as the Phase-1 status surface.
+    """
+    health = _provider_health()
+    default_model = resolve_default_model()
+    config_default = config_default_model()
+    return {
+        "ok": health["ok"],
+        "provider": health["provider"],
+        "detail": health["detail"],
+        "models": health["models"],
+        "default_model": default_model,
+        "config_default_model": config_default,
+        "is_custom": bool(default_model) and default_model != config_default,
+    }
+
+
+class DefaultModelError(Exception):
+    """A requested default-model change was refused.
+
+    Carries a short, **sanitised** reason safe to surface to the admin
+    UI: it never echoes back a raw provider exception, the configured
+    host, or the caller-supplied string verbatim.
+    """
+
+
+def set_default_model(model: str) -> dict:
+    """Validate ``model`` against the active provider, then persist it.
+
+    The model must be a non-empty, reasonably short string **and** appear
+    in the active provider's currently-reported model list. The provider
+    is always the configured backend — no provider name is accepted from
+    the caller. On success the choice is written to the global
+    ``settings`` table and the new state is returned; any failure raises
+    :class:`DefaultModelError` with a sanitised message and **writes
+    nothing**:
+
+    * empty / non-string / over-:data:`MAX_MODEL_NAME_LEN` → refused;
+    * provider unreachable (its model list can't be verified) → refused
+      with a fixed, non-sensitive message (no raw transport detail, no
+      host);
+    * model not in the provider's reported list → refused.
+
+    Returns ``{"ok": True, "default_model", "config_default_model",
+    "is_custom", "provider", "models"}`` on success.
+    """
+    if not isinstance(model, str):
+        raise DefaultModelError("A model name is required.")
+    candidate = model.strip()
+    if not candidate:
+        raise DefaultModelError("A model name is required.")
+    if len(candidate) > MAX_MODEL_NAME_LEN:
+        raise DefaultModelError("Model name is too long.")
+
+    health = _provider_health()
+    if not health["ok"]:
+        # Deliberately do NOT echo health["detail"] here: a raw transport
+        # error can carry the configured host. The Phase-1 status surface
+        # already shows a redacted host; the *write* path stays maximally
+        # conservative and says nothing about why the backend is down.
+        raise DefaultModelError(
+            "The active model provider is unreachable, so the requested "
+            "model could not be verified against its installed models. "
+            "No change was made."
+        )
+
+    models = health["models"]
+    if candidate not in models:
+        # Don't reflect the rejected string back; name the provider
+        # (already operator-visible via Phase 1) and point at the list.
+        raise DefaultModelError(
+            f"That model is not installed on the active provider "
+            f"({health['provider']}). Choose one of the models the "
+            f"provider reports."
+        )
+
+    from core.settings import save_system_setting
+
+    save_system_setting(DEFAULT_MODEL_SETTING_KEY, candidate)
+
+    config_default = config_default_model()
+    return {
+        "ok": True,
+        "default_model": candidate,
+        "config_default_model": config_default,
+        "is_custom": candidate != config_default,
+        "provider": health["provider"],
+        "models": models,
+    }
+
+
+__all__ = [
+    "DEFAULT_MODEL_SETTING_KEY",
+    "MAX_MODEL_NAME_LEN",
+    "DefaultModelError",
+    "config_default_model",
+    "resolve_default_model",
+    "list_available_models",
+    "set_default_model",
+]

--- a/core/router.py
+++ b/core/router.py
@@ -21,6 +21,11 @@ Request: {query}
 
 Reply with ONE word (simple/code/normal/advanced):"""
 
+# Compiled-in routing map. Kept as a module constant (and asserted as
+# such by the registry / pull suites) so the *config* routing contract
+# is documented and unchanged. The admin-selected default model is an
+# overlay applied at call time in ``route`` below — it never rewrites
+# this map, so `code`/`advanced` routing is untouched.
 MODEL_MAP = {
     "simple":   MODELS["default"],
     "normal":   MODELS["default"],
@@ -31,8 +36,34 @@ MODEL_MAP = {
 FALLBACK_MODEL = MODELS["default"]
 
 
+def _default_model() -> str:
+    """The default chat model: admin-selected if safely persisted, else config.
+
+    Resolved per call (not bound at import) so an admin's validated
+    choice takes effect without a restart. Network-free and never
+    raises; with nothing persisted it returns ``config.MODELS["default"]``
+    so existing behaviour — and the routing-preserved suites — are
+    unaffected.
+    """
+    try:
+        from core.model_settings import resolve_default_model
+
+        return resolve_default_model()
+    except Exception:  # never let routing fail on a settings read
+        return FALLBACK_MODEL
+
+
 def route(user_input: str) -> str:
     """Choisit le bon modèle selon la complexité de la requête."""
+    default_model = _default_model()
+    # `simple`/`normal` and the fallback follow the admin-selected
+    # default; `code`/`advanced` keep their dedicated config models.
+    model_map = {
+        "simple":   default_model,
+        "normal":   default_model,
+        "advanced": MODELS["advanced"],
+        "code":     MODELS["code"],
+    }
     prompt = ROUTER_PROMPT.format(query=user_input)
     try:
         response = client.chat(
@@ -41,7 +72,7 @@ def route(user_input: str) -> str:
         )
         content = response["message"]["content"].strip().lower()
         category = content.split()[0] if content else ""
-        return MODEL_MAP.get(category, FALLBACK_MODEL)
+        return model_map.get(category, default_model)
     except (ollama.ResponseError, ConnectionError, httpx.HTTPError) as e:
         logger.warning("Router model unavailable, falling back to default: %s", e)
-        return FALLBACK_MODEL
+        return default_model

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -1,17 +1,20 @@
 # Nova Model Providers
 
 > **Status: shipped (Phases: provider abstraction + read-only provider
-> settings), local-first.**
+> settings + admin default-model selection), local-first.**
 > This document describes the seam that lets Nova's model backend be
-> replaced without rewriting Nova, and the admin-only surface for
-> *seeing and validating* which backend is active. It lives inside the
-> boundaries set by
+> replaced without rewriting Nova, the admin-only surface for *seeing
+> and validating* which backend is active, and the admin-only,
+> *validated* choice of which model that backend is asked for by
+> default. It lives inside the boundaries set by
 > [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md).
 > Nothing here grants Nova new powers, adds a new model runtime, performs
 > model downloads, runs shell, touches a Docker socket, integrates a
-> cloud provider, or migrates settings. The settings surface is
-> **read-only**: provider selection stays env-driven and **Ollama
-> remains the default and is fully supported.**
+> cloud provider, or migrates settings. **Provider _selection_ stays
+> read-only and env-driven** (`NOVA_MODEL_PROVIDER`); the only thing an
+> admin can write is the default *model*, and only after it is validated
+> against the active provider's own list. **Ollama remains the default
+> provider and is fully supported.**
 
 ## Why Nova has model providers
 
@@ -147,6 +150,88 @@ Guardrails baked into this surface:
 - **No secrets.** The only env-derived string surfaced is the Ollama
   host, with any `user:pass@` userinfo redacted before display.
 
+## Choosing Nova's default model (admin, validated)
+
+Phase 1 made the active provider *visible*. Phase 2 lets an admin pick
+**which model that provider is asked for by default** — from the models
+the provider actually reports, validated before anything is persisted.
+It still adds no runtime, pulls nothing, and never changes which
+*provider* is used.
+
+### How Nova chooses the default model
+
+There are two layers, and Phase 2 only changes the second:
+
+1. **Per-request routing is unchanged.** A free-chat message is still
+   classified by `core.router.route` into `simple` / `normal` / `code`
+   / `advanced`; `code` and `advanced` keep their dedicated
+   `config.MODELS` entries, and an explicit *Code* / *Deep* UI mode
+   still forces those exact models. None of that is configurable here.
+2. **The _default_ model is now resolvable, not hard-coded.** Wherever
+   Nova previously read `config.MODELS["default"]` as "the general chat
+   model" — `simple`/`normal` routing and the router fallback, the
+   explicit *Chat* mode, the vision/image path, background memory
+   extraction, and the model label on the unreachable-provider reply —
+   it now calls `core.model_settings.resolve_default_model()`.
+
+`resolve_default_model()` returns the **admin-selected model if one has
+been safely persisted, otherwise `config.MODELS["default"]`**. It reads
+a single host-wide row from the `settings` table, performs **no network
+I/O**, and never raises — so the chat hot path is exactly as fast and
+offline-safe as before, and **every existing install (no row set)
+behaves identically to before this phase.** `core.router.MODEL_MAP` and
+`MODEL_MAP`-equivalent constants stay pinned to `config.MODELS` (the
+compiled-in contract is unchanged); the admin choice is an *overlay*
+applied at call time, not a rewrite of routing.
+
+The selection is **host-wide and admin-owned**, the same scope as
+`config.MODELS` — it is deliberately *not* the per-user `nova_model_name`
+preference, which is a separate, untouched feature.
+
+### The admin surface
+
+`core/model_settings.py` is the foundation; two admin-only endpoints
+(both `require_admin`) expose it:
+
+| Endpoint | Role |
+| --- | --- |
+| `GET /admin/provider/models` | Read-only. Reuses the Phase-1 `health()` probe (`client.list()` for Ollama — never a pull or a generation) and returns `{ok, provider, detail, models, default_model, config_default_model, is_custom}`. An unreachable provider is a calm `ok=false` with an empty list, never a 500. |
+| `POST /admin/provider/default-model` | Validates the chosen model against the active provider's reported list, then persists it. Body is `{ "model": "<name>" }` only (`extra="forbid"`). Returns the new state on success; a refusal is a sanitised `400`. |
+
+**Settings → Models** gains a *Default model* card next to the existing
+read-only provider summary: it shows the current default (tagged
+*custom* or *config default*), lists the installed models, and offers a
+**Set as default** action. Because the choice is host-wide, the action
+goes through an explicit `confirm()` first (the same stray-click guard
+the maintenance pull/restart buttons use) before the validated write.
+It is hidden for non-admins on the client and the endpoints are
+admin-only on the server.
+
+### Guardrails
+
+- **Validated, never arbitrary.** A model is persisted only if the
+  *active* provider currently lists it. An empty / over-long string, a
+  model the provider does not report, or an unreachable provider is
+  refused and **nothing is written**.
+- **The active provider only.** No provider name is ever accepted from
+  the client (`extra="forbid"`, and the core never takes one) — the
+  provider is always the configured backend, so a stray / test-only /
+  unknown backend can never be selected through this surface. Provider
+  selection stays env-driven.
+- **No secrets.** The unreachable-provider refusal is a fixed,
+  non-sensitive message — it never echoes a raw transport error or the
+  configured host (the Phase-1 status surface already shows a redacted
+  host; the *write* path says nothing about why the backend is down).
+  The candidate string is not reflected back either.
+- **Read path stays safe.** `resolve_default_model()` does no network
+  I/O and swallows every error to the config default, so a bad DB can
+  never wedge chat. If a persisted model is later removed from the
+  provider, chat degrades through the existing "provider unreachable /
+  error" handling exactly as an unknown model always has — no new
+  failure mode, no auto-repull.
+- **No downloads, no new runtime.** Listing is read-only; nothing here
+  pulls, imports, or runs a model. `MockProvider` stays test-only.
+
 ## Future providers
 
 New **local** runtimes can be added cleanly in later phases — for
@@ -156,6 +241,15 @@ runtime (`NovaModelProvider`). Each only implements `generate()`,
 `stream()`, and `health()` and registers a name. **This phase adds none
 of them**, performs no model downloads, and adds no cloud providers and
 no API keys — those are explicitly out of scope.
+
+The default-model surface needs **no per-provider code** to support a
+future backend: model listing flows through the same `health()` the
+provider already implements (`ProviderHealth.models`), so a new
+provider's installed models appear in `GET /admin/provider/models` —
+and become validly selectable defaults — automatically once it returns
+them from its own read-only probe. A provider that cannot enumerate
+models simply returns an empty list; the surface degrades to the calm
+"no models reported" state instead of offering an unvalidated choice.
 
 ## Nova identity is above provider identity
 
@@ -197,3 +291,21 @@ liveness probe always returns the stable shape, even when the provider
 breaks the "health never raises" contract). `tests/test_provider_endpoints.py`
 pins the wire contract (`require_admin` gating, the status / probe JSON
 shapes, and that an unreachable or unknown backend stays a calm 200).
+
+The Phase-2 default-model selection adds two more suites.
+`tests/test_model_settings.py` pins the core: `resolve_default_model()`
+falls back to `config.MODELS["default"]` when unset and is network-free
+even when the provider explodes; `set_default_model()` only persists a
+model the active provider lists, refuses empty / oversized / not-listed
+/ unreachable with **nothing written**, and the unreachable refusal
+leaks neither host nor transport detail nor the candidate string; the
+key is host-wide (not a user setting) and unreachable through the
+generic `/settings` allowlist. `tests/test_provider_default_model_endpoints.py`
+pins the wire contract (`require_admin` gating on both endpoints,
+listing stays a calm 200 when the backend is down, a not-installed
+model is a `400`, an empty / extra-field body is a schema `422`, an
+unreachable provider is a sanitised `400`, and a successful set really
+persists). The existing chat / streaming / routing / model-access /
+registry / pull suites continue to pass unchanged — with nothing
+persisted, every default-model lookup returns the same
+`config.MODELS["default"]` as before.

--- a/static/index.html
+++ b/static/index.html
@@ -3478,6 +3478,36 @@
                         <div id="settings-provider-test-error" style="color:var(--danger);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
                         <div id="settings-provider-test-result" style="margin-top:8px;"></div>
                     </div>
+
+                    <!--
+                      Default model (admin-only). Lists the models the
+                      active provider actually reports and lets an admin
+                      choose which one Nova uses by default. The chosen
+                      model is validated against the provider's list on
+                      the server before it is persisted; nothing is
+                      pulled or downloaded and the provider itself is
+                      never changed here. Hidden entirely for non-admins
+                      (the endpoints are admin-only and would 403).
+                    -->
+                    <div class="settings-row" id="settings-default-model-row" style="display:none;">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-default-model-title">Default model</span>
+                                <span class="settings-row-hint" id="settings-default-model-hint">The model Nova uses by default for chat. Validated against installed models · admin-only.</span>
+                            </div>
+                            <button class="memory-btn" id="settings-default-model-refresh-btn" onclick="loadDefaultModelCard()" style="white-space:nowrap;">Refresh</button>
+                        </div>
+                        <div id="settings-default-model-summary" style="margin-top:10px;">
+                            <div class="admin-empty">Loading…</div>
+                        </div>
+                        <div id="settings-default-model-picker" style="margin-top:10px;display:none;flex-wrap:wrap;gap:8px;align-items:center;">
+                            <select id="settings-default-model-select"
+                                style="flex:1;min-width:180px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:monospace;font-size:0.8rem;padding:6px 10px;outline:none;box-sizing:border-box;"></select>
+                            <button class="memory-btn" id="settings-default-model-set-btn" onclick="setDefaultModel()" style="white-space:nowrap;">Set as default</button>
+                        </div>
+                        <div id="settings-default-model-error" style="color:var(--danger);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
+                        <div id="settings-default-model-ok" style="color:var(--text-dim);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
+                    </div>
                 </section>
 
                 <!-- ADMIN (admin-only) -->
@@ -7917,11 +7947,13 @@
         document.querySelectorAll(".settings-pane").forEach(p => {
             p.classList.toggle("active", p.id === "settings-pane-" + pane);
         });
-        // The provider summary is admin-only and read-only; refresh it
-        // when the Models pane is shown (the loader self-gates and hides
-        // the row for non-admins, so this is free in the common path).
+        // The provider summary and the default-model picker are
+        // admin-only; refresh them when the Models pane is shown. Both
+        // loaders self-gate and hide their row for non-admins, so this
+        // is free in the common path.
         if (pane === "models") {
             loadModelsProviderCard().catch(() => {});
+            loadDefaultModelCard().catch(() => {});
         }
     }
 
@@ -9765,6 +9797,175 @@
             if (resEl) resEl.innerHTML = _providerHealthHtml(await res.json());
         } catch (e) {
             if (errEl) errEl.textContent = "Network error while testing the provider connection.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    }
+
+    // ── Settings → Models: default-model picker (admin-only) ──────
+    //
+    // Lists the models the active provider actually reports and lets an
+    // admin choose Nova's default. Admin-gated on the client (the row
+    // is hidden for non-admins) and on the server (the endpoints are
+    // require_admin). The server validates the chosen model against the
+    // provider's reported list before persisting — nothing is pulled,
+    // downloaded, or generated, and the provider itself is unchanged.
+    async function loadDefaultModelCard() {
+        const row = document.getElementById("settings-default-model-row");
+        if (!row) return;
+        const isAdmin = !!(currentUser && currentUser.role === "admin");
+        if (!isAdmin) { row.style.display = "none"; return; }
+        row.style.display = "";
+        const summary = document.getElementById("settings-default-model-summary");
+        const picker = document.getElementById("settings-default-model-picker");
+        const errEl = document.getElementById("settings-default-model-error");
+        const okEl = document.getElementById("settings-default-model-ok");
+        if (errEl) errEl.textContent = "";
+        if (okEl) okEl.textContent = "";
+        if (picker) picker.style.display = "none";
+        if (summary) summary.innerHTML = '<div class="admin-empty">Loading…</div>';
+        try {
+            const res = await fetch("/admin/provider/models", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) { row.style.display = "none"; return; }
+            if (!res.ok) {
+                if (summary) summary.innerHTML = '<div class="admin-empty">Failed to load models.</div>';
+                return;
+            }
+            renderDefaultModelCard(await res.json());
+        } catch (e) {
+            if (summary) summary.innerHTML = '<div class="admin-empty">Failed to load models.</div>';
+        }
+    }
+
+    function renderDefaultModelCard(data) {
+        const summary = document.getElementById("settings-default-model-summary");
+        const picker = document.getElementById("settings-default-model-picker");
+        const select = document.getElementById("settings-default-model-select");
+        const setBtn = document.getElementById("settings-default-model-set-btn");
+        if (!summary || !picker || !select) return;
+        const models = Array.isArray(data.models) ? data.models : [];
+        const current = data.default_model || "—";
+        const configDefault = data.config_default_model || "—";
+        const sourceTag = data.is_custom
+            ? `<span class="admin-tag installed">custom</span>`
+            : `<span class="admin-tag">config default</span>`;
+        const parts = [];
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">current default model</span>` +
+            sourceTag +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(current)}</div>` +
+            `<div class="admin-progress-meta">compiled-in default: <code>${escapeHtml(configDefault)}</code> · provider: <code>${escapeHtml(data.provider || "unknown")}</code></div>` +
+            `</div>`
+        );
+        if (!data.ok) {
+            // Provider unreachable: show a calm message and a sanitised
+            // detail (the provider's own short health string). The
+            // picker stays hidden — we cannot validate a choice while
+            // the provider's model list is unknown.
+            parts.push(
+                `<div class="admin-warning error">` +
+                `<span class="admin-warning-level">error</span>` +
+                `<span class="admin-warning-msg">The active model provider is unreachable, so its installed models can't be listed. The default model can't be changed until it is reachable again.</span>` +
+                `</div>`
+            );
+            if (data.detail) {
+                parts.push(
+                    `<div class="admin-progress-meta">detail: <code>${escapeHtml(data.detail)}</code></div>`
+                );
+            }
+            summary.innerHTML = parts.join("");
+            picker.style.display = "none";
+            return;
+        }
+        if (!models.length) {
+            parts.push(
+                `<div class="admin-warning info">` +
+                `<span class="admin-warning-level">info</span>` +
+                `<span class="admin-warning-msg">The provider is reachable but reports no installed models. Install a model with the provider, then refresh.</span>` +
+                `</div>`
+            );
+            summary.innerHTML = parts.join("");
+            picker.style.display = "none";
+            return;
+        }
+        summary.innerHTML = parts.join("");
+        // Populate the picker; pre-select the current default when it is
+        // one of the installed models so "Set as default" is a no-op
+        // until the admin actually changes the selection.
+        select.innerHTML = models
+            .map(m => `<option value="${escapeHtml(m)}"${m === data.default_model ? " selected" : ""}>${escapeHtml(m)}</option>`)
+            .join("");
+        if (setBtn) setBtn.disabled = false;
+        picker.style.display = "flex";
+    }
+
+    async function setDefaultModel() {
+        const select = document.getElementById("settings-default-model-select");
+        const btn = document.getElementById("settings-default-model-set-btn");
+        const errEl = document.getElementById("settings-default-model-error");
+        const okEl = document.getElementById("settings-default-model-ok");
+        if (errEl) errEl.textContent = "";
+        if (okEl) okEl.textContent = "";
+        if (!select || !btn) return;
+        const model = select.value;
+        if (!model) {
+            if (errEl) errEl.textContent = "Choose a model first.";
+            return;
+        }
+        // Host-wide change: this becomes the default chat model for
+        // every user, so require an explicit confirmation before the
+        // (validated) write. A stray click cannot change it silently.
+        if (!confirm(
+            `Set "${model}" as Nova's default model for everyone?\n\n` +
+            `This changes the default chat model host-wide. ` +
+            `Code/Deep modes and per-user overrides are unaffected. ` +
+            `It is validated against the provider's installed models ` +
+            `before saving.`
+        )) {
+            return;
+        }
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Saving…";
+        try {
+            const res = await fetch("/admin/provider/default-model", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ model }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                if (errEl) errEl.textContent = "Access denied.";
+                return;
+            }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const b = await res.json();
+                    if (b && b.detail) detail = b.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            if (okEl) {
+                okEl.textContent = `Nova's default model is now "${body.default_model}".`;
+            }
+            // Reload so the summary, the "custom" tag, and the
+            // pre-selected option reflect the persisted state.
+            loadDefaultModelCard().catch(() => {});
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while saving the default model.";
         } finally {
             btn.disabled = false;
             btn.textContent = original;

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -1,0 +1,214 @@
+"""Tests for the Phase-2 admin default-model selection core
+(``core/model_settings.py``).
+
+Pinned contracts:
+
+* ``resolve_default_model`` falls back to ``config.MODELS["default"]``
+  when nothing is persisted (existing installs behave exactly as
+  before) and returns the persisted choice once one is set — without
+  any network I/O and without ever raising;
+* ``set_default_model`` only persists a model the *active* provider
+  currently reports, and refuses (writing nothing) an empty / oversized
+  string, a model the provider does not list, or an unreachable
+  provider;
+* the unreachable refusal is sanitised — no raw transport detail and no
+  configured host leak into the message;
+* ``list_available_models`` returns the stable JSON shape the admin UI
+  renders, including the current vs. compiled-in default.
+
+The provider is always driven by a registry override / MockProvider so
+the suite never assumes a reachable Ollama daemon.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from config import MODELS  # noqa: E402
+from core import memory as core_memory  # noqa: E402
+from core import model_settings as ms  # noqa: E402
+from core import settings as core_settings  # noqa: E402
+from core.model_providers import (  # noqa: E402
+    MockProvider,
+    ModelProviderError,
+    reset as reset_registry,
+    set_override,
+)
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """A registry override / cached instance never leaks between tests."""
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """A fresh nova.db with every table / migration applied."""
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+# ── resolve_default_model ───────────────────────────────────────────
+
+
+class TestResolveDefaultModel:
+    def test_unset_falls_back_to_config_default(self, db_path):
+        # The default for every existing install: no row → config model.
+        assert ms.resolve_default_model() == MODELS["default"]
+        assert ms.config_default_model() == MODELS["default"]
+
+    def test_persisted_value_is_returned(self, db_path):
+        core_settings.save_system_setting(
+            ms.DEFAULT_MODEL_SETTING_KEY, "llama3:8b"
+        )
+        assert ms.resolve_default_model() == "llama3:8b"
+
+    def test_blank_persisted_value_falls_back(self, db_path):
+        core_settings.save_system_setting(ms.DEFAULT_MODEL_SETTING_KEY, "   ")
+        assert ms.resolve_default_model() == MODELS["default"]
+
+    def test_read_path_never_touches_the_provider(self, db_path):
+        # A provider that explodes on every call must not affect the
+        # read path — resolving the default is network-free.
+        set_override(MockProvider(error=ModelProviderError("boom")))
+        assert ms.resolve_default_model() == MODELS["default"]
+
+
+# ── list_available_models ───────────────────────────────────────────
+
+
+class TestListAvailableModels:
+    def test_reachable_lists_models_and_default(self, db_path):
+        set_override(MockProvider(healthy=True, models=["m1", "m2"]))
+        out = ms.list_available_models()
+        assert out["ok"] is True
+        assert out["provider"] == "mock"
+        assert out["models"] == ["m1", "m2"]
+        assert out["default_model"] == MODELS["default"]
+        assert out["config_default_model"] == MODELS["default"]
+        assert out["is_custom"] is False
+
+    def test_custom_default_flagged(self, db_path):
+        core_settings.save_system_setting(
+            ms.DEFAULT_MODEL_SETTING_KEY, "m2"
+        )
+        set_override(MockProvider(healthy=True, models=["m1", "m2"]))
+        out = ms.list_available_models()
+        assert out["default_model"] == "m2"
+        assert out["is_custom"] is True
+
+    def test_unreachable_is_calm_empty(self, db_path):
+        set_override(MockProvider(healthy=False))
+        out = ms.list_available_models()
+        assert out["ok"] is False
+        assert out["models"] == []
+        # Still surfaces what Nova *would* use by default.
+        assert out["default_model"] == MODELS["default"]
+
+
+# ── set_default_model ───────────────────────────────────────────────
+
+
+class TestSetDefaultModel:
+    def test_valid_model_is_persisted_and_resolves(self, db_path):
+        set_override(MockProvider(healthy=True, models=["keep", "pick"]))
+        result = ms.set_default_model("pick")
+        assert result["ok"] is True
+        assert result["default_model"] == "pick"
+        assert result["is_custom"] is True
+        # Persisted: a fresh resolve (network-free) returns the choice.
+        assert ms.resolve_default_model() == "pick"
+
+    def test_whitespace_is_trimmed_before_validation(self, db_path):
+        set_override(MockProvider(healthy=True, models=["pick"]))
+        result = ms.set_default_model("  pick  ")
+        assert result["default_model"] == "pick"
+        assert ms.resolve_default_model() == "pick"
+
+    def test_model_not_in_provider_list_is_rejected(self, db_path):
+        set_override(MockProvider(healthy=True, models=["only-this"]))
+        with pytest.raises(ms.DefaultModelError):
+            ms.set_default_model("not-installed")
+        # Nothing was written — the default is still the config model.
+        assert ms.resolve_default_model() == MODELS["default"]
+
+    @pytest.mark.parametrize("bad", ["", "   ", "x" * (ms.MAX_MODEL_NAME_LEN + 1)])
+    def test_empty_or_oversized_is_rejected(self, db_path, bad):
+        set_override(MockProvider(healthy=True, models=["m"]))
+        with pytest.raises(ms.DefaultModelError):
+            ms.set_default_model(bad)
+        assert ms.resolve_default_model() == MODELS["default"]
+
+    def test_non_string_is_rejected(self, db_path):
+        set_override(MockProvider(healthy=True, models=["m"]))
+        with pytest.raises(ms.DefaultModelError):
+            ms.set_default_model(None)  # type: ignore[arg-type]
+
+    def test_unreachable_provider_refuses_with_sanitised_message(
+        self, db_path
+    ):
+        # The mock's health detail names the host-shaped string below;
+        # the refusal must NOT echo it (no raw transport / host leak).
+        secret_host = "http://bob:hunter2@ollama.internal:11434"
+        set_override(
+            MockProvider(
+                healthy=False,
+                error=ModelProviderError(secret_host),
+            )
+        )
+        with pytest.raises(ms.DefaultModelError) as excinfo:
+            ms.set_default_model("anything")
+        msg = str(excinfo.value)
+        assert "hunter2" not in msg
+        assert "ollama.internal" not in msg
+        assert "unreachable" in msg.lower()
+        assert ms.resolve_default_model() == MODELS["default"]
+
+    def test_rejection_does_not_reflect_the_candidate_string(self, db_path):
+        set_override(MockProvider(healthy=True, models=["safe"]))
+        injected = "<script>evil</script>"
+        with pytest.raises(ms.DefaultModelError) as excinfo:
+            ms.set_default_model(injected)
+        assert injected not in str(excinfo.value)
+
+
+def test_settings_key_is_not_user_scoped():
+    # The default model is host-wide: it must not be treated as a
+    # per-user key (that would scope it to one account by mistake).
+    assert not core_settings.is_user_setting(ms.DEFAULT_MODEL_SETTING_KEY)
+
+
+def test_default_model_not_writable_via_generic_allowed_settings():
+    # The dedicated, validated endpoint is the only writer — the key
+    # must never ride in on the generic settings allowlist.
+    from config import ALLOWED_SETTINGS
+
+    assert ms.DEFAULT_MODEL_SETTING_KEY not in ALLOWED_SETTINGS
+
+
+def test_persisted_default_survives_a_separate_connection(db_path):
+    # Sanity: the value really lands in the shared settings table, not
+    # a per-test in-memory shim.
+    set_override(MockProvider(healthy=True, models=["persisted"]))
+    ms.set_default_model("persisted")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT value FROM settings WHERE key = ?",
+            (ms.DEFAULT_MODEL_SETTING_KEY,),
+        ).fetchone()
+    assert row is not None and row[0] == "persisted"

--- a/tests/test_provider_default_model_endpoints.py
+++ b/tests/test_provider_default_model_endpoints.py
@@ -1,0 +1,265 @@
+"""Wire-level tests for the Phase-2 admin default-model endpoints.
+
+Pins the contract of ``GET /admin/provider/models`` and
+``POST /admin/provider/default-model``:
+
+* both are admin-only — non-admin and restricted users get 403,
+  unauthenticated callers get 401 / 403;
+* listing returns the stable shape (models + current/compiled-in
+  default) and stays a calm 200 even when the provider is unreachable;
+* setting validates the chosen model against the active provider's
+  reported list before persisting — a not-installed model is a 400, an
+  empty / extra-field body is a 422 (schema), and an unreachable
+  provider is a sanitised 400 (no host / transport leak);
+* a successful set actually persists (a follow-up list reflects it).
+
+Mirrors ``tests/test_provider_endpoints.py`` fixtures so the two
+provider suites stay consistent.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core import memory as core_memory, users  # noqa: E402
+from core.model_providers import (  # noqa: E402
+    MockProvider,
+    ModelProviderError,
+    reset as reset_registry,
+    set_override,
+)
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """A registry override / cached instance never leaks between tests."""
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post(
+        "/login", json={"username": username, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+# ── Auth gating ─────────────────────────────────────────────────────
+
+
+_ENDPOINTS = [
+    ("GET", "/admin/provider/models", None),
+    ("POST", "/admin/provider/default-model", {"model": "x"}),
+]
+
+
+class TestDefaultModelEndpointsAuth:
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_non_admin_forbidden(
+        self, web_client, user_token, method, path, body,
+    ):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(user_token))
+        else:
+            resp = web_client.post(path, headers=_h(user_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_restricted_forbidden(
+        self, web_client, restricted_token, method, path, body,
+    ):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(restricted_token))
+        else:
+            resp = web_client.post(
+                path, headers=_h(restricted_token), json=body,
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_unauthenticated_blocked(self, web_client, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path)
+        else:
+            resp = web_client.post(path, json=body)
+        assert resp.status_code in (401, 403)
+
+
+# ── GET /admin/provider/models ──────────────────────────────────────
+
+
+class TestModelsEndpoint:
+    def test_lists_models_and_default(self, web_client, admin_token):
+        set_override(MockProvider(healthy=True, models=["m1", "m2"]))
+        resp = web_client.get(
+            "/admin/provider/models", headers=_h(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["models"] == ["m1", "m2"]
+        assert isinstance(body["default_model"], str) and body["default_model"]
+        assert isinstance(body["config_default_model"], str)
+        assert body["is_custom"] is False
+
+    def test_unreachable_is_calm_200(self, web_client, admin_token):
+        set_override(MockProvider(healthy=False))
+        resp = web_client.get(
+            "/admin/provider/models", headers=_h(admin_token),
+        )
+        # Unreachable is data, not a server error (mirrors Phase 1).
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["models"] == []
+        assert body["default_model"]
+
+
+# ── POST /admin/provider/default-model ──────────────────────────────
+
+
+class TestSetDefaultModelEndpoint:
+    def test_valid_model_persists(self, web_client, admin_token):
+        set_override(MockProvider(healthy=True, models=["keep", "chosen"]))
+        resp = web_client.post(
+            "/admin/provider/default-model",
+            headers=_h(admin_token),
+            json={"model": "chosen"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["default_model"] == "chosen"
+        assert body["is_custom"] is True
+        # A follow-up list reflects the persisted choice.
+        listing = web_client.get(
+            "/admin/provider/models", headers=_h(admin_token),
+        ).json()
+        assert listing["default_model"] == "chosen"
+        assert listing["is_custom"] is True
+
+    def test_not_installed_model_is_400(self, web_client, admin_token):
+        set_override(MockProvider(healthy=True, models=["only-this"]))
+        resp = web_client.post(
+            "/admin/provider/default-model",
+            headers=_h(admin_token),
+            json={"model": "not-installed"},
+        )
+        assert resp.status_code == 400, resp.text
+        # Default is unchanged — nothing was written.
+        listing = web_client.get(
+            "/admin/provider/models", headers=_h(admin_token),
+        ).json()
+        assert listing["is_custom"] is False
+
+    def test_empty_model_is_422(self, web_client, admin_token):
+        set_override(MockProvider(healthy=True, models=["m"]))
+        resp = web_client.post(
+            "/admin/provider/default-model",
+            headers=_h(admin_token),
+            json={"model": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_extra_field_is_rejected(self, web_client, admin_token):
+        set_override(MockProvider(healthy=True, models=["m"]))
+        resp = web_client.post(
+            "/admin/provider/default-model",
+            headers=_h(admin_token),
+            json={"model": "m", "provider": "evil"},
+        )
+        # `extra="forbid"` — a smuggled provider name never reaches the
+        # core (which never accepts one anyway).
+        assert resp.status_code == 422
+
+    def test_unreachable_provider_is_sanitised_400(
+        self, web_client, admin_token,
+    ):
+        secret_host = "http://bob:hunter2@ollama.internal:11434"
+        set_override(
+            MockProvider(
+                healthy=False,
+                error=ModelProviderError(secret_host),
+            )
+        )
+        resp = web_client.post(
+            "/admin/provider/default-model",
+            headers=_h(admin_token),
+            json={"model": "anything"},
+        )
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert "hunter2" not in detail
+        assert "ollama.internal" not in detail
+        assert "unreachable" in detail.lower()

--- a/web.py
+++ b/web.py
@@ -71,6 +71,7 @@ from core.security import SilentGuardProvider as _SilentGuardProvider
 from core import maintenance as _maintenance
 from core import storage_status as _storage_status
 from core import provider_status as _provider_status
+from core import model_settings as _model_settings
 from core import data_export as _data_export
 from core import voice as _voice
 import sqlite3 as _sqlite3
@@ -842,6 +843,15 @@ def _resolve_forced_model(request: ChatRequest, user: CurrentUser) -> str | None
         return get_user_setting(
             user.id, "nova_model_name", NOVA_MODEL_DEFAULT_NAME
         )
+    # The explicit "chat" mode *is* Nova's default model, so it follows
+    # the admin-selected default (validated + persisted in Settings →
+    # Models) instead of the static MODE_MAP entry. `code`/`deep` keep
+    # their dedicated config models; an unknown / auto mode returns None
+    # so `core.router.route` decides (it applies the same default). With
+    # nothing persisted this resolves to `config.MODELS["default"]`, so
+    # existing behaviour is unchanged.
+    if request.mode == "chat":
+        return _model_settings.resolve_default_model()
     return MODE_MAP.get(request.mode)
 
 
@@ -2970,6 +2980,63 @@ def provider_test_connection_endpoint(
     maintenance / storage endpoints.
     """
     return _provider_status.probe_provider_health()
+
+
+# ── ADMIN: DEFAULT MODEL SELECTION (Phase 2) ──────────────────────────
+# Lets an admin see the models the active provider actually reports and
+# choose which one Nova uses by default. Both endpoints are
+# ``require_admin`` (model names and the provider state are
+# operator-sensitive). Safety, enforced in ``core.model_settings``:
+#
+#   * listing is read-only — it reuses the Phase-1 ``health()`` probe
+#     (``client.list()`` for Ollama; never a pull or a generation);
+#   * the chosen model is validated against the active provider's
+#     reported list *before* it is persisted — an unreachable provider,
+#     an empty/oversized string, or a model the provider does not list
+#     is refused and nothing is written;
+#   * no provider name is accepted from the client — the provider is
+#     always the configured one, so a stray/unknown backend can never
+#     be selected here;
+#   * the value is a single host-wide ``settings`` row, never per-user,
+#     and never reachable through the generic ``/settings`` path.
+
+
+@app.get("/admin/provider/models")
+def provider_models_endpoint(_: CurrentUser = Depends(require_admin)):
+    """Read-only: models the active provider reports + the current default.
+
+    Returns ``{ok, provider, detail, models, default_model,
+    config_default_model, is_custom}``. An unreachable provider is a
+    calm 200 with ``ok=false`` and an empty ``models`` list — never a
+    500. Nothing is written, pulled, generated, or restarted.
+    """
+    return _model_settings.list_available_models()
+
+
+class SetDefaultModelRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    model: str = Field(min_length=1, max_length=_model_settings.MAX_MODEL_NAME_LEN)
+
+
+@app.post("/admin/provider/default-model")
+def provider_set_default_model_endpoint(
+    req: SetDefaultModelRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Validate the chosen model against the active provider, then persist.
+
+    The model must appear in the active provider's currently-reported
+    model list; the provider is always the configured backend (no
+    provider name is accepted). On success the host-wide default is
+    updated and the new state is returned. A refusal (provider
+    unreachable, or the model is not installed on the provider) is a
+    400 with a short, sanitised message — no raw transport detail, no
+    host — and **nothing is written**.
+    """
+    try:
+        return _model_settings.set_default_model(req.model)
+    except _model_settings.DefaultModelError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

Phase 1 made the active model provider *visible* and *probeable*. Phase 2 lets an admin **choose which model that provider is asked for by default**, picked from the models the provider actually reports and **validated before anything is persisted**. No new runtime, no model downloads, provider *selection* stays env-driven, and **Ollama remains the default provider**.

- **`core/model_settings.py`** (new):
  - `resolve_default_model()` — network-free, never raises, returns the admin-selected model if safely persisted, else `config.MODELS["default"]`.
  - `list_available_models()` — reuses the Phase-1 read-only `health()` probe (`client.list()` for Ollama — never a pull or generation).
  - `set_default_model()` — validates the choice against the *active* provider's reported list, then persists a single host-wide `settings` row. An unreachable provider, an empty/oversized string, or a not-installed model is refused with a **sanitised** reason and **nothing is written** (no host/transport leak, candidate not reflected).
- **Endpoints (admin-only, `require_admin`)**: `GET /admin/provider/models` and `POST /admin/provider/default-model` (`extra="forbid"`; no provider name ever accepted from the client; sanitised `400` on refusal, calm `200` listing even when the backend is down).
- **Chat wiring**: the default is resolved at call time in `core/router.py` (`MODEL_MAP`/`FALLBACK_MODEL` kept as static constants — overlay only, so `code`/`advanced` routing is untouched), `core/chat.py` (vision / memory-extraction / unreachable label), and `web.py` `_resolve_forced_model` (explicit *Chat* mode). With nothing persisted this is exactly `config.MODELS["default"]`, so existing installs and the routing-preserved suites behave identically.
- **UI**: Settings → Models gains an admin-only *Default model* card (current default tagged custom/config-default, installed-model picker, **Set as default** behind a host-wide `confirm()` matching the maintenance pull/restart guard).
- **MockProvider** gains a test-only `models=` for `health()` — stays test-only.
- **Docs**: `docs/model-providers.md` (how the default is chosen, Ollama stays default, future providers list models via `health()`) + `CHANGELOG.md`.

## Safety

- Admin-only on client and server; no secrets surfaced; no arbitrary provider names; validated against the live provider list before saving; host-wide key not reachable via the generic `/settings` allowlist.
- No change to memory / projects / storage / export / restore. Chat behavior changes only by using the selected default model when safely persisted.

## Test plan

- [x] `flake8 .` clean
- [x] New: `tests/test_model_settings.py`, `tests/test_provider_default_model_endpoints.py` (32 tests) — admin-gating, sanitized unreachable error, validates against provider list, invalid rejected, persistence round-trip
- [x] Affected suites green (260): router, chat_stream, model_access, model_registry, model_pulls, provider_status, provider_endpoints, model_providers, settings_scoping
- [x] Required categories green (230): projects, storage_endpoints, storage_status, data_export, migration, conversation_scoping, memory
- [ ] CI full suite on PR (authoritative)

https://claude.ai/code/session_012AschiRYGTzwgt4EykM9Pg

---
_Generated by [Claude Code](https://claude.ai/code/session_012AschiRYGTzwgt4EykM9Pg)_