### PR TITLE
feat(dev-workspace): read-only local Git context for Projects (Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,39 @@ NOVA_MAINTENANCE_REPO_PATH=
 NOVA_MAINTENANCE_RESTART_MODE=disabled
 NOVA_MAINTENANCE_SYSTEMD_UNIT=nova.service
 
+# ── Dev Workspace: linked local repos (read-only Phase 1) ─────────
+# Off by default. When set, a Nova Project may link a local Git
+# checkout so Nova can *understand* its state (branch, clean/dirty,
+# recent commits, changed files) while helping you code. Phase 1 is
+# strictly read-only.
+#
+# Safety boundaries (enforced in core/dev_workspace.py):
+#   * Opt-in: a repo only links when it resolves INSIDE one of the
+#     directories listed here. Unset / empty → the feature is off and
+#     no path validates.
+#   * Hard path validation: must be an absolute path (no ~, no ..),
+#     resolve (symlinks included) to a directory containing .git, and
+#     must NOT be "/", a top-level dir, or a broad system path
+#     (/home, /mnt, /etc, /usr, /var, /root, …) even if a root points
+#     at one.
+#   * Allowlisted, read-only git only: status --short,
+#     branch --show-current, log --oneline -n 20, diff --stat,
+#     status --porcelain. shell=False, timeouts, no network
+#     subcommands (no fetch/pull/push/clone/remote), no file writes,
+#     no sudo, no GitHub/Codeberg calls, no background scans.
+#
+# See docs/dev-workspace.md for the full walkthrough and the
+# Phase 2-6 roadmap (all later phases stay behind explicit
+# confirmation; nothing here can commit, push, or branch).
+#
+#   NOVA_DEV_WORKSPACE_ROOTS — OS-path-separator- or comma-separated
+#                              absolute directories that may contain
+#                              linkable repositories. Point this at
+#                              the parent folder you keep checkouts
+#                              in — never "/", "/home", or a broad
+#                              system path.
+NOVA_DEV_WORKSPACE_ROOTS=
+
 # ── Optional local media: Jellyfin (read-only Phase 1) ────────────
 # A small, opt-in bridge that lets Nova help you *explore* a local
 # Jellyfin music library and suggest playlists. Nova is a media

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Dev Workspace (Phase 1, read-only): a Nova Project can optionally
+  link a local Git checkout so Nova *understands* its state when
+  helping the user code — without modifying anything yet. A new
+  `core/dev_workspace.py` resolves operator-configured allowed roots
+  (`NOVA_DEV_WORKSPACE_ROOTS`, off by default), validates a candidate
+  path hard (absolute, no `~`/`..`/control chars, resolves through
+  symlinks to a directory containing `.git`, refuses `/`, top-level
+  dirs, and broad system paths like `/home` `/mnt` `/etc`, and must
+  resolve *inside* an allowed root — a symlink escaping the root is
+  refused), and exposes read-only Git facts via a frozen allowlist of
+  subcommands only: `status --short`, `branch --show-current`,
+  `log --oneline -n 20`, `diff --stat`, `status --porcelain` (changed
+  files). Every spawn is `shell=False`, timed out, stdin-closed, with
+  `GIT_TERMINAL_PROMPT=0`/`GIT_OPTIONAL_LOCKS=0`; the repo path is the
+  cwd, never an argv element. No commit, push, branch, fetch, clone,
+  remote, file write, sudo, GitHub/Codeberg call, or background scan
+  is reachable, and snapshots never raise or leak secrets/stderr
+  (calm `state`: `ready`/`disabled`/`invalid_path`/`git_unavailable`/
+  `error`). `core/projects.py` gains an idempotent, additive
+  `local_repo_path` column and a user-scoped `set`/`get` (invalid
+  path → `ProjectError`/400, foreign project → 404). Two read-only,
+  user-scoped endpoints: `PUT /projects/{id}/repo` (link/unlink) and
+  `GET /projects/{id}/repo/status`. The project bar gains a `⎇`
+  Dev Workspace panel (linked path, branch, clean/dirty, latest
+  commits, changed files, diff summary; all dynamic git output is
+  rendered via `textContent`, never `innerHTML`). New suite
+  `tests/test_dev_workspace.py` covers path validation, the module
+  safety contract (no `shell=True`, no privilege escalation, no
+  `os.system`, allowlist is read-only and refuses anything else), the
+  git helpers against a real throwaway repo, the projects integration,
+  and the endpoints. Later phases (patch propose → apply →
+  branch/commit → PR draft → optional push) stay behind explicit
+  confirmation and are **not** in Phase 1. See
+  [`docs/dev-workspace.md`](docs/dev-workspace.md).
 - Model provider settings (Phase 1, read-only): a small admin-only
   surface to *see and validate* which model backend Nova is using,
   without adding a runtime. A new `core/provider_status.py` reports the

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Shipped today:
   the safety/identity contract and can never override it. The sidebar
   gains a small project selector; nothing else in the UI changes. See
   [docs/projects.md](docs/projects.md).
+- **Dev Workspace (read-only, Phase 1).** A project can optionally
+  link a local Git checkout so Nova *understands* its state — branch,
+  clean/dirty, recent commits, changed files — while helping you code.
+  Opt-in via `NOVA_DEV_WORKSPACE_ROOTS` and strictly read-only: no
+  commit, push, branch, fetch, file writes, sudo, or GitHub/Codeberg
+  calls. Hard path validation keeps links inside an operator-allowed
+  root. See [docs/dev-workspace.md](docs/dev-workspace.md).
 - **Session continuity.** A small, deterministic "continue where we
   left off" summary surfaces recent conversation topics on return.
   Derived from data already in the sidebar, dismissable, never
@@ -862,6 +869,7 @@ All configuration is read from `.env` at startup. Key variables:
 | `NOVA_PASSWORD` | — | Login password for the seeded admin |
 | `NOVA_SECRET_KEY` | — | JWT signing secret |
 | `NOVA_DATA_DIR` | — | Optional absolute path that holds `nova.db`, backups, and reserved subdirectories. Blank = legacy layout (DB next to the checkout). See [`docs/data-directory.md`](docs/data-directory.md), or [`docs/portable-workspace.md`](docs/portable-workspace.md) for a self-contained parent layout that works for both systemd and Docker. |
+| `NOVA_DEV_WORKSPACE_ROOTS` | — | OS-path-separator- or comma-separated absolute directories that may contain repos a Project can link (read-only Phase 1). Blank = the Dev Workspace feature is off. Never set to `/`, `/home`, or a broad system path. See [`docs/dev-workspace.md`](docs/dev-workspace.md). |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
 | `NOVA_AUTO_WEB_LEARNING` | `false` | Enable background RSS/web learning |
 | `LOGIN_RATE_LIMIT_MAX` | `5` | Max login attempts per window |

--- a/core/dev_workspace.py
+++ b/core/dev_workspace.py
@@ -1,0 +1,584 @@
+"""
+Dev Workspace — read-only local Git context for Nova Projects (Phase 1).
+
+A Nova *project* can optionally be linked to a local Git checkout so
+Nova can understand the repository's state (branch, clean/dirty,
+recent commits, changed files) when helping the user code. Phase 1 is
+**strictly read-only**: this module can *observe* a repo, never modify
+one.
+
+What this module is *not*:
+
+  * a command runner or web terminal,
+  * a way to commit / push / branch / write files,
+  * a GitHub / Codeberg client,
+  * a filesystem scanner,
+  * a privilege-escalation helper.
+
+Safety contract (enforced here):
+
+  * **Opt-in by the operator.** A repo can only be linked when it
+    resolves *inside* one of the absolute directories listed in
+    ``NOVA_DEV_WORKSPACE_ROOTS``. Unset / empty → the feature is off
+    and no path validates. Nova never invents an allowed root.
+  * **Hard path validation.** The path must exist, be a directory,
+    contain ``.git``, resolve (symlinks included) within an allowed
+    root, and must not be the filesystem root, a top-level directory,
+    or any broad system path (``/``, ``/home``, ``/mnt``, ``/etc`` …).
+    ``..`` traversal is refused outright.
+  * **Allowlisted git only.** Every subprocess is built from a
+    hard-coded argv tuple drawn from a frozen allowlist of read-only
+    subcommands (``status --short``, ``branch --show-current``,
+    ``log --oneline -n 20``, ``diff --stat``, ``status --porcelain``).
+    No user / model / chat input is ever concatenated into argv; the
+    only varying value is the validated repo path, used solely as the
+    process *cwd* — never inside the command.
+  * **``shell=False`` everywhere.** No string commands, no shell
+    interpretation. ``stdin`` is closed; ``GIT_TERMINAL_PROMPT=0`` and
+    ``GIT_OPTIONAL_LOCKS=0`` keep git non-interactive and lock-free so
+    a read can never prompt, hang, or write a lock.
+  * **No network subcommands.** ``fetch`` / ``pull`` / ``clone`` /
+    ``remote`` are not in the allowlist, so Phase 1 makes no network
+    calls and performs no background scans.
+  * **No ``sudo`` / ``pkexec`` / ``doas`` / ``su`` / ``runuser``.**
+  * **Timeouts + caps.** Every call has a small timeout; every list
+    field is line- and length-capped so a huge repo cannot wedge a
+    request or balloon the JSON payload.
+  * **Calm errors.** Snapshots never raise and never embed secrets,
+    environment variables, raw stderr, or stack traces — only short,
+    fixed, frontend-safe summaries.
+
+This is the single module in ``core`` allowed to import ``subprocess``
+for dev-workspace git reads. The web layer must call only the public
+functions here and keep them user-scoped.
+
+See ``docs/dev-workspace.md`` for the operator walkthrough, the
+explicit non-goals, and the Phase 2-6 roadmap.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration ───────────────────────────────────────────────────
+#
+# ``NOVA_DEV_WORKSPACE_ROOTS`` is an OS-path-separator- or
+# comma-separated list of absolute directories that are permitted to
+# contain linkable repositories. Read fresh on every call so a
+# tests-time ``monkeypatch.setenv`` propagates without a reload, and so
+# an operator changing the env (then restarting) takes effect cleanly.
+ENV_ROOTS = "NOVA_DEV_WORKSPACE_ROOTS"
+
+# Internal limits. All dev-workspace git calls are local and read-only,
+# so a single small timeout is enough; a misbehaving repo maps to a
+# calm error snapshot rather than a wedged request.
+_GIT_TIMEOUT_SECONDS = 5.0
+
+_MAX_LOG_LINES = 20          # mirrors ``git log --oneline -n 20``
+_MAX_STATUS_LINES = 200
+_MAX_DIFF_LINES = 100
+_MAX_CHANGED_FILES = 200
+_MAX_LINE_CHARS = 300
+_MAX_RAW_PATH_CHARS = 4096
+
+# Resolved absolute paths a repo may *never* be, regardless of the
+# configured roots. An operator who points a root at one of these (or
+# at ``/``) still cannot link it — the denylist wins. The "top-level
+# directory" check below additionally refuses any first-level path
+# (parent == filesystem anchor), covering broad roots not named here.
+_DENY_EXACT = frozenset(
+    {
+        "/",
+        "/home",
+        "/mnt",
+        "/media",
+        "/root",
+        "/etc",
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib32",
+        "/lib64",
+        "/var",
+        "/boot",
+        "/dev",
+        "/proc",
+        "/sys",
+        "/opt",
+        "/srv",
+        "/run",
+        "/tmp",
+    }
+)
+
+# The complete set of git subcommands this module may ever spawn. Each
+# entry is the *exact* argv tail (everything after the git binary).
+# ``_run_git`` refuses anything not in this set, so the module cannot
+# be coaxed into a write, a network call, or an arbitrary command even
+# by a future code change that forgets the contract.
+_ALLOWED_GIT_ARGV: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("status", "--short"),
+        ("status", "--porcelain"),
+        ("branch", "--show-current"),
+        ("log", "--oneline", "-n", "20"),
+        ("diff", "--stat"),
+    }
+)
+
+# Calm, frontend-safe ``state`` values.
+STATE_DISABLED = "disabled"        # no allowed roots configured
+STATE_INVALID_PATH = "invalid_path"  # stored path no longer validates
+STATE_GIT_UNAVAILABLE = "git_unavailable"  # git binary missing
+STATE_ERROR = "error"              # git ran but a core read failed
+STATE_READY = "ready"              # snapshot populated
+
+
+class RepoPathError(ValueError):
+    """Raised when a candidate repo path fails validation.
+
+    The web layer maps this to a 400 with the (short, safe) message so
+    the user sees *why* the path was refused instead of a 500.
+    """
+
+
+# ── Allowed-roots resolution ────────────────────────────────────────
+
+
+def _split_roots(raw: str) -> list[str]:
+    """Split the raw env value on the OS path separator and commas.
+
+    Both separators are accepted so the variable is forgiving to copy
+    from a shell ``PATH``-style list or a comma list in a ``.env``.
+    """
+    parts: list[str] = []
+    for chunk in raw.split(os.pathsep):
+        parts.extend(chunk.split(","))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def configured_roots() -> tuple[Path, ...]:
+    """Return the resolved, absolute allowed workspace roots.
+
+    Read from ``NOVA_DEV_WORKSPACE_ROOTS`` on every call. Entries that
+    are blank, relative, or unresolvable are dropped silently — Nova
+    never treats an ambiguous value as "allow everything". The result
+    is de-duplicated while preserving order.
+    """
+    raw = os.environ.get(ENV_ROOTS, "")
+    if not raw or not raw.strip():
+        return ()
+    seen: set[str] = set()
+    roots: list[Path] = []
+    for entry in _split_roots(raw):
+        try:
+            candidate = Path(entry).expanduser()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if not candidate.is_absolute():
+            continue
+        try:
+            resolved = candidate.resolve()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        key = str(resolved)
+        if key in seen:
+            continue
+        # A root that is itself a denied/top-level path can never make
+        # anything linkable; drop it so it cannot widen the surface.
+        if key in _DENY_EXACT or _is_top_level(resolved):
+            continue
+        seen.add(key)
+        roots.append(resolved)
+    return tuple(roots)
+
+
+def feature_enabled() -> bool:
+    """True only when at least one usable allowed root is configured."""
+    return len(configured_roots()) > 0
+
+
+# ── Path validation ─────────────────────────────────────────────────
+
+
+def _is_top_level(path: Path) -> bool:
+    """True when ``path`` is a first-level directory (parent is ``/``).
+
+    ``/home``, ``/mnt``, ``/srv`` … all have the filesystem anchor as
+    their parent. Refusing these blocks broad roots even when they are
+    not in the explicit denylist.
+    """
+    return path.parent == Path(path.anchor)
+
+
+def _within_a_root(path: Path, roots: Sequence[Path]) -> bool:
+    """True when ``path`` equals or is nested under an allowed root."""
+    for root in roots:
+        try:
+            if path == root or path.is_relative_to(root):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def validate_repo_path(
+    raw: str | os.PathLike[str],
+    *,
+    roots: Optional[Sequence[Path]] = None,
+) -> Path:
+    """Validate a candidate local repo path and return its resolved form.
+
+    Enforces, in order: non-empty clean string → absolute → no ``..``
+    traversal → resolves to an existing directory → contains ``.git``
+    → not the filesystem root / a top-level dir / a denied system path
+    → at least one allowed root is configured → resolves inside an
+    allowed root. Raises :class:`RepoPathError` (short, safe message)
+    on the first failure; returns the fully resolved absolute path on
+    success.
+
+    ``roots`` is overridable for tests; production passes ``None`` and
+    the function reads :func:`configured_roots`.
+    """
+    if raw is None or isinstance(raw, bool):
+        raise RepoPathError("repository path is required")
+    try:
+        text = os.fspath(raw)
+    except TypeError:
+        raise RepoPathError("repository path must be a string")
+    if not isinstance(text, str):
+        raise RepoPathError("repository path must be a string")
+    text = text.strip()
+    if not text:
+        raise RepoPathError("repository path cannot be empty")
+    if len(text) > _MAX_RAW_PATH_CHARS:
+        raise RepoPathError("repository path is too long")
+    if "\x00" in text or "\n" in text or "\r" in text:
+        raise RepoPathError("repository path contains invalid characters")
+    if "~" in text:
+        # No home-directory expansion: keep the allowed-root containment
+        # check honest and predictable.
+        raise RepoPathError("repository path must be an absolute path")
+
+    candidate = Path(text)
+    if not candidate.is_absolute():
+        raise RepoPathError("repository path must be an absolute path")
+    if ".." in candidate.parts:
+        raise RepoPathError("repository path must not contain '..'")
+
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError, ValueError):
+        raise RepoPathError("repository path could not be resolved")
+
+    if str(resolved) in _DENY_EXACT:
+        raise RepoPathError(
+            "repository path is a protected system directory"
+        )
+    if _is_top_level(resolved):
+        raise RepoPathError(
+            "repository path must not be a top-level directory"
+        )
+
+    try:
+        if not resolved.is_dir():
+            raise RepoPathError("repository path does not exist")
+    except OSError:
+        raise RepoPathError("repository path could not be read")
+
+    git_marker = resolved / ".git"
+    try:
+        has_git = git_marker.exists()
+    except OSError:
+        has_git = False
+    if not has_git:
+        raise RepoPathError("repository path is not a Git checkout")
+
+    active_roots = (
+        tuple(roots) if roots is not None else configured_roots()
+    )
+    if not active_roots:
+        raise RepoPathError(
+            "no allowed workspace roots are configured "
+            f"(set {ENV_ROOTS})"
+        )
+    if not _within_a_root(resolved, active_roots):
+        raise RepoPathError(
+            "repository path is outside the allowed workspace roots"
+        )
+
+    return resolved
+
+
+def is_valid_repo_path(
+    raw: str | os.PathLike[str],
+    *,
+    roots: Optional[Sequence[Path]] = None,
+) -> bool:
+    """Boolean convenience wrapper around :func:`validate_repo_path`."""
+    try:
+        validate_repo_path(raw, roots=roots)
+        return True
+    except RepoPathError:
+        return False
+
+
+# ── Subprocess primitive ────────────────────────────────────────────
+
+
+def _git_path() -> Optional[str]:
+    """Absolute path to the git binary, or ``None`` when unavailable."""
+    return shutil.which("git")
+
+
+def _git_env() -> dict[str, str]:
+    """A copy of the environment hardened for non-interactive reads.
+
+    ``GIT_TERMINAL_PROMPT=0`` guarantees git never blocks on a
+    credential / passphrase prompt. ``GIT_OPTIONAL_LOCKS=0`` keeps even
+    ``status`` from taking a repository lock, so a Nova read can never
+    interfere with a concurrent human ``git`` session.
+    """
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    return env
+
+
+def _run_git(
+    argv_tail: Sequence[str],
+    *,
+    repo_path: str,
+    timeout: float = _GIT_TIMEOUT_SECONDS,
+) -> tuple[int, str, str]:
+    """Run ``git <argv_tail>`` in ``repo_path`` with a strict allowlist.
+
+    ``argv_tail`` must be exactly one of :data:`_ALLOWED_GIT_ARGV`; any
+    other value is a programming error and raises ``ValueError`` (it
+    can never originate from user input — callers pass literals). The
+    function otherwise never raises: a missing binary or a timeout maps
+    to ``(-1, "", "")`` so callers branch on the rc. ``shell=False`` is
+    mandatory, stdin is closed, the repo path is only ever the *cwd*.
+    """
+    key = tuple(argv_tail)
+    if key not in _ALLOWED_GIT_ARGV:
+        raise ValueError(f"git argv not allowlisted: {key!r}")
+
+    binary = _git_path()
+    if binary is None:
+        return -1, "", ""
+    argv = [binary, *key]
+    try:
+        result = subprocess.run(
+            argv,
+            cwd=repo_path,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+            shell=False,
+            env=_git_env(),
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("dev-workspace git %s timed out", key)
+        return -1, "", ""
+    except (OSError, ValueError) as exc:
+        logger.debug("dev-workspace git %s failed to spawn: %s", key, exc)
+        return -1, "", ""
+    stdout = (result.stdout or b"").decode("utf-8", errors="replace")
+    stderr = (result.stderr or b"").decode("utf-8", errors="replace")
+    return result.returncode, stdout, stderr
+
+
+def _truncate(line: str) -> str:
+    """Clip one output line so a pathological repo cannot bloat JSON."""
+    if len(line) <= _MAX_LINE_CHARS:
+        return line
+    return line[:_MAX_LINE_CHARS] + "…"
+
+
+def _lines(out: str, cap: int) -> tuple[str, ...]:
+    rows = [_truncate(s) for s in out.splitlines() if s.strip()]
+    return tuple(rows[:cap])
+
+
+# ── Read-only git helpers ───────────────────────────────────────────
+
+
+def git_current_branch(repo_path: str) -> str:
+    """Current branch name, or ``""`` (detached HEAD / failure)."""
+    rc, out, _ = _run_git(["branch", "--show-current"], repo_path=repo_path)
+    return out.strip() if rc == 0 else ""
+
+
+def git_status_short(repo_path: str) -> tuple[str, ...]:
+    """``git status --short`` lines, capped."""
+    rc, out, _ = _run_git(["status", "--short"], repo_path=repo_path)
+    if rc != 0:
+        return ()
+    return _lines(out, _MAX_STATUS_LINES)
+
+
+def git_is_clean(repo_path: str) -> bool:
+    """True when the working tree is clean.
+
+    An unreadable status is reported as *dirty* — Nova never claims a
+    tree is clean when it could not actually inspect it.
+    """
+    rc, out, _ = _run_git(["status", "--porcelain"], repo_path=repo_path)
+    if rc != 0:
+        return False
+    return out.strip() == ""
+
+
+def git_log_oneline(repo_path: str) -> tuple[str, ...]:
+    """Up to the latest 20 commits as ``<sha> <subject>`` lines."""
+    rc, out, _ = _run_git(
+        ["log", "--oneline", "-n", "20"], repo_path=repo_path
+    )
+    if rc != 0:
+        return ()
+    return _lines(out, _MAX_LOG_LINES)
+
+
+def git_diff_stat(repo_path: str) -> tuple[str, ...]:
+    """``git diff --stat`` (unstaged working-tree changes), capped."""
+    rc, out, _ = _run_git(["diff", "--stat"], repo_path=repo_path)
+    if rc != 0:
+        return ()
+    return _lines(out, _MAX_DIFF_LINES)
+
+
+def git_changed_files(repo_path: str) -> tuple[dict, ...]:
+    """Changed paths parsed from ``git status --porcelain``.
+
+    Returns ``{"status": <2-char code, trimmed>, "path": <path>}``
+    entries (staged, unstaged, and untracked), capped. Rename entries
+    keep git's ``old -> new`` text in ``path``. Read-only: this only
+    parses ``status`` output, it never touches the index.
+    """
+    rc, out, _ = _run_git(["status", "--porcelain"], repo_path=repo_path)
+    if rc != 0:
+        return ()
+    entries: list[dict] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        code = line[:2].strip()
+        path = _truncate(line[3:].strip()) if len(line) > 3 else ""
+        if not path:
+            continue
+        entries.append({"status": code, "path": path})
+        if len(entries) >= _MAX_CHANGED_FILES:
+            break
+    return tuple(entries)
+
+
+# ── Snapshot ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RepoStatus:
+    """Calm, frontend-safe snapshot of a linked repo's Git state.
+
+    ``state`` is one of the module ``STATE_*`` values. Only when it is
+    :data:`STATE_READY` are the repo fields meaningful; otherwise they
+    stay at their defaults so the response shape is stable. No env
+    vars, raw stderr, or absolute paths beyond the validated
+    ``repo_path`` are ever included.
+    """
+
+    state: str
+    repo_path: str = ""
+    branch: str = ""
+    clean: bool = True
+    status_short: tuple[str, ...] = field(default_factory=tuple)
+    diff_stat: tuple[str, ...] = field(default_factory=tuple)
+    changed_files: tuple[dict, ...] = field(default_factory=tuple)
+    recent_commits: tuple[str, ...] = field(default_factory=tuple)
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "repo_path": self.repo_path,
+            "branch": self.branch,
+            "clean": self.clean,
+            "status_short": list(self.status_short),
+            "diff_stat": list(self.diff_stat),
+            "changed_files": [dict(e) for e in self.changed_files],
+            "recent_commits": list(self.recent_commits),
+            "detail": self.detail,
+        }
+
+
+def read_status(
+    raw_path: str | os.PathLike[str],
+    *,
+    roots: Optional[Sequence[Path]] = None,
+) -> RepoStatus:
+    """Validate ``raw_path`` and return a read-only :class:`RepoStatus`.
+
+    Never raises. The stored path is re-validated here (defence in
+    depth) so a repo that was moved/removed, or a workspace-root config
+    that changed since the link was created, degrades to a calm
+    ``invalid_path`` snapshot instead of an error or stale data.
+    """
+    if not feature_enabled() and roots is None:
+        return RepoStatus(
+            state=STATE_DISABLED,
+            detail="Dev Workspace is not enabled on this host.",
+        )
+    try:
+        resolved = validate_repo_path(raw_path, roots=roots)
+    except RepoPathError as exc:
+        return RepoStatus(state=STATE_INVALID_PATH, detail=str(exc))
+
+    repo = str(resolved)
+    if _git_path() is None:
+        return RepoStatus(
+            state=STATE_GIT_UNAVAILABLE,
+            repo_path=repo,
+            detail="git is not available on this host.",
+        )
+
+    branch = git_current_branch(repo)
+    clean = git_is_clean(repo)
+    status_short = git_status_short(repo)
+    diff_stat = git_diff_stat(repo)
+    changed_files = git_changed_files(repo)
+    recent_commits = git_log_oneline(repo)
+
+    # ``log`` failing on a brand-new repo with no commits is normal and
+    # not an error; a failing ``status`` (clean forced False with no
+    # detail) means we could not inspect the tree at all.
+    rc, _, _ = _run_git(["status", "--porcelain"], repo_path=repo)
+    if rc != 0:
+        return RepoStatus(
+            state=STATE_ERROR,
+            repo_path=repo,
+            branch=branch,
+            detail="Could not read the repository's Git status.",
+        )
+
+    return RepoStatus(
+        state=STATE_READY,
+        repo_path=repo,
+        branch=branch,
+        clean=clean,
+        status_short=status_short,
+        diff_stat=diff_stat,
+        changed_files=changed_files,
+        recent_commits=recent_commits,
+        detail="" if clean else "Working tree has uncommitted changes.",
+    )

--- a/core/projects.py
+++ b/core/projects.py
@@ -23,7 +23,15 @@ rules; it only stores rows and answers ownership questions.
 Scope is intentionally narrow (Phase 1):
   * create / list / get / rename+describe / archive
   * everything is scoped to ``user_id`` exactly like conversations
-  * no deletes, no autonomous actions, no repo/file/cloud behaviour
+  * no deletes, no autonomous actions, no file/cloud behaviour
+
+Dev Workspace link (Phase 1, read-only): a project may *optionally*
+carry a ``local_repo_path``. Storing it only records a validated,
+resolved absolute path — it grants Nova no power to modify the repo.
+The path is validated by ``core.dev_workspace`` (must exist, contain
+``.git``, and resolve inside an operator-configured allowed root); all
+git access through that module is strictly read-only. Clearing the
+link is always allowed and never touches the repository.
 """
 
 from __future__ import annotations
@@ -53,6 +61,12 @@ _PROJECTS_USER_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_projects_user_id ON projects(user_id)"
 )
 
+# Phase 1 Dev Workspace: an optional, nullable column holding the
+# validated absolute path of a linked local Git checkout. Added via an
+# idempotent ALTER so existing installs gain it with no backfill — a
+# project with no link keeps ``NULL`` and behaves exactly as before.
+_PROJECTS_REPO_COLUMN = "local_repo_path"
+
 
 class ProjectError(ValueError):
     """Raised for invalid project input (empty/oversized name, etc.).
@@ -66,6 +80,13 @@ def _now_iso() -> str:
     return datetime.now().isoformat()
 
 
+def _project_columns(conn: sqlite3.Connection) -> set[str]:
+    return {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(projects)").fetchall()
+    }
+
+
 def migrate(db_path: str) -> None:
     """Create the ``projects`` table + index if missing. Idempotent.
 
@@ -73,10 +94,19 @@ def migrate(db_path: str) -> None:
     existing row. Requires the ``users`` table to exist (the chat data
     layer runs this after ``users.migrate()``), but does not depend on
     it having rows — an empty install simply has no projects yet.
+
+    The ``local_repo_path`` column (Phase 1 Dev Workspace) is added by
+    an idempotent ALTER guarded on ``PRAGMA table_info`` so re-running
+    the migration on an install that already has the column is a no-op
+    and never raises.
     """
     with sqlite3.connect(db_path) as conn:
         conn.execute(_PROJECTS_TABLE_SQL)
         conn.execute(_PROJECTS_USER_INDEX_SQL)
+        if _PROJECTS_REPO_COLUMN not in _project_columns(conn):
+            conn.execute(
+                f"ALTER TABLE projects ADD COLUMN {_PROJECTS_REPO_COLUMN} TEXT"
+            )
 
 
 def _validate_name(name: str) -> str:
@@ -107,6 +137,15 @@ def _validate_description(description: Optional[str]) -> str:
 
 
 def _row_to_dict(row: sqlite3.Row) -> dict:
+    # ``local_repo_path`` is read defensively: every read path runs
+    # through ``initialize_db`` which applies the migration, but a
+    # missing column must never turn a project list into a 500.
+    keys = row.keys()
+    repo_path = (
+        row[_PROJECTS_REPO_COLUMN]
+        if _PROJECTS_REPO_COLUMN in keys
+        else None
+    )
     return {
         "id": row["id"],
         "name": row["name"],
@@ -115,6 +154,8 @@ def _row_to_dict(row: sqlite3.Row) -> dict:
         "updated_at": row["updated_at"],
         "archived_at": row["archived_at"],
         "archived": row["archived_at"] is not None,
+        "local_repo_path": repo_path or None,
+        "has_local_repo": bool(repo_path),
     }
 
 
@@ -323,3 +364,77 @@ def unarchive_project(
             (_now_iso(), project_id, user_id),
         )
     return get_project(project_id, user_id, db_path=resolved)
+
+
+# ── Dev Workspace link (Phase 1, read-only) ─────────────────────────
+#
+# Storing a ``local_repo_path`` only records *where* a linked checkout
+# is. It confers no write power: every git access goes through
+# ``core.dev_workspace``, which is allowlisted to read-only
+# subcommands. The path is validated there before it is persisted, so
+# the DB can never hold a path outside the operator's configured
+# workspace roots.
+
+
+def get_local_repo_path(
+    project_id: int, user_id: int, db_path: str | None = None
+) -> Optional[str]:
+    """Return the linked repo path for a project the caller owns.
+
+    ``None`` when the project does not exist, is not owned by the
+    caller, or simply has no repo linked — the web layer maps the
+    "not owned" case to 404 so existence is not leaked.
+    """
+    project = get_project(project_id, user_id, db_path=db_path)
+    if project is None:
+        return None
+    return project.get("local_repo_path")
+
+
+def set_local_repo_path(
+    project_id: int,
+    user_id: int,
+    path: Optional[str],
+    db_path: str | None = None,
+) -> Optional[dict]:
+    """Link / unlink a local Git checkout to a project the caller owns.
+
+    ``path`` of ``None`` or an empty/whitespace string *unlinks* the
+    repo (always safe, never touches the filesystem). A non-empty
+    ``path`` is validated by :func:`core.dev_workspace.validate_repo_path`
+    — it must exist, contain ``.git``, and resolve inside an
+    operator-configured allowed root — and the *resolved* absolute
+    path is what gets stored.
+
+    Returns the updated project, or ``None`` if it does not exist /
+    belongs to another user (the web layer maps that to 404). Raises
+    :class:`ProjectError` with a short, safe message when a non-empty
+    path fails validation so the web layer can return 400.
+    """
+    from core.memory import DB_PATH
+
+    resolved_db = db_path or DB_PATH
+    existing = get_project(project_id, user_id, db_path=resolved_db)
+    if existing is None:
+        return None
+
+    if path is None or not str(path).strip():
+        stored: Optional[str] = None
+    else:
+        # Imported lazily so the projects data layer has no hard
+        # dependency on the dev-workspace module (import-cycle safe,
+        # and projects keeps working if the feature is unused).
+        from core import dev_workspace
+
+        try:
+            stored = str(dev_workspace.validate_repo_path(path))
+        except dev_workspace.RepoPathError as exc:
+            raise ProjectError(str(exc)) from exc
+
+    with sqlite3.connect(resolved_db) as conn:
+        conn.execute(
+            "UPDATE projects SET local_repo_path = ?, updated_at = ? "
+            "WHERE id = ? AND user_id = ?",
+            (stored, _now_iso(), project_id, user_id),
+        )
+    return get_project(project_id, user_id, db_path=resolved_db)

--- a/docs/dev-workspace.md
+++ b/docs/dev-workspace.md
@@ -1,0 +1,147 @@
+# Dev Workspace — read-only local Git context (Phase 1)
+
+> **Status: shipped (Phase 1), opt-in, strictly read-only.** A Nova
+> Project can optionally link to a local Git checkout so Nova
+> understands the repository's state (branch, clean/dirty, recent
+> commits, changed files) when helping you code. Phase 1 **observes
+> only** — it can never commit, push, branch, fetch, write files, or
+> run an arbitrary command. The feature is off until an operator
+> configures an allowed workspace root.
+
+This document describes the safety boundaries the feature commits to
+and the setup required before anything happens. It sits inside the
+limits set by
+[`nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md)
+and alongside [`projects.md`](projects.md) and
+[`maintenance-center.md`](maintenance-center.md); nothing here weakens
+those documents or grants Nova new powers.
+
+## Why this exists
+
+To evolve Nova into a local-first development copilot it needs to
+*understand* the repository you are working in — what branch you are
+on, whether the tree is dirty, what changed, the recent history — so
+its help is grounded in your actual code. Phase 1 delivers exactly
+that understanding and **nothing else**: it is the read-only
+foundation the later phases build on.
+
+## What Phase 1 does
+
+- Lets a project optionally store one **linked local repository path**.
+- Validates that path hard (see below) before it is ever stored.
+- Exposes a small set of **read-only** Git facts for a linked repo:
+  - `git status --short`
+  - `git branch --show-current`
+  - `git log --oneline -n 20`
+  - `git diff --stat`
+  - the list of changed files (parsed from `git status --porcelain`)
+- Surfaces them in the project's **Dev Workspace** panel (the `⎇`
+  button next to the project selector): linked path, current branch,
+  clean/dirty badge, latest commits, changed files, diff summary.
+
+## What Phase 1 deliberately does NOT do
+
+- No commit, push, branch creation, merge, rebase, reset, or stash.
+- No file writes anywhere in the repository.
+- No `git fetch` / `pull` / `clone` / `remote` — **no network calls**
+  and no background scans of the filesystem.
+- No arbitrary command execution and no shell interpretation.
+- No `sudo` / `pkexec` / `doas` / `su` / `runuser`.
+- No GitHub / Codeberg API calls.
+- No secrets read, stored, or surfaced.
+- No autonomous actions of any kind — every read is triggered by you
+  opening the panel.
+
+## Safety boundaries (enforced in code)
+
+These are enforced in `core/dev_workspace.py` and covered by
+`tests/test_dev_workspace.py`:
+
+1. **Opt-in by the operator.** A repo can only be linked when it
+   resolves *inside* one of the absolute directories listed in
+   `NOVA_DEV_WORKSPACE_ROOTS`. Unset / empty → the feature is off and
+   no path validates. Nova never invents an allowed root.
+2. **Hard path validation.** The candidate path must:
+   - be a non-empty, absolute string (no `~`, no `..`, no NUL /
+     newline, length-capped),
+   - resolve (symlinks included) to an existing **directory**,
+   - contain a `.git` entry,
+   - **not** be `/`, a top-level directory (e.g. `/home`, `/mnt`,
+     `/srv`), or any broad system path (`/etc`, `/usr`, `/var`,
+     `/root`, …) — even if an operator points a root at one,
+   - resolve **inside** a configured allowed root.
+
+   A symlink that lives in an allowed root but points outside it is
+   refused, because containment is checked on the *resolved* path.
+3. **Allowlisted git only.** Every subprocess is built from a
+   hard-coded argv tuple drawn from a frozen allowlist of the
+   read-only subcommands above. No user / model / chat input is ever
+   concatenated into a command; the validated repo path is used solely
+   as the process working directory, never inside argv.
+4. **`shell=False` everywhere**, stdin closed, per-call timeouts, and
+   `GIT_TERMINAL_PROMPT=0` / `GIT_OPTIONAL_LOCKS=0` so a read can
+   never prompt, hang, or take a repository lock.
+5. **Calm, capped, sanitised output.** Every list field is line- and
+   length-capped. Snapshots never raise and never embed secrets,
+   environment variables, raw stderr, or stack traces — only short,
+   fixed, frontend-safe summaries (`state` is one of `ready`,
+   `disabled`, `invalid_path`, `git_unavailable`, `error`).
+6. **User-scoped.** The link and its status are per-project and
+   per-user exactly like the rest of the project surface; a foreign /
+   unknown project id returns `404` (never `403`) so existence is not
+   leaked across accounts.
+
+The linked path is **contextual data only** — storing it confers no
+write power. It is surfaced to the model the same way other project
+context is: strictly *below* the identity / safety contract in the
+system prompt, where it cannot override safety, identity, auth, or
+admin rules.
+
+## Setup
+
+The feature is off until you list at least one allowed root. Set, in
+your environment / `.env`:
+
+```sh
+# OS-path-separator- or comma-separated absolute directories that may
+# contain linkable repositories. Pick the parent folder you keep
+# checkouts in — never "/", "/home", or a broad system path.
+NOVA_DEV_WORKSPACE_ROOTS=/home/me/code:/srv/projects
+```
+
+Then, in a project, click the `⎇` button next to the project
+selector, paste the **absolute path** of a checkout that lives under
+one of those roots, and click **Link**. The panel then shows that
+repo's read-only Git state. **Unlink** clears the stored path and
+never touches the repository.
+
+## API surface (Phase 1)
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `PUT` | `/projects/{id}/repo` | Body `{ "path": "<abs path>" \| null }`. A non-empty path is validated then stored (resolved); `null` / empty unlinks. Invalid path → `400` with a short reason; foreign project → `404`. |
+| `GET` | `/projects/{id}/repo/status` | `{ "linked": false }` when no repo; otherwise a calm read-only snapshot (`state`, `branch`, `clean`, `status_short`, `recent_commits`, `changed_files`, `diff_stat`, `detail`). Foreign project → `404`. |
+
+`GET /projects` and the other project endpoints additionally report
+`local_repo_path` and `has_local_repo` so the UI can show which
+projects are linked.
+
+## Roadmap (later phases — not in Phase 1)
+
+Each phase is additive and stays behind explicit user confirmation;
+nothing below is enabled by Phase 1.
+
+- **Phase 2 — patch proposal mode.** Nova may *propose* a unified diff;
+  it is shown for review and never applied automatically.
+- **Phase 3 — apply patch with approval.** Apply a reviewed patch to
+  the working tree only after explicit per-patch approval.
+- **Phase 4 — branch + commit locally.** Create a local feature branch
+  and commit, never on `main`, never pushed.
+- **Phase 5 — PR draft assistant.** Help draft a PR description from
+  the local diff — still no network writes.
+- **Phase 6 — optional push after explicit confirmation.** A push,
+  only after an unmistakable, per-action confirmation; never to
+  `main`, never autonomous.
+
+These are intentionally out of scope for Phase 1 to keep it small,
+auditable, and safe.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -174,7 +174,10 @@ and export/restore behaviour is unchanged.
   preference stated inside a project is recognised as global).
 - Scoping the `forget …` commands and the memory audit view to the
   active project.
-- Linked local repository path per project.
+- ~~Linked local repository path per project.~~ **Shipped** as the
+  read-only Dev Workspace foundation — see
+  [`dev-workspace.md`](dev-workspace.md). It is opt-in, strictly
+  read-only, and cannot commit / push / branch / write files.
 - Project import / export.
 - Project-specific model settings.
 - Project files / attachments.

--- a/static/index.html
+++ b/static/index.html
@@ -383,6 +383,115 @@
         }
         .project-btn:hover { color: var(--text); background: rgba(255, 255, 255, 0.05); }
 
+        /* Dev Workspace (Phase 1, read-only) modal */
+        #repo-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.55);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            z-index: 31;
+            align-items: center;
+            justify-content: center;
+        }
+        #repo-overlay.open { display: flex; animation: fadeIn 220ms var(--ease); }
+        #repo-panel {
+            background: rgba(19, 21, 23, 0.92);
+            backdrop-filter: blur(24px) saturate(140%);
+            -webkit-backdrop-filter: blur(24px) saturate(140%);
+            border: 1px solid var(--border);
+            border-radius: var(--r-xl);
+            width: 92%;
+            max-width: 620px;
+            max-height: 84dvh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            box-shadow: var(--shadow-lg);
+            animation: popIn 240ms var(--ease);
+        }
+        #repo-header {
+            padding: 18px 24px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            border-bottom: 1px solid var(--border);
+        }
+        #repo-header h2 { font-size: 0.95rem; margin: 0; letter-spacing: 0.02em; }
+        #repo-close {
+            background: none; border: none; color: var(--text-dim);
+            font-size: 1rem; cursor: pointer; padding: 4px 8px; border-radius: 8px;
+        }
+        #repo-close:hover { color: var(--text); background: rgba(255,255,255,0.06); }
+        #repo-body { padding: 20px 24px; overflow-y: auto; }
+        .repo-note {
+            font-size: 0.78rem; color: var(--text-dim); line-height: 1.5;
+            margin: 0 0 16px; padding: 10px 12px;
+            background: rgba(255,255,255,0.025); border-radius: 10px;
+        }
+        .repo-field { margin-bottom: 18px; }
+        .repo-label, .repo-block-title, .repo-status-key {
+            display: block; font-size: 0.7rem; text-transform: uppercase;
+            letter-spacing: 0.06em; color: var(--text-dim); margin-bottom: 6px;
+        }
+        #repo-path-input {
+            width: 100%; padding: 9px 12px; box-sizing: border-box;
+            background: rgba(255,255,255,0.025);
+            border: 1px solid var(--border); border-radius: 10px;
+            color: var(--text); font-size: 0.82rem; outline: none;
+            font-family: var(--mono, monospace);
+        }
+        #repo-path-input:focus {
+            border-color: var(--cyan-glow); box-shadow: 0 0 0 3px var(--cyan-soft);
+        }
+        .repo-actions { display: flex; gap: 8px; margin-top: 10px; }
+        .repo-btn {
+            padding: 7px 14px; background: rgba(255,255,255,0.04);
+            border: 1px solid var(--border); border-radius: 9px;
+            color: var(--text); font-size: 0.8rem; cursor: pointer;
+            transition: background var(--t-base);
+        }
+        .repo-btn:hover { background: rgba(255,255,255,0.08); }
+        .repo-btn-primary { border-color: var(--cyan-glow); color: var(--cyan-glow); }
+        .repo-msg {
+            margin-top: 10px; font-size: 0.78rem; padding: 8px 10px;
+            border-radius: 8px; line-height: 1.45;
+        }
+        .repo-msg.ok { color: #7fe0a8; background: rgba(80,200,140,0.08); }
+        .repo-msg.err { color: #f0a0a0; background: rgba(220,90,90,0.08); }
+        .repo-status-row {
+            display: flex; align-items: center; gap: 12px;
+            padding: 8px 0; border-bottom: 1px solid var(--border);
+        }
+        .repo-status-key { margin: 0; flex: 0 0 90px; }
+        .repo-status-val { font-size: 0.84rem; color: var(--text); word-break: break-all; }
+        .repo-badge {
+            display: inline-block; padding: 2px 10px; border-radius: 999px;
+            font-size: 0.74rem; font-weight: 600;
+        }
+        .repo-badge.clean { color: #7fe0a8; background: rgba(80,200,140,0.12); }
+        .repo-badge.dirty { color: #f0c479; background: rgba(220,170,90,0.12); }
+        .repo-block { margin-top: 16px; }
+        .repo-list {
+            list-style: none; margin: 0; padding: 0;
+            font-family: var(--mono, monospace); font-size: 0.76rem;
+            color: var(--text); max-height: 220px; overflow-y: auto;
+        }
+        .repo-list li {
+            padding: 4px 0; border-bottom: 1px solid var(--border);
+            word-break: break-all;
+        }
+        .repo-list li:last-child { border-bottom: none; }
+        .repo-changed-code {
+            color: var(--cyan-glow); margin-right: 8px; font-weight: 600;
+        }
+        .repo-pre {
+            margin: 0; font-family: var(--mono, monospace); font-size: 0.74rem;
+            color: var(--text-dim); white-space: pre-wrap; word-break: break-all;
+            max-height: 220px; overflow-y: auto;
+        }
+
         .conv-group-header {
             font-size: 0.66rem;
             color: var(--text-dim);
@@ -2880,6 +2989,7 @@
                 <select id="project-select" onchange="onProjectChange()" title="Projet"></select>
                 <button id="new-project-btn" class="project-btn" type="button" onclick="createProjectPrompt()" title="Nouveau projet">+</button>
                 <button id="archive-project-btn" class="project-btn" type="button" onclick="archiveActiveProject()" title="Archiver" style="display:none;">⊟</button>
+                <button id="repo-settings-btn" class="project-btn" type="button" onclick="openRepoSettings()" title="Dépôt local du projet" style="display:none;">⎇</button>
             </div>
             <div id="conv-search-wrap">
                 <input type="text" id="conv-search" placeholder="Rechercher..." autocomplete="off" oninput="onConvSearchInput(this.value)" />
@@ -3158,6 +3268,49 @@
 </div>
 
 <!-- SETTINGS PANEL -->
+<div id="repo-overlay" onclick="handleRepoOverlayClick(event)">
+    <div id="repo-panel">
+        <div id="repo-header">
+            <h2 id="repo-title">⎇ Dev Workspace</h2>
+            <button id="repo-close" onclick="closeRepoSettings()">✕</button>
+        </div>
+        <div id="repo-body">
+            <p class="repo-note" id="repo-intro-text"></p>
+            <div class="repo-field">
+                <label class="repo-label" id="repo-path-label" for="repo-path-input">Repository path</label>
+                <input type="text" id="repo-path-input" autocomplete="off" spellcheck="false" />
+                <div class="repo-actions">
+                    <button id="repo-save-btn" class="repo-btn repo-btn-primary" type="button" onclick="saveRepoPath()">Link</button>
+                    <button id="repo-unlink-btn" class="repo-btn" type="button" onclick="unlinkRepo()" style="display:none;">Unlink</button>
+                </div>
+                <div id="repo-msg" class="repo-msg" style="display:none;"></div>
+            </div>
+            <div id="repo-status" style="display:none;">
+                <div class="repo-status-row">
+                    <span class="repo-status-key" id="repo-branch-label">Branch</span>
+                    <span class="repo-status-val" id="repo-branch-val">—</span>
+                </div>
+                <div class="repo-status-row">
+                    <span class="repo-status-key" id="repo-state-label">State</span>
+                    <span class="repo-status-val"><span id="repo-state-badge" class="repo-badge">—</span></span>
+                </div>
+                <div class="repo-block" id="repo-commits-block" style="display:none;">
+                    <div class="repo-block-title" id="repo-commits-label">Latest commits</div>
+                    <ul class="repo-list" id="repo-commits-list"></ul>
+                </div>
+                <div class="repo-block" id="repo-changed-block" style="display:none;">
+                    <div class="repo-block-title" id="repo-changed-label">Changed files</div>
+                    <ul class="repo-list" id="repo-changed-list"></ul>
+                </div>
+                <div class="repo-block" id="repo-diffstat-block" style="display:none;">
+                    <div class="repo-block-title" id="repo-diffstat-label">Diff summary</div>
+                    <pre class="repo-pre" id="repo-diffstat-pre"></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div id="settings-overlay" onclick="handleSettingsOverlayClick(event)">
     <div id="settings-panel">
         <div id="settings-header">
@@ -3591,6 +3744,28 @@
             project_name_prompt: "Nom du projet :",
             project_archive_confirm: "Archiver ce projet ? Ses conversations et sa mémoire sont conservées.",
             project_archive: "Archiver le projet actif",
+            repo_settings: "Dépôt local du projet",
+            repo_title: "Dépôt local — lecture seule (Phase 1)",
+            repo_intro: "Liez un dépôt Git local pour que Nova comprenne son état. Phase 1 : strictement en lecture seule — aucun commit, push, branche ou écriture de fichier.",
+            repo_path_label: "Chemin du dépôt",
+            repo_path_ph: "/chemin/absolu/vers/le/depot",
+            repo_save: "Lier",
+            repo_unlink: "Délier",
+            repo_unlink_confirm: "Délier ce dépôt ? Le dépôt lui-même n'est pas modifié.",
+            repo_none: "Aucun dépôt lié à ce projet.",
+            repo_branch: "Branche",
+            repo_state: "État",
+            repo_clean: "Propre",
+            repo_dirty: "Modifications non validées",
+            repo_commits: "Derniers commits",
+            repo_changed: "Fichiers modifiés",
+            repo_diffstat: "Résumé des modifications",
+            repo_disabled: "Le Dev Workspace n'est pas activé sur cet hôte (définissez NOVA_DEV_WORKSPACE_ROOTS).",
+            repo_invalid: "Chemin du dépôt invalide",
+            repo_git_missing: "git n'est pas disponible sur cet hôte.",
+            repo_error: "Impossible de lire l'état Git du dépôt.",
+            repo_saved: "Dépôt lié.",
+            repo_unlinked: "Dépôt délié.",
             no_match: "Aucun résultat",
             search_placeholder: "Rechercher...",
             group_today: "AUJOURD'HUI",
@@ -3785,6 +3960,28 @@
             project_name_prompt: "Project name:",
             project_archive_confirm: "Archive this project? Its conversations and memory are kept.",
             project_archive: "Archive active project",
+            repo_settings: "Project local repository",
+            repo_title: "Dev Workspace — read-only (Phase 1)",
+            repo_intro: "Link a local Git repository so Nova can understand its state. Phase 1 is strictly read-only — no commit, push, branch, or file writes.",
+            repo_path_label: "Repository path",
+            repo_path_ph: "/absolute/path/to/the/repo",
+            repo_save: "Link",
+            repo_unlink: "Unlink",
+            repo_unlink_confirm: "Unlink this repository? The repository itself is not modified.",
+            repo_none: "No repository linked to this project.",
+            repo_branch: "Branch",
+            repo_state: "State",
+            repo_clean: "Clean",
+            repo_dirty: "Uncommitted changes",
+            repo_commits: "Latest commits",
+            repo_changed: "Changed files",
+            repo_diffstat: "Diff summary",
+            repo_disabled: "Dev Workspace is not enabled on this host (set NOVA_DEV_WORKSPACE_ROOTS).",
+            repo_invalid: "Invalid repository path",
+            repo_git_missing: "git is not available on this host.",
+            repo_error: "Could not read the repository's Git status.",
+            repo_saved: "Repository linked.",
+            repo_unlinked: "Repository unlinked.",
             no_match: "No matches",
             search_placeholder: "Search...",
             group_today: "TODAY",
@@ -3984,6 +4181,7 @@
         if (newProjBtn) newProjBtn.title = t("project_new");
         const archProjBtn = document.getElementById("archive-project-btn");
         if (archProjBtn) archProjBtn.title = t("project_archive");
+        applyRepoLabels();
         renderProjectSelect();
 
         // Input
@@ -4589,10 +4787,7 @@
             try { localStorage.setItem("nova_project", ""); } catch {}
         }
         sel.value = activeProjectId;
-        const archiveBtn = document.getElementById("archive-project-btn");
-        if (archiveBtn) {
-            archiveBtn.style.display = activeProjectId === "" ? "none" : "";
-        }
+        updateProjectActionButtons();
     }
 
     async function loadProjects() {
@@ -4611,14 +4806,22 @@
         renderProjectSelect();
     }
 
+    // Archive + Dev Workspace buttons only make sense for a real
+    // project. General (activeProjectId === "") hides both so the
+    // pre-projects experience is unchanged.
+    function updateProjectActionButtons() {
+        const show = activeProjectId === "" ? "none" : "";
+        const archiveBtn = document.getElementById("archive-project-btn");
+        if (archiveBtn) archiveBtn.style.display = show;
+        const repoBtn = document.getElementById("repo-settings-btn");
+        if (repoBtn) repoBtn.style.display = show;
+    }
+
     function onProjectChange() {
         const sel = document.getElementById("project-select");
         activeProjectId = sel ? sel.value : "";
         try { localStorage.setItem("nova_project", activeProjectId); } catch {}
-        const archiveBtn = document.getElementById("archive-project-btn");
-        if (archiveBtn) {
-            archiveBtn.style.display = activeProjectId === "" ? "none" : "";
-        }
+        updateProjectActionButtons();
         // Switching workspace starts a fresh, unselected view so the
         // user does not accidentally keep typing into a thread from a
         // different project; the conversation list reloads filtered.
@@ -4670,6 +4873,219 @@
         await loadProjects();
         newConversation();
         loadConversations();
+    }
+
+    // ── DEV WORKSPACE (Phase 1, read-only) ──
+    // A small project-scoped modal: link an absolute local repo path
+    // and observe its Git state. Every dynamic value the server
+    // returns (commit subjects, file paths, the path itself) is
+    // written with textContent, never innerHTML, so a repo with HTML
+    // metacharacters in a commit message can never inject markup.
+
+    function applyRepoLabels() {
+        const set = (id, key) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = t(key);
+        };
+        set("repo-title", "repo_title");
+        set("repo-intro-text", "repo_intro");
+        set("repo-path-label", "repo_path_label");
+        set("repo-branch-label", "repo_branch");
+        set("repo-state-label", "repo_state");
+        set("repo-commits-label", "repo_commits");
+        set("repo-changed-label", "repo_changed");
+        set("repo-diffstat-label", "repo_diffstat");
+        set("repo-save-btn", "repo_save");
+        set("repo-unlink-btn", "repo_unlink");
+        const input = document.getElementById("repo-path-input");
+        if (input) input.placeholder = t("repo_path_ph");
+        const repoBtn = document.getElementById("repo-settings-btn");
+        if (repoBtn) repoBtn.title = t("repo_settings");
+    }
+
+    function openRepoSettings() {
+        if (activeProjectId === "") return;
+        applyRepoLabels();
+        _repoMsg("", null);
+        document.getElementById("repo-status").style.display = "none";
+        document.getElementById("repo-path-input").value = "";
+        document.getElementById("repo-overlay").classList.add("open");
+        closeSidebar();
+        loadRepoStatus();
+    }
+
+    function closeRepoSettings() {
+        document.getElementById("repo-overlay").classList.remove("open");
+    }
+
+    function handleRepoOverlayClick(e) {
+        if (e.target === document.getElementById("repo-overlay")) {
+            closeRepoSettings();
+        }
+    }
+
+    function _repoMsg(text, kind) {
+        const box = document.getElementById("repo-msg");
+        if (!box) return;
+        if (!text) { box.style.display = "none"; box.textContent = ""; return; }
+        box.textContent = text;
+        box.className = "repo-msg " + (kind === "ok" ? "ok" : "err");
+        box.style.display = "";
+    }
+
+    async function loadRepoStatus() {
+        if (activeProjectId === "") return;
+        let data;
+        try {
+            const res = await fetch(
+                `/projects/${encodeURIComponent(activeProjectId)}/repo/status`,
+                { headers: { "Authorization": `Bearer ${token}` } }
+            );
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 404) { closeRepoSettings(); return; }
+            if (!res.ok) { _repoMsg(t("repo_error"), "err"); return; }
+            data = await res.json();
+        } catch { _repoMsg(t("repo_error"), "err"); return; }
+        renderRepoStatus(data);
+    }
+
+    function _clearList(el) { while (el.firstChild) el.removeChild(el.firstChild); }
+
+    function renderRepoStatus(data) {
+        const statusBox = document.getElementById("repo-status");
+        const unlinkBtn = document.getElementById("repo-unlink-btn");
+        const input = document.getElementById("repo-path-input");
+
+        if (!data || data.linked === false) {
+            statusBox.style.display = "none";
+            unlinkBtn.style.display = "none";
+            if (!input.value) _repoMsg(t("repo_none"), "ok");
+            return;
+        }
+
+        // Linked: show the resolved path + Unlink, then the snapshot.
+        input.value = data.repo_path || "";
+        unlinkBtn.style.display = "";
+
+        const state = data.state || "error";
+        if (state === "disabled") { _repoMsg(t("repo_disabled"), "err"); statusBox.style.display = "none"; return; }
+        if (state === "invalid_path") { _repoMsg((t("repo_invalid") + ": " + (data.detail || "")).trim(), "err"); statusBox.style.display = "none"; return; }
+        if (state === "git_unavailable") { _repoMsg(t("repo_git_missing"), "err"); statusBox.style.display = "none"; return; }
+        if (state === "error") { _repoMsg(t("repo_error"), "err"); statusBox.style.display = "none"; return; }
+
+        // state === "ready"
+        _repoMsg("", null);
+        statusBox.style.display = "";
+
+        document.getElementById("repo-branch-val").textContent =
+            data.branch || "—";
+
+        const badge = document.getElementById("repo-state-badge");
+        if (data.clean) {
+            badge.textContent = t("repo_clean");
+            badge.className = "repo-badge clean";
+        } else {
+            badge.textContent = t("repo_dirty");
+            badge.className = "repo-badge dirty";
+        }
+
+        const commits = Array.isArray(data.recent_commits) ? data.recent_commits : [];
+        const cBlock = document.getElementById("repo-commits-block");
+        const cList = document.getElementById("repo-commits-list");
+        _clearList(cList);
+        if (commits.length) {
+            commits.forEach(line => {
+                const li = document.createElement("li");
+                li.textContent = line;
+                cList.appendChild(li);
+            });
+            cBlock.style.display = "";
+        } else { cBlock.style.display = "none"; }
+
+        const changed = Array.isArray(data.changed_files) ? data.changed_files : [];
+        const fBlock = document.getElementById("repo-changed-block");
+        const fList = document.getElementById("repo-changed-list");
+        _clearList(fList);
+        if (changed.length) {
+            changed.forEach(entry => {
+                const li = document.createElement("li");
+                const code = document.createElement("span");
+                code.className = "repo-changed-code";
+                code.textContent = (entry && entry.status) || "?";
+                const p = document.createElement("span");
+                p.textContent = (entry && entry.path) || "";
+                li.appendChild(code);
+                li.appendChild(p);
+                fList.appendChild(li);
+            });
+            fBlock.style.display = "";
+        } else { fBlock.style.display = "none"; }
+
+        const diff = Array.isArray(data.diff_stat) ? data.diff_stat : [];
+        const dBlock = document.getElementById("repo-diffstat-block");
+        const dPre = document.getElementById("repo-diffstat-pre");
+        if (diff.length) {
+            dPre.textContent = diff.join("\n");
+            dBlock.style.display = "";
+        } else { dBlock.style.display = "none"; }
+    }
+
+    async function saveRepoPath() {
+        if (activeProjectId === "") return;
+        const input = document.getElementById("repo-path-input");
+        const path = input.value.trim();
+        if (!path) { _repoMsg(t("repo_invalid"), "err"); return; }
+        try {
+            const res = await fetch(
+                `/projects/${encodeURIComponent(activeProjectId)}/repo`,
+                {
+                    method: "PUT",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Authorization": `Bearer ${token}`
+                    },
+                    body: JSON.stringify({ path })
+                }
+            );
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 404) { closeRepoSettings(); return; }
+            if (res.status === 400) {
+                let detail = t("repo_invalid");
+                try { const j = await res.json(); if (j && j.detail) detail = j.detail; } catch {}
+                _repoMsg(detail, "err");
+                return;
+            }
+            if (!res.ok) { _repoMsg(t("repo_error"), "err"); return; }
+        } catch { _repoMsg(t("repo_error"), "err"); return; }
+        _repoMsg(t("repo_saved"), "ok");
+        await loadProjects();
+        await loadRepoStatus();
+    }
+
+    async function unlinkRepo() {
+        if (activeProjectId === "") return;
+        if (!window.confirm(t("repo_unlink_confirm"))) return;
+        try {
+            const res = await fetch(
+                `/projects/${encodeURIComponent(activeProjectId)}/repo`,
+                {
+                    method: "PUT",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Authorization": `Bearer ${token}`
+                    },
+                    body: JSON.stringify({ path: null })
+                }
+            );
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 404) { closeRepoSettings(); return; }
+            if (!res.ok) { _repoMsg(t("repo_error"), "err"); return; }
+        } catch { _repoMsg(t("repo_error"), "err"); return; }
+        document.getElementById("repo-path-input").value = "";
+        document.getElementById("repo-status").style.display = "none";
+        document.getElementById("repo-unlink-btn").style.display = "none";
+        _repoMsg(t("repo_unlinked"), "ok");
+        await loadProjects();
     }
 
     // ── CONVERSATIONS ──

--- a/tests/test_dev_workspace.py
+++ b/tests/test_dev_workspace.py
@@ -1,0 +1,591 @@
+"""
+Tests for the Dev Workspace foundation — Phase 1 (read-only).
+
+Covers:
+  * allowed-root resolution from ``NOVA_DEV_WORKSPACE_ROOTS``
+  * hard path validation (existence, ``.git``, containment, denylist,
+    top-level / ``..`` / ``~`` refusal, symlink-escape refusal)
+  * the module safety contract (no ``shell=True``, no privilege
+    escalation, no ``os.system``; the git argv allowlist is read-only
+    and refuses anything outside it)
+  * the read-only git helpers against a real throwaway repo
+  * the ``RepoStatus`` snapshot states
+  * the projects ``local_repo_path`` migration + user-scoped setter
+  * the read-only HTTP endpoints (link / unlink / status)
+
+These tests never modify a repo: the only repository written to is a
+disposable one created under ``tmp_path`` purely so the read helpers
+have something real to observe.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import os
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core import dev_workspace as dw
+from core import memory as core_memory, projects as core_projects, users
+from memory import store as natural_store
+
+_GIT = shutil.which("git")
+_needs_git = pytest.mark.skipif(_GIT is None, reason="git not on PATH")
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw"):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [_GIT, *args],
+        cwd=str(repo),
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+    )
+
+
+@pytest.fixture
+def real_repo(tmp_path):
+    """A real, committed git repo under an allowed root.
+
+    Returns ``(repo_path, allowed_root)``. The caller points
+    ``NOVA_DEV_WORKSPACE_ROOTS`` at ``allowed_root`` (or passes it
+    explicitly via ``roots=``).
+    """
+    root = tmp_path / "workspace"
+    repo = root / "demo"
+    repo.mkdir(parents=True)
+    if _GIT is not None:
+        _git(repo, "init", "-q")
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "Test")
+        # Disposable repo: never sign throwaway test commits (some
+        # hosts enforce commit signing globally). This only affects
+        # the test scaffold — Nova's helpers never commit.
+        _git(repo, "config", "commit.gpgsign", "false")
+        _git(repo, "config", "tag.gpgsign", "false")
+        (repo / "README.md").write_text("hello\n", encoding="utf-8")
+        _git(repo, "add", "README.md")
+        _git(repo, "commit", "-q", "-m", "initial commit")
+    else:
+        # Still create the marker so path-validation tests (which do
+        # not need git) work even on a git-less host.
+        (repo / ".git").mkdir()
+    return repo, root
+
+
+# ── Allowed-root resolution ─────────────────────────────────────────
+
+
+class TestConfiguredRoots:
+    def test_unset_means_feature_off(self, monkeypatch):
+        monkeypatch.delenv(dw.ENV_ROOTS, raising=False)
+        assert dw.configured_roots() == ()
+        assert dw.feature_enabled() is False
+
+    def test_blank_is_off(self, monkeypatch):
+        monkeypatch.setenv(dw.ENV_ROOTS, "   ")
+        assert dw.configured_roots() == ()
+        assert dw.feature_enabled() is False
+
+    def test_comma_and_pathsep_separators(self, tmp_path, monkeypatch):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        monkeypatch.setenv(
+            dw.ENV_ROOTS, f"{a}{os.pathsep}{b},{tmp_path / 'c'}"
+        )
+        roots = dw.configured_roots()
+        assert a.resolve() in roots and b.resolve() in roots
+        assert dw.feature_enabled() is True
+
+    def test_relative_entries_dropped(self, monkeypatch):
+        monkeypatch.setenv(dw.ENV_ROOTS, "relative/path,./also")
+        assert dw.configured_roots() == ()
+
+    def test_denied_or_top_level_roots_dropped(self, monkeypatch):
+        monkeypatch.setenv(dw.ENV_ROOTS, f"/{os.pathsep}/home{os.pathsep}/mnt")
+        assert dw.configured_roots() == ()
+        assert dw.feature_enabled() is False
+
+
+# ── Path validation ─────────────────────────────────────────────────
+
+
+class TestValidateRepoPath:
+    @pytest.mark.parametrize(
+        "bad", [None, True, False, 123, b"x"]
+    )
+    def test_non_string_rejected(self, bad):
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path(bad, roots=[Path("/tmp")])
+
+    @pytest.mark.parametrize("bad", ["", "   ", "\t"])
+    def test_empty_rejected(self, bad):
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path(bad, roots=[Path("/tmp")])
+
+    def test_relative_rejected(self):
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path("relative/repo", roots=[Path("/")])
+
+    def test_dotdot_rejected(self):
+        with pytest.raises(dw.RepoPathError, match="'\\.\\.'"):
+            dw.validate_repo_path("/srv/code/../../etc", roots=[Path("/srv")])
+
+    def test_tilde_rejected(self):
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path("~/code/nova", roots=[Path("/home")])
+
+    @pytest.mark.parametrize("bad", ["/srv/a\x00b", "/srv/a\nb", "/srv/a\rb"])
+    def test_control_chars_rejected(self, bad):
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path(bad, roots=[Path("/srv")])
+
+    def test_too_long_rejected(self):
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path("/" + "a" * 5000, roots=[Path("/")])
+
+    @pytest.mark.parametrize(
+        "p", ["/", "/home", "/mnt", "/etc", "/usr", "/var", "/root"]
+    )
+    def test_denylisted_system_dirs_rejected(self, p):
+        # Even with the broadest possible explicit root, a denied path
+        # can never validate.
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path(p, roots=[Path("/")])
+
+    def test_top_level_dir_rejected(self):
+        with pytest.raises(dw.RepoPathError, match="top-level"):
+            dw.validate_repo_path("/nova_repo_xyz", roots=[Path("/")])
+
+    def test_nonexistent_rejected(self, tmp_path):
+        missing = tmp_path / "nope" / "repo"
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path(str(missing), roots=[tmp_path])
+
+    def test_not_a_dir_rejected(self, tmp_path):
+        f = tmp_path / "file"
+        f.write_text("x")
+        with pytest.raises(dw.RepoPathError):
+            dw.validate_repo_path(str(f), roots=[tmp_path])
+
+    def test_missing_git_marker_rejected(self, tmp_path):
+        d = tmp_path / "plain"
+        d.mkdir()
+        with pytest.raises(dw.RepoPathError, match="Git checkout"):
+            dw.validate_repo_path(str(d), roots=[tmp_path])
+
+    def test_no_roots_configured_rejected(self, real_repo, monkeypatch):
+        repo, _ = real_repo
+        monkeypatch.delenv(dw.ENV_ROOTS, raising=False)
+        with pytest.raises(dw.RepoPathError, match="allowed workspace roots"):
+            dw.validate_repo_path(str(repo))
+
+    def test_outside_allowed_root_rejected(self, real_repo, tmp_path):
+        repo, _ = real_repo
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        with pytest.raises(dw.RepoPathError, match="outside"):
+            dw.validate_repo_path(str(repo), roots=[other])
+
+    def test_happy_path_returns_resolved(self, real_repo):
+        repo, root = real_repo
+        resolved = dw.validate_repo_path(str(repo), roots=[root])
+        assert resolved == repo.resolve()
+        assert resolved.is_absolute()
+
+    def test_env_driven_happy_path(self, real_repo, monkeypatch):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        assert dw.is_valid_repo_path(str(repo)) is True
+
+    def test_symlink_escape_rejected(self, real_repo, tmp_path):
+        """A symlink inside an allowed root that points outside it
+        must resolve and be refused — containment is checked on the
+        *resolved* path, so the link cannot smuggle an outside repo in.
+        """
+        repo, root = real_repo
+        outside = tmp_path / "outside_repo"
+        outside.mkdir()
+        (outside / ".git").mkdir()
+        link = root / "sneaky"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        with pytest.raises(dw.RepoPathError, match="outside"):
+            dw.validate_repo_path(str(link), roots=[root])
+
+
+# ── Module safety contract ──────────────────────────────────────────
+
+
+class TestModuleSafetyContract:
+    def test_no_shell_true_anywhere(self):
+        tree = ast.parse(Path(dw.__file__).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                for kw in node.keywords or []:
+                    if kw.arg == "shell":
+                        assert isinstance(kw.value, ast.Constant)
+                        assert kw.value.value is False
+
+    def test_no_privilege_escalation_strings(self):
+        source = Path(dw.__file__).read_text(encoding="utf-8")
+        for needle in (
+            '"sudo"', "'sudo'", " sudo ",
+            '"pkexec"', "'pkexec'",
+            '"doas"', "'doas'",
+            '"runuser"', "'runuser'",
+        ):
+            assert needle not in source
+
+    def test_no_os_system_or_popen(self):
+        tree = ast.parse(Path(dw.__file__).read_text(encoding="utf-8"))
+        bad = {"system", "popen", "spawnl", "spawnv", "spawnlp", "spawnvp"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(
+                node.value, ast.Name
+            ):
+                if node.value.id == "os" and node.attr in bad:
+                    pytest.fail(f"must not call os.{node.attr}")
+
+    def test_allowlist_is_read_only(self):
+        # No write / network / history-rewriting subcommand may ever
+        # appear in the allowlist.
+        forbidden = {
+            "push", "commit", "fetch", "pull", "clone", "remote",
+            "checkout", "merge", "rebase", "reset", "add", "rm",
+            "mv", "tag", "stash", "apply", "am", "cherry-pick",
+            "revert", "gc", "prune", "fsck", "init", "config",
+            "switch", "restore", "worktree", "submodule",
+        }
+        for argv in dw._ALLOWED_GIT_ARGV:
+            assert argv[0] in {"status", "branch", "log", "diff"}
+            assert not (set(argv) & forbidden)
+
+    def test_run_git_refuses_non_allowlisted_argv(self, real_repo):
+        repo, _ = real_repo
+        with pytest.raises(ValueError, match="not allowlisted"):
+            dw._run_git(["push", "origin", "main"], repo_path=str(repo))
+        with pytest.raises(ValueError, match="not allowlisted"):
+            dw._run_git(["status"], repo_path=str(repo))
+
+    def test_repo_path_is_never_in_argv(self, real_repo, monkeypatch):
+        """The repo path is only ever the cwd — never an argv element."""
+        repo, _ = real_repo
+        seen = {}
+
+        class _R:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+
+        def fake_run(argv, **kwargs):
+            seen["argv"] = argv
+            seen["cwd"] = kwargs.get("cwd")
+            seen["shell"] = kwargs.get("shell")
+            return _R()
+
+        monkeypatch.setattr(dw.subprocess, "run", fake_run)
+        dw._run_git(["status", "--short"], repo_path=str(repo))
+        assert seen["cwd"] == str(repo)
+        assert seen["shell"] is False
+        assert str(repo) not in seen["argv"][1:]
+        assert seen["argv"][1:] == ["status", "--short"]
+
+
+# ── Read-only git helpers (real repo) ───────────────────────────────
+
+
+@_needs_git
+class TestGitHelpers:
+    def test_branch_and_clean_after_commit(self, real_repo):
+        repo, _ = real_repo
+        assert dw.git_current_branch(str(repo)) in ("main", "master")
+        assert dw.git_is_clean(str(repo)) is True
+        assert dw.git_status_short(str(repo)) == ()
+
+    def test_dirty_after_untracked_file(self, real_repo):
+        repo, _ = real_repo
+        (repo / "new.txt").write_text("data\n", encoding="utf-8")
+        assert dw.git_is_clean(str(repo)) is False
+        short = dw.git_status_short(str(repo))
+        assert any("new.txt" in line for line in short)
+        changed = dw.git_changed_files(str(repo))
+        assert any(e["path"].endswith("new.txt") for e in changed)
+        assert all("status" in e and "path" in e for e in changed)
+
+    def test_diff_stat_after_modifying_tracked_file(self, real_repo):
+        repo, _ = real_repo
+        (repo / "README.md").write_text("hello\nworld\n", encoding="utf-8")
+        diff = dw.git_diff_stat(str(repo))
+        assert any("README.md" in line for line in diff)
+
+    def test_log_oneline(self, real_repo):
+        repo, _ = real_repo
+        log = dw.git_log_oneline(str(repo))
+        assert len(log) == 1
+        assert "initial commit" in log[0]
+
+    def test_log_capped_at_twenty(self, real_repo):
+        repo, _ = real_repo
+        for i in range(25):
+            (repo / f"f{i}").write_text("x", encoding="utf-8")
+            _git(repo, "add", f"f{i}")
+            _git(repo, "commit", "-q", "-m", f"commit {i}")
+        log = dw.git_log_oneline(str(repo))
+        assert len(log) == dw._MAX_LOG_LINES == 20
+
+    def test_read_status_ready_snapshot(self, real_repo):
+        repo, root = real_repo
+        snap = dw.read_status(str(repo), roots=[root])
+        d = snap.as_dict()
+        assert d["state"] == dw.STATE_READY
+        assert d["repo_path"] == str(repo.resolve())
+        assert d["clean"] is True
+        assert d["branch"] in ("main", "master")
+        assert isinstance(d["recent_commits"], list)
+        assert d["recent_commits"]
+
+    def test_read_status_reports_dirty(self, real_repo):
+        repo, root = real_repo
+        (repo / "wip.py").write_text("x = 1\n", encoding="utf-8")
+        snap = dw.read_status(str(repo), roots=[root]).as_dict()
+        assert snap["state"] == dw.STATE_READY
+        assert snap["clean"] is False
+        assert snap["detail"]
+
+
+class TestReadStatusErrorStates:
+    def test_disabled_when_no_roots(self, real_repo, monkeypatch):
+        repo, _ = real_repo
+        monkeypatch.delenv(dw.ENV_ROOTS, raising=False)
+        snap = dw.read_status(str(repo)).as_dict()
+        assert snap["state"] == dw.STATE_DISABLED
+
+    def test_invalid_path_state(self, tmp_path):
+        snap = dw.read_status(str(tmp_path / "gone"), roots=[tmp_path])
+        assert snap.state == dw.STATE_INVALID_PATH
+
+    def test_git_unavailable_state(self, real_repo, monkeypatch):
+        repo, root = real_repo
+        monkeypatch.setattr(dw, "_git_path", lambda: None)
+        snap = dw.read_status(str(repo), roots=[root]).as_dict()
+        assert snap["state"] == dw.STATE_GIT_UNAVAILABLE
+
+
+# ── Projects data-layer integration ─────────────────────────────────
+
+
+class TestProjectsRepoColumn:
+    def test_column_added_and_idempotent(self, db_path):
+        core_projects.migrate(db_path)
+        core_projects.migrate(db_path)  # second run must be a no-op
+        with sqlite3.connect(db_path) as conn:
+            cols = {
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(projects)"
+                ).fetchall()
+            }
+        assert "local_repo_path" in cols
+
+    def test_new_project_has_no_repo(self, db_path):
+        uid = _make_user(db_path, "alice")
+        p = core_projects.create_project("Nova", uid, db_path=db_path)
+        assert p["local_repo_path"] is None
+        assert p["has_local_repo"] is False
+
+    def test_set_and_get_repo_path(self, db_path, real_repo):
+        repo, root = real_repo
+        uid = _make_user(db_path, "alice")
+        p = core_projects.create_project("Nova", uid, db_path=db_path)
+        with patch.object(dw, "configured_roots", lambda: (root.resolve(),)):
+            updated = core_projects.set_local_repo_path(
+                p["id"], uid, str(repo), db_path=db_path
+            )
+        assert updated["local_repo_path"] == str(repo.resolve())
+        assert updated["has_local_repo"] is True
+        assert core_projects.get_local_repo_path(
+            p["id"], uid, db_path=db_path
+        ) == str(repo.resolve())
+
+    def test_unlink_with_none(self, db_path, real_repo):
+        repo, root = real_repo
+        uid = _make_user(db_path, "alice")
+        p = core_projects.create_project("Nova", uid, db_path=db_path)
+        with patch.object(dw, "configured_roots", lambda: (root.resolve(),)):
+            core_projects.set_local_repo_path(
+                p["id"], uid, str(repo), db_path=db_path
+            )
+        cleared = core_projects.set_local_repo_path(
+            p["id"], uid, None, db_path=db_path
+        )
+        assert cleared["local_repo_path"] is None
+        assert cleared["has_local_repo"] is False
+
+    def test_invalid_path_raises_project_error(self, db_path):
+        uid = _make_user(db_path, "alice")
+        p = core_projects.create_project("Nova", uid, db_path=db_path)
+        with pytest.raises(core_projects.ProjectError):
+            core_projects.set_local_repo_path(
+                p["id"], uid, "/etc", db_path=db_path
+            )
+
+    def test_set_is_user_scoped(self, db_path, real_repo):
+        repo, root = real_repo
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        p = core_projects.create_project("Nova", a, db_path=db_path)
+        with patch.object(dw, "configured_roots", lambda: (root.resolve(),)):
+            # Bob cannot touch Alice's project — returns None (web → 404).
+            assert core_projects.set_local_repo_path(
+                p["id"], b, str(repo), db_path=db_path
+            ) is None
+        assert core_projects.get_local_repo_path(
+            p["id"], b, db_path=db_path
+        ) is None
+
+
+# ── HTTP endpoints ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post(
+        "/login", json={"username": username, "password": password}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestRepoEndpoints:
+    def test_status_unlinked_returns_linked_false(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.get(
+            f"/projects/{pid}/repo/status", headers=_h(tok)
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"linked": False}
+
+    def test_link_invalid_path_is_400(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": "/etc"},
+            headers=_h(tok),
+        )
+        assert resp.status_code == 400
+        assert "detail" in resp.json()
+
+    def test_link_foreign_project_is_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a = _login(web_client, "alice")
+        b = _login(web_client, "bob")
+        pid = web_client.post(
+            "/projects", json={"name": "Priv"}, headers=_h(a)
+        ).json()["id"]
+        assert web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": None},
+            headers=_h(b),
+        ).status_code == 404
+        assert web_client.get(
+            f"/projects/{pid}/repo/status", headers=_h(b)
+        ).status_code == 404
+
+    def test_unlink_is_always_allowed(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.put(
+            f"/projects/{pid}/repo", json={"path": None}, headers=_h(tok)
+        )
+        assert resp.status_code == 200
+        assert resp.json()["local_repo_path"] is None
+
+    @_needs_git
+    def test_full_link_then_status(
+        self, db_path, web_client, real_repo, monkeypatch
+    ):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+
+        linked = web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": str(repo)},
+            headers=_h(tok),
+        )
+        assert linked.status_code == 200, linked.text
+        assert linked.json()["local_repo_path"] == str(repo.resolve())
+
+        status = web_client.get(
+            f"/projects/{pid}/repo/status", headers=_h(tok)
+        ).json()
+        assert status["linked"] is True
+        assert status["state"] == dw.STATE_READY
+        assert status["branch"] in ("main", "master")
+        assert status["clean"] is True
+        assert status["recent_commits"]

--- a/web.py
+++ b/web.py
@@ -304,6 +304,21 @@ class ProjectUpdateRequest(BaseModel):
     description: str | None = None
 
 
+class RepoLinkRequest(BaseModel):
+    """Body for ``PUT /projects/{id}/repo`` (Phase 1 Dev Workspace).
+
+    ``path`` is the absolute path of a local Git checkout to link.
+    ``None`` or an empty string *unlinks* the repo (always safe — it
+    only clears the stored string and never touches the filesystem).
+    A non-empty path is validated server-side by
+    ``core.dev_workspace`` before it is stored; an invalid path yields
+    a 400 with a short, safe reason.
+    """
+    model_config = {"extra": "forbid"}
+
+    path: str | None = None
+
+
 class MemoryUpdateRequest(BaseModel):
     category: str
     content: str
@@ -614,6 +629,66 @@ def unarchive_project_endpoint(
     if restored is None:
         raise HTTPException(status_code=404, detail="Projet introuvable.")
     return restored
+
+
+# ── DEV WORKSPACE (Phase 1, read-only) ──
+#
+# A project may optionally link a local Git checkout. These two
+# endpoints are user-scoped exactly like the rest of the project
+# surface (foreign / unknown id → 404, existence not leaked) and are
+# strictly read-only with respect to the repository: PUT only stores /
+# clears a validated path string, and GET only *observes* git state
+# via the allowlisted read-only helpers in ``core.dev_workspace``.
+# Nothing here can commit, push, branch, fetch, or write files; see
+# ``docs/dev-workspace.md``.
+
+@app.put("/projects/{project_id}/repo")
+def set_project_repo_endpoint(
+    project_id: int,
+    request: RepoLinkRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Link or unlink a local Git checkout for a project.
+
+    A ``null`` / empty ``path`` unlinks (always allowed). A non-empty
+    path is validated server-side; an invalid path is a 400 with a
+    short reason, a foreign / unknown project id is a 404.
+    """
+    try:
+        updated = _projects.set_local_repo_path(
+            project_id, user.id, request.path
+        )
+    except _projects.ProjectError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Projet introuvable.")
+    return updated
+
+
+@app.get("/projects/{project_id}/repo/status")
+def get_project_repo_status_endpoint(
+    project_id: int,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Return the read-only Git snapshot of a project's linked repo.
+
+    ``{"linked": false}`` when the project has no repo linked. When a
+    repo is linked the stored path is re-validated (defence in depth)
+    and a calm :class:`core.dev_workspace.RepoStatus` snapshot is
+    returned — never raising, never modifying the repository. A
+    foreign / unknown project id is a 404 so existence is not leaked.
+    """
+    project = _projects.get_project(project_id, user.id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Projet introuvable.")
+    repo_path = project.get("local_repo_path")
+    if not repo_path:
+        return {"linked": False}
+    from core import dev_workspace
+
+    snapshot = dev_workspace.read_status(repo_path).as_dict()
+    snapshot["linked"] = True
+    return snapshot
 
 
 @app.get("/conversations/{conversation_id}/messages")


### PR DESCRIPTION
## Summary

Adds the **Dev Workspace** foundation so a Nova Project can optionally link a local Git checkout and Nova can *understand* its state when helping the user code — **without modifying anything**. Phase 1 is strictly read-only and opt-in.

- **`core/dev_workspace.py`** — hard path validation + an allowlisted, read-only git surface:
  - Validation: absolute path only (no `~`, no `..`, no NUL/newline, length-capped), resolves through symlinks to a **directory containing `.git`**, refuses `/`, top-level dirs, and broad system paths (`/home`, `/mnt`, `/etc`, `/usr`, `/var`, `/root`, …), and must resolve **inside** an operator-configured allowed root. A symlink that escapes the root is refused.
  - Opt-in via `NOVA_DEV_WORKSPACE_ROOTS` (OS-pathsep/comma list of absolute dirs). Unset → feature off, nothing validates.
  - Frozen git allowlist: `status --short`, `branch --show-current`, `log --oneline -n 20`, `diff --stat`, `status --porcelain` (changed files). `shell=False`, per-call timeouts, stdin closed, `GIT_TERMINAL_PROMPT=0`/`GIT_OPTIONAL_LOCKS=0`. The repo path is the process **cwd only — never an argv element**.
- **`core/projects.py`** — idempotent, additive `local_repo_path` column + user-scoped `set`/`get` (invalid path → `ProjectError`/400, foreign project → 404). No backfill.
- **`web.py`** — two read-only, user-scoped endpoints: `PUT /projects/{id}/repo` (link/unlink) and `GET /projects/{id}/repo/status`.
- **UI** — project bar gains a `⎇` Dev Workspace panel (linked path, branch, clean/dirty badge, latest commits, changed files, diff summary). All dynamic git output is rendered via `textContent`, never `innerHTML` (XSS-safe). FR/EN i18n.
- **Docs** — new [`docs/dev-workspace.md`](docs/dev-workspace.md) (read-only contract + Phase 2–6 roadmap), cross-link from `docs/projects.md`, `.env.example` block, README row + feature bullet, CHANGELOG entry.

## Safety (enforced + tested)

read-only only · no commit/push/branch/file writes · no shell injection · no arbitrary commands · no `sudo` · no secrets · no GitHub/Codeberg API calls · no background scans · no direct writes to `main` · no autonomous actions. Mirrors the proven `core/maintenance.py` hardening pattern.

Later phases (patch propose → apply → branch/commit → PR draft → optional push) stay behind explicit confirmation and are **not** in Phase 1.

## Test plan

- [x] `tests/test_dev_workspace.py` — 63 tests, all green
  - [x] Path validation: empty/non-string, relative, `..`, `~`, control chars, too long, denylisted system dirs, top-level dir, nonexistent, not-a-dir, missing `.git`, no roots configured, outside allowed root, **symlink escape**, happy path, env-driven happy path
  - [x] Module safety contract: no `shell=True`, no privilege-escalation strings, no `os.system`/`os.popen`, allowlist is read-only, `_run_git` refuses non-allowlisted argv, repo path never in argv
  - [x] Git helpers against a real throwaway repo: branch, clean/dirty, `status --short`, `diff --stat`, `log` (capped at 20), changed-files parsing, `RepoStatus` states (ready/dirty/disabled/invalid_path/git_unavailable)
  - [x] Projects integration: column added + idempotent, set/get/unlink, invalid → `ProjectError`, user-scoped
  - [x] Endpoints: unlinked → `{linked:false}`, invalid → 400, foreign → 404, unlink always allowed, full link→status flow
- [x] No regressions: `test_projects.py` (CRUD/endpoints/migration), `test_maintenance.py` safety contract, `test_paths.py` — 228 passed. The only failures (`TestNaturalMemoryScoping`, 5) are **pre-existing** and unrelated (stubbed embeddings → MagicMock not JSON serializable on this host; confirmed failing on the clean baseline).
- [ ] Manual UI smoke test in a browser (could not run a browser in this environment)

https://claude.ai/code/session_01Wp1GYF127aEAsMeNnEXuvu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp1GYF127aEAsMeNnEXuvu)_