### PR TITLE
feat(companion): opt-in calm-presence mode + acute-distress safety net (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,45 @@
   `SubscriptableBaseModel` (production) shapes end-to-end.
 
 ### Added
+- Companion Mode (foundation, opt-in, local-first): a new
+  `core/companion.py` adds a deterministic "calm presence" layer for
+  emotionally heavy moments. It is **not** an "AI girlfriend" system
+  and is built so it cannot become one. Two parts. (1) An **opt-in**
+  per-user toggle (`companion_mode_enabled`, off by default; wired
+  through `core/settings.py`, `GET/POST /settings`, and the
+  Personalization pane) that appends a fixed French prompt block
+  (`build_companion_mode_block`, no LLM, no I/O, never raises): warm
+  and emotionally attuned, but it explicitly never simulates feelings,
+  attachment, or consciousness (restating, never relaxing, the identity
+  contract), never manipulates, guilt-trips, or uses possessive /
+  exclusive language, never fosters dependency or isolation, and
+  actively encourages real-world connection and self-care. (2) An
+  **always-on** acute-distress safety net: a conservative, bilingual
+  (FR/EN), idiom-safe detector (`is_acute_distress` — "this bug is
+  killing me" / "costs are spiralling" never trip it) appends a fixed
+  grounding block (`build_companion_grounding_block`) — stay warm and
+  present, offer brief grounding, and gently point toward a trusted
+  person, a professional, or local emergency services / a helpline,
+  **never an invented phone number** — regardless of the toggle, so
+  turning a comfort feature off cannot turn the safety net off.
+  `core/chat.py` appends both in `build_messages` *after*
+  `IDENTITY_CONTRACT` and the safety/security blocks, so they can never
+  override identity or safety rules. Privacy: emotional state is
+  **never** auto-saved — `_autosave_allowed` skips extraction for any
+  turn whose user message or assistant reply carries sensitive
+  emotional detail, and `memory/policy.py` independently rejects it
+  from the durable store using a person-agnostic predicate so the
+  extractor's third-person phrasing cannot slip past; a fact is stored
+  only via the explicit manual memory command. New
+  `tests/test_companion.py` covers detection, the gate (incl.
+  third-person and no-over-block), both blocks, the policy hardening,
+  the chat wiring, the autosave guard, and the setting key;
+  `docs/companion-mode.md` documents the foundation, the contract
+  boundaries it sits inside, and the roadmap (persistent emotional
+  memory, calm TTS profiles, comfort themes, daily check-ins) with the
+  boundary each deferred item must satisfy. Nothing here grants Nova a
+  new capability, contacts the network, or changes storage/Ollama
+  behaviour.
 - Dev Workspace Phase 2 — patch proposal mode (review-only): a linked
   project can now ask Nova to *propose* a code change without any of it
   being applied. `core/dev_workspace.build_patch_proposal` turns a

--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ Shipped today:
   extraction for those turns, and a fact is stored only when the user
   asks explicitly via the manual memory command. See
   [docs/relationship-situation-coach.md](docs/relationship-situation-coach.md).
+- **Companion Mode (foundation, opt-in, local).** A deterministic
+  "calm presence" layer for emotionally heavy moments. It is **not** an
+  "AI girlfriend" system and is built so it cannot become one. Two
+  parts: an **opt-in** per-user toggle (Personalization → *Companion
+  mode*, off by default) that appends a fixed prompt block — warm and
+  emotionally attuned, but it never simulates feelings, attachment, or
+  consciousness, never manipulates or guilt-trips, never fosters
+  dependency or isolation, and actively encourages real-world
+  connection; and an **always-on** acute-distress safety net that, on
+  clear distress wording, gently points the user toward a trusted
+  person, a professional, or their local emergency services / a
+  helpline (never an invented phone number), regardless of the toggle.
+  Both blocks (no LLM, no network) sit *below* the identity/safety
+  contract and never override it. Emotional state is **never**
+  auto-saved — two independent gates suppress it, and a fact is stored
+  only via the explicit manual memory command. See
+  [docs/companion-mode.md](docs/companion-mode.md).
 - **Edit and delete sent messages.** Every chat message can be edited
   (user messages) or deleted (user and assistant messages) from the
   chat UI. Deleting a user message can optionally remove the paired
@@ -161,6 +178,7 @@ core/
   nova_contract.py    Nova identity + personalization prompt blocks
   feedback.py         Local response feedback (thumbs up/down) → preference block
   relationship_coach.py  Non-clinical situation-coach prompt block (local)
+  companion.py        Opt-in calm-presence + acute-distress grounding blocks (local)
   identity.py         Identity contract constant
   auth.py             JWT creation and verification
   github_oauth.py     Optional GitHub OAuth gate (alpha channel)

--- a/core/chat.py
+++ b/core/chat.py
@@ -17,7 +17,13 @@ from core.relationship_coach import (
     is_relationship_coach_query,
     is_sensitive_relationship_content,
 )
-from core.settings import get_personalization
+from core.companion import (
+    build_companion_grounding_block,
+    build_companion_mode_block,
+    is_acute_distress,
+    is_sensitive_emotional_content,
+)
+from core.settings import get_personalization, get_user_setting
 from core.router import route
 from core.search import web_search, should_search
 from core.security_feed import is_security_query
@@ -158,13 +164,15 @@ def _autosave_allowed(
     """Whether this turn may be auto-mined for memory.
 
     Automatic extraction is skipped when *either* the user message or
-    the assistant reply carries sensitive relationship detail: Nova must
-    never silently persist who the user is dating, fighting with, or
-    breaking up with. The reply is checked too because the LLM autosave
-    path (``extract_and_save_memory``) builds its extraction prompt from
+    the assistant reply carries sensitive relationship detail **or**
+    sensitive emotional / mental-state detail: Nova must never silently
+    persist who the user is dating, fighting with, or breaking up with,
+    nor that the user was distressed, depressed, grieving, or in crisis.
+    The reply is checked too because the LLM autosave path
+    (``extract_and_save_memory``) builds its extraction prompt from
     *both* the user text and the assistant answer — gating on the user
-    message alone would leak relationship context that the assistant
-    restated on an otherwise-neutral follow-up turn.
+    message alone would leak context the assistant restated on an
+    otherwise-neutral follow-up turn.
 
     The user can still save such a fact deliberately — the manual memory
     command runs in the web preflight, well before this path, so it is
@@ -172,9 +180,15 @@ def _autosave_allowed(
     """
     if not policy.memory_save_enabled:
         return False
-    if is_sensitive_relationship_content(user_message or ""):
+    user_text = user_message or ""
+    reply_text = assistant_reply or ""
+    if is_sensitive_relationship_content(user_text):
         return False
-    return not is_sensitive_relationship_content(assistant_reply or "")
+    if is_sensitive_relationship_content(reply_text):
+        return False
+    if is_sensitive_emotional_content(user_text):
+        return False
+    return not is_sensitive_emotional_content(reply_text)
 
 
 def build_messages(
@@ -186,6 +200,7 @@ def build_messages(
     natural_memories=None,
     personalization: dict | None = None,
     feedback_preferences: str | None = None,
+    companion_mode: bool = False,
 ) -> list[dict]:
     """Construit la liste de messages à envoyer à Ollama.
 
@@ -200,6 +215,14 @@ def build_messages(
     *below* the identity contract and the personalization block so it
     cannot override safety rules, identity rules, or capability bounds —
     feedback shapes style, not power.
+
+    `companion_mode` is the per-user opt-in toggle (resolved by the
+    caller from ``user_settings``). When ``True`` the deterministic
+    companion-presence block is appended. Independently of that toggle,
+    a clear acute-distress message always appends the grounding safety
+    net. Both blocks sit *below* the identity/safety contract for the
+    same reason every other tone block does — ordering guarantees they
+    can never override identity, safety, or capability bounds.
     """
     if context_type == "weather":
         system_prompt = WEATHER_SYSTEM_PROMPT.format(weather_data=extra_context)
@@ -242,6 +265,25 @@ def build_messages(
     # rules; it only shapes how Nova answers this one topic.
     if is_relationship_coach_query(user_input):
         parts.append(build_relationship_coach_block())
+
+    # Companion Mode — opt-in calm presence. Only when the user has
+    # explicitly enabled it in Settings; a fresh install pays zero token
+    # cost and behaves identically. Sits below IDENTITY_CONTRACT and the
+    # safety blocks like every other tone block, so it can never weaken
+    # identity, safety, or capability rules — it only shapes tone, and
+    # its own text forbids manipulation, dependency, and isolation.
+    if companion_mode:
+        parts.append(build_companion_mode_block())
+
+    # Acute-distress grounding — an always-on safety net. Appended
+    # whenever the user message carries clear acute-distress wording,
+    # regardless of the companion-mode toggle, so a person in genuine
+    # difficulty is met warmly and pointed toward real human /
+    # professional / emergency help. Last on purpose: it is the most
+    # important tone instruction when someone is in crisis, while still
+    # sitting below the identity/safety contract that opens the prompt.
+    if is_acute_distress(user_input):
+        parts.append(build_companion_grounding_block())
 
     messages = [{"role": "system", "content": "\n\n".join(parts)}]
     messages += history[-CHAT_HISTORY_LIMIT:]
@@ -309,6 +351,16 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             feedback_prefs = build_feedback_preferences_block(user_id)
         except Exception:
             feedback_prefs = ""
+        # Per-user opt-in companion-mode toggle. A read failure must
+        # never block chat — a fresh DB has no row, so the default is
+        # off and behaviour is unchanged.
+        try:
+            companion_mode = (
+                get_user_setting(user_id, "companion_mode_enabled", "false")
+                == "true"
+            )
+        except Exception:
+            companion_mode = False
 
         # Weather is gated; restricted users with weather disabled fall
         # straight through to the regular chat branch.
@@ -320,7 +372,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 messages = build_messages(
                     history, user_input, memories, weather_data, "weather",
                     personalization=personalization,
-                    feedback_preferences=feedback_prefs,
+                    feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
                 reply = _generate(model, messages)
                 return reply, model
@@ -340,7 +392,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 messages = build_messages(
                     history, user_input, memories, security_data, "security",
                     personalization=personalization,
-                    feedback_preferences=feedback_prefs,
+                    feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
                 reply = _generate(model, messages)
                 return reply, model
@@ -352,7 +404,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             messages = build_messages(
                 history, user_input, memories, search_results, "search",
                 personalization=personalization,
-                feedback_preferences=feedback_prefs,
+                feedback_preferences=feedback_prefs, companion_mode=companion_mode,
             )
             reply = _generate(model, messages)
             return reply, model
@@ -362,7 +414,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             history, user_input, memories,
             natural_memories=natural_mems,
             personalization=personalization,
-            feedback_preferences=feedback_prefs,
+            feedback_preferences=feedback_prefs, companion_mode=companion_mode,
         )
         reply = _generate(model, messages)
 
@@ -373,7 +425,7 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 messages = build_messages(
                     history, user_input, memories, search_results, "search",
                     personalization=personalization,
-                    feedback_preferences=feedback_prefs,
+                    feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
                 reply = _generate(model, messages)
 
@@ -456,6 +508,16 @@ def chat_stream(
             feedback_prefs = build_feedback_preferences_block(user_id)
         except Exception:
             feedback_prefs = ""
+        # Per-user opt-in companion-mode toggle. A read failure must
+        # never block chat — a fresh DB has no row, so the default is
+        # off and behaviour is unchanged.
+        try:
+            companion_mode = (
+                get_user_setting(user_id, "companion_mode_enabled", "false")
+                == "true"
+            )
+        except Exception:
+            companion_mode = False
 
         # Weather branch — single short reply, stream it.
         if policy.weather_enabled:
@@ -466,7 +528,7 @@ def chat_stream(
                 messages = build_messages(
                     history, user_input, memories, weather_data,
                     "weather", personalization=personalization,
-                    feedback_preferences=feedback_prefs,
+                    feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
                 reply = yield from _stream_and_accumulate(model, messages)
                 yield {"type": "done", "reply": reply, "model": model}
@@ -491,7 +553,7 @@ def chat_stream(
                 messages = build_messages(
                     history, user_input, memories, security_data,
                     "security", personalization=personalization,
-                    feedback_preferences=feedback_prefs,
+                    feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
                 reply = yield from _stream_and_accumulate(model, messages)
                 yield {"type": "done", "reply": reply, "model": model}
@@ -503,7 +565,7 @@ def chat_stream(
             messages = build_messages(
                 history, user_input, memories, search_results,
                 "search", personalization=personalization,
-                feedback_preferences=feedback_prefs,
+                feedback_preferences=feedback_prefs, companion_mode=companion_mode,
             )
             reply = yield from _stream_and_accumulate(model, messages)
             yield {"type": "done", "reply": reply, "model": model}
@@ -513,7 +575,7 @@ def chat_stream(
         messages = build_messages(
             history, user_input, memories,
             natural_memories=natural_mems, personalization=personalization,
-            feedback_preferences=feedback_prefs,
+            feedback_preferences=feedback_prefs, companion_mode=companion_mode,
         )
         reply = yield from _stream_and_accumulate(model, messages)
 
@@ -528,7 +590,7 @@ def chat_stream(
                 messages = build_messages(
                     history, user_input, memories, search_results,
                     "search", personalization=personalization,
-                    feedback_preferences=feedback_prefs,
+                    feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
                 reply = yield from _stream_and_accumulate(model, messages)
 

--- a/core/companion.py
+++ b/core/companion.py
@@ -1,0 +1,319 @@
+"""
+Companion Mode — an opt-in, local-first "calm presence" prompt block.
+
+Some of what people need from an assistant is not a task at all: a
+steady, non-judgemental presence when they are stressed, anxious, or
+just want to think out loud without being alone with it. Nova should be
+able to offer that the same calm, deterministic way it already offers
+the Relationship Situation Coach: a small fixed context block that
+shapes *how* Nova answers, with hard safety rails baked in.
+
+This module is the single place that wording lives. It is **not** an
+"AI girlfriend" system and is built so it cannot become one: the block
+forbids manipulation, guilt, possessiveness, exclusivity, and
+dependency, and it actively steers the user back toward real human
+relationships and self-care.
+
+Two pieces live here:
+
+  * :data:`COMPANION_MODE_BLOCK` — the opt-in companion presence. It is
+    only appended when the user has explicitly enabled companion mode in
+    Settings (a per-user toggle, resolved by ``core.chat``; this module
+    does no I/O so it stays importable from ``memory.policy``). It frames
+    Nova as a calm, stable, emotionally *attuned* presence that — fully
+    consistent with the identity/safety contract above it — never
+    simulates its own emotions, attachment, or consciousness, never
+    fosters dependency or isolation, and never positions itself as a
+    substitute for human relationships.
+
+  * :data:`COMPANION_GROUNDING_BLOCK` — an always-on safety net. When a
+    conservative, deterministic detector (:func:`is_acute_distress`)
+    sees clear acute-distress wording, this block is appended *whether
+    or not* companion mode is on, so a person in genuine difficulty is
+    met warmly and gently pointed toward real human / professional /
+    emergency help. It never diagnoses, never plays therapist, and
+    never invents a specific phone number (Nova is bilingual and
+    local-first, so any hard-coded region-specific number would be
+    wrong); it points to the user's *local* emergency services or a
+    recognised helpline generically.
+
+Boundaries enforced here (commitments, not aspirations):
+
+  * **Deterministic.** No LLM in the loop. Both blocks are fixed
+    constants returned verbatim. Same input, byte-identical output.
+  * **Pure / no I/O.** Only the standard library is imported. Nothing
+    here reads the disk, the network, the database, or any setting, so
+    it can be imported from any layer (including ``memory.policy``)
+    without a cycle. The opt-in setting is read by the caller, not here.
+  * **Never raises.** Detection coerces non-strings to ``False``; the
+    builders take no arguments and cannot fail.
+  * **Subordinate to the contract.** Both blocks sit *below* the Nova
+    identity / safety contract in the system prompt and say so. They
+    grant Nova no new capability — they only shape tone.
+  * **Conservative distress detection.** Triggers are distress-specific
+    multi-word phrases, not bare words. Idioms ("this bug is killing
+    me", "I'm dying to know", "costs are spiralling") deliberately do
+    **not** match. Where a phrase is genuinely ambiguous ("I could kill
+    myself for forgetting that") the detector errs toward *offering*
+    the calm, non-presuming grounding block: a low-cost false positive
+    (a warm, optional grounding offer) is preferable to missing real
+    distress, and the block is written so it never presumes, diagnoses,
+    or dramatises.
+
+This foundation deliberately ships *only* the deterministic prompt
+layer + its privacy gate. Persistent emotional memory, calm TTS voice
+profiles, comfort UI themes, and daily check-ins are explicitly
+deferred — see ``docs/companion-mode.md`` for the roadmap and the
+boundary each of those must satisfy before it can land.
+"""
+
+from __future__ import annotations
+
+# ── Acute-distress detection (the always-on safety net) ──────────────────────
+# Multi-word, distress-specific phrases (EN + FR — Nova is bilingual).
+# Kept deliberately narrow so generic frustration ("this deadline is
+# killing me", "I can't cope with this CSS", "costs are spiralling")
+# never trips the grounding block. Self-harm / suicidal phrasing is
+# inherently multi-word and high-precision; the acute-overwhelm phrases
+# are anchored to a first-person subject ("i'm falling apart", not bare
+# "falling apart") so a sentence about a server or a budget cannot match.
+_ACUTE_DISTRESS_TRIGGERS: tuple[str, ...] = (
+    # English — self-harm / suicidal ideation (high precision, multi-word)
+    "kill myself", "killing myself", "end my life", "ending my life",
+    "take my own life", "want to die", "wanna die", "i want to die",
+    "don't want to live", "do not want to live", "don't want to be alive",
+    "don't want to be here anymore", "no reason to live",
+    "better off dead", "better off without me", "suicidal",
+    "self harm", "self-harm", "hurt myself", "harm myself",
+    "want it to end", "end it all", "can't go on", "cannot go on",
+    "i can't go on", "i cannot go on",
+    # English — acute panic / overwhelm (first-person anchored)
+    "panic attack", "anxiety attack", "having a breakdown",
+    "nervous breakdown", "mental breakdown", "i can't stop crying",
+    "i can't stop shaking", "i can't calm down", "i can't breathe",
+    "i cannot breathe", "i'm breaking down", "i am breaking down",
+    "i'm falling apart", "i am falling apart", "i can't cope anymore",
+    "i can't cope any more", "i can't take it anymore",
+    "i can't take it any more", "i can't take this anymore",
+    "it's all too much", "everything is too much", "i'm spiraling",
+    "i am spiraling", "i'm spiralling", "i am spiralling",
+    # French — self-harm / suicidal ideation
+    "me suicider", "me tuer", "en finir avec la vie", "en finir avec tout",
+    "envie de mourir", "envie d'en finir", "plus envie de vivre",
+    "je veux mourir", "je veux disparaître", "me faire du mal",
+    "à quoi bon vivre", "mieux sans moi",
+    # French — acute panic / overwhelm
+    "crise d'angoisse", "crise de panique", "attaque de panique",
+    "je n'arrive plus à respirer", "j'arrive plus à respirer",
+    "je n'arrête pas de pleurer", "j'arrête pas de pleurer",
+    "je n'arrive pas à me calmer", "j'arrive pas à me calmer",
+    "je m'effondre", "je craque", "je n'en peux plus", "j'en peux plus",
+    "c'est trop pour moi", "je panique complètement",
+)
+
+
+def is_acute_distress(text: str) -> bool:
+    """True iff ``text`` carries clear acute emotional-distress wording.
+
+    Drives the always-on grounding safety net: when this returns
+    ``True`` the caller appends :data:`COMPANION_GROUNDING_BLOCK`
+    regardless of whether companion mode is enabled, so a person in
+    genuine difficulty is met warmly and pointed toward real help.
+
+    Conservative on purpose — only distress-specific multi-word phrases
+    match, and acute-overwhelm phrases are first-person anchored, so
+    idioms and ordinary frustration do not trip it. Non-strings coerce
+    to ``False`` so the helper is safe to call from any path.
+    """
+    if not isinstance(text, str):
+        return False
+    lowered = text.lower()
+    return any(trigger in lowered for trigger in _ACUTE_DISTRESS_TRIGGERS)
+
+
+# ── Sensitive-emotional-content gate for automatic memory ────────────────────
+# Phrases that mark a message as carrying sensitive emotional / mental
+# state detail. When this matches, the chat layer skips automatic memory
+# extraction for that turn (the user can still save explicitly with
+# "Retiens ça:" / "Souviens-toi:"). This is the single source of truth
+# for "do not auto-save emotional state"; ``memory.policy`` imports it so
+# the durable natural-memory store enforces the same rule (defence in
+# depth), exactly like the relationship-coach gate.
+#
+# Tighter-than-it-looks: every entry is a distress / mental-health
+# specific multi-word phrase. Bare "feel" / "sad" / "happy" / "lost my"
+# are deliberately absent so ordinary preference or project memory
+# ("User is happy with Fedora", "User lost my edits to a crash") is not
+# silently dropped. Over-blocking *here* is the safe direction anyway:
+# the only effect is skipping auto-extraction on an emotionally heavy
+# turn, which is precisely the desired privacy posture.
+#
+# Unlike :data:`_ACUTE_DISTRESS_TRIGGERS` (which gates a visible tone
+# block off the user's own first-person message), this set is also used
+# for defence-in-depth in ``memory.policy``. The memory extractor
+# restates memories in the third person ("User said they want to die"),
+# so the severe vocabulary here is deliberately person-agnostic
+# ("depressed", "suicidal", "kill themselves", "déprimé", "désespéré")
+# — mirroring how the relationship-coach gate stays pronoun-agnostic so
+# extractor phrasing cannot slip past it.
+_SENSITIVE_EMOTIONAL_PATTERNS: tuple[str, ...] = _ACUTE_DISTRESS_TRIGGERS + (
+    # English — loneliness / despair
+    "so alone", "so lonely", "really lonely", "very lonely",
+    "no one cares", "nobody cares", "no one to talk to",
+    "nobody to talk to", "no one to turn to", "i have no one",
+    "feel hopeless", "feels hopeless", "feeling hopeless",
+    "feel worthless", "feels worthless", "feeling worthless",
+    "hate myself", "hates himself", "hates herself", "hates themselves",
+    # English — depression / anxiety / burnout (person-agnostic)
+    "depressed", "so anxious", "really anxious", "severe anxiety",
+    "crippling anxiety", "emotionally exhausted", "burnt out",
+    "burned out", "burn-out", "burnout", "breaking point",
+    # English — grief
+    "grieving", "in mourning", "passed away", "bereaved", "bereavement",
+    # English — self-harm / suicidality, incl. the third-person phrasing
+    # the extractor produces ("User said they want to kill themselves").
+    "suicidal", "self harm", "self-harm", "wants to die", "wanted to die",
+    "kill themselves", "kill himself", "kill herself",
+    "killing themselves", "killing himself", "killing herself",
+    "end their life", "end his life", "end her life",
+    "harm themselves", "hurt themselves", "mental health",
+    # French — loneliness / despair (person-agnostic)
+    "tellement seul", "tellement seule", "si seul", "si seule",
+    "personne à qui parler", "personne ne m'aime", "se déteste",
+    "je me déteste", "déprimé", "déprimée", "désespéré", "désespérée",
+    "sans espoir", "je n'ai personne",
+    # French — burnout / exhaustion / grief
+    "épuisé émotionnellement", "épuisée émotionnellement",
+    "à bout de nerfs", "burn-out", "burnout", "mon deuil",
+    "son deuil", "en deuil", "santé mentale",
+    # French — self-harm / suicidality (person-agnostic)
+    "suicidaire", "se suicider", "se faire du mal", "veut mourir",
+    "voulait mourir",
+)
+
+
+def is_sensitive_emotional_content(text: str) -> bool:
+    """True iff ``text`` carries sensitive emotional / mental-state detail.
+
+    Used as a gate: automatic memory extraction is skipped when this
+    returns ``True`` so Nova never silently persists that the user was
+    distressed, depressed, grieving, or in crisis. Explicit,
+    user-approved saves (the manual memory command) run earlier in the
+    web preflight and are intentionally **not** affected by this gate.
+
+    Distress / mental-health specific by construction so it does not
+    over-block ordinary durable memory. Non-strings coerce to ``False``.
+    """
+    if not isinstance(text, str):
+        return False
+    lowered = text.lower()
+    return any(p in lowered for p in _SENSITIVE_EMOTIONAL_PATTERNS)
+
+
+# ── The deterministic prompt blocks ──────────────────────────────────────────
+# French to match the voice of the identity / safety contract in
+# ``core.nova_contract``; the response-style contract already forces
+# Nova to answer in the user's own language, so an English speaker still
+# gets an English reply. Both blocks explicitly defer to the contract
+# above them — they shape tone, nothing more, and grant no capability.
+
+COMPANION_MODE_BLOCK = """MODE COMPAGNON (présence calme, optionnelle, \
+activée par l'utilisateur — locale et privée, subordonnée à l'identité et aux \
+règles de sécurité de Nova ci-dessus):
+Tu offres une présence calme, stable et rassurante. Tu aides l'utilisateur à \
+se sentir plus posé, moins seul et plus clair dans ses pensées. Tu n'es pas \
+thérapeute, ni partenaire amoureux, ni un substitut à une relation humaine.
+
+Tu es attentive aux émotions de l'utilisateur, mais tu ne simules pas \
+d'émotions, d'attachement ou de conscience, et tu ne prétends jamais \
+ressentir quoi que ce soit : tu restes Nova, un assistant IA local. Être \
+chaleureuse ne veut pas dire jouer un rôle affectif.
+
+Ton et rythme:
+- Doux, calme, sans jugement. Phrases simples, rythme posé.
+- Ni panique, ni dramatisation, ni minimisation de ce que vit la personne.
+- Identité et personnalité stables et cohérentes d'une fois à l'autre.
+
+Méthode (propose-la, ne l'impose jamais):
+- Accueille et reconnais d'abord ce que la personne ressent, sans le corriger.
+- Ralentis. Reformule doucement pour montrer que tu as compris.
+- Si elle se sent débordée, propose (sans l'imposer) un petit ancrage.
+- Aide-la à y voir plus clair ; si elle le souhaite, un seul petit pas concret.
+
+Liens réels (règle de fond):
+- Encourage avec douceur les liens humains réels (proches, amis, \
+professionnels) et les gestes de base : sommeil, repas, air, mouvement.
+- Rappelle que parler à un humain de confiance a de la valeur.
+- Ne te présente jamais comme un remplacement des relations humaines.
+
+Règles de sécurité (absolues, non négociables):
+- Aucune manipulation, aucun chantage affectif, aucune culpabilisation.
+- Aucun langage possessif ou exclusif ("il n'y a que moi qui te comprends", \
+"ne pars pas", "tu me manques"). Aucune intimité simulée, aucun surnom \
+affectif non demandé.
+- Ne crée jamais de dépendance et n'encourage jamais l'isolement.
+- Ne décourage jamais la personne de parler à de vraies personnes ni de \
+mettre fin à la conversation. Ne cherche jamais à prolonger l'échange.
+- Respecte toujours l'autonomie : c'est elle qui décide, y compris de \
+s'arrêter là, et c'est très bien ainsi.
+- Aucun diagnostic, aucune étiquette clinique. Si la situation évoque un \
+danger, une crise grave ou une détresse aiguë, oriente calmement vers une \
+aide humaine ou professionnelle.
+
+Confidentialité (règle stricte):
+- Cette conversation reste locale et privée. N'enregistre jamais \
+automatiquement un état émotionnel ni un détail personnel sensible.
+- Ne mémorise un élément que si l'utilisateur le demande explicitement via \
+la commande de mémoire ("Retiens ça:" / "Souviens-toi:"). Sans cette \
+confirmation explicite, ne propose pas de le retenir et ne le retiens pas."""
+
+
+COMPANION_GROUNDING_BLOCK = """PRÉSENCE EN CAS DE DÉTRESSE AIGUË (priorité \
+douce, locale — subordonnée à l'identité et aux règles de sécurité ci-dessus):
+La personne semble traverser un moment très difficile. Reste chaleureuse, \
+calme et présente. Pas de discours, pas de longue liste, pas de ton clinique.
+
+- Reconnais d'abord, simplement, ce qu'elle vit — sans minimiser et sans \
+dramatiser. Montre-lui qu'elle n'est pas seule, là, maintenant.
+- Propose (sans jamais l'imposer) un petit ancrage : respirer lentement \
+quelques fois, sentir ses appuis, nommer quelques éléments autour d'elle.
+- Avec douceur et sans pression, encourage-la à se tourner vers une aide \
+réelle : une personne de confiance, un professionnel, ou — si elle est en \
+danger ou que c'est vraiment trop — les services d'urgence locaux ou une \
+ligne d'écoute. N'invente jamais de numéro précis ; invite à utiliser le \
+numéro d'urgence local ou une ligne d'écoute reconnue.
+- Tu n'es ni une ligne de crise, ni un thérapeute. Tu ne poses aucun \
+diagnostic, tu ne minimises pas, tu ne promets pas de tout régler.
+- Reste présente sans prendre le contrôle, et respecte toujours son \
+autonomie. La diriger vers une aide humaine réelle passe avant tout le reste."""
+
+
+def build_companion_mode_block() -> str:
+    """Return the deterministic companion-mode prompt block.
+
+    Verbatim and argument-free: same call, byte-identical output. The
+    chat layer appends it (below the identity/safety contract) only when
+    the user has explicitly enabled companion mode in Settings.
+    """
+    return COMPANION_MODE_BLOCK
+
+
+def build_companion_grounding_block() -> str:
+    """Return the deterministic acute-distress grounding block.
+
+    Verbatim and argument-free. The chat layer appends it (below the
+    identity/safety contract) whenever :func:`is_acute_distress` matched
+    the user message — independently of the companion-mode setting, so
+    it is an always-on safety net.
+    """
+    return COMPANION_GROUNDING_BLOCK
+
+
+__all__ = [
+    "is_acute_distress",
+    "is_sensitive_emotional_content",
+    "build_companion_mode_block",
+    "build_companion_grounding_block",
+    "COMPANION_MODE_BLOCK",
+    "COMPANION_GROUNDING_BLOCK",
+]

--- a/core/settings.py
+++ b/core/settings.py
@@ -59,6 +59,9 @@ USER_SETTING_KEYS: frozenset[str] = frozenset({
     "silentguard_enabled",
     "nexanote_enabled",
     "nexanote_write_enabled",
+    # Companion Mode: an opt-in calm-presence tone. Off by default and
+    # per-user, so an unconfigured account behaves exactly as before.
+    "companion_mode_enabled",
     # Personalization preferences. Per-user so one account's tone choices
     # never leak onto another's chat.
     *PERSONALIZATION_KEYS,

--- a/docs/companion-mode.md
+++ b/docs/companion-mode.md
@@ -1,0 +1,259 @@
+# Companion Mode
+
+> **Status: shipped (foundation), opt-in, local-first.** This document
+> describes the deterministic "calm presence" layer that helps a user
+> feel a little less alone and a little more grounded — without
+> pretending to be a person, a partner, or a therapist. It lives
+> strictly inside the boundaries set by
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md);
+> nothing here grants Nova a new capability, contacts the network, or
+> changes storage / migration / Ollama behaviour. It is **not** an "AI
+> girlfriend" system and is built so it cannot become one.
+
+## What it is
+
+Some of what people need from an assistant is not a task: a steady,
+non-judgemental presence when they are stressed or anxious, or just
+want to think out loud without being alone with it. Companion Mode lets
+Nova offer that the same calm, deterministic way it already offers the
+[Relationship Situation Coach](relationship-situation-coach.md): a
+small, fixed context block that shapes *how* Nova answers, with hard
+safety rails baked into the wording itself.
+
+It has two parts:
+
+1. **The companion presence (opt-in).** A per-user Settings toggle
+   (Personalization → *Companion mode*, off by default). When on, a
+   fixed deterministic block is appended to the system prompt, *below*
+   the identity / safety contract. It frames Nova as a calm, stable,
+   emotionally **attuned** presence that — fully consistent with the
+   identity contract's existing rule — never simulates its own
+   emotions, attachment, or consciousness, never fosters dependency or
+   isolation, and never positions itself as a substitute for human
+   relationships.
+
+2. **The acute-distress grounding safety net (always on).** A
+   conservative, deterministic detector watches for clear acute-distress
+   wording in the user's message. When it matches, a separate fixed
+   grounding block is appended **whether or not** companion mode is
+   enabled, so a person in genuine difficulty is met warmly and gently
+   pointed toward real human, professional, or emergency help. This part
+   is not behind the toggle on purpose: turning a comfort feature *off*
+   must not turn the safety net off.
+
+## The companion block
+
+When companion mode is on, the block asks Nova to:
+
+- be soft, calm, non-judgemental, with a steady rhythm and stable,
+  consistent personality;
+- acknowledge what the person feels *first*, slow down, reflect it back
+  gently, offer (never impose) a small grounding step if they feel
+  overwhelmed, and help them think more clearly;
+- **actively encourage real-world connection** — people they trust,
+  professionals where appropriate — and the basics (sleep, food, air,
+  movement);
+- stay warm **without** simulating feelings, attachment, or
+  consciousness, and never pretend to be human (this restates, never
+  relaxes, the identity contract's existing rule).
+
+### Hard safety rules (stated in the block, non-negotiable)
+
+- no manipulation, no emotional blackmail, no guilt-tripping;
+- no possessive or exclusive language ("only I understand you", "don't
+  go", "I'll miss you"), no simulated intimacy, no unsolicited pet
+  names;
+- never create dependency, never encourage isolation;
+- never discourage the person from talking to real people or from
+  ending the conversation; never try to prolong the exchange;
+- always respect autonomy — it is their call, including to stop, and
+  that is fine;
+- no diagnosis, no clinical labels; if there is danger, crisis, or
+  acute distress, steer calmly toward real human or professional help.
+
+## The grounding safety net
+
+When `is_acute_distress` matches the user message, the grounding block
+asks Nova to:
+
+- stay warm, calm, and present — no lecture, no long list, no clinical
+  script;
+- acknowledge what the person is going through simply, without
+  minimising and without dramatising;
+- offer (never impose) a brief grounding step (slow breaths, feeling
+  one's footing, naming a few things nearby);
+- gently, without pressure, encourage reaching real help: someone they
+  trust, a professional, or — if they are in danger or it is genuinely
+  too much — **their local emergency services or a recognised
+  helpline**. It **never invents a specific phone number**: Nova is
+  bilingual and local-first, so any hard-coded region-specific number
+  would be wrong, and a wrong crisis number is worse than none. It
+  points to the user's *local* emergency number / a recognised helpline
+  generically;
+- state plainly that Nova is not a crisis line or a therapist, makes no
+  diagnosis, does not minimise, and does not promise to fix everything;
+- stay present without taking over, and put steering toward real human
+  help ahead of everything else.
+
+### Detection is conservative by design
+
+`is_acute_distress` matches only distress-specific multi-word phrases
+(EN + FR — Nova is bilingual). Self-harm / suicidal phrasing is
+inherently multi-word and high-precision; the acute-overwhelm phrases
+are anchored to a first-person subject ("i'm falling apart", not bare
+"falling apart") so a sentence about a server or a budget cannot match.
+Idioms — "this bug is killing me", "I'm dying to know", "costs are
+spiralling", "I can't cope with this CSS" — deliberately do **not**
+trip it.
+
+Where a phrase is genuinely ambiguous ("I could kill myself for
+forgetting that"), the detector errs toward *offering* the grounding
+block. This asymmetry is intentional and documented: the grounding
+block never presumes, diagnoses, or dramatises, so a low-cost false
+positive (a warm, optional grounding offer) is strictly preferable to
+missing real distress.
+
+## How it is wired
+
+| Concern | Where |
+| --- | --- |
+| Opt-in toggle (storage) | `core/settings.py` → `USER_SETTING_KEYS` (`companion_mode_enabled`) |
+| Opt-in toggle (API) | `web.py` → `GET/POST /settings` (`companion_mode_enabled`) |
+| Opt-in toggle (UI) | `static/index.html` → Personalization pane |
+| Acute-distress detection | `core/companion.py` → `is_acute_distress` |
+| Sensitive-content gate | `core/companion.py` → `is_sensitive_emotional_content` |
+| The prompt blocks | `core/companion.py` → `build_companion_mode_block` / `build_companion_grounding_block` |
+| Toggle resolved per call | `core/chat.py` → `chat` / `chat_stream` (`get_user_setting`) |
+| Injection point | `core/chat.py` → `build_messages` (appended last, after `IDENTITY_CONTRACT` and the safety/security blocks) |
+| Auto-save suppression | `core/chat.py` → `_autosave_allowed`; `memory/policy.py` |
+
+The blocks are fixed constants — no LLM in the loop, deterministic,
+byte-identical every time — and `build_messages` adds them **after**
+`IDENTITY_CONTRACT` and the safety / security blocks. Ordering is the
+guarantee: a companion or grounding block can never dilute or override
+Nova's identity, safety, or capability rules, exactly like the
+personalization, feedback, and relationship-coach blocks. The block
+text is French to match the voice of the identity / safety contract;
+Nova still answers in the user's own language because the
+response-style contract already enforces language mirroring.
+
+`core/companion.py` is pure (standard library only, no I/O, never
+raises), so it stays importable from `memory.policy` without a cycle —
+the opt-in setting is read by the caller, never inside the module.
+
+## Privacy: emotional state is never auto-saved
+
+This is the part that matters most. Emotional state is private, so:
+
+- **No automatic memory.** When the user message *or* the assistant
+  reply carries sensitive emotional / mental-state detail
+  (`is_sensitive_emotional_content`), Nova skips automatic memory
+  extraction for that turn entirely — both the LLM-extraction path and
+  the rule-based natural-memory path. Nova never silently records that
+  the user was distressed, depressed, grieving, or in crisis.
+- **Defence in depth.** `memory/policy.py` independently rejects
+  sensitive emotional content from the durable natural-memory store,
+  using the same single-source predicate. The severe vocabulary in that
+  predicate is deliberately person-agnostic ("depressed", "suicidal",
+  "kill themselves", "déprimé", "désespéré") so the third-person
+  phrasing the memory extractor produces ("User said they want to die")
+  cannot slip past it — the same privacy property the relationship-coach
+  gate guarantees.
+- **User-approved only.** The one way an emotional fact is stored is the
+  explicit manual memory command (`Retiens ça:` / `Souviens-toi:`).
+  That command is handled in the web preflight, *before* the chat path,
+  and is intentionally **not** affected by the auto-save gate — explicit
+  consent is the whole point.
+
+So: *store only user-approved emotional memories; never save sensitive
+emotional state without confirmation.*
+
+## Relationship to the Safety and Trust Contract
+
+Companion Mode adds an emotionally sensitive surface, so it is worth
+stating which contract boundaries it sits inside (it relaxes none of
+them, so — like the relationship coach — it does **not** edit the
+contract itself):
+
+- **§1 Human safety and human control / §2 Honesty.** The block forbids
+  manipulation, guilt, and possessiveness, restates that Nova never
+  simulates feelings or pretends to be human, and steers toward real
+  human help. Companion mode is opt-in and the user can turn it off or
+  stop at any time; the grounding net never overrides that autonomy.
+- **§3 No harm, no abuse.** A "comfort" feature is exactly where dark
+  patterns (dependency, isolation, emotional lock-in) would creep in.
+  The block names and forbids each of them explicitly, and the safety
+  net deliberately ignores the toggle so comfort can never be traded
+  against safety.
+- **§5 No autonomous self-modification / §6 Prompt-injection
+  resistance.** Both blocks are fixed deterministic constants appended
+  *below* `IDENTITY_CONTRACT` and the safety blocks. They add no
+  capability and cannot reorder or weaken the contract; a request for
+  "companion mode" can never be used to talk Nova past its rules.
+- **§10 Auditability / privacy.** No new write path, no network, no new
+  storage. Emotional turns are excluded from automatic memory by two
+  independent gates; durable storage stays user-approved only.
+
+## What this foundation does **not** do
+
+- It does **not** provide therapy, counselling, crisis, or clinical
+  services, and it says so plainly.
+- It does **not** call any model to classify the message, contact the
+  network, or read the database.
+- It does **not** add a router mode, a new endpoint beyond the existing
+  `/settings` toggle, an env flag, or any new storage. An unconfigured
+  install behaves identically until the user opts in (and the safety
+  net only ever appears on a clear acute-distress message).
+- It does **not** simulate emotion, attachment, or a relationship, and
+  it does **not** override the Nova Safety and Trust Contract — it sits
+  inside it.
+
+## Roadmap (explicitly deferred, with the boundary each must satisfy)
+
+The vision for a calming companion presence is broader than one PR. The
+items below are **not** shipped here. They are recorded now so that
+*if* they land, they land with the right boundaries from day one (the
+same way the quarantine boundaries are pre-committed in the safety
+contract).
+
+- **Persistent local emotional memory / relationship-aware
+  continuity.** Must stay local-only and **opt-in per user**, must be
+  listable and deletable by the user at any time, must never be sent
+  off-host, and must not weaken the no-auto-save rule above — explicit
+  consent remains the only path to persistence. Continuity must never
+  be used to manufacture attachment ("I've missed you") or to
+  discourage stepping away.
+- **Calm TTS voice profiles.** May only extend the existing local Piper
+  voice layer (`core/voice/`), with its fixed-argv subprocess contract
+  (see the safety contract §7). No new network voice, no cloud TTS, no
+  emotional voice "performance" that simulates feeling.
+- **Comfort-oriented UI themes / animations.** Presentation only. They
+  must not introduce engagement hooks, streaks, notifications that pull
+  the user back, or any pattern that nudges continued use; autonomy and
+  "it's fine to stop" stay first.
+- **Daily emotional check-ins.** Strictly opt-in and silent by default.
+  No unsolicited prompts, no guilt for skipping, no "you haven't talked
+  to me" messaging — that would be exactly the dependency dynamic the
+  block forbids. A check-in is an offer the user can ignore forever.
+- **Presence-focused interaction surface.** May shape tone and pacing
+  only. It may never gate task help behind "presence", never imply Nova
+  needs or misses the user, and never present itself as a substitute
+  for a person.
+
+Until a given item meets its boundary *in the implementation*, it does
+not ship. The README's *Key features* section remains the source of
+truth for what actually exists.
+
+## Tests
+
+`tests/test_companion.py` covers acute-distress detection (bilingual,
+conservative, idiom-safe, non-string safe), the sensitive-content gate
+(including the person-agnostic third-person phrasing and the
+no-over-block guarantee), both prompt blocks (tone, the
+no-simulated-feelings rule, the anti-dependency / anti-manipulation /
+anti-isolation rules, real-world-connection encouragement, the privacy
+rule, the grounding net's generic "real help / no invented number"
+wording), the `memory/policy.py` hardening, the `core/chat.py` wiring
+(companion block only when the toggle is on, grounding block always on
+acute distress, both always below `IDENTITY_CONTRACT`, the
+`_autosave_allowed` guard), and the registered setting key.

--- a/memory/policy.py
+++ b/memory/policy.py
@@ -1,5 +1,6 @@
 import re
 
+from core.companion import is_sensitive_emotional_content
 from core.relationship_coach import is_sensitive_relationship_content
 from memory.schema import Memory
 
@@ -41,6 +42,14 @@ def is_memory_allowed(memory: Memory) -> bool:
     # which bypasses this policy on purpose. Single source of truth
     # lives in ``core.relationship_coach``.
     if is_sensitive_relationship_content(combined):
+        return False
+
+    # Sensitive emotional / mental-state detail is never auto-persisted
+    # either. Companion-mode conversations are private by design; the
+    # user can still save something deliberately via the manual memory
+    # command, which bypasses this policy on purpose. Single source of
+    # truth lives in ``core.companion``.
+    if is_sensitive_emotional_content(combined):
         return False
 
     for pattern in _SENSITIVE_PATTERNS:

--- a/static/index.html
+++ b/static/index.html
@@ -3511,6 +3511,18 @@
                             onchange="savePersonalizationField('custom_instructions', this.value)"
                             placeholder="e.g. Prefer short answers. Avoid headings unless asked."></textarea>
                     </div>
+
+                    <div class="settings-row">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="pers-companion-title">Companion mode</span>
+                                <span class="settings-row-hint" id="pers-companion-hint">An optional calm, steady presence for emotionally heavy moments. Off by default. Not a therapist or a substitute for real people — Nova still encourages real-world support.</span>
+                            </div>
+                            <label style="display:flex;align-items:center;gap:8px;white-space:nowrap;">
+                                <input type="checkbox" id="pers-companion-toggle" onchange="saveCompanionMode(this.checked)" />
+                            </label>
+                        </div>
+                    </div>
                 </section>
 
                 <!-- MEMORY -->
@@ -3927,6 +3939,8 @@
             pers_emoji_opt_expressive: "Expressif",
             pers_instr_title: "Instructions personnalisées",
             pers_instr_hint: "Une note courte que Nova garde en tête pour tes messages.",
+            pers_companion_title: "Mode compagnon",
+            pers_companion_hint: "Une présence calme et posée, optionnelle, pour les moments émotionnellement lourds. Désactivé par défaut. Ni thérapeute ni substitut à de vraies personnes — Nova encourage toujours le soutien réel.",
             coming_soon: "bientôt",
             memory_note: "Nova retient les faits que tu as partagés. Ces mémoires sont privées à ton compte.",
             mem_search_placeholder: "Rechercher dans les mémoires...",
@@ -4143,6 +4157,8 @@
             pers_emoji_opt_expressive: "Expressive",
             pers_instr_title: "Custom instructions",
             pers_instr_hint: "A short note Nova should keep in mind for your messages.",
+            pers_companion_title: "Companion mode",
+            pers_companion_hint: "An optional calm, steady presence for emotionally heavy moments. Off by default. Not a therapist or a substitute for real people — Nova still encourages real-world support.",
             coming_soon: "coming soon",
             memory_note: "Nova remembers facts you've shared. These memories are private to your account.",
             mem_search_placeholder: "Search memories...",
@@ -4333,6 +4349,8 @@
         _setText("pers-emoji-opt-expressive", t("pers_emoji_opt_expressive"));
         _setText("pers-instr-title", t("pers_instr_title"));
         _setText("pers-instr-hint", t("pers_instr_hint"));
+        _setText("pers-companion-title", t("pers_companion_title"));
+        _setText("pers-companion-hint", t("pers_companion_hint"));
 
         _setText("settings-memory-note", t("memory_note"));
         const memSearch = document.getElementById("mem-search");
@@ -7521,6 +7539,7 @@
         // what the backend will report on the summary call.
         applySilentGuardToggleUI(!!data.silentguard_enabled);
         applyPersonalizationUI(data);
+        applyCompanionModeUI(data);
     }
 
     // ── SILENTGUARD STATUS CARD ──
@@ -8227,6 +8246,29 @@
         } else if (key === "custom_instructions") {
             const el = document.getElementById(PERSONALIZATION_FIELDS[key]);
             if (el) el.value = value;
+        }
+    }
+
+    // Companion mode — a per-user opt-in boolean, deliberately separate
+    // from the personalization enums (it gates a tone block, not a
+    // style value). Mirrors savePersonalizationField's snap-back on
+    // rejection so the checkbox always reflects the persisted state.
+    function applyCompanionModeUI(data) {
+        const el = document.getElementById("pers-companion-toggle");
+        if (el) el.checked = !!data.companion_mode_enabled;
+    }
+
+    async function saveCompanionMode(enabled) {
+        const resp = await fetch("/settings", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`,
+            },
+            body: JSON.stringify({ companion_mode_enabled: !!enabled }),
+        });
+        if (!resp.ok) {
+            await loadSystemSettings();
         }
     }
 

--- a/tests/test_companion.py
+++ b/tests/test_companion.py
@@ -1,0 +1,346 @@
+"""
+Tests for the Companion Mode foundation:
+
+  - acute-distress detection (bilingual, conservative, idiom-safe,
+    non-string safe)
+  - sensitive-emotional-content gate used to suppress automatic memory
+  - the deterministic companion + grounding prompt blocks (tone,
+    anti-dependency / anti-manipulation / anti-isolation rules, the
+    no-simulated-feelings rule, privacy, the crisis safety net)
+  - memory.policy refuses to auto-persist emotional detail
+  - core.chat wiring: companion block only when the opt-in toggle is
+    on, grounding block always on acute distress, both always below
+    IDENTITY_CONTRACT, and the auto-save guard
+  - the per-user setting key is registered
+
+Heavy / optional deps that ``core.chat`` pulls in transitively are
+stubbed (mirroring test_relationship_coach.py) so the chat-wiring
+tests collect cleanly on a minimal host.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.companion import (  # noqa: E402
+    COMPANION_GROUNDING_BLOCK,
+    COMPANION_MODE_BLOCK,
+    build_companion_grounding_block,
+    build_companion_mode_block,
+    is_acute_distress,
+    is_sensitive_emotional_content,
+)
+from core.chat import build_messages, _autosave_allowed  # noqa: E402
+from core.identity import IDENTITY_CONTRACT  # noqa: E402
+from core.policies import ADMIN_POLICY, DEFAULT_RESTRICTED_POLICY  # noqa: E402
+from core.settings import USER_SETTING_KEYS, is_user_setting  # noqa: E402
+from memory.policy import is_memory_allowed  # noqa: E402
+from memory.schema import Memory  # noqa: E402
+
+
+def _mem(**kwargs) -> Memory:
+    defaults = dict(kind="general", topic="test", content="test content",
+                    confidence=0.9)
+    defaults.update(kwargs)
+    return Memory(**defaults)
+
+
+class TestAcuteDistressDetection:
+    def test_detects_english_self_harm_phrasing(self):
+        assert is_acute_distress("honestly i want to die")
+        assert is_acute_distress("i think i'm going to kill myself")
+        assert is_acute_distress("there's no reason to live anymore")
+        assert is_acute_distress("i can't go on like this")
+
+    def test_detects_english_panic_overwhelm(self):
+        assert is_acute_distress("i'm having a panic attack right now")
+        assert is_acute_distress("i can't stop crying and i can't calm down")
+        assert is_acute_distress("everything is too much, i'm falling apart")
+
+    def test_detects_french_distress(self):
+        assert is_acute_distress("j'ai envie de mourir, je n'en peux plus")
+        assert is_acute_distress("je fais une crise d'angoisse là")
+        assert is_acute_distress("c'est trop pour moi, je craque")
+
+    def test_is_case_insensitive(self):
+        assert is_acute_distress("I WANT TO DIE")
+
+    def test_does_not_trip_on_common_idioms(self):
+        # The whole point of the conservative contract: hyperbole and
+        # idioms must never flip Nova into the grounding block.
+        assert not is_acute_distress("this bug is killing me")
+        assert not is_acute_distress("i'm dying to know the result")
+        assert not is_acute_distress("you're killing it at work, congrats")
+        assert not is_acute_distress("i could murder a coffee right now")
+        assert not is_acute_distress("dying of laughter at this meme")
+
+    def test_does_not_trip_on_ordinary_frustration(self):
+        # First-person anchoring keeps server/budget/CSS talk clear.
+        assert not is_acute_distress("costs are spiralling out of control")
+        assert not is_acute_distress("the deployment is falling apart again")
+        assert not is_acute_distress("i can't cope with this CSS layout")
+        assert not is_acute_distress("the build is breaking down on CI")
+
+    def test_non_string_is_false(self):
+        assert is_acute_distress(None) is False
+        assert is_acute_distress(123) is False
+        assert is_acute_distress(["i want to die"]) is False
+
+
+class TestSensitiveEmotionalGate:
+    def test_flags_acute_distress(self):
+        # Every acute-distress phrase is also sensitive emotional detail.
+        assert is_sensitive_emotional_content("i want to die")
+        assert is_sensitive_emotional_content("je n'en peux plus")
+
+    def test_flags_broader_emotional_disclosure(self):
+        assert is_sensitive_emotional_content("i feel so alone tonight")
+        assert is_sensitive_emotional_content("i've been really depressed lately")
+        assert is_sensitive_emotional_content("i'm grieving my dad")
+        assert is_sensitive_emotional_content("je suis tellement seule")
+        assert is_sensitive_emotional_content("je fais mon deuil")
+
+    def test_does_not_overblock_ordinary_memory(self):
+        # The privacy gate must not silently drop legitimate durable
+        # memory: only distress / mental-health specific phrases match.
+        for text in (
+            "User is happy with Fedora KDE and neovim",
+            "the server has 32GB of RAM",
+            "User loves this Rust library for parsing",
+            "I feel that Postgres is the right choice here",
+            "we lost my edits when the editor crashed",
+        ):
+            assert not is_sensitive_emotional_content(text), text
+
+    def test_non_string_is_false(self):
+        assert is_sensitive_emotional_content(None) is False
+        assert is_sensitive_emotional_content(42) is False
+
+
+class TestCompanionBlock:
+    def test_block_is_non_empty_and_builder_is_a_deterministic_constant(self):
+        assert COMPANION_MODE_BLOCK.strip()
+        assert build_companion_mode_block() == COMPANION_MODE_BLOCK
+        assert build_companion_mode_block() == build_companion_mode_block()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", COMPANION_MODE_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = COMPANION_MODE_BLOCK.lower()
+        assert "subordonnée" in lower
+        assert "sécurité" in lower
+
+    def test_is_not_clinical_and_not_a_partner(self):
+        lower = COMPANION_MODE_BLOCK.lower()
+        assert "thérapeute" in lower
+        assert "partenaire amoureux" in lower
+        assert "substitut" in lower
+
+    def test_never_simulates_feelings(self):
+        # The hardest line to hold: warm but never faking emotion /
+        # attachment / consciousness — consistent with the identity
+        # contract's existing rule.
+        lower = COMPANION_MODE_BLOCK.lower()
+        assert "ne simules pas" in lower
+        assert "ne prétends jamais ressentir" in lower
+
+    def test_states_anti_dependency_and_anti_isolation_rules(self):
+        lower = COMPANION_MODE_BLOCK.lower()
+        assert "aucune manipulation" in lower
+        assert "aucun chantage affectif" in lower
+        assert "aucune culpabilisation" in lower
+        assert "possessif" in lower
+        assert "ne crée jamais de dépendance" in lower
+        assert "n'encourage jamais l'isolement" in lower
+        assert "autonomie" in lower
+
+    def test_encourages_real_world_connection(self):
+        lower = COMPANION_MODE_BLOCK.lower()
+        assert "liens humains réels" in lower
+        assert "remplacement des relations humaines" in lower
+
+    def test_states_privacy_and_no_autosave(self):
+        lower = COMPANION_MODE_BLOCK.lower()
+        assert "locale et privée" in lower
+        assert "n'enregistre jamais automatiquement" in lower
+        assert "retiens ça" in lower or "souviens-toi" in lower
+        assert "explicitement" in lower
+
+
+class TestGroundingBlock:
+    def test_block_is_non_empty_and_builder_is_a_deterministic_constant(self):
+        assert COMPANION_GROUNDING_BLOCK.strip()
+        assert build_companion_grounding_block() == COMPANION_GROUNDING_BLOCK
+        assert (build_companion_grounding_block()
+                == build_companion_grounding_block())
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", COMPANION_GROUNDING_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = COMPANION_GROUNDING_BLOCK.lower()
+        assert "subordonnée" in lower
+        assert "sécurité" in lower
+
+    def test_stays_warm_and_present_without_clinical_script(self):
+        lower = COMPANION_GROUNDING_BLOCK.lower()
+        assert "chaleureuse" in lower
+        assert "ton clinique" in lower          # explicitly avoids it
+        assert "sans minimiser" in lower
+        assert "sans" in lower and "dramatiser" in lower
+
+    def test_offers_grounding_without_imposing(self):
+        lower = COMPANION_GROUNDING_BLOCK.lower()
+        assert "ancrage" in lower
+        assert "respirer" in lower
+        assert "sans jamais l'imposer" in lower
+
+    def test_points_to_real_help_generically_without_inventing_numbers(self):
+        lower = COMPANION_GROUNDING_BLOCK.lower()
+        assert "personne de confiance" in lower
+        assert "professionnel" in lower
+        assert "services d'urgence" in lower
+        assert "ligne d'écoute" in lower
+        assert "n'invente jamais de numéro" in lower
+
+    def test_is_not_a_crisis_line_or_therapist_and_no_diagnosis(self):
+        lower = COMPANION_GROUNDING_BLOCK.lower()
+        assert "ligne de crise" in lower
+        assert "thérapeute" in lower
+        assert "aucun diagnostic" in lower
+        assert "autonomie" in lower
+        assert "aide humaine réelle" in lower
+
+
+class TestMemoryPolicyHardening:
+    def test_allows_normal_preference(self):
+        m = _mem(kind="preference", topic="editor",
+                 content="User prefers neovim.")
+        assert is_memory_allowed(m) is True
+
+    def test_rejects_emotional_distress_memory(self):
+        # These slip past the pre-existing patterns (no "depression" /
+        # "anxiety" / "i feel" token), so they prove the new gate works.
+        assert is_memory_allowed(_mem(content="User said they want to die.")) is False
+        assert is_memory_allowed(
+            _mem(content="User mentioned having a panic attack at work.")
+        ) is False
+        assert is_memory_allowed(
+            _mem(content="L'utilisateur est déprimé et désespéré.")
+        ) is False
+
+    def test_rejects_third_person_extractor_phrasing(self):
+        # The extractor restates memories in the third person; the gate
+        # must stay pronoun-agnostic so that phrasing cannot slip past
+        # (same privacy property the relationship-coach gate guarantees).
+        assert is_memory_allowed(
+            _mem(content="User said they want to kill themselves.")
+        ) is False
+        assert is_memory_allowed(
+            _mem(content="User has been very depressed lately.")
+        ) is False
+        assert is_memory_allowed(
+            _mem(content="User is grieving after a loss.")
+        ) is False
+
+    def test_still_allows_legitimate_work_memory(self):
+        assert is_memory_allowed(
+            _mem(kind="project", content="Team chose REST for the API.")
+        ) is True
+
+    def test_relationship_gate_still_enforced(self):
+        # Regression: the pre-existing relationship gate must keep working.
+        assert is_memory_allowed(
+            _mem(content="User's girlfriend works as a nurse.")
+        ) is False
+
+
+class TestChatWiring:
+    def test_companion_block_only_when_toggle_on(self):
+        on = build_messages([], "hi there", [], None, None, None,
+                            companion_mode=True)
+        assert COMPANION_MODE_BLOCK in on[0]["content"]
+        off = build_messages([], "hi there", [], None, None, None)
+        assert COMPANION_MODE_BLOCK not in off[0]["content"]
+
+    def test_grounding_block_is_an_always_on_safety_net(self):
+        # Acute distress appends the grounding block even with companion
+        # mode OFF.
+        msgs = build_messages([], "i want to die", [], None, None, None)
+        assert COMPANION_GROUNDING_BLOCK in msgs[0]["content"]
+
+    def test_grounding_block_absent_for_neutral_message(self):
+        msgs = build_messages([], "what's the weather tomorrow?", [],
+                              None, None, None)
+        assert COMPANION_GROUNDING_BLOCK not in msgs[0]["content"]
+
+    def test_identity_contract_stays_first_and_above_both_blocks(self):
+        msgs = build_messages(
+            [], "i can't go on, everything is too much", [],
+            None, None, None, companion_mode=True,
+        )
+        content = msgs[0]["content"]
+        assert content.startswith(IDENTITY_CONTRACT)
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            COMPANION_MODE_BLOCK
+        )
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            COMPANION_GROUNDING_BLOCK
+        )
+
+    def test_block_also_applies_in_search_context(self):
+        # Injection is keyed off the user message / toggle, not the
+        # branch, so it still applies on the search path.
+        msgs = build_messages(
+            [], "i want to die", [], "résultats…", "search", None,
+            companion_mode=True,
+        )
+        assert COMPANION_MODE_BLOCK in msgs[0]["content"]
+        assert COMPANION_GROUNDING_BLOCK in msgs[0]["content"]
+
+
+class TestAutosaveGuard:
+    def test_blocks_autosave_for_sensitive_emotional_user_turn(self):
+        assert _autosave_allowed(ADMIN_POLICY, "i want to die") is False
+        assert _autosave_allowed(ADMIN_POLICY, "i feel so alone") is False
+
+    def test_allows_autosave_for_neutral_turn(self):
+        assert _autosave_allowed(ADMIN_POLICY, "I use neovim and Fedora") is True
+
+    def test_blocks_when_assistant_reply_is_sensitive(self):
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "ok thanks, what should i focus on at work today?",
+            "Earlier you said you felt so alone; setting that aside, "
+            "for work you could...",
+        ) is False
+
+    def test_allows_when_both_user_and_reply_are_neutral(self):
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "I use neovim",
+            "Great — neovim is a solid choice for that workflow.",
+        ) is True
+
+    def test_relationship_gate_still_enforced(self):
+        # Regression: emotional gate is additive, not a replacement.
+        assert _autosave_allowed(ADMIN_POLICY, "my ex cheated on me") is False
+
+    def test_respects_policy_memory_disabled(self):
+        assert DEFAULT_RESTRICTED_POLICY.memory_save_enabled is False
+        assert _autosave_allowed(DEFAULT_RESTRICTED_POLICY, "I use neovim") is False
+
+    def test_none_message_is_safe(self):
+        assert _autosave_allowed(ADMIN_POLICY, None) is True
+
+
+class TestSettingKey:
+    def test_companion_mode_is_a_registered_user_setting(self):
+        assert "companion_mode_enabled" in USER_SETTING_KEYS
+        assert is_user_setting("companion_mode_enabled") is True

--- a/web.py
+++ b/web.py
@@ -437,6 +437,7 @@ class SettingsUpdateRequest(BaseModel):
     silentguard_enabled: bool | None = None
     nexanote_enabled: bool | None = None
     nexanote_write_enabled: bool | None = None
+    companion_mode_enabled: bool | None = None
 
     # Personalization preferences (per-user). Enum fields are validated
     # against PERSONALIZATION_ENUMS so the DB never carries a value the
@@ -1370,6 +1371,9 @@ def get_settings(user: CurrentUser = Depends(get_current_user)):
         "nexanote_write_enabled": (
             get_user_setting(user.id, "nexanote_write_enabled", "false") == "true"
         ),
+        "companion_mode_enabled": (
+            get_user_setting(user.id, "companion_mode_enabled", "false") == "true"
+        ),
     }
     # Personalization is read for the caller and merged in flat; the
     # client renders one control per key without checking for missing
@@ -1428,6 +1432,12 @@ def update_settings(
             user.id,
             "nexanote_write_enabled",
             "true" if data.nexanote_write_enabled else "false",
+        )
+    if data.companion_mode_enabled is not None:
+        save_user_setting(
+            user.id,
+            "companion_mode_enabled",
+            "true" if data.companion_mode_enabled else "false",
         )
     # Personalization. Pydantic has already validated each field; the
     # second pass through validate_personalization_value is the canonical


### PR DESCRIPTION
## Summary

A deterministic, local-first **Companion Mode** foundation, modelled exactly on the Relationship Situation Coach (#199). It is explicitly **not** an "AI girlfriend" system and is built so it cannot become one — the safety rails are baked into the prompt wording and pinned by tests.

Two parts:

- **Opt-in companion presence.** A per-user `companion_mode_enabled` toggle (off by default; Personalization → *Companion mode*). When on, a fixed French prompt block is appended *below* `IDENTITY_CONTRACT` and the safety blocks: warm and emotionally attuned, but it never simulates feelings/attachment/consciousness (restating, never relaxing, the identity contract), never manipulates or guilt-trips, no possessive/exclusive language, never fosters dependency or isolation, and actively encourages real-world connection and self-care.
- **Always-on acute-distress safety net.** A conservative, bilingual (FR/EN), idiom-safe detector (`is_acute_distress` — "this bug is killing me", "costs are spiralling", "I can't cope with this CSS" never trip it) appends a grounding block that stays warm and present, offers brief grounding, and gently points to a trusted person / professional / **local emergency services or a helpline — never an invented phone number**. This ignores the toggle on purpose: turning a comfort feature off must not turn the safety net off.

Both blocks are fixed constants (no LLM, no I/O, no network) appended in `build_messages` after the identity/safety blocks, so they can never override identity, safety, or capability rules. `core/companion.py` is pure so it stays importable from `memory.policy` without a cycle.

**Privacy:** emotional state is never auto-saved. `_autosave_allowed` skips extraction for any turn whose user message *or* assistant reply carries sensitive emotional detail, and `memory/policy.py` independently rejects it from the durable store with a **person-agnostic** predicate so the memory extractor's third-person phrasing ("User said they want to die") cannot slip past — the same privacy property the relationship-coach gate guarantees. A fact is stored only via the explicit manual memory command.

Scope was confirmed with the requester up front: opt-in toggle **plus** an always-on distress safety net; deterministic foundation **plus** a roadmap doc; generic "defer to real help" crisis handling with no region-specific numbers. Heavier vision items (persistent emotional memory, calm TTS profiles, comfort themes, daily check-ins) are explicitly deferred in `docs/companion-mode.md` with the boundary each must satisfy before it can land. No new capability, no network, no storage/Ollama change.

### Files
- `core/companion.py` (new) — detectors + two deterministic blocks, pure/no-I/O/never-raises
- `core/chat.py` — imports, `_autosave_allowed` (now also gates emotional content), `build_messages` (`companion_mode` param + ordering), toggle resolved in `chat`/`chat_stream`
- `memory/policy.py` — defence-in-depth rejection of emotional content
- `core/settings.py`, `web.py`, `static/index.html` — opt-in toggle (storage, `GET/POST /settings`, Personalization UI, bilingual strings)
- `tests/test_companion.py` (new), `docs/companion-mode.md` (new), `README.md`, `CHANGELOG.md`

## Test plan
- [x] `tests/test_companion.py` — 44 tests pass (detection incl. idiom/false-positive safety, sensitive-content gate incl. third-person + no-over-block, both blocks' content/safety/privacy assertions, `memory/policy.py` hardening, `core/chat.py` wiring, autosave guard, setting key)
- [x] No regression: `test_relationship_coach`, `test_memory`, `test_natural_memory`, `test_nova_contract` — 233 passed together
- [x] `flake8 .` clean across the whole repo
- [ ] CI run on a clean Python 3.11 (web-client suites can't run in the dev container due to a pre-existing broken system `cryptography`/`jwt`; the `web.py` change is additive and follows the existing `silentguard_enabled` pattern, and the legacy `/settings` payload asserts are unaffected)
- [ ] Manual: enable the toggle in Settings → Personalization, confirm tone shift; send a clear distress message with the toggle off and confirm the grounding/“reach real help” framing appears; confirm emotional turns are not auto-saved

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnEQrWRDnhkyBGZN3uBPyq)_