### PR TITLE
feat(dev-workspace): review-only patch proposal mode (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Dev Workspace Phase 2 — patch proposal mode (review-only): a linked
+  project can now ask Nova to *propose* a code change without any of it
+  being applied. `core/dev_workspace.build_patch_proposal` turns a
+  structured, model-produced description into a calm, validated
+  `PatchProposal` (summary, implementation plan, the repo-relative
+  files it would touch, a per-file + combined unified-diff preview
+  built locally with `difflib`, suggested tests, and a risk checklist).
+  It is a *pure transform*: it re-validates the linked repo with the
+  same hard rules as Phase 1 and then validates every proposed path
+  (`validate_proposed_path`) — repo-relative only (absolute / `~` /
+  `\` / `..` traversal refused), never a secret/private file (`.env` /
+  `*.env`, `nova.db` / `*.db` / `*.sqlite*`, SSH/key material, tokens,
+  credentials, logs, backups, exports, memory-packs, `.git`, …; the
+  documented `.env.example`/`.sample`/`.template`/`.dist` samples stay
+  allowed), and contained inside the repo (a symlinked subdir pointing
+  out is refused) — while spawning **no** process, touching **no** git,
+  writing **no** file, and making **no** network call. Every field is
+  capped and the result restates `review_only: true` / `applied:
+  false` with a fixed safety note. Reachable per linked project at
+  `POST /projects/{id}/repo/patch-proposal` (no linked repo or any
+  invalid path/proposal → `400`; foreign project → `404`; extra body
+  field → `422`). New regression tests cover safe-output proposals,
+  every rejection path, the caps, and the no-write / no-subprocess
+  invariants; `docs/dev-workspace.md` now documents Phase 1 + Phase 2,
+  the cumulative safety model, and the Phase 3-6 roadmap. Nothing in
+  Phase 2 grants Nova power to modify files, commit, push, or branch.
 - Relationship Situation Coach (foundation, local-first): a new
   `core/relationship_coach.py` adds a non-clinical "situation coach"
   that helps the user respond calmly and respectfully to an

--- a/core/dev_workspace.py
+++ b/core/dev_workspace.py
@@ -52,18 +52,30 @@ This is the single module in ``core`` allowed to import ``subprocess``
 for dev-workspace git reads. The web layer must call only the public
 functions here and keep them user-scoped.
 
+Phase 2 — **patch proposal mode** — is also implemented here (see the
+"Patch proposal" section near the bottom). It is a *pure* transform: it
+turns a structured, model-produced change description into a validated,
+review-only :class:`PatchProposal` (plan, likely files, a unified-diff
+preview, suggested tests, a risk checklist). It performs **no** git
+calls, **no** file writes, and **no** subprocess work — it never
+applies, stages, commits, pushes, or branches anything. Every proposed
+path is validated to be repo-relative, traversal-free, non-secret, and
+contained inside the linked repo. Applying a reviewed patch is a
+deliberately separate, later phase.
+
 See ``docs/dev-workspace.md`` for the operator walkthrough, the
 explicit non-goals, and the Phase 2-6 roadmap.
 """
 
 from __future__ import annotations
 
+import difflib
 import logging
 import os
 import shutil
 import subprocess
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional, Sequence
 
 logger = logging.getLogger(__name__)
@@ -581,4 +593,503 @@ def read_status(
         changed_files=changed_files,
         recent_commits=recent_commits,
         detail="" if clean else "Working tree has uncommitted changes.",
+    )
+
+
+# ════════════════════════════════════════════════════════════════════
+# Patch proposal mode (Phase 2)
+# ════════════════════════════════════════════════════════════════════
+#
+# Phase 2 lets Nova *propose* code changes for a linked repo. The model
+# describes the change (a plan, the files it would touch with
+# before/after content, suggested tests, risks); this module turns that
+# into a calm, validated, **review-only** :class:`PatchProposal`:
+#
+#   * It is a pure transform — no git, no subprocess, no file writes,
+#     no network. Nothing is applied, staged, committed, pushed, or
+#     branched. The on-disk repo is never touched (``resolve()`` only
+#     reads path metadata, exactly as Phase 1 already does).
+#   * Every proposed path is validated to be **repo-relative**
+#     (absolute paths refused), free of ``..`` traversal, not a
+#     secret/private file (``.env``, ``*.db``/``nova.db``, SSH keys,
+#     tokens, credentials, logs, backups, exports, ``.git`` internals,
+#     …), and contained inside the validated linked repo.
+#   * The diff is produced locally with :mod:`difflib` from the
+#     model-supplied before/after text — Nova does not read the working
+#     tree to build it, so a proposal cannot leak file contents the
+#     model was not already given. Verifying a patch against disk is a
+#     deliberately separate, later (apply) phase.
+#   * Every field is capped so a runaway model reply cannot balloon the
+#     payload, and the result restates that nothing was applied.
+
+
+class PatchProposalError(ValueError):
+    """Raised when a model-produced patch proposal fails validation.
+
+    The web layer maps this to a 400 with the short, safe message so the
+    user learns *why* the proposal was refused instead of getting a 500.
+    Never carries secrets, stack traces, or raw model output.
+    """
+
+
+# Caps. A patch proposal is model-produced text; every list and blob is
+# bounded so a runaway reply cannot wedge a request or bloat the JSON.
+_MAX_PROPOSAL_SUMMARY_CHARS = 300
+_MAX_PROPOSAL_PLAN_STEPS = 40
+_MAX_PROPOSAL_FILES = 50
+_MAX_PROPOSAL_FILE_DIFF_LINES = 400
+_MAX_PROPOSAL_DIFF_LINES = 800
+_MAX_PROPOSAL_TESTS = 40
+_MAX_PROPOSAL_RISKS = 40
+_MAX_PROPOSAL_CONTENT_CHARS = 200_000
+
+_PATCH_ACTIONS = frozenset({"modify", "add", "delete"})
+
+# Path *segments* (any directory component, or a final component) that a
+# proposal may never target: VCS / key / credential stores and the
+# private Nova runtime directories (data, db sidecars, backups, exports,
+# memory packs, logs). Matched case-insensitively.
+_SECRET_SEGMENTS = frozenset(
+    {
+        ".git",
+        ".ssh",
+        ".gnupg",
+        ".aws",
+        ".azure",
+        ".kube",
+        ".docker",
+        "data",
+        "novadata",
+        "novaportable",
+        "backups",
+        "exports",
+        "memory-packs",
+        "logs",
+        "__pycache__",
+        ".venv",
+        "node_modules",
+    }
+)
+
+# Exact (case-insensitive) basenames that are always secret/private.
+_SECRET_BASENAMES = frozenset(
+    {
+        ".env",
+        "nova.env",
+        "nova.db",
+        "nexus.db",
+        ".netrc",
+        ".pgpass",
+        ".htpasswd",
+        ".npmrc",
+        ".pypirc",
+        ".dockercfg",
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "credentials",
+        "credentials.json",
+        "secrets",
+        "secrets.json",
+        "secrets.yaml",
+        "secrets.yml",
+        "token",
+        "tokens",
+    }
+)
+
+# Basename suffixes that mark data / key / log / backup material. Source
+# code (``.py``/``.md``/``.sql``/…) is intentionally *not* here so a
+# normal code change is never blocked; only sensitive blobs are.
+_SECRET_SUFFIXES = (
+    ".db",
+    ".sqlite",
+    ".sqlite3",
+    ".pem",
+    ".key",
+    ".pfx",
+    ".p12",
+    ".keystore",
+    ".jks",
+    ".log",
+    ".backup",
+    ".bak",
+    ".save",
+)
+
+# Documented, secret-free ``.env`` companions an operator may legitimately
+# want a proposal to touch (samples committed to the repo).
+_ENV_SAMPLE_SUFFIXES = (".example", ".sample", ".template", ".dist")
+
+# Fixed, frontend-safe reminder attached to every proposal so the review
+# UI (and the model, when this is echoed back) cannot lose the contract.
+_PROPOSAL_SAFETY_NOTES = (
+    "This is a proposal only — Nova has not modified any file.",
+    "Nothing was written to disk, staged, committed, pushed, or branched.",
+    "No command was run; the working tree is unchanged.",
+    "Review it, then apply it yourself. A later phase will add an "
+    "explicit, per-patch approval step before anything is written.",
+)
+
+
+def _is_secret_path(rel_posix: str) -> bool:
+    """True when a repo-relative path targets a protected/secret file.
+
+    Conservative on purpose: a false *positive* only refuses one
+    proposed edit (the user can still edit that file by hand); a false
+    *negative* could surface a secret. Source code is never matched.
+    """
+    parts = PurePosixPath(rel_posix).parts
+    if not parts:
+        return True
+    for seg in parts:
+        if seg.lower() in _SECRET_SEGMENTS:
+            return True
+    base = parts[-1].lower()
+    if base in _SECRET_BASENAMES:
+        return True
+    # ``.env`` and ``.env.<env>`` are secret; ``.env.example`` and the
+    # other documented sample suffixes are explicitly allowed.
+    if base == ".env" or base.startswith(".env."):
+        if not any(base.endswith(s) for s in _ENV_SAMPLE_SUFFIXES):
+            return True
+    if any(base.endswith(suff) for suff in _SECRET_SUFFIXES):
+        return True
+    return False
+
+
+def validate_proposed_path(repo_root: Path, raw: object) -> str:
+    """Validate one model-proposed, repo-relative file path.
+
+    Enforces, in order: present → string → non-empty (trimmed) →
+    length-capped → no NUL/newline → no ``~`` → ``/``-separated (no
+    ``\\``) → **repo-relative, not absolute** → no ``..`` traversal →
+    collapses to a real target → not a secret/private file → resolves
+    **inside** ``repo_root``. A leading ``./`` (and other ``.``/empty
+    segments) is normalised away; a path that is *only* ``.`` has no
+    target and is refused. Returns the normalised POSIX repo-relative
+    path on success; raises
+    :class:`PatchProposalError` (short, safe message) on the first
+    failure. ``repo_root`` must already be the resolved absolute repo
+    path from :func:`validate_repo_path`.
+    """
+    if raw is None or isinstance(raw, bool):
+        raise PatchProposalError("proposed file path is required")
+    if not isinstance(raw, str):
+        raise PatchProposalError("proposed file path must be a string")
+    text = raw.strip()
+    if not text:
+        raise PatchProposalError("proposed file path cannot be empty")
+    if len(text) > _MAX_RAW_PATH_CHARS:
+        raise PatchProposalError("proposed file path is too long")
+    if "\x00" in text or "\n" in text or "\r" in text:
+        raise PatchProposalError(
+            "proposed file path contains invalid characters"
+        )
+    if "~" in text:
+        raise PatchProposalError(
+            "proposed file path must be repo-relative (no '~')"
+        )
+    if "\\" in text:
+        raise PatchProposalError(
+            "proposed file path must use '/' separators"
+        )
+
+    candidate = PurePosixPath(text)
+    if candidate.is_absolute():
+        raise PatchProposalError(
+            "proposed file path must be repo-relative, not absolute"
+        )
+    parts = candidate.parts
+    if any(p == ".." for p in parts):
+        raise PatchProposalError(
+            "proposed file path must not contain '..'"
+        )
+    # ``PurePosixPath`` normalises away ``.`` and empty segments, so a
+    # path that is *only* ``.`` (or otherwise collapses to nothing) has
+    # no real target.
+    if not parts:
+        raise PatchProposalError(
+            "proposed file path is not a normalised relative path"
+        )
+
+    rel = candidate.as_posix()
+    if _is_secret_path(rel):
+        raise PatchProposalError(
+            "proposed file path targets a protected or secret file"
+        )
+
+    # Defence in depth: even though ``..``/absolute are already refused,
+    # resolve the join so a symlinked directory *inside* the repo that
+    # points outside it cannot smuggle an out-of-tree write target into
+    # a later apply phase. ``resolve()`` only reads path metadata.
+    try:
+        joined = (repo_root / rel).resolve()
+    except (OSError, RuntimeError, ValueError):
+        raise PatchProposalError(
+            "proposed file path could not be resolved"
+        )
+    try:
+        inside = joined == repo_root or joined.is_relative_to(repo_root)
+    except ValueError:
+        inside = False
+    if not inside:
+        raise PatchProposalError(
+            "proposed file path resolves outside the linked repository"
+        )
+    return rel
+
+
+@dataclass(frozen=True)
+class ProposedFileChange:
+    """One reviewed-only change to a single repo-relative file.
+
+    ``diff`` is a unified diff built locally from the model-supplied
+    before/after text — it is *not* applied anywhere. ``added`` /
+    ``removed`` count the changed body lines (diff headers excluded).
+    """
+
+    path: str
+    action: str
+    diff: str = ""
+    added: int = 0
+    removed: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "action": self.action,
+            "diff": self.diff,
+            "added": self.added,
+            "removed": self.removed,
+        }
+
+
+@dataclass(frozen=True)
+class PatchProposal:
+    """Calm, frontend-safe, **review-only** patch proposal.
+
+    Holds the implementation plan, the files Nova would change (with a
+    capped unified-diff preview each), suggested tests, and a risk
+    checklist. Nothing here has been applied; ``as_dict`` always reports
+    ``review_only`` / ``applied`` and the standing safety notes so the
+    contract travels with the data.
+    """
+
+    repo_path: str
+    summary: str = ""
+    plan: tuple[str, ...] = field(default_factory=tuple)
+    files: tuple[ProposedFileChange, ...] = field(default_factory=tuple)
+    suggested_tests: tuple[str, ...] = field(default_factory=tuple)
+    risks: tuple[str, ...] = field(default_factory=tuple)
+    diff_preview: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "review_only": True,
+            "applied": False,
+            "repo_path": self.repo_path,
+            "summary": self.summary,
+            "plan": list(self.plan),
+            "files": [f.as_dict() for f in self.files],
+            "suggested_tests": list(self.suggested_tests),
+            "risks": list(self.risks),
+            "diff_preview": self.diff_preview,
+            "safety": list(_PROPOSAL_SAFETY_NOTES),
+        }
+
+
+def _string_list(value: object, cap: int) -> tuple[str, ...]:
+    """Coerce model output into a capped tuple of short, clean strings.
+
+    ``None`` → ``()``; a bare string → a one-item list. Blank entries
+    are dropped and each survivor is length-clipped. Any non-string item
+    is a hard error so a malformed proposal fails loudly, not silently.
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple)):
+        raise PatchProposalError("expected a list of strings")
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise PatchProposalError("list items must be strings")
+        cleaned = item.strip()
+        if not cleaned:
+            continue
+        out.append(_truncate(cleaned))
+        if len(out) >= cap:
+            break
+    return tuple(out)
+
+
+def _build_file_diff(
+    path: str, action: str, old: str, new: str
+) -> tuple[str, int, int]:
+    """Local unified diff + (added, removed) body-line counts.
+
+    Pure :mod:`difflib`; never reads the working tree. The per-file diff
+    is line-capped so one giant file cannot dominate the preview.
+    """
+    old_lines = old.splitlines()
+    new_lines = new.splitlines()
+    if action == "add":
+        fromfile, tofile = "/dev/null", f"b/{path}"
+    elif action == "delete":
+        fromfile, tofile = f"a/{path}", "/dev/null"
+    else:
+        fromfile, tofile = f"a/{path}", f"b/{path}"
+    raw = list(
+        difflib.unified_diff(
+            old_lines, new_lines,
+            fromfile=fromfile, tofile=tofile, lineterm="",
+        )
+    )
+    added = removed = 0
+    for line in raw:
+        if line.startswith("+") and not line.startswith("+++"):
+            added += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            removed += 1
+    if len(raw) > _MAX_PROPOSAL_FILE_DIFF_LINES:
+        raw = raw[:_MAX_PROPOSAL_FILE_DIFF_LINES]
+        raw.append("… (file diff truncated for preview)")
+    return "\n".join(raw), added, removed
+
+
+def build_patch_proposal(
+    repo_path: str | os.PathLike[str],
+    proposal: object,
+    *,
+    roots: Optional[Sequence[Path]] = None,
+) -> PatchProposal:
+    """Turn model output into a validated, review-only patch proposal.
+
+    ``repo_path`` is the project's linked checkout; it is re-validated
+    here with :func:`validate_repo_path` (same hard rules as Phase 1) so
+    a proposal can only ever be scoped to a real, allowed linked repo.
+    ``proposal`` is the model's structured description::
+
+        {
+          "summary": "<one line>",
+          "plan": ["step", ...],
+          "changes": [
+            {"path": "core/foo.py", "action": "modify",
+             "old_content": "...", "new_content": "..."},
+            ...
+          ],
+          "tests": ["pytest ...", ...],
+          "risks": ["touches auth", ...],
+        }
+
+    Every change's path is validated by :func:`validate_proposed_path`
+    (repo-relative, no traversal, non-secret, inside the repo) and the
+    diff is computed locally. **Nothing is applied**; this never writes,
+    spawns a process, or touches git. Raises :class:`PatchProposalError`
+    (short, safe message) on any validation failure.
+    """
+    try:
+        resolved = validate_repo_path(repo_path, roots=roots)
+    except RepoPathError as exc:
+        raise PatchProposalError(
+            f"linked repository is not usable: {exc}"
+        ) from exc
+
+    if not isinstance(proposal, dict):
+        raise PatchProposalError("patch proposal must be an object")
+
+    summary_raw = proposal.get("summary") or ""
+    if not isinstance(summary_raw, str):
+        raise PatchProposalError("summary must be a string")
+    # Collapse whitespace so the summary stays a single safe line.
+    summary = " ".join(summary_raw.split())[:_MAX_PROPOSAL_SUMMARY_CHARS]
+
+    plan = _string_list(proposal.get("plan"), _MAX_PROPOSAL_PLAN_STEPS)
+    tests = _string_list(proposal.get("tests"), _MAX_PROPOSAL_TESTS)
+    risks = _string_list(proposal.get("risks"), _MAX_PROPOSAL_RISKS)
+
+    raw_changes = proposal.get("changes")
+    if not isinstance(raw_changes, (list, tuple)) or not raw_changes:
+        raise PatchProposalError(
+            "patch proposal must include at least one file change"
+        )
+
+    files: list[ProposedFileChange] = []
+    seen: set[str] = set()
+    for change in raw_changes:
+        if not isinstance(change, dict):
+            raise PatchProposalError("each change must be an object")
+        action = change.get("action") or "modify"
+        if not isinstance(action, str) or action not in _PATCH_ACTIONS:
+            raise PatchProposalError(
+                "change action must be one of: modify, add, delete"
+            )
+        rel = validate_proposed_path(resolved, change.get("path"))
+        if rel in seen:
+            raise PatchProposalError(f"duplicate change for path: {rel}")
+        seen.add(rel)
+
+        old = change.get("old_content")
+        new = change.get("new_content")
+        old = "" if (old is None or action == "add") else old
+        new = "" if (new is None or action == "delete") else new
+        if not isinstance(old, str) or not isinstance(new, str):
+            raise PatchProposalError("file content must be a string")
+        if (
+            len(old) > _MAX_PROPOSAL_CONTENT_CHARS
+            or len(new) > _MAX_PROPOSAL_CONTENT_CHARS
+        ):
+            raise PatchProposalError(
+                "proposed file content is too large to preview"
+            )
+        if action == "modify" and old == new:
+            raise PatchProposalError(
+                f"modify change for {rel} has no difference"
+            )
+        if action == "add" and not new:
+            raise PatchProposalError(
+                f"add change for {rel} has empty content"
+            )
+        if action == "delete" and not old:
+            raise PatchProposalError(
+                f"delete change for {rel} has no original content"
+            )
+
+        diff, added, removed = _build_file_diff(rel, action, old, new)
+        files.append(
+            ProposedFileChange(
+                path=rel, action=action,
+                diff=diff, added=added, removed=removed,
+            )
+        )
+        if len(files) >= _MAX_PROPOSAL_FILES:
+            break
+
+    # Combined, capped preview across all files.
+    preview_parts: list[str] = []
+    preview_lines = 0
+    for f in files:
+        if not f.diff:
+            continue
+        block = f.diff.splitlines()
+        if preview_lines + len(block) > _MAX_PROPOSAL_DIFF_LINES:
+            room = _MAX_PROPOSAL_DIFF_LINES - preview_lines
+            if room > 0:
+                preview_parts.append("\n".join(block[:room]))
+            preview_parts.append("… (combined preview truncated)")
+            break
+        preview_parts.append(f.diff)
+        preview_lines += len(block)
+
+    return PatchProposal(
+        repo_path=str(resolved),
+        summary=summary,
+        plan=plan,
+        files=tuple(files),
+        suggested_tests=tests,
+        risks=risks,
+        diff_preview="\n".join(preview_parts),
     )

--- a/docs/dev-workspace.md
+++ b/docs/dev-workspace.md
@@ -1,12 +1,16 @@
-# Dev Workspace — read-only local Git context (Phase 1)
+# Dev Workspace — read-only Git context (Phase 1) + patch proposal mode (Phase 2)
 
-> **Status: shipped (Phase 1), opt-in, strictly read-only.** A Nova
-> Project can optionally link to a local Git checkout so Nova
-> understands the repository's state (branch, clean/dirty, recent
-> commits, changed files) when helping you code. Phase 1 **observes
-> only** — it can never commit, push, branch, fetch, write files, or
-> run an arbitrary command. The feature is off until an operator
-> configures an allowed workspace root.
+> **Status: shipped (Phase 1 + Phase 2), opt-in, never modifies your
+> repo.** A Nova Project can optionally link to a local Git checkout so
+> Nova understands the repository's state (branch, clean/dirty, recent
+> commits, changed files) when helping you code. **Phase 1** observes
+> only. **Phase 2** lets Nova *propose* code changes as a reviewable
+> patch — an implementation plan, the files it would touch, a
+> unified-diff preview, suggested tests, and a risk checklist — that is
+> **displayed for review only and never applied**. Neither phase can
+> commit, push, branch, fetch, write files, or run an arbitrary
+> command. The feature is off until an operator configures an allowed
+> workspace root.
 
 This document describes the safety boundaries the feature commits to
 and the setup required before anything happens. It sits inside the
@@ -39,18 +43,45 @@ foundation the later phases build on.
   button next to the project selector): linked path, current branch,
   clean/dirty badge, latest commits, changed files, diff summary.
 
-## What Phase 1 deliberately does NOT do
+## What Phase 2 does (patch proposal mode)
 
+Phase 2 lets Nova help you *plan and propose* a code change for a
+linked project — but it still **cannot modify your files**. Given a
+structured change description from the model, the
+`core.dev_workspace.build_patch_proposal` helper returns a calm,
+validated, **review-only** object containing:
+
+- a short **summary** and an **implementation plan**,
+- the **files likely to change** (repo-relative paths),
+- a **unified-diff preview** per file plus a combined preview,
+- **suggested tests**, and
+- a **risk checklist**.
+
+The diff is computed locally with Python's `difflib` from the
+before/after text the model supplies; Nova does not read your working
+tree to build it, so a proposal cannot surface file contents the model
+was not already given. The result always carries `review_only: true`,
+`applied: false`, and a fixed safety note restating that nothing was
+written. You review it and apply it yourself — an explicit,
+per-patch *apply* step is a deliberately separate, later phase.
+
+It is reachable per linked project at
+`POST /projects/{id}/repo/patch-proposal`.
+
+## What Phase 1 and Phase 2 deliberately do NOT do
+
+- No applying a patch, no file writes anywhere in the repository.
 - No commit, push, branch creation, merge, rebase, reset, or stash.
-- No file writes anywhere in the repository.
 - No `git fetch` / `pull` / `clone` / `remote` — **no network calls**
   and no background scans of the filesystem.
-- No arbitrary command execution and no shell interpretation.
+- No arbitrary command execution and no shell interpretation. Phase 2
+  is a *pure transform* — it spawns no process and touches no git.
 - No `sudo` / `pkexec` / `doas` / `su` / `runuser`.
 - No GitHub / Codeberg API calls.
-- No secrets read, stored, or surfaced.
-- No autonomous actions of any kind — every read is triggered by you
-  opening the panel.
+- No secrets read, stored, or surfaced; a proposal can never target a
+  secret/private file (see the safety boundaries below).
+- No autonomous actions of any kind — every read and every proposal is
+  triggered by you.
 
 ## Safety boundaries (enforced in code)
 
@@ -86,16 +117,37 @@ These are enforced in `core/dev_workspace.py` and covered by
    environment variables, raw stderr, or stack traces — only short,
    fixed, frontend-safe summaries (`state` is one of `ready`,
    `disabled`, `invalid_path`, `git_unavailable`, `error`).
-6. **User-scoped.** The link and its status are per-project and
-   per-user exactly like the rest of the project surface; a foreign /
-   unknown project id returns `404` (never `403`) so existence is not
-   leaked across accounts.
+6. **User-scoped.** The link, its status, and any patch proposal are
+   per-project and per-user exactly like the rest of the project
+   surface; a foreign / unknown project id returns `404` (never `403`)
+   so existence is not leaked across accounts.
+7. **Patch proposals are a pure, review-only transform (Phase 2).**
+   `build_patch_proposal` re-validates the linked repo with the same
+   hard rules as Phase 1, then for every proposed change:
+   - the path must be **repo-relative** — an absolute path, a `~`, a
+     `\` separator, a NUL/newline, or any `..` traversal is refused;
+   - the path may not target a **secret/private file**: `.env` /
+     `*.env` (documented `.env.example`/`.sample`/`.template`/`.dist`
+     samples are allowed), `nova.db` / `*.db` / `*.sqlite*`, key
+     material (`*.pem`, `*.key`, `*.pfx`, `*.p12`, SSH keys,
+     `.ssh` / `.gnupg` / `.aws` / `.kube` / `.docker`), credentials /
+     tokens, logs, `*.bak` / `*.backup` / `*.save`, and the private
+     Nova runtime dirs (`data`, `backups`, `exports`, `memory-packs`,
+     `logs`, `.git`, `__pycache__`, `.venv`, `node_modules`);
+   - the path must still resolve **inside** the linked repo (a
+     symlinked subdir pointing outside it is refused);
+   - the diff is built locally with `difflib` from the model-supplied
+     before/after text — **no git, no subprocess, no file I/O, no
+     network**; nothing is applied, staged, committed, pushed, or
+     branched, and every field is capped. The result restates
+     `review_only: true` / `applied: false`.
 
-The linked path is **contextual data only** — storing it confers no
-write power. It is surfaced to the model the same way other project
-context is: strictly *below* the identity / safety contract in the
-system prompt, where it cannot override safety, identity, auth, or
-admin rules.
+The linked path **and any patch proposal** are **contextual data
+only** — they confer no write power. They are surfaced to the model
+the same way other project context is: strictly *below* the identity /
+safety contract in the system prompt, where they cannot override
+safety, identity, auth, or admin rules. A proposal is a suggestion you
+review and apply yourself.
 
 ## Setup
 
@@ -115,33 +167,42 @@ one of those roots, and click **Link**. The panel then shows that
 repo's read-only Git state. **Unlink** clears the stored path and
 never touches the repository.
 
-## API surface (Phase 1)
+## API surface (Phase 1 + Phase 2)
 
 | Method | Path | Purpose |
 | ------ | ---- | ------- |
 | `PUT` | `/projects/{id}/repo` | Body `{ "path": "<abs path>" \| null }`. A non-empty path is validated then stored (resolved); `null` / empty unlinks. Invalid path → `400` with a short reason; foreign project → `404`. |
 | `GET` | `/projects/{id}/repo/status` | `{ "linked": false }` when no repo; otherwise a calm read-only snapshot (`state`, `branch`, `clean`, `status_short`, `recent_commits`, `changed_files`, `diff_stat`, `detail`). Foreign project → `404`. |
+| `POST` | `/projects/{id}/repo/patch-proposal` | Body is the model's structured change description: `{ "summary"?, "plan"?: [str], "changes": [{ "path", "action"?: "modify"\|"add"\|"delete", "old_content"?, "new_content"? }], "tests"?: [str], "risks"?: [str] }`. Returns a **review-only** `PatchProposal` (`review_only`, `applied:false`, `summary`, `plan`, `files[].diff`, `diff_preview`, `suggested_tests`, `risks`, `safety`). Nothing is written. No linked repo → `400`; any invalid path / proposal → `400` with a short reason; foreign project → `404`; an extra body field → `422`. |
 
 `GET /projects` and the other project endpoints additionally report
 `local_repo_path` and `has_local_repo` so the UI can show which
 projects are linked.
 
-## Roadmap (later phases — not in Phase 1)
+## Roadmap
 
 Each phase is additive and stays behind explicit user confirmation;
-nothing below is enabled by Phase 1.
+nothing below is enabled until its phase ships.
 
-- **Phase 2 — patch proposal mode.** Nova may *propose* a unified diff;
-  it is shown for review and never applied automatically.
-- **Phase 3 — apply patch with approval.** Apply a reviewed patch to
-  the working tree only after explicit per-patch approval.
-- **Phase 4 — branch + commit locally.** Create a local feature branch
-  and commit, never on `main`, never pushed.
-- **Phase 5 — PR draft assistant.** Help draft a PR description from
-  the local diff — still no network writes.
-- **Phase 6 — optional push after explicit confirmation.** A push,
-  only after an unmistakable, per-action confirmation; never to
+- **Phase 1 — read-only Git context.** *Shipped.* Observe a linked
+  repo's state; never modify it.
+- **Phase 2 — patch proposal mode.** *Shipped.* Nova may *propose* a
+  validated unified diff (plan, files, tests, risks); it is shown for
+  review only and **never applied** — no writes, no git, no process.
+- **Phase 3 — apply patch with approval.** *Not yet.* Apply a reviewed
+  patch to the working tree only after an explicit, per-patch approval;
+  still no commit / push / branch.
+- **Phase 4 — branch + commit locally.** *Not yet.* Create a local
+  feature branch and commit, never on `main`, never pushed.
+- **Phase 5 — PR draft assistant.** *Not yet.* Help draft a PR
+  description from the local diff — still no network writes.
+- **Phase 6 — optional push after explicit confirmation.** *Not yet.*
+  A push, only after an unmistakable, per-action confirmation; never to
   `main`, never autonomous.
 
-These are intentionally out of scope for Phase 1 to keep it small,
-auditable, and safe.
+The safety model is cumulative: each phase keeps every guarantee of the
+phases before it (opt-in operator root, hard path validation, no secret
+files, user scoping, capped/sanitised output) and only adds the one
+narrowly-scoped capability named in that phase, always behind explicit
+user action. Phases 3-6 are intentionally out of scope today to keep
+the surface small, auditable, and safe.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -175,9 +175,10 @@ and export/restore behaviour is unchanged.
 - Scoping the `forget …` commands and the memory audit view to the
   active project.
 - ~~Linked local repository path per project.~~ **Shipped** as the
-  read-only Dev Workspace foundation — see
-  [`dev-workspace.md`](dev-workspace.md). It is opt-in, strictly
-  read-only, and cannot commit / push / branch / write files.
+  Dev Workspace — see [`dev-workspace.md`](dev-workspace.md). Phase 1
+  is read-only Git context; Phase 2 adds review-only patch *proposals*
+  (plan, diff preview, tests, risks). Both are opt-in and cannot apply
+  a patch, commit, push, branch, or write files.
 - Project import / export.
 - Project-specific model settings.
 - Project files / attachments.

--- a/tests/test_dev_workspace.py
+++ b/tests/test_dev_workspace.py
@@ -1,5 +1,6 @@
 """
-Tests for the Dev Workspace foundation — Phase 1 (read-only).
+Tests for the Dev Workspace — Phase 1 (read-only) + Phase 2 (patch
+proposal mode, review-only).
 
 Covers:
   * allowed-root resolution from ``NOVA_DEV_WORKSPACE_ROOTS``
@@ -12,10 +13,16 @@ Covers:
   * the ``RepoStatus`` snapshot states
   * the projects ``local_repo_path`` migration + user-scoped setter
   * the read-only HTTP endpoints (link / unlink / status)
+  * Phase 2: proposed-path validation (repo-relative only, no
+    absolute / ``..`` / secret paths, contained in the repo),
+    ``build_patch_proposal`` from safe model output, the review-only
+    invariants (no file writes, no subprocess), and the
+    ``POST .../repo/patch-proposal`` endpoint
 
 These tests never modify a repo: the only repository written to is a
 disposable one created under ``tmp_path`` purely so the read helpers
-have something real to observe.
+have something real to observe. The Phase 2 tests additionally assert
+that building a proposal leaves the repo tree byte-for-byte unchanged.
 """
 
 from __future__ import annotations
@@ -589,3 +596,523 @@ class TestRepoEndpoints:
         assert status["branch"] in ("main", "master")
         assert status["clean"] is True
         assert status["recent_commits"]
+
+
+# ════════════════════════════════════════════════════════════════════
+# Phase 2 — patch proposal mode (review-only)
+# ════════════════════════════════════════════════════════════════════
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    """Byte-for-byte map of every file under ``root`` (for tamper checks)."""
+    snap: dict[str, bytes] = {}
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            snap[str(p.relative_to(root))] = p.read_bytes()
+    return snap
+
+
+class TestValidateProposedPath:
+    def _root(self, real_repo):
+        repo, _ = real_repo
+        return repo.resolve()
+
+    @pytest.mark.parametrize("bad", [None, True, False, 123, b"x", ["a"]])
+    def test_non_string_rejected(self, real_repo, bad):
+        with pytest.raises(dw.PatchProposalError):
+            dw.validate_proposed_path(self._root(real_repo), bad)
+
+    @pytest.mark.parametrize("bad", ["", "   ", "\t"])
+    def test_empty_rejected(self, real_repo, bad):
+        with pytest.raises(dw.PatchProposalError):
+            dw.validate_proposed_path(self._root(real_repo), bad)
+
+    @pytest.mark.parametrize(
+        "bad", ["/etc/passwd", "/srv/code/x.py", "/home/me/repo/a.py"]
+    )
+    def test_absolute_rejected(self, real_repo, bad):
+        with pytest.raises(dw.PatchProposalError, match="absolute"):
+            dw.validate_proposed_path(self._root(real_repo), bad)
+
+    @pytest.mark.parametrize(
+        "bad", ["../escape.py", "a/../../b.py", "src/../../etc/x"]
+    )
+    def test_traversal_rejected(self, real_repo, bad):
+        with pytest.raises(dw.PatchProposalError, match="'\\.\\.'"):
+            dw.validate_proposed_path(self._root(real_repo), bad)
+
+    def test_backslash_rejected(self, real_repo):
+        with pytest.raises(dw.PatchProposalError, match="'/'"):
+            dw.validate_proposed_path(
+                self._root(real_repo), "src\\win\\path.py"
+            )
+
+    def test_tilde_rejected(self, real_repo):
+        with pytest.raises(dw.PatchProposalError, match="~"):
+            dw.validate_proposed_path(self._root(real_repo), "~/secret")
+
+    @pytest.mark.parametrize(
+        "bad", ["a\x00b.py", "a\nb.py", "a\rb.py"]
+    )
+    def test_control_chars_rejected(self, real_repo, bad):
+        with pytest.raises(dw.PatchProposalError):
+            dw.validate_proposed_path(self._root(real_repo), bad)
+
+    def test_too_long_rejected(self, real_repo):
+        with pytest.raises(dw.PatchProposalError):
+            dw.validate_proposed_path(
+                self._root(real_repo), "a/" * 3000 + "x.py"
+            )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            ".env",
+            "config/.env",
+            "nova.db",
+            "var/nexus.db",
+            "data/x.json",
+            "backups/dump.tar",
+            "exports/pack.zip",
+            "logs/app.log",
+            "memory-packs/p.json",
+            "deploy/app.bak",
+            "store.sqlite3",
+            "db/snap.db",
+            "keys/server.pem",
+            "tls/server.key",
+            "id_rsa",
+            ".ssh/id_ed25519",
+            ".git/config",
+            "src/__pycache__/m.pyc",
+            ".aws/credentials",
+            "secrets.yaml",
+            "deploy/token",
+        ],
+    )
+    def test_secret_or_private_paths_rejected(self, real_repo, bad):
+        with pytest.raises(
+            dw.PatchProposalError, match="protected or secret"
+        ):
+            dw.validate_proposed_path(self._root(real_repo), bad)
+
+    @pytest.mark.parametrize(
+        "ok",
+        [
+            "core/dev_workspace.py",
+            "docs/dev-workspace.md",
+            "tests/test_dev_workspace.py",
+            ".env.example",
+            "config/.env.sample",
+            "docs/schema.sql",
+            "deep/nested/dir/module.py",
+        ],
+    )
+    def test_safe_source_paths_allowed(self, real_repo, ok):
+        assert dw.validate_proposed_path(self._root(real_repo), ok) == ok
+
+    def test_leading_dot_segment_is_normalised(self, real_repo):
+        # ``./a.py`` collapses to the safe ``a.py``; a path that is only
+        # ``.`` has no target and is refused.
+        assert (
+            dw.validate_proposed_path(self._root(real_repo), "./a.py")
+            == "a.py"
+        )
+        with pytest.raises(dw.PatchProposalError, match="normalised"):
+            dw.validate_proposed_path(self._root(real_repo), ".")
+
+    def test_symlink_escape_rejected(self, real_repo, tmp_path):
+        """A symlinked dir inside the repo pointing outside must not
+        let a proposed path resolve out of the linked tree."""
+        repo, _ = real_repo
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = repo / "sneaky"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        with pytest.raises(dw.PatchProposalError, match="outside"):
+            dw.validate_proposed_path(
+                repo.resolve(), "sneaky/escaped.py"
+            )
+
+
+def _safe_proposal() -> dict:
+    return {
+        "summary": "Add a greeting helper\nwith   messy   spacing",
+        "plan": ["Add greet()", "Cover it with a test", "  "],
+        "changes": [
+            {
+                "path": "core/greet.py",
+                "action": "add",
+                "new_content": "def greet(n):\n    return f'hi {n}'\n",
+            },
+            {
+                "path": "README.md",
+                "action": "modify",
+                "old_content": "hello\n",
+                "new_content": "hello\nworld\n",
+            },
+        ],
+        "tests": ["pytest tests/test_greet.py -q"],
+        "risks": ["New public helper — keep the surface small."],
+    }
+
+
+@_needs_git
+class TestBuildPatchProposal:
+    def test_happy_path_from_safe_model_output(self, real_repo):
+        repo, root = real_repo
+        before = _tree_snapshot(repo)
+        prop = dw.build_patch_proposal(
+            str(repo), _safe_proposal(), roots=[root]
+        )
+        d = prop.as_dict()
+
+        # Review-only invariants travel with the payload.
+        assert d["review_only"] is True
+        assert d["applied"] is False
+        assert d["safety"] and all(isinstance(s, str) for s in d["safety"])
+        assert d["repo_path"] == str(repo.resolve())
+
+        # Summary whitespace is collapsed to one safe line.
+        assert d["summary"] == "Add a greeting helper with messy spacing"
+        # Blank plan entry dropped.
+        assert d["plan"] == ["Add greet()", "Cover it with a test"]
+        assert d["suggested_tests"] == ["pytest tests/test_greet.py -q"]
+        assert d["risks"]
+
+        files = {f["path"]: f for f in d["files"]}
+        assert set(files) == {"core/greet.py", "README.md"}
+        assert files["core/greet.py"]["action"] == "add"
+        assert files["core/greet.py"]["added"] >= 1
+        assert files["core/greet.py"]["removed"] == 0
+        assert files["README.md"]["added"] == 1
+        assert "+world" in files["README.md"]["diff"]
+        assert d["diff_preview"]
+        assert "b/core/greet.py" in d["diff_preview"]
+
+        # Nothing on disk changed.
+        assert _tree_snapshot(repo) == before
+
+    def test_invalid_repo_path_raises(self, tmp_path):
+        with pytest.raises(
+            dw.PatchProposalError, match="not usable"
+        ):
+            dw.build_patch_proposal(
+                str(tmp_path / "missing"),
+                _safe_proposal(),
+                roots=[tmp_path],
+            )
+
+    def test_proposal_must_be_object(self, real_repo):
+        repo, root = real_repo
+        with pytest.raises(dw.PatchProposalError, match="object"):
+            dw.build_patch_proposal(str(repo), ["nope"], roots=[root])
+
+    def test_requires_at_least_one_change(self, real_repo):
+        repo, root = real_repo
+        with pytest.raises(dw.PatchProposalError, match="at least one"):
+            dw.build_patch_proposal(
+                str(repo), {"changes": []}, roots=[root]
+            )
+
+    def test_bad_action_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {"path": "a.py", "action": "push", "new_content": "x"}
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="action"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_secret_path_in_change_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": ".env",
+                    "action": "modify",
+                    "old_content": "A=1\n",
+                    "new_content": "A=2\n",
+                }
+            ]
+        }
+        with pytest.raises(
+            dw.PatchProposalError, match="protected or secret"
+        ):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_absolute_path_in_change_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {"path": "/etc/hosts", "new_content": "x", "action": "add"}
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="absolute"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_duplicate_path_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {"path": "a.py", "action": "add", "new_content": "1\n"},
+                {"path": "a.py", "action": "add", "new_content": "2\n"},
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="duplicate"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_modify_without_difference_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": "a.py",
+                    "action": "modify",
+                    "old_content": "same\n",
+                    "new_content": "same\n",
+                }
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="no difference"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_empty_add_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {"path": "a.py", "action": "add", "new_content": ""}
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="empty content"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_oversized_content_rejected(self, real_repo):
+        repo, root = real_repo
+        huge = "x\n" * (dw._MAX_PROPOSAL_CONTENT_CHARS // 2 + 10)
+        bad = {
+            "changes": [
+                {"path": "a.py", "action": "add", "new_content": huge}
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="too large"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_delete_change_diff(self, real_repo):
+        repo, root = real_repo
+        prop = dw.build_patch_proposal(
+            str(repo),
+            {
+                "changes": [
+                    {
+                        "path": "old.py",
+                        "action": "delete",
+                        "old_content": "gone\n",
+                    }
+                ]
+            },
+            roots=[root],
+        )
+        f = prop.files[0]
+        assert f.action == "delete"
+        assert f.removed == 1 and f.added == 0
+        assert "/dev/null" in f.diff
+
+    def test_non_string_list_item_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "plan": ["ok", 5],
+            "changes": [
+                {"path": "a.py", "action": "add", "new_content": "x\n"}
+            ],
+        }
+        with pytest.raises(dw.PatchProposalError, match="must be strings"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_files_capped(self, real_repo):
+        repo, root = real_repo
+        changes = [
+            {"path": f"f{i}.py", "action": "add", "new_content": f"{i}\n"}
+            for i in range(dw._MAX_PROPOSAL_FILES + 25)
+        ]
+        prop = dw.build_patch_proposal(
+            str(repo), {"changes": changes}, roots=[root]
+        )
+        assert len(prop.files) == dw._MAX_PROPOSAL_FILES
+
+    def test_file_diff_truncated(self, real_repo):
+        repo, root = real_repo
+        new = "".join(f"line {i}\n" for i in range(2000))
+        prop = dw.build_patch_proposal(
+            str(repo),
+            {
+                "changes": [
+                    {"path": "big.py", "action": "add", "new_content": new}
+                ]
+            },
+            roots=[root],
+        )
+        assert "truncated" in prop.files[0].diff
+
+    def test_does_not_spawn_subprocess(self, real_repo, monkeypatch):
+        """Phase 2 is a pure transform — building a proposal must never
+        shell out (no git, no command)."""
+        repo, root = real_repo
+
+        def _boom(*a, **k):  # pragma: no cover - must never run
+            raise AssertionError("build_patch_proposal spawned a process")
+
+        monkeypatch.setattr(dw.subprocess, "run", _boom)
+        monkeypatch.setattr(dw.subprocess, "Popen", _boom)
+        prop = dw.build_patch_proposal(
+            str(repo), _safe_proposal(), roots=[root]
+        )
+        assert prop.files
+
+    def test_repo_tree_unchanged(self, real_repo):
+        """Building a proposal touches nothing on disk."""
+        repo, root = real_repo
+        before = _tree_snapshot(repo)
+        dw.build_patch_proposal(str(repo), _safe_proposal(), roots=[root])
+        dw.build_patch_proposal(
+            str(repo),
+            {
+                "changes": [
+                    {
+                        "path": "README.md",
+                        "action": "delete",
+                        "old_content": "hello\n",
+                    }
+                ]
+            },
+            roots=[root],
+        )
+        assert _tree_snapshot(repo) == before
+
+
+class TestPatchProposalEndpoint:
+    def test_unlinked_project_is_400(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.post(
+            f"/projects/{pid}/repo/patch-proposal",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ]
+            },
+            headers=_h(tok),
+        )
+        assert resp.status_code == 400
+        assert "detail" in resp.json()
+
+    def test_foreign_project_is_404(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a = _login(web_client, "alice")
+        b = _login(web_client, "bob")
+        pid = web_client.post(
+            "/projects", json={"name": "Priv"}, headers=_h(a)
+        ).json()["id"]
+        resp = web_client.post(
+            f"/projects/{pid}/repo/patch-proposal",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ]
+            },
+            headers=_h(b),
+        )
+        assert resp.status_code == 404
+
+    @_needs_git
+    def test_full_link_then_patch_proposal(
+        self, db_path, web_client, real_repo, monkeypatch
+    ):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        assert web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": str(repo)},
+            headers=_h(tok),
+        ).status_code == 200
+
+        before = _tree_snapshot(repo)
+        resp = web_client.post(
+            f"/projects/{pid}/repo/patch-proposal",
+            json=_safe_proposal(),
+            headers=_h(tok),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["review_only"] is True
+        assert body["applied"] is False
+        assert {f["path"] for f in body["files"]} == {
+            "core/greet.py",
+            "README.md",
+        }
+        assert body["diff_preview"]
+        # The endpoint is read-only w.r.t. the repository.
+        assert _tree_snapshot(repo) == before
+
+    @_needs_git
+    def test_secret_path_via_endpoint_is_400(
+        self, db_path, web_client, real_repo, monkeypatch
+    ):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": str(repo)},
+            headers=_h(tok),
+        )
+        resp = web_client.post(
+            f"/projects/{pid}/repo/patch-proposal",
+            json={
+                "changes": [
+                    {
+                        "path": "../../etc/cron.d/x",
+                        "action": "add",
+                        "new_content": "* * * * * root id\n",
+                    }
+                ]
+            },
+            headers=_h(tok),
+        )
+        assert resp.status_code == 400
+        assert "detail" in resp.json()
+
+    def test_extra_fields_forbidden(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.post(
+            f"/projects/{pid}/repo/patch-proposal",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ],
+                "apply": True,
+            },
+            headers=_h(tok),
+        )
+        assert resp.status_code == 422

--- a/web.py
+++ b/web.py
@@ -320,6 +320,38 @@ class RepoLinkRequest(BaseModel):
     path: str | None = None
 
 
+class PatchProposalChange(BaseModel):
+    """One proposed file change inside a ``POST .../repo/patch-proposal``.
+
+    ``path`` is repo-relative (absolute / ``..`` / secret paths are
+    refused server-side by ``core.dev_workspace``). ``old_content`` /
+    ``new_content`` are the model's before/after text; the diff is
+    computed locally and **never applied**.
+    """
+    model_config = {"extra": "forbid"}
+
+    path: str
+    action: str | None = "modify"
+    old_content: str | None = None
+    new_content: str | None = None
+
+
+class PatchProposalRequest(BaseModel):
+    """Body for ``POST /projects/{id}/repo/patch-proposal`` (Phase 2).
+
+    A structured, model-produced change description. The endpoint turns
+    it into a calm, validated, **review-only** patch preview — it never
+    writes files, commits, pushes, branches, or runs a command.
+    """
+    model_config = {"extra": "forbid"}
+
+    summary: str | None = None
+    plan: list[str] | None = None
+    changes: list[PatchProposalChange]
+    tests: list[str] | None = None
+    risks: list[str] | None = None
+
+
 class MemoryUpdateRequest(BaseModel):
     category: str
     content: str
@@ -690,6 +722,44 @@ def get_project_repo_status_endpoint(
     snapshot = dev_workspace.read_status(repo_path).as_dict()
     snapshot["linked"] = True
     return snapshot
+
+
+@app.post("/projects/{project_id}/repo/patch-proposal")
+def create_project_repo_patch_proposal_endpoint(
+    project_id: int,
+    request: PatchProposalRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Build a **review-only** patch proposal for a linked repo (Phase 2).
+
+    Turns the model's structured change description into a validated,
+    calm :class:`core.dev_workspace.PatchProposal` (plan, likely files,
+    a unified-diff preview, suggested tests, risk checklist). This is a
+    pure transform: it never writes files, stages, commits, pushes,
+    branches, or runs a command — the repo is not touched.
+
+    A foreign / unknown project id is a 404 (existence not leaked); a
+    project with no linked repo, or any proposal/path that fails
+    validation, is a 400 with a short, safe reason.
+    """
+    project = _projects.get_project(project_id, user.id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Projet introuvable.")
+    repo_path = project.get("local_repo_path")
+    if not repo_path:
+        raise HTTPException(
+            status_code=400,
+            detail="Aucun dépôt local n'est lié à ce projet.",
+        )
+    from core import dev_workspace
+
+    try:
+        proposal = dev_workspace.build_patch_proposal(
+            repo_path, request.model_dump()
+        )
+    except dev_workspace.PatchProposalError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return proposal.as_dict()
 
 
 @app.get("/conversations/{conversation_id}/messages")


### PR DESCRIPTION
## Summary

Dev Workspace **Phase 2 — patch proposal mode**. Nova can now help *plan and propose* code changes for a linked project, but **still cannot modify files, commit, push, or branch**.

- **`core/dev_workspace.py`** — new `PatchProposalError`, `validate_proposed_path`, `ProposedFileChange`, `PatchProposal`, and `build_patch_proposal`. A **pure transform**: it re-validates the linked repo with the same hard rules as Phase 1, validates every proposed path, and builds the unified diff locally with `difflib`. No git, no subprocess, no file writes, no network — nothing is applied, staged, committed, pushed, or branched.
- **`web.py`** — `POST /projects/{id}/repo/patch-proposal` (user-scoped, review-only). No linked repo or any invalid path/proposal → `400`; foreign project → `404`; extra body field → `422`.
- **Docs** — `docs/dev-workspace.md` rewritten for Phase 1 + Phase 2, the cumulative safety model, and the Phase 3–6 roadmap; `docs/projects.md` + `CHANGELOG.md` updated.

### Safety model (enforced + tested)

Every proposed path must be **repo-relative** (absolute / `~` / `\` / `..` traversal refused), must **not** target a secret/private file (`.env`/`*.env`, `nova.db`/`*.db`/`*.sqlite*`, SSH & key material, tokens, credentials, logs, backups, exports, memory-packs, `.git`, …; documented `.env.example`/`.sample`/`.template`/`.dist` samples stay allowed), and must resolve **inside** the linked repo (a symlinked subdir pointing out is refused). All fields are capped; the result restates `review_only: true` / `applied: false` with a fixed safety note. Project context cannot override safety/system rules.

## Test plan

- [x] `pytest tests/test_dev_workspace.py` — 136 passed (Phase 1 + ~50 new Phase 2 tests)
- [x] Phase 2 coverage: proposal from safe model output; invalid/empty/absolute/`..`/`\`/`~`/control-char paths rejected; secret/private paths rejected; outside-repo (symlink-escape) rejected; invalid linked repo rejected; duplicate path, no-diff modify, empty add, oversized content rejected; files cap & diff truncation; **no file writes / no subprocess** invariants; endpoint 200/400/404/422 paths
- [x] Regression: projects/memory/storage/provider/data-export — 408 passed, 1 skipped
- [x] Full suite — **2225 passed, 2 skipped** (4 pre-existing JWT warnings, unrelated)
- [x] Full collection — 2227 tests collect cleanly (no import breakage)
- [x] Flake8 clean

https://claude.ai/code/session_01KmW7jdWiMVy1uYSS8GV97h

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmW7jdWiMVy1uYSS8GV97h)_