### PR TITLE
feat(relationship-coach): add non-clinical situation coach foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Relationship Situation Coach (foundation, local-first): a new
+  `core/relationship_coach.py` adds a non-clinical "situation coach"
+  that helps the user respond calmly and respectfully to an
+  emotionally sensitive relationship message. A conservative,
+  bilingual (FR/EN) topic detector (`is_relationship_coach_query`,
+  multi-word relationship phrases only — "reply"/"elle" alone never
+  trips it) gates a fixed, deterministic French prompt block
+  (`build_relationship_coach_block`, no LLM, no I/O, never raises)
+  that `core/chat.py` appends in `build_messages` *after*
+  `IDENTITY_CONTRACT` and the safety/security blocks, so it can never
+  override identity or safety rules. The block frames Nova as a
+  non-clinical coach (not a therapist, no partner diagnosis), gives a
+  light method (summarise; surface possible readings without
+  mind-reading; choose a calm response; avoid accusatory/needy
+  wording; keep healthy boundaries; speak now or wait), offers three
+  styles (soft / neutral / direct but respectful), and states hard
+  safety rules (no manipulation, coercion, gaslighting, revenge
+  advice, or diagnosing the partner; always toward calm communication
+  and consent). Privacy: sensitive relationship detail is never
+  auto-persisted — a shared `is_sensitive_relationship_content` gate
+  makes `core/chat.py` skip automatic memory extraction for those
+  turns (new `_autosave_allowed` helper) and `memory/policy.py` reject
+  such content from the durable natural-memory store; the explicit
+  manual memory command ("Retiens ça:" / "Souviens-toi:"), handled in
+  the web preflight, is the only path that stores a relationship fact
+  and is intentionally unaffected. Documented in
+  `docs/relationship-situation-coach.md`; covered by
+  `tests/test_relationship_coach.py` (detection, sensitive-content
+  gate, block content, memory-policy hardening, chat wiring,
+  auto-save guard).
 - Dev Workspace (Phase 1, read-only): a Nova Project can optionally
   link a local Git checkout so Nova *understands* its state when
   helping the user code — without modifying anything yet. A new

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ Shipped today:
   override the identity contract or the Nova Safety and Trust Contract.
   See [docs/nova-safety-and-trust-contract.md](docs/nova-safety-and-trust-contract.md)
   for the boundaries this layer sits inside.
+- **Relationship Situation Coach (foundation, local).** A non-clinical
+  "situation coach" that helps the user answer an emotionally sensitive
+  relationship message calmly and respectfully. When the user describes
+  a relationship situation, a small deterministic prompt block (no LLM,
+  no network) is appended *below* the identity/safety contract — it
+  never overrides it. It offers a light method (summarise what
+  happened; surface a few *possible* readings without mind-reading;
+  pick a calm response; avoid accusatory or needy wording; keep
+  healthy boundaries; decide whether to speak now or wait) and three
+  response styles (soft / neutral / direct but respectful). Hard
+  safety rules: no manipulation, coercion, gaslighting, revenge
+  advice, or diagnosing the partner; always toward calm communication
+  and consent. It is local and private: sensitive relationship details
+  are **never** auto-saved — Nova suppresses automatic memory
+  extraction for those turns, and a fact is stored only when the user
+  asks explicitly via the manual memory command. See
+  [docs/relationship-situation-coach.md](docs/relationship-situation-coach.md).
 - **Edit and delete sent messages.** Every chat message can be edited
   (user messages) or deleted (user and assistant messages) from the
   chat UI. Deleting a user message can optionally remove the paired
@@ -143,6 +160,7 @@ core/
   memory_importer.py  Local-only Markdown memory pack importer
   nova_contract.py    Nova identity + personalization prompt blocks
   feedback.py         Local response feedback (thumbs up/down) → preference block
+  relationship_coach.py  Non-clinical situation-coach prompt block (local)
   identity.py         Identity contract constant
   auth.py             JWT creation and verification
   github_oauth.py     Optional GitHub OAuth gate (alpha channel)

--- a/core/chat.py
+++ b/core/chat.py
@@ -12,6 +12,11 @@ from core.identity import IDENTITY_CONTRACT
 from core.nova_contract import build_personalization_block
 from core.feedback import build_feedback_preferences_block
 from core.policies import ADMIN_POLICY, Policy
+from core.relationship_coach import (
+    build_relationship_coach_block,
+    is_relationship_coach_query,
+    is_sensitive_relationship_content,
+)
 from core.settings import get_personalization
 from core.router import route
 from core.search import web_search, should_search
@@ -145,6 +150,20 @@ def extract_and_save_memory(
     parse_and_save(result, user_id, project_id)
 
 
+def _autosave_allowed(policy: Policy, user_message: str | None) -> bool:
+    """Whether this turn may be auto-mined for memory.
+
+    Automatic extraction is skipped when the user message carries
+    sensitive relationship detail: Nova must never silently persist who
+    the user is dating, fighting with, or breaking up with. The user can
+    still save such a fact deliberately — the manual memory command runs
+    in the web preflight, well before this path, so it is unaffected.
+    """
+    if not policy.memory_save_enabled:
+        return False
+    return not is_sensitive_relationship_content(user_message or "")
+
+
 def build_messages(
     history: list[dict],
     user_input: str,
@@ -203,6 +222,14 @@ def build_messages(
     if sec_block:
         parts.append(sec_block)
 
+    # Relationship Situation Coach — a deterministic, local tone block
+    # appended only when the user message is clearly about a sensitive
+    # relationship situation. It sits last, well below IDENTITY_CONTRACT
+    # and the safety blocks, so it can never override identity or safety
+    # rules; it only shapes how Nova answers this one topic.
+    if is_relationship_coach_query(user_input):
+        parts.append(build_relationship_coach_block())
+
     messages = [{"role": "system", "content": "\n\n".join(parts)}]
     messages += history[-CHAT_HISTORY_LIMIT:]
     messages.append({"role": "user", "content": user_input})
@@ -248,7 +275,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             messages = build_image_messages(user_input, image)
             default_model = resolve_default_model()
             reply = _generate(default_model, messages)
-            if policy.memory_save_enabled:
+            if _autosave_allowed(policy, user_input):
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
                 )
@@ -337,7 +364,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 )
                 reply = _generate(model, messages)
 
-        if policy.memory_save_enabled:
+        if _autosave_allowed(policy, user_input):
             extract_and_save_memory(user_input, reply, user_id, project_id)
             _extract_and_save_natural_memories(
                 user_input, user_id, project_id
@@ -392,7 +419,7 @@ def chat_stream(
             messages = build_image_messages(user_input, image)
             default_model = resolve_default_model()
             reply = _generate(default_model, messages)
-            if policy.memory_save_enabled:
+            if _autosave_allowed(policy, user_input):
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
                 )
@@ -492,7 +519,7 @@ def chat_stream(
                 )
                 reply = yield from _stream_and_accumulate(model, messages)
 
-        if policy.memory_save_enabled:
+        if _autosave_allowed(policy, user_input):
             extract_and_save_memory(user_input, reply, user_id, project_id)
             _extract_and_save_natural_memories(
                 user_input, user_id, project_id

--- a/core/chat.py
+++ b/core/chat.py
@@ -150,18 +150,31 @@ def extract_and_save_memory(
     parse_and_save(result, user_id, project_id)
 
 
-def _autosave_allowed(policy: Policy, user_message: str | None) -> bool:
+def _autosave_allowed(
+    policy: Policy,
+    user_message: str | None,
+    assistant_reply: str | None = None,
+) -> bool:
     """Whether this turn may be auto-mined for memory.
 
-    Automatic extraction is skipped when the user message carries
-    sensitive relationship detail: Nova must never silently persist who
-    the user is dating, fighting with, or breaking up with. The user can
-    still save such a fact deliberately — the manual memory command runs
-    in the web preflight, well before this path, so it is unaffected.
+    Automatic extraction is skipped when *either* the user message or
+    the assistant reply carries sensitive relationship detail: Nova must
+    never silently persist who the user is dating, fighting with, or
+    breaking up with. The reply is checked too because the LLM autosave
+    path (``extract_and_save_memory``) builds its extraction prompt from
+    *both* the user text and the assistant answer — gating on the user
+    message alone would leak relationship context that the assistant
+    restated on an otherwise-neutral follow-up turn.
+
+    The user can still save such a fact deliberately — the manual memory
+    command runs in the web preflight, well before this path, so it is
+    unaffected.
     """
     if not policy.memory_save_enabled:
         return False
-    return not is_sensitive_relationship_content(user_message or "")
+    if is_sensitive_relationship_content(user_message or ""):
+        return False
+    return not is_sensitive_relationship_content(assistant_reply or "")
 
 
 def build_messages(
@@ -275,7 +288,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             messages = build_image_messages(user_input, image)
             default_model = resolve_default_model()
             reply = _generate(default_model, messages)
-            if _autosave_allowed(policy, user_input):
+            if _autosave_allowed(policy, user_input, reply):
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
                 )
@@ -364,7 +377,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 )
                 reply = _generate(model, messages)
 
-        if _autosave_allowed(policy, user_input):
+        if _autosave_allowed(policy, user_input, reply):
             extract_and_save_memory(user_input, reply, user_id, project_id)
             _extract_and_save_natural_memories(
                 user_input, user_id, project_id
@@ -419,7 +432,7 @@ def chat_stream(
             messages = build_image_messages(user_input, image)
             default_model = resolve_default_model()
             reply = _generate(default_model, messages)
-            if _autosave_allowed(policy, user_input):
+            if _autosave_allowed(policy, user_input, reply):
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
                 )
@@ -519,7 +532,7 @@ def chat_stream(
                 )
                 reply = yield from _stream_and_accumulate(model, messages)
 
-        if _autosave_allowed(policy, user_input):
+        if _autosave_allowed(policy, user_input, reply):
             extract_and_save_memory(user_input, reply, user_id, project_id)
             _extract_and_save_natural_memories(
                 user_input, user_id, project_id

--- a/core/relationship_coach.py
+++ b/core/relationship_coach.py
@@ -51,6 +51,8 @@ Boundaries enforced here (commitments, not aspirations):
 
 from __future__ import annotations
 
+import re
+
 # ── Topic detection ──────────────────────────────────────────────────────────
 # Multi-word, relationship-specific phrases (EN + FR — Nova is
 # bilingual). Kept deliberately narrow: a single ambiguous word like
@@ -113,35 +115,49 @@ def is_relationship_coach_query(user_input: str) -> bool:
 # "Retiens ça:" / "Souviens-toi:"). This is the single source of truth
 # for "do not auto-save relationship details"; ``memory.policy`` imports
 # it so the durable natural-memory store enforces the same rule.
+# Unambiguous substrings: nouns / phrases that are almost never
+# anything but a romantic relationship, so they are safe to match in
+# *any* phrasing — first / second / third person, including the
+# extractor's "User's wife…" form. "fiance" (ASCII) is listed before
+# the accented forms and subsumes "fiancee"/"fiances".
 _SENSITIVE_RELATIONSHIP_PATTERNS: tuple[str, ...] = (
-    # English — standalone nouns that are almost never anything but a
-    # romantic relationship. Caught in *any* phrasing — first person,
-    # second person, or the third-person form the memory extractor
-    # produces ("User's wife…", "your husband…", "his girlfriend…").
+    # English
     "girlfriend", "boyfriend", "wife", "husband", "spouse",
-    # "fiance" (ASCII) is listed first and subsumes "fiancee"/"fiances";
-    # the accented forms stay for users who type the diacritic.
     "fiance", "fiancé", "fiancée",
     "marriage", "married", "divorce", "breakup", "broke up", "break up",
     "cheated on", "cheating on", "infidelity", "in love with",
-    # English — genuinely ambiguous on their own ("partner" could be a
-    # business partner, "ex" a substring of "example"), kept multi-word
-    # for precision.
-    "my partner", "my ex", "my relationship",
-    "our relationship", "my marriage", "my couple", "we argued",
-    "we had a fight", "we had an argument", "we slept together",
-    "relationship problem", "relationship tension",
-    # French — standalone unambiguous relationship nouns.
+    "my relationship", "our relationship", "my marriage", "my couple",
+    "we argued", "we had a fight", "we had an argument",
+    "we slept together", "relationship problem", "relationship tension",
+    # French
     "copine", "copain", "compagne", "compagnon", "petite amie",
     "petit ami", "époux", "épouse", "conjoint", "conjointe",
     "rupture", "infidèle", "infidélité", "amoureux de", "amoureuse de",
-    # French — kept multi-word ("femme"≈"woman", "mari" safer but
-    # paired for symmetry).
-    "ma femme", "mon mari", "mon ex", "mon ou ma partenaire",
-    "ma partenaire", "ma relation", "notre relation", "mon couple",
-    "on a rompu", "il m'a trompé", "elle m'a trompé", "on a couché",
+    "ma relation", "notre relation", "mon couple", "on a rompu",
+    "il m'a trompé", "elle m'a trompé", "on a couché",
     "dispute de couple", "tension dans mon couple",
     "tension dans ma relation",
+)
+
+# A few nouns are too ambiguous to match bare: "partner" (a *business*
+# partner), "ex" (substring of "example"/"next"), French "mari"
+# (substring of "marin"/"marinade") and "femme" ("a woman"). Requiring
+# a possessive / pronoun determiner right before the noun keeps them
+# precise while still catching every grammatical person — first
+# ("my partner"), second ("your partner", "ton mari") and third, the
+# form an assistant reply or the memory extractor restates context in
+# ("his partner", "User's partner", "son mari", "votre femme", or
+# "la femme de l'utilisateur"). \b…\b boundaries stop "your example",
+# "next", and "marina" from matching. Enumerating determiners — rather
+# than one more first-person string per round — is what actually closes
+# the cross-pronoun privacy hole.
+_AMBIGUOUS_RELATIONSHIP_RE = re.compile(
+    r"\b(?:"
+    r"my|your|his|her|their|our|its|user'?s|users|"
+    r"mon|ma|mes|ton|ta|tes|son|sa|ses|votre|vos|notre|nos|leur|leurs"
+    r")\s+(?:ex[-\s]?)?(?:partner|partenaire|mari|femme|ex)\b"
+    r"|\b(?:partner|partenaire|mari|femme)\s+de\s+l['’]utilisateur\b",
+    re.IGNORECASE,
 )
 
 
@@ -154,12 +170,21 @@ def is_sensitive_relationship_content(text: str) -> bool:
     saves (the manual memory command) are handled elsewhere and are
     intentionally **not** affected by this gate.
 
+    Matching is two-tier: a fast substring pass over the unambiguous
+    vocabulary, then a determiner-anchored regex for the handful of
+    nouns ("partner", "ex", "mari", "femme") that are only sensitive
+    when owned by someone. The regex is pronoun-agnostic on purpose so
+    a reply that restates context in the second or third person is
+    still blocked.
+
     Non-strings coerce to ``False``.
     """
     if not isinstance(text, str):
         return False
     lowered = text.lower()
-    return any(p in lowered for p in _SENSITIVE_RELATIONSHIP_PATTERNS)
+    if any(p in lowered for p in _SENSITIVE_RELATIONSHIP_PATTERNS):
+        return True
+    return _AMBIGUOUS_RELATIONSHIP_RE.search(lowered) is not None
 
 
 # ── The deterministic prompt block ───────────────────────────────────────────

--- a/core/relationship_coach.py
+++ b/core/relationship_coach.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 _COACH_TRIGGERS: tuple[str, ...] = (
     # English — partner / relationship anchors
     "my partner", "my girlfriend", "my boyfriend", "my wife",
-    "my husband", "my spouse", "my fiancé", "my fiancee", "my fiancée",
+    "my husband", "my spouse", "my fiance", "my fiancé", "my fiancée",
     "my relationship", "our relationship", "my marriage",
     "in my couple", "with my partner",
     # English — situation phrasing. Every entry carries a relationship
@@ -119,7 +119,9 @@ _SENSITIVE_RELATIONSHIP_PATTERNS: tuple[str, ...] = (
     # second person, or the third-person form the memory extractor
     # produces ("User's wife…", "your husband…", "his girlfriend…").
     "girlfriend", "boyfriend", "wife", "husband", "spouse",
-    "fiancé", "fiancee", "fiancée",
+    # "fiance" (ASCII) is listed first and subsumes "fiancee"/"fiances";
+    # the accented forms stay for users who type the diacritic.
+    "fiance", "fiancé", "fiancée",
     "marriage", "married", "divorce", "breakup", "broke up", "break up",
     "cheated on", "cheating on", "infidelity", "in love with",
     # English — genuinely ambiguous on their own ("partner" could be a

--- a/core/relationship_coach.py
+++ b/core/relationship_coach.py
@@ -65,13 +65,14 @@ _COACH_TRIGGERS: tuple[str, ...] = (
     "my husband", "my spouse", "my fiance", "my fiancé", "my fiancée",
     "my relationship", "our relationship", "my marriage",
     "in my couple", "with my partner",
-    # English — situation phrasing. Every entry carries a relationship
-    # anchor ("relationship", "my partner") or names the user as half
-    # of the pair ("we …"). Anchor-less phrases like "she got upset",
-    # "respond to her", or "text him back" were intentionally removed:
-    # they match coworker / client / family conflicts just as well and
-    # would break the conservative-detection contract above.
-    "we had a fight", "we had an argument", "we argued",
+    # English — situation phrasing. Every entry names a relationship
+    # explicitly ("relationship", "my partner"). Bare conflict phrases
+    # ("we argued", "we had a fight/argument") and anchor-less phrases
+    # ("she got upset", "respond to her", "text him back") were removed:
+    # a work team is also a "we", so they match coworker / project /
+    # family disputes and would break the conservative-detection
+    # contract above. A relationship argument still triggers via its
+    # partner anchor ("my girlfriend and I had a fight").
     "relationship advice", "relationship tension", "relationship problem",
     "how do i tell my partner", "how to talk to my partner",
     # French — partner / relationship anchors
@@ -79,13 +80,12 @@ _COACH_TRIGGERS: tuple[str, ...] = (
     "ma femme", "mon mari", "mon époux", "mon épouse",
     "ma relation", "notre relation", "mon couple", "dans mon couple",
     "ma partenaire", "mon ou ma partenaire",
-    # French — situation phrasing (same rule: anchored, or names the
-    # user as half of the pair via "on s'est …"). Generic third-person
-    # phrases ("elle est fâchée contre moi", "il m'en veut", "une
-    # dispute avec") were removed for the same reason as the English
-    # ones.
-    "on s'est disputé", "on s'est disputés", "on s'est disputée",
-    "on s'est engueulé", "tension dans mon couple",
+    # French — situation phrasing (same rule: every entry names a
+    # relationship). Bare conflict phrases ("on s'est disputé/engueulé"
+    # — "we argued", a work "on" too) and generic third-person ones
+    # ("elle est fâchée contre moi", "il m'en veut", "une dispute
+    # avec") were removed for the same reason as the English ones.
+    "tension dans mon couple",
     "tension dans ma relation", "conseil relationnel",
     "comment répondre à ma copine", "comment répondre à mon copain",
     "comment répondre à ma compagne", "comment répondre à mon compagnon",
@@ -126,8 +126,12 @@ _SENSITIVE_RELATIONSHIP_PATTERNS: tuple[str, ...] = (
     "fiance", "fiancé", "fiancée",
     "marriage", "married", "divorce", "breakup", "broke up", "break up",
     "cheated on", "cheating on", "infidelity", "in love with",
+    # NB: bare conflict phrases ("we argued", "we had a fight/argument")
+    # are deliberately NOT here — they are common in work / project
+    # contexts, so matching them would make the gate over-block
+    # legitimate non-relationship memory. A relationship argument is
+    # still caught via a partner noun ("my wife and I had a fight").
     "my relationship", "our relationship", "my marriage", "my couple",
-    "we argued", "we had a fight", "we had an argument",
     "we slept together", "relationship problem", "relationship tension",
     # French
     "copine", "copain", "compagne", "compagnon", "petite amie",

--- a/core/relationship_coach.py
+++ b/core/relationship_coach.py
@@ -63,30 +63,32 @@ _COACH_TRIGGERS: tuple[str, ...] = (
     "my husband", "my spouse", "my fiancé", "my fiancee", "my fiancée",
     "my relationship", "our relationship", "my marriage",
     "in my couple", "with my partner",
-    # English — situation phrasing
+    # English — situation phrasing. Every entry carries a relationship
+    # anchor ("relationship", "my partner") or names the user as half
+    # of the pair ("we …"). Anchor-less phrases like "she got upset",
+    # "respond to her", or "text him back" were intentionally removed:
+    # they match coworker / client / family conflicts just as well and
+    # would break the conservative-detection contract above.
     "we had a fight", "we had an argument", "we argued",
-    "got into a fight", "got into an argument",
     "relationship advice", "relationship tension", "relationship problem",
-    "how do i respond to her", "how do i respond to him",
-    "how should i reply to her", "how should i reply to him",
     "how do i tell my partner", "how to talk to my partner",
-    "should i text her back", "should i text him back",
-    "she got upset", "he got upset", "she's upset with me",
-    "he's upset with me", "they got upset with me",
     # French — partner / relationship anchors
     "ma copine", "mon copain", "ma compagne", "mon compagnon",
     "ma femme", "mon mari", "mon époux", "mon épouse",
     "ma relation", "notre relation", "mon couple", "dans mon couple",
     "ma partenaire", "mon ou ma partenaire",
-    # French — situation phrasing
+    # French — situation phrasing (same rule: anchored, or names the
+    # user as half of the pair via "on s'est …"). Generic third-person
+    # phrases ("elle est fâchée contre moi", "il m'en veut", "une
+    # dispute avec") were removed for the same reason as the English
+    # ones.
     "on s'est disputé", "on s'est disputés", "on s'est disputée",
-    "on s'est engueulé", "une dispute avec", "tension dans mon couple",
+    "on s'est engueulé", "tension dans mon couple",
     "tension dans ma relation", "conseil relationnel",
     "comment répondre à ma copine", "comment répondre à mon copain",
     "comment répondre à ma compagne", "comment répondre à mon compagnon",
-    "comment lui répondre sans", "comment parler à mon ou ma partenaire",
-    "comment dire à mon ou ma partenaire", "elle est fâchée contre moi",
-    "il est fâché contre moi", "elle m'en veut", "il m'en veut",
+    "comment parler à mon ou ma partenaire",
+    "comment dire à mon ou ma partenaire",
 )
 
 

--- a/core/relationship_coach.py
+++ b/core/relationship_coach.py
@@ -1,0 +1,226 @@
+"""
+Relationship Situation Coach — a non-clinical, local-first prompt block.
+
+Some of the hardest things people ask an assistant are not technical:
+*"My partner said this — how do I respond without making it worse?"*
+Nova should be able to help with that calmly, the same way it already
+helps with code or security: a small, deterministic context block that
+shapes *how* Nova answers, gated by a conservative topic detector so a
+fresh install pays zero token cost on every unrelated message.
+
+This module is the single place that wording lives. It produces a
+short, bullet-shaped French block (Nova still answers in the user's
+language — the response-style contract enforces that) that:
+
+  * frames Nova as a calm, non-clinical *situation coach* — never a
+    therapist, never a diagnosis, never a substitute for professional
+    or crisis help;
+  * gives a small, repeatable method: summarise what happened, surface
+    a few *possible* readings without mind-reading, pick a calm
+    response, avoid accusatory / needy wording, keep healthy
+    boundaries, and decide whether to speak now or wait;
+  * offers three response styles the user can ask for — *doux*
+    (soft), *neutre* (neutral), *direct mais respectueux* (direct but
+    respectful);
+  * states hard safety rules: no manipulation, no coercion, no
+    gaslighting, no revenge advice, no diagnosing the partner; always
+    steer toward calm communication and mutual consent;
+  * restates the privacy rule: sensitive relationship details are
+    **never** auto-saved. They are stored only when the user asks
+    explicitly via the manual memory command.
+
+Boundaries enforced here (commitments, not aspirations):
+
+  * **Deterministic.** No LLM in the loop. The block is a fixed
+    constant; :func:`build_relationship_coach_block` returns it
+    verbatim. Same input, byte-identical output.
+  * **Pure / no I/O.** Only the standard library is imported. Nothing
+    here reads the disk, the network, or the database, so it can be
+    imported from any layer (including ``memory.policy``) without a
+    cycle.
+  * **Never raises.** Detection coerces non-strings to ``False``; the
+    builder takes no arguments and cannot fail.
+  * **Subordinate to the contract.** The block sits *below* the Nova
+    identity / safety contract in the system prompt and says so. It
+    grants Nova no new capability — it only shapes tone for one topic.
+  * **Conservative detection.** Triggers are relationship-specific
+    multi-word phrases, not bare words like "she"/"reply", so generic
+    chat (or an email question) does not silently flip Nova into coach
+    framing.
+"""
+
+from __future__ import annotations
+
+# ── Topic detection ──────────────────────────────────────────────────────────
+# Multi-word, relationship-specific phrases (EN + FR — Nova is
+# bilingual). Kept deliberately narrow: a single ambiguous word like
+# "reply" or "elle" must never trip the coach, or every other message
+# would pay the token cost and get re-framed. Mirrors the shape of
+# ``core.security_feed.is_security_query``.
+_COACH_TRIGGERS: tuple[str, ...] = (
+    # English — partner / relationship anchors
+    "my partner", "my girlfriend", "my boyfriend", "my wife",
+    "my husband", "my spouse", "my fiancé", "my fiancee", "my fiancée",
+    "my relationship", "our relationship", "my marriage",
+    "in my couple", "with my partner",
+    # English — situation phrasing
+    "we had a fight", "we had an argument", "we argued",
+    "got into a fight", "got into an argument",
+    "relationship advice", "relationship tension", "relationship problem",
+    "how do i respond to her", "how do i respond to him",
+    "how should i reply to her", "how should i reply to him",
+    "how do i tell my partner", "how to talk to my partner",
+    "should i text her back", "should i text him back",
+    "she got upset", "he got upset", "she's upset with me",
+    "he's upset with me", "they got upset with me",
+    # French — partner / relationship anchors
+    "ma copine", "mon copain", "ma compagne", "mon compagnon",
+    "ma femme", "mon mari", "mon époux", "mon épouse",
+    "ma relation", "notre relation", "mon couple", "dans mon couple",
+    "ma partenaire", "mon ou ma partenaire",
+    # French — situation phrasing
+    "on s'est disputé", "on s'est disputés", "on s'est disputée",
+    "on s'est engueulé", "une dispute avec", "tension dans mon couple",
+    "tension dans ma relation", "conseil relationnel",
+    "comment répondre à ma copine", "comment répondre à mon copain",
+    "comment répondre à ma compagne", "comment répondre à mon compagnon",
+    "comment lui répondre sans", "comment parler à mon ou ma partenaire",
+    "comment dire à mon ou ma partenaire", "elle est fâchée contre moi",
+    "il est fâché contre moi", "elle m'en veut", "il m'en veut",
+)
+
+
+def is_relationship_coach_query(user_input: str) -> bool:
+    """True iff ``user_input`` looks like a request for relationship-situation help.
+
+    Conservative on purpose: only relationship-specific multi-word
+    phrases match, so generic conversation never silently switches Nova
+    into coach mode. Non-strings coerce to ``False`` so the helper is
+    safe to call from any path without a guard.
+    """
+    if not isinstance(user_input, str):
+        return False
+    lowered = user_input.lower()
+    return any(trigger in lowered for trigger in _COACH_TRIGGERS)
+
+
+# ── Sensitive-content gate for automatic memory ──────────────────────────────
+# Phrases that mark a message as carrying *sensitive relationship
+# detail*. When this matches, the chat layer skips automatic memory
+# extraction for that turn (the user can still save explicitly with
+# "Retiens ça:" / "Souviens-toi:"). This is the single source of truth
+# for "do not auto-save relationship details"; ``memory.policy`` imports
+# it so the durable natural-memory store enforces the same rule.
+_SENSITIVE_RELATIONSHIP_PATTERNS: tuple[str, ...] = (
+    # English — standalone nouns that are almost never anything but a
+    # romantic relationship. Caught in any phrasing, including the
+    # third-person form the memory extractor produces ("User's wife…").
+    "girlfriend", "boyfriend", "spouse", "fiancé", "fiancee", "fiancée",
+    "marriage", "married", "divorce", "breakup", "broke up", "break up",
+    "cheated on", "cheating on", "infidelity", "in love with",
+    # English — ambiguous on their own ("wife"≈relationship but "partner"
+    # could be a business partner), kept multi-word for precision.
+    "my partner", "my wife", "my husband", "my ex", "my relationship",
+    "our relationship", "my marriage", "my couple", "we argued",
+    "we had a fight", "we had an argument", "we slept together",
+    "relationship problem", "relationship tension",
+    # French — standalone unambiguous relationship nouns.
+    "copine", "copain", "compagne", "compagnon", "petite amie",
+    "petit ami", "époux", "épouse", "conjoint", "conjointe",
+    "rupture", "infidèle", "infidélité", "amoureux de", "amoureuse de",
+    # French — kept multi-word ("femme"≈"woman", "mari" safer but
+    # paired for symmetry).
+    "ma femme", "mon mari", "mon ex", "mon ou ma partenaire",
+    "ma partenaire", "ma relation", "notre relation", "mon couple",
+    "on a rompu", "il m'a trompé", "elle m'a trompé", "on a couché",
+    "dispute de couple", "tension dans mon couple",
+    "tension dans ma relation",
+)
+
+
+def is_sensitive_relationship_content(text: str) -> bool:
+    """True iff ``text`` carries sensitive relationship detail.
+
+    Used as a gate: automatic memory extraction is skipped when this
+    returns ``True`` so Nova never silently persists who the user is
+    dating, fighting with, or breaking up with. Explicit, user-approved
+    saves (the manual memory command) are handled elsewhere and are
+    intentionally **not** affected by this gate.
+
+    Non-strings coerce to ``False``.
+    """
+    if not isinstance(text, str):
+        return False
+    lowered = text.lower()
+    return any(p in lowered for p in _SENSITIVE_RELATIONSHIP_PATTERNS)
+
+
+# ── The deterministic prompt block ───────────────────────────────────────────
+# French to match the voice of the identity / safety contract in
+# ``core.nova_contract``; the response-style contract already forces
+# Nova to answer in the user's own language, so an English speaker
+# still gets an English reply. The block explicitly defers to the
+# contract above it — it shapes tone for one topic, nothing more.
+RELATIONSHIP_COACH_BLOCK = """COACH DE SITUATION RELATIONNELLE (mode non clinique, \
+local et privé — subordonné à l'identité et aux règles de sécurité de Nova ci-dessus):
+Tu aides l'utilisateur à répondre avec calme et respect à une situation \
+relationnelle sensible. Tu n'es pas thérapeute, ni médiateur, ni juge : tu \
+n'établis aucun diagnostic et tu ne remplaces pas un professionnel. Si la \
+situation évoque un danger, de la violence ou une détresse grave, invite \
+calmement à chercher une aide humaine ou professionnelle adaptée.
+
+Méthode (propose-la, ne l'impose pas):
+- Résume d'abord ce qui s'est passé, en faits, sans jugement.
+- Propose deux ou trois interprétations *possibles* — présente-les comme des \
+hypothèses, jamais comme la vérité. Ne lis pas dans les pensées du partenaire.
+- Aide à choisir une réponse calme et posée.
+- Évite toute formulation accusatrice ("tu fais toujours…") ou \
+dans le besoin / suppliante ; préfère le "je" et une demande claire.
+- Aide à poser et garder des limites saines, sans punir l'autre.
+- Aide à décider s'il vaut mieux répondre maintenant ou attendre d'être apaisé.
+
+Styles de réponse (laisse l'utilisateur choisir ; par défaut, neutre):
+- doux : chaleureux, rassurant, ménage l'autre tout en restant honnête.
+- neutre : factuel, posé, ni froid ni distant.
+- direct mais respectueux : clair et net sur le besoin, sans agressivité \
+ni mépris.
+
+Règles de sécurité (absolues, non négociables):
+- Aucune manipulation, aucun chantage affectif, aucune tactique pour \
+"gagner" ou contrôler l'autre.
+- Aucune coercition : ne pousse jamais à forcer une réponse, une présence \
+ou un contact non désiré.
+- Aucun gaslighting : ne suggère jamais de nier la réalité ou les ressentis \
+de l'autre.
+- Aucun conseil de vengeance, de représailles, ni de jeu de pouvoir punitif.
+- Aucun diagnostic du partenaire (ne le qualifie pas de narcissique, \
+toxique, bipolaire, etc.). Décris des comportements, pas des étiquettes.
+- Oriente toujours vers une communication calme, le respect mutuel et le \
+consentement des deux personnes.
+
+Confidentialité (règle stricte):
+- Cette conversation reste locale et privée. N'enregistre jamais \
+automatiquement un détail relationnel sensible (qui est le partenaire, une \
+dispute, une rupture, une infidélité…).
+- Ne mémorise un élément relationnel que si l'utilisateur le demande \
+explicitement via la commande de mémoire ("Retiens ça:" / "Souviens-toi:"). \
+Sans cette confirmation explicite, ne propose pas de le retenir et ne le \
+retiens pas."""
+
+
+def build_relationship_coach_block() -> str:
+    """Return the deterministic relationship-coach prompt block.
+
+    Verbatim and argument-free: same call, byte-identical output. The
+    chat layer appends it (below the identity/safety contract) only
+    when :func:`is_relationship_coach_query` matched the user message.
+    """
+    return RELATIONSHIP_COACH_BLOCK
+
+
+__all__ = [
+    "is_relationship_coach_query",
+    "is_sensitive_relationship_content",
+    "build_relationship_coach_block",
+    "RELATIONSHIP_COACH_BLOCK",
+]

--- a/core/relationship_coach.py
+++ b/core/relationship_coach.py
@@ -115,14 +115,17 @@ def is_relationship_coach_query(user_input: str) -> bool:
 # it so the durable natural-memory store enforces the same rule.
 _SENSITIVE_RELATIONSHIP_PATTERNS: tuple[str, ...] = (
     # English — standalone nouns that are almost never anything but a
-    # romantic relationship. Caught in any phrasing, including the
-    # third-person form the memory extractor produces ("User's wife…").
-    "girlfriend", "boyfriend", "spouse", "fiancé", "fiancee", "fiancée",
+    # romantic relationship. Caught in *any* phrasing — first person,
+    # second person, or the third-person form the memory extractor
+    # produces ("User's wife…", "your husband…", "his girlfriend…").
+    "girlfriend", "boyfriend", "wife", "husband", "spouse",
+    "fiancé", "fiancee", "fiancée",
     "marriage", "married", "divorce", "breakup", "broke up", "break up",
     "cheated on", "cheating on", "infidelity", "in love with",
-    # English — ambiguous on their own ("wife"≈relationship but "partner"
-    # could be a business partner), kept multi-word for precision.
-    "my partner", "my wife", "my husband", "my ex", "my relationship",
+    # English — genuinely ambiguous on their own ("partner" could be a
+    # business partner, "ex" a substring of "example"), kept multi-word
+    # for precision.
+    "my partner", "my ex", "my relationship",
     "our relationship", "my marriage", "my couple", "we argued",
     "we had a fight", "we had an argument", "we slept together",
     "relationship problem", "relationship tension",

--- a/docs/relationship-situation-coach.md
+++ b/docs/relationship-situation-coach.md
@@ -1,0 +1,135 @@
+# Relationship Situation Coach
+
+> **Status: shipped (foundation), local-first.** This document
+> describes the non-clinical "situation coach" that helps the user
+> answer an emotionally sensitive relationship message calmly and
+> respectfully. It lives inside the boundaries set by
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md);
+> nothing here grants Nova new powers, contacts the network, or
+> changes storage / migration / Ollama behaviour.
+
+## What it does
+
+Some of the hardest things people ask an assistant are not technical:
+*"My partner said this — how do I respond without making it worse?"*
+Nova should be able to help with that the same calm way it helps with
+code or security.
+
+When the user's message is clearly about a sensitive relationship
+situation, Nova appends a small, fixed **coach block** to the system
+prompt. The block shapes *how* Nova answers this one topic — it does
+not add any capability. It frames Nova as a calm, **non-clinical**
+situation coach:
+
+- **not a therapist**, not a mediator, not a judge;
+- no diagnosis of the user and **no diagnosis of the partner**
+  ("narcissist", "toxic", "bipolar" — describe behaviour, not labels);
+- if the situation suggests danger, violence, or serious distress,
+  Nova calmly points toward appropriate human or professional help
+  instead of role-playing a counsellor.
+
+### The method it offers
+
+The block proposes (never imposes) a small, repeatable method:
+
+1. **Summarise** what happened, in facts, without judgement.
+2. Surface two or three **possible interpretations** — explicitly as
+   hypotheses, never as the truth. No mind-reading of the partner.
+3. Help choose a **calm, grounded response**.
+4. Avoid **accusatory** ("you always…") or **needy / pleading**
+   wording; prefer "I" statements and a clear request.
+5. Help set and keep **healthy boundaries** without punishing the
+   other person.
+6. Help decide whether to **speak now or wait** until calmer.
+
+### Response styles
+
+The user can ask for a tone; the default is *neutral*:
+
+- **soft** — warm and reassuring, gentle on the other person while
+  still honest;
+- **neutral** — factual and composed, neither cold nor distant;
+- **direct but respectful** — clear and firm about the need, with no
+  aggression or contempt.
+
+### Hard safety rules
+
+These are stated in the block and are non-negotiable:
+
+- no manipulation or emotional blackmail;
+- no coercion (never push to force a reply, presence, or contact);
+- no gaslighting (never suggest denying the other person's reality or
+  feelings);
+- no revenge, retaliation, or punitive power-play advice;
+- no diagnosing the partner;
+- always steer toward **calm communication, mutual respect, and
+  consent**.
+
+## How it is wired
+
+| Concern | Where |
+| --- | --- |
+| Topic detection | `core/relationship_coach.py` → `is_relationship_coach_query` |
+| The prompt block | `core/relationship_coach.py` → `build_relationship_coach_block` / `RELATIONSHIP_COACH_BLOCK` |
+| Injection point | `core/chat.py` → `build_messages` (appended last) |
+| Auto-save suppression | `core/chat.py` → `_autosave_allowed`; `memory/policy.py` |
+
+Detection is **conservative**: only relationship-specific multi-word
+phrases match (EN + FR — Nova is bilingual). A bare word like "reply"
+or "elle" never trips the coach, so an unrelated email or support
+question is unaffected and pays zero token cost. The block is a fixed
+constant — no LLM in the loop, deterministic, byte-identical every
+time — and `build_messages` adds it **after** `IDENTITY_CONTRACT` and
+the safety / security blocks. Ordering is the guarantee: a coaching
+request can never dilute or override Nova's identity or safety rules,
+exactly like the personalization and feedback blocks.
+
+The block text is French to match the voice of the identity / safety
+contract; Nova still answers in the user's own language because the
+response-style contract already enforces language mirroring.
+
+## Privacy: relationship detail is never auto-saved
+
+This is the part that matters most. Relationship situations are
+private, so:
+
+- **No automatic memory.** When the user message carries sensitive
+  relationship detail (`is_sensitive_relationship_content`), Nova
+  **skips automatic memory extraction for that turn entirely** — both
+  the LLM-extraction path and the rule-based natural-memory path.
+  Nova never silently records who the user is dating, fighting with,
+  or breaking up with.
+- **Defence in depth.** `memory/policy.py` independently rejects
+  sensitive relationship content from the durable natural-memory
+  store, using the same single-source predicate, so even a future
+  caller that bypasses the chat guard cannot auto-persist it.
+- **User-approved only.** The one way a relationship fact is stored is
+  the explicit manual memory command (`Retiens ça:` /
+  `Souviens-toi:`). That command is handled in the web preflight,
+  *before* the chat path, and is intentionally **not** affected by the
+  auto-save gate — explicit consent is the whole point.
+
+So: *store only user-approved relationship memories; never save
+sensitive relationship details without confirmation.*
+
+## What this foundation does not do
+
+- It does **not** add a new router mode, endpoint, setting, or env
+  flag. It is always available and entirely local; an unconfigured
+  install behaves identically until the user actually describes a
+  relationship situation.
+- It does **not** call any model to classify the message, contact the
+  network, or read the database.
+- It does **not** provide clinical, legal, or crisis services, and it
+  says so.
+- It does **not** override the Nova Safety and Trust Contract — it
+  sits inside it.
+
+## Tests
+
+`tests/test_relationship_coach.py` covers detection (bilingual,
+conservative, non-string safe), the sensitive-content gate, the block
+content (method, the three styles, every safety rule, the privacy
+rule, non-clinical framing), the `memory/policy.py` hardening, and the
+`core/chat.py` wiring (block injected only on a coach query, always
+below `IDENTITY_CONTRACT`, and the `_autosave_allowed` guard).

--- a/memory/policy.py
+++ b/memory/policy.py
@@ -1,4 +1,6 @@
 import re
+
+from core.relationship_coach import is_sensitive_relationship_content
 from memory.schema import Memory
 
 # Credentials, tokens, financial details, and personal identifiers
@@ -33,6 +35,13 @@ def is_memory_allowed(memory: Memory) -> bool:
     Rejects credentials, sensitive identity info, and transient emotions.
     """
     combined = f"{memory.topic} {memory.content}".lower()
+
+    # Sensitive relationship detail is never auto-persisted. The user
+    # can still save it deliberately via the manual memory command,
+    # which bypasses this policy on purpose. Single source of truth
+    # lives in ``core.relationship_coach``.
+    if is_sensitive_relationship_content(combined):
+        return False
 
     for pattern in _SENSITIVE_PATTERNS:
         if re.search(pattern, combined, re.IGNORECASE):

--- a/tests/test_relationship_coach.py
+++ b/tests/test_relationship_coach.py
@@ -127,6 +127,48 @@ class TestSensitiveContentGate:
         assert is_sensitive_relationship_content("User's fiancee is a vet.")
         assert is_sensitive_relationship_content("ma fiancée est partie")
 
+    def test_flags_partner_and_ex_across_pronouns(self):
+        # Codex review P1 (round 4): the determiner-anchored regex must
+        # catch "partner"/"ex" owned by ANY person, not only "my".
+        for text in (
+            "my partner and I argued",
+            "Earlier you mentioned your partner was upset",
+            "his partner called twice",
+            "her ex keeps texting",
+            "their partner moved out",
+            "User's partner is a vet.",
+            "the user's ex came back",
+            "talk to your ex-partner first",
+        ):
+            assert is_sensitive_relationship_content(text), text
+
+    def test_flags_french_spouse_partner_across_pronouns(self):
+        # Codex review P1 (round 4): "ton mari"/"votre mari"/"son mari"
+        # and the extractor's "la femme de l'utilisateur" must match.
+        for text in (
+            "tu as parlé de ton mari hier",
+            "votre mari vous a dit ça",
+            "son mari travaille de nuit",
+            "sa femme est partie",
+            "la femme de l'utilisateur est médecin",
+            "le partenaire de l'utilisateur a déménagé",
+        ):
+            assert is_sensitive_relationship_content(text), text
+
+    def test_determiner_gate_avoids_false_positives(self):
+        # Bare / non-possessed ambiguous nouns must NOT trip the gate,
+        # or legitimate memory (work, names) would be silently dropped.
+        for text in (
+            "I met a business partner at the conference",
+            "the partner track at the law firm",
+            "your example was very clear",
+            "what are the next steps",
+            "we sailed past a marina",
+            "there was a woman named Marie at the talk",
+            "une femme a posé une question",
+        ):
+            assert not is_sensitive_relationship_content(text), text
+
     def test_ignores_non_relationship_text(self):
         assert not is_sensitive_relationship_content(
             "User prefers Fedora KDE and neovim"
@@ -228,6 +270,22 @@ class TestMemoryPolicyHardening:
             _mem(content="User's husband works nights.")
         ) is False
 
+    def test_rejects_third_person_partner_memory(self):
+        # Codex review P1 (round 4): determiner-anchored "partner"/FR
+        # spouse must also be rejected from the durable store.
+        assert is_memory_allowed(
+            _mem(content="User's partner is a teacher.")
+        ) is False
+        assert is_memory_allowed(
+            _mem(content="La femme de l'utilisateur est avocate.")
+        ) is False
+
+    def test_allows_business_partner_memory(self):
+        # The determiner gate must not over-block legitimate facts.
+        assert is_memory_allowed(
+            _mem(kind="project", content="User has a business partner named Sam.")
+        ) is True
+
 
 class TestChatWiring:
     def test_block_injected_for_coach_query(self):
@@ -310,3 +368,26 @@ class TestAutosaveGuard:
             "Earlier you mentioned your husband; setting that aside, "
             "at work you could...",
         ) is False
+
+    def test_blocks_when_reply_mentions_partner_or_fr_spouse(self):
+        # Codex review P1 (round 4): "your partner" / "votre mari" in
+        # the reply must block autosave on a neutral user turn too.
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "thanks, anything else for the sprint?",
+            "Earlier you mentioned your partner was unhappy; for the "
+            "sprint though...",
+        ) is False
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "merci, et pour le projet ?",
+            "Vous aviez parlé de votre mari ; pour le projet, vous "
+            "pourriez...",
+        ) is False
+
+    def test_allows_business_partner_in_reply(self):
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "who should I loop in?",
+            "Loop in your business partner and the design lead.",
+        ) is True

--- a/tests/test_relationship_coach.py
+++ b/tests/test_relationship_coach.py
@@ -1,0 +1,234 @@
+"""
+Tests for the Relationship Situation Coach foundation:
+
+  - topic detection (bilingual, conservative, non-string safe)
+  - sensitive-content gate used to suppress automatic memory
+  - the deterministic prompt block (method, styles, safety, privacy)
+  - memory.policy refuses to auto-persist relationship detail
+  - core.chat wiring: block injected only on a coach query, always
+    below IDENTITY_CONTRACT, and the auto-save guard
+
+Heavy / optional deps that ``core.chat`` pulls in transitively are
+stubbed by ``tests/conftest.py`` when the real wheel is absent, so the
+chat-wiring tests collect cleanly on a minimal host.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Match the defensive stubbing used by test_identity.py so importing
+# core.chat never fails for a missing optional dep.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.relationship_coach import (  # noqa: E402
+    RELATIONSHIP_COACH_BLOCK,
+    build_relationship_coach_block,
+    is_relationship_coach_query,
+    is_sensitive_relationship_content,
+)
+from core.chat import build_messages, _autosave_allowed  # noqa: E402
+from core.identity import IDENTITY_CONTRACT  # noqa: E402
+from core.policies import ADMIN_POLICY, DEFAULT_RESTRICTED_POLICY  # noqa: E402
+from memory.policy import is_memory_allowed  # noqa: E402
+from memory.schema import Memory  # noqa: E402
+
+
+def _mem(**kwargs) -> Memory:
+    defaults = dict(kind="general", topic="test", content="test content",
+                    confidence=0.9)
+    defaults.update(kwargs)
+    return Memory(**defaults)
+
+
+class TestDetection:
+    def test_detects_french_partner_situation(self):
+        assert is_relationship_coach_query(
+            "On s'est disputé hier soir, comment répondre à ma copine "
+            "sans être accusateur ?"
+        )
+
+    def test_detects_english_partner_situation(self):
+        assert is_relationship_coach_query(
+            "my girlfriend got upset with me — how do i respond to her?"
+        )
+
+    def test_detects_relationship_advice_phrase(self):
+        assert is_relationship_coach_query("I need some relationship advice")
+        assert is_relationship_coach_query("j'ai besoin d'un conseil relationnel")
+
+    def test_is_case_insensitive(self):
+        assert is_relationship_coach_query("MY PARTNER said something hurtful")
+
+    def test_ignores_generic_message(self):
+        assert not is_relationship_coach_query("what's the weather tomorrow?")
+        assert not is_relationship_coach_query("écris-moi une fonction python")
+
+    def test_does_not_trip_on_unrelated_reply_question(self):
+        # "reply" / "respond" alone must not flip Nova into coach mode —
+        # otherwise every email/support question would pay the cost.
+        assert not is_relationship_coach_query(
+            "how should i reply to this email from a client?"
+        )
+
+    def test_non_string_is_false(self):
+        assert is_relationship_coach_query(None) is False
+        assert is_relationship_coach_query(123) is False
+        assert is_relationship_coach_query(["my partner"]) is False
+
+
+class TestSensitiveContentGate:
+    def test_flags_english_relationship_detail(self):
+        assert is_sensitive_relationship_content("my ex cheated on me")
+        assert is_sensitive_relationship_content("we broke up last week")
+        assert is_sensitive_relationship_content("my wife and I had a fight")
+
+    def test_flags_french_relationship_detail(self):
+        assert is_sensitive_relationship_content("mon copain m'a trompé")
+        assert is_sensitive_relationship_content(
+            "on a rompu, c'est une rupture difficile"
+        )
+
+    def test_ignores_non_relationship_text(self):
+        assert not is_sensitive_relationship_content(
+            "User prefers Fedora KDE and neovim"
+        )
+        assert not is_sensitive_relationship_content("the server has 32GB RAM")
+
+    def test_non_string_is_false(self):
+        assert is_sensitive_relationship_content(None) is False
+        assert is_sensitive_relationship_content(42) is False
+
+
+class TestCoachBlock:
+    def test_block_is_non_empty(self):
+        assert RELATIONSHIP_COACH_BLOCK.strip()
+
+    def test_builder_returns_constant(self):
+        assert build_relationship_coach_block() == RELATIONSHIP_COACH_BLOCK
+
+    def test_builder_is_deterministic(self):
+        assert build_relationship_coach_block() == build_relationship_coach_block()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", RELATIONSHIP_COACH_BLOCK)
+
+    def test_declares_non_clinical_and_not_a_therapist(self):
+        lower = RELATIONSHIP_COACH_BLOCK.lower()
+        assert "non clinique" in lower
+        assert "thérapeute" in lower
+
+    def test_states_it_is_subordinate_to_the_contract(self):
+        # The header must make clear the block sits below identity /
+        # safety rules so a coaching request can't dilute the contract.
+        lower = RELATIONSHIP_COACH_BLOCK.lower()
+        assert "subordonné" in lower
+        assert "sécurité" in lower
+
+    def test_covers_the_six_method_steps(self):
+        lower = RELATIONSHIP_COACH_BLOCK.lower()
+        assert "résume" in lower                       # summarize
+        assert "interprétation" in lower               # interpretations
+        assert "ne lis pas dans les pensées" in lower  # no mind-reading
+        assert "réponse calme" in lower                # calm response
+        assert "accusatrice" in lower                  # avoid accusatory
+        assert "besoin" in lower                       # avoid needy wording
+        assert "limites saines" in lower               # healthy boundaries
+        assert ("attendre" in lower
+                and "maintenant" in lower)             # speak now or wait
+
+    def test_offers_the_three_response_styles(self):
+        lower = RELATIONSHIP_COACH_BLOCK.lower()
+        assert "doux" in lower
+        assert "neutre" in lower
+        assert "direct mais respectueux" in lower
+
+    def test_states_all_safety_rules(self):
+        lower = RELATIONSHIP_COACH_BLOCK.lower()
+        assert "aucune manipulation" in lower
+        assert "aucune coercition" in lower
+        assert "aucun gaslighting" in lower
+        assert "aucun conseil de vengeance" in lower
+        assert "aucun diagnostic du partenaire" in lower
+        assert "consentement" in lower
+        assert "communication calme" in lower
+
+    def test_states_local_private_and_no_autosave(self):
+        lower = RELATIONSHIP_COACH_BLOCK.lower()
+        assert "locale et privée" in lower
+        assert "n'enregistre jamais" in lower or "ne mémorise" in lower
+        # Only the explicit manual command may persist a relationship fact.
+        assert "retiens ça" in lower or "souviens-toi" in lower
+        assert "explicitement" in lower
+
+
+class TestMemoryPolicyHardening:
+    def test_allows_normal_preference(self):
+        m = _mem(kind="preference", topic="editor",
+                 content="User prefers neovim.")
+        assert is_memory_allowed(m) is True
+
+    def test_rejects_partner_detail(self):
+        m = _mem(content="User's girlfriend works as a nurse.")
+        assert is_memory_allowed(m) is False
+
+    def test_rejects_french_relationship_detail(self):
+        m = _mem(content="L'utilisateur s'est disputé avec ma copine.")
+        assert is_memory_allowed(m) is False
+
+    def test_still_rejects_legacy_ex_drama(self):
+        # Pre-existing transient rule must keep working.
+        m = _mem(content="User's ex cheated on them.")
+        assert is_memory_allowed(m) is False
+
+
+class TestChatWiring:
+    def test_block_injected_for_coach_query(self):
+        msgs = build_messages(
+            [], "on s'est disputé avec ma copine, comment lui répondre",
+            [], None, None, None,
+        )
+        assert RELATIONSHIP_COACH_BLOCK in msgs[0]["content"]
+
+    def test_block_absent_for_neutral_query(self):
+        msgs = build_messages([], "quelle heure est-il ?", [], None, None, None)
+        assert RELATIONSHIP_COACH_BLOCK not in msgs[0]["content"]
+
+    def test_identity_contract_still_first(self):
+        # The coach block must never displace the identity/safety
+        # contract from the front of the system prompt.
+        msgs = build_messages(
+            [], "my husband and I had a fight, how do i respond to him",
+            [], None, None, None,
+        )
+        assert msgs[0]["content"].startswith(IDENTITY_CONTRACT)
+        assert msgs[0]["content"].index(IDENTITY_CONTRACT) < msgs[0][
+            "content"
+        ].index(RELATIONSHIP_COACH_BLOCK)
+
+    def test_block_also_applies_in_search_context(self):
+        # Injection is keyed off the user message, not the branch, so a
+        # coach query still gets the framing even on the search path.
+        msgs = build_messages(
+            [], "relationship advice please", [], "résultats…", "search", None,
+        )
+        assert RELATIONSHIP_COACH_BLOCK in msgs[0]["content"]
+
+
+class TestAutosaveGuard:
+    def test_blocks_autosave_for_sensitive_relationship_turn(self):
+        assert _autosave_allowed(ADMIN_POLICY, "my ex cheated on me") is False
+
+    def test_allows_autosave_for_neutral_turn(self):
+        assert _autosave_allowed(ADMIN_POLICY, "I use neovim and Fedora") is True
+
+    def test_respects_policy_memory_disabled(self):
+        # A restricted policy with memory saving off must stay off even
+        # for a perfectly neutral message.
+        assert DEFAULT_RESTRICTED_POLICY.memory_save_enabled is False
+        assert _autosave_allowed(DEFAULT_RESTRICTED_POLICY, "I use neovim") is False
+
+    def test_none_message_is_safe(self):
+        assert _autosave_allowed(ADMIN_POLICY, None) is True

--- a/tests/test_relationship_coach.py
+++ b/tests/test_relationship_coach.py
@@ -92,6 +92,27 @@ class TestDetection:
             "mon collègue m'en veut après une dispute avec lui au bureau"
         )
 
+    def test_bare_conflict_phrases_do_not_trigger(self):
+        # Codex review P2 (round 5): "we argued" / "we had a fight" are
+        # common in work/project contexts and must not reframe a normal
+        # support request as relationship coaching.
+        assert not is_relationship_coach_query(
+            "we argued about the database schema at standup"
+        )
+        assert not is_relationship_coach_query(
+            "the team and i had a fight over priorities"
+        )
+        assert not is_relationship_coach_query(
+            "on s'est disputé au boulot avec un collègue"
+        )
+
+    def test_relationship_argument_still_triggers_via_anchor(self):
+        # Removing the bare phrases must not regress the core use case:
+        # a relationship argument still triggers through its anchor.
+        assert is_relationship_coach_query(
+            "my girlfriend and i had a fight, how do i respond?"
+        )
+
     def test_non_string_is_false(self):
         assert is_relationship_coach_query(None) is False
         assert is_relationship_coach_query(123) is False
@@ -168,6 +189,20 @@ class TestSensitiveContentGate:
             "une femme a posé une question",
         ):
             assert not is_sensitive_relationship_content(text), text
+
+    def test_bare_conflict_phrases_are_not_sensitive(self):
+        # Codex review P1 (round 5): generic dispute phrases must not
+        # make the gate over-block legitimate non-relationship memory.
+        assert not is_sensitive_relationship_content(
+            "we argued about the API design and chose REST"
+        )
+        assert not is_sensitive_relationship_content(
+            "we had a fight over the deployment window"
+        )
+        # …but a relationship argument is still caught via the anchor.
+        assert is_sensitive_relationship_content(
+            "my wife and I had a fight about money"
+        )
 
     def test_ignores_non_relationship_text(self):
         assert not is_sensitive_relationship_content(
@@ -286,6 +321,14 @@ class TestMemoryPolicyHardening:
             _mem(kind="project", content="User has a business partner named Sam.")
         ) is True
 
+    def test_allows_work_dispute_memory(self):
+        # Codex review P1 (round 5): a generic work argument is a valid
+        # durable memory and must not be rejected by the gate.
+        assert is_memory_allowed(
+            _mem(kind="project",
+                 content="Team argued about the API and chose REST.")
+        ) is True
+
 
 class TestChatWiring:
     def test_block_injected_for_coach_query(self):
@@ -390,4 +433,13 @@ class TestAutosaveGuard:
             ADMIN_POLICY,
             "who should I loop in?",
             "Loop in your business partner and the design lead.",
+        ) is True
+
+    def test_allows_autosave_for_work_argument_turn(self):
+        # Codex review P1 (round 5): a work dispute must not suppress
+        # auto-memory for the whole turn.
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "we argued about the API design today",
+            "Sounds like REST won; I'll note the decision.",
         ) is True

--- a/tests/test_relationship_coach.py
+++ b/tests/test_relationship_coach.py
@@ -72,6 +72,21 @@ class TestDetection:
             "how should i reply to this email from a client?"
         )
 
+    def test_does_not_trip_on_non_romantic_conflicts(self):
+        # Anchor-less phrases were removed: coworker / client / family
+        # conflicts must not be silently reframed as relationship
+        # coaching (Codex review P2).
+        assert not is_relationship_coach_query(
+            "my client got upset with me about the invoice"
+        )
+        assert not is_relationship_coach_query(
+            "my coworker got upset, how do i respond to her?"
+        )
+        assert not is_relationship_coach_query("should i text him back?")
+        assert not is_relationship_coach_query(
+            "mon collègue m'en veut après une dispute avec lui au bureau"
+        )
+
     def test_non_string_is_false(self):
         assert is_relationship_coach_query(None) is False
         assert is_relationship_coach_query(123) is False
@@ -232,3 +247,26 @@ class TestAutosaveGuard:
 
     def test_none_message_is_safe(self):
         assert _autosave_allowed(ADMIN_POLICY, None) is True
+
+    def test_blocks_when_assistant_reply_is_sensitive(self):
+        # Codex review P1: the LLM autosave path mines BOTH the user
+        # message and the assistant reply, so a neutral follow-up whose
+        # reply restates relationship context must still be blocked.
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "ok thanks, what should i focus on at work today?",
+            "Earlier you mentioned your girlfriend was upset; setting "
+            "that aside, for work you could...",
+        ) is False
+
+    def test_allows_when_both_user_and_reply_are_neutral(self):
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "I use neovim",
+            "Great — neovim is a solid choice for that workflow.",
+        ) is True
+
+    def test_reply_arg_is_optional(self):
+        # Backward-compatible default: callers that pass only the user
+        # message still work and only gate on it.
+        assert _autosave_allowed(ADMIN_POLICY, "I use Fedora") is True

--- a/tests/test_relationship_coach.py
+++ b/tests/test_relationship_coach.py
@@ -61,6 +61,11 @@ class TestDetection:
     def test_is_case_insensitive(self):
         assert is_relationship_coach_query("MY PARTNER said something hurtful")
 
+    def test_detects_ascii_fiance_spelling(self):
+        assert is_relationship_coach_query(
+            "my fiance said something hurtful, how do i respond?"
+        )
+
     def test_ignores_generic_message(self):
         assert not is_relationship_coach_query("what's the weather tomorrow?")
         assert not is_relationship_coach_query("écris-moi une fonction python")
@@ -114,6 +119,13 @@ class TestSensitiveContentGate:
         )
         assert is_sensitive_relationship_content("User's wife is a teacher.")
         assert is_sensitive_relationship_content("his girlfriend called")
+
+    def test_flags_ascii_fiance_spelling(self):
+        # Codex review P1 (round 3): the common unaccented "fiance"
+        # spelling must be caught, not only "fiancé"/"fiancée".
+        assert is_sensitive_relationship_content("my fiance and I argued")
+        assert is_sensitive_relationship_content("User's fiancee is a vet.")
+        assert is_sensitive_relationship_content("ma fiancée est partie")
 
     def test_ignores_non_relationship_text(self):
         assert not is_sensitive_relationship_content(

--- a/tests/test_relationship_coach.py
+++ b/tests/test_relationship_coach.py
@@ -105,6 +105,16 @@ class TestSensitiveContentGate:
             "on a rompu, c'est une rupture difficile"
         )
 
+    def test_flags_spouse_terms_across_pronouns(self):
+        # Codex review P1 (round 2): spouse nouns must match in any
+        # phrasing, not only the first-person "my wife" form, or the
+        # third-person assistant/extractor phrasing leaks past the gate.
+        assert is_sensitive_relationship_content(
+            "Earlier you mentioned your husband was upset"
+        )
+        assert is_sensitive_relationship_content("User's wife is a teacher.")
+        assert is_sensitive_relationship_content("his girlfriend called")
+
     def test_ignores_non_relationship_text(self):
         assert not is_sensitive_relationship_content(
             "User prefers Fedora KDE and neovim"
@@ -198,6 +208,14 @@ class TestMemoryPolicyHardening:
         m = _mem(content="User's ex cheated on them.")
         assert is_memory_allowed(m) is False
 
+    def test_rejects_third_person_spouse_memory(self):
+        # Codex review P1 (round 2): an extracted "User's wife …"
+        # memory must not slip into the durable store.
+        assert is_memory_allowed(_mem(content="User's wife is a nurse.")) is False
+        assert is_memory_allowed(
+            _mem(content="User's husband works nights.")
+        ) is False
+
 
 class TestChatWiring:
     def test_block_injected_for_coach_query(self):
@@ -270,3 +288,13 @@ class TestAutosaveGuard:
         # Backward-compatible default: callers that pass only the user
         # message still work and only gate on it.
         assert _autosave_allowed(ADMIN_POLICY, "I use Fedora") is True
+
+    def test_blocks_when_reply_mentions_spouse_in_second_person(self):
+        # Codex review P1 (round 2): "your husband" in the assistant
+        # reply must block autosave even on a neutral user turn.
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "ok, what should i prioritise at work?",
+            "Earlier you mentioned your husband; setting that aside, "
+            "at work you could...",
+        ) is False


### PR DESCRIPTION
## Summary

Adds a **Relationship Situation Coach** foundation: a non-clinical, local-first "situation coach" that helps the user respond calmly and respectfully to an emotionally sensitive relationship message — the same contract-bounded way Nova already helps with code or security.

It follows the established Nova pattern for deterministic, detection-gated prompt-context blocks (like the SilentGuard security context and time context): no LLM in the loop, no network, no new endpoint/setting/env flag, always local.

### How it works

- **`core/relationship_coach.py`** (new, pure module — only stdlib, never raises):
  - `is_relationship_coach_query` — conservative bilingual (FR/EN) detector. Only relationship-specific *multi-word* phrases match; a bare "reply"/"elle" never trips it, so unrelated chat pays zero token cost.
  - `build_relationship_coach_block` / `RELATIONSHIP_COACH_BLOCK` — a fixed, deterministic French block (Nova still answers in the user's language via the existing response-style contract).
  - `is_sensitive_relationship_content` — single-source predicate for the memory gate.
- **`core/chat.py`** — `build_messages` appends the block **after** `IDENTITY_CONTRACT` and the safety/security blocks, so it can never override identity or safety. New `_autosave_allowed` helper folds the relationship-sensitivity gate into the existing `policy.memory_save_enabled` check at all four auto-save sites.
- **`memory/policy.py`** — independently rejects sensitive relationship content from the durable natural-memory store (defence in depth, shared predicate).

### What the block enforces

- Frames Nova as a **non-clinical** coach — not a therapist, **no diagnosis of the partner**; points toward human/professional help on danger or serious distress.
- Method (proposed, not imposed): summarise what happened → surface a few *possible* readings without mind-reading → choose a calm response → avoid accusatory or needy wording → keep healthy boundaries → decide whether to speak now or wait.
- Three response styles: **soft / neutral / direct but respectful**.
- Hard safety rules: no manipulation, coercion, gaslighting, revenge advice, or diagnosing the partner; always toward calm communication and consent.

### Privacy

Sensitive relationship detail is **never auto-saved**. Nova suppresses automatic memory extraction for those turns, and `memory/policy.py` refuses to persist such content to the durable store. The explicit manual memory command (`Retiens ça:` / `Souviens-toi:`), handled in the web preflight before the chat path, is the only — user-approved — way a relationship fact is stored, and is intentionally unaffected.

Documented in `docs/relationship-situation-coach.md`; README + CHANGELOG updated.

## Test plan

- [x] `tests/test_relationship_coach.py` — 33/33 pass: detection (FR/EN, conservative, non-string safe), sensitive-content gate, block content (method, three styles, every safety rule, privacy, non-clinical framing, subordinate-to-contract), `memory/policy.py` hardening, chat wiring (block injected only on a coach query, always below `IDENTITY_CONTRACT`, also on the search branch), `_autosave_allowed` guard.
- [x] No regressions in affected suites: `test_nova_contract.py`, `test_identity.py`, `test_memory_command.py`, `test_memory_parsing.py`, `test_personalization_chat_wiring.py`, `test_natural_memory.py::TestPolicy` (12/12), `test_chat_stream.py` (18/18 incl. endpoint). The only failures in the run are pre-existing environment issues (optional `ollama`/embedding deps stubbed as `MagicMock`) — confirmed identical on the unmodified base.
- [ ] Manual smoke once Ollama is available: a FR and an EN relationship message gets the coach framing; an unrelated message does not; a relationship message is not auto-remembered while `Retiens ça:` still saves.

https://claude.ai/code/session_01T8KDVEcYHXNtufG8ceVJV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8KDVEcYHXNtufG8ceVJV2)_