### PR TITLE
feat(dev-workspace): add patch-proposal preview UI + binary refusal (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,60 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Dev Workspace Phase 2 — patch proposal preview surface (review-only):
+  the Dev Workspace panel (`⎇`) gains a "Patch proposal preview"
+  section that appears whenever a project's linked repo is in the
+  `ready` state. Paste a structured proposal as JSON, click
+  **Preview proposal**, and the panel renders the validated reply
+  side by side — title, one-line summary, implementation plan,
+  affected files (action badge + `+/−` line counts), the proposed
+  unified diff in a scrollable code block, suggested tests, warnings,
+  and the standing safety notes — followed by **Copy patch** and
+  **Copy test plan** clipboard helpers. There is intentionally no
+  "Apply" button, no commit / push / branch affordance, and no
+  persistence: the preview is a strict, transient, client-side
+  rendering of the calm `PatchProposal` dict returned by the backend.
+  Every dynamic value (diff lines, file paths, plan steps, the title
+  itself) is written via `textContent`, never `innerHTML`, so a
+  proposal that happens to contain HTML metacharacters cannot inject
+  markup. Bilingual labels (FR/EN) match the rest of the Dev Workspace
+  UI.
+- Dev Workspace Phase 2 — `PatchProposal` gains optional `title`,
+  transient `id` (random UUID), and UTC `created_at` ISO timestamp so
+  a review UI can pin a preview to the exact build it is rendering;
+  `warnings` is accepted as a synonym for `risks` on input and is
+  mirrored on output, matching both the Phase 2 spec wording and the
+  original endpoint shape. The title is collapsed to a single safe
+  line and length-capped (`_MAX_PROPOSAL_TITLE_CHARS = 120`); none of
+  these additions are persisted (Phase 2 stays transient).
+- Dev Workspace Phase 2 — binary patch rejection: any change whose
+  `old_content` or `new_content` contains a NUL byte (the cheapest
+  reliable text-vs-binary signal, the same heuristic `git` uses to
+  flag a file as "Binary") fails validation with `PatchProposalError`
+  ("binary content is not supported for <path>"). Pure text patches,
+  including emoji / CJK / RTL content, are unaffected; reviewing
+  binary changes is deliberately deferred to a later phase.
+- Dev Workspace Phase 2 — spec-suggested validate endpoint alias:
+  `POST /projects/{id}/patch-proposals/validate` shares the same body,
+  per-project / per-user scope, and response as
+  `POST /projects/{id}/repo/patch-proposal`. The URL's `.../validate`
+  ending makes the "we are only validating, nothing is applied"
+  intent explicit; both endpoints route through one shared
+  `_build_patch_proposal_response` helper so they cannot drift.
+  Foreign project → `404`, no linked repo → `400`, invalid
+  proposal/path/binary → `400`, extra body field → `422`, missing
+  auth → `401`. Regression tests cover all of these paths plus
+  end-to-end title / warnings handling.
+- `docs/dev-workspace.md` documents the new fields (`title`, `id`,
+  `created_at`), the binary-content refusal, the validate-endpoint
+  alias, and the patch-proposal preview surface inside the Dev
+  Workspace panel; the safety-boundaries section adds the "no Apply
+  affordance in the UI" guarantee. The Phase 2 roadmap entry is
+  rewritten to reflect the shipped UI surface and the new endpoint
+  path. Phase 2 still grants Nova **no** power to write files,
+  commit, push, or branch.
+
 ### Fixed
 - Streaming chat no longer surfaces "Nova didn't produce a reply." for
   every prompt. The chunk extractor used to filter Ollama events with

--- a/core/dev_workspace.py
+++ b/core/dev_workspace.py
@@ -55,13 +55,15 @@ functions here and keep them user-scoped.
 Phase 2 — **patch proposal mode** — is also implemented here (see the
 "Patch proposal" section near the bottom). It is a *pure* transform: it
 turns a structured, model-produced change description into a validated,
-review-only :class:`PatchProposal` (plan, likely files, a unified-diff
-preview, suggested tests, a risk checklist). It performs **no** git
+review-only :class:`PatchProposal` (title, summary, plan, likely files,
+a unified-diff preview, suggested tests, a risk/warning checklist, plus
+a transient ``id`` + UTC ``created_at`` stamp). It performs **no** git
 calls, **no** file writes, and **no** subprocess work — it never
 applies, stages, commits, pushes, or branches anything. Every proposed
 path is validated to be repo-relative, traversal-free, non-secret, and
-contained inside the linked repo. Applying a reviewed patch is a
-deliberately separate, later phase.
+contained inside the linked repo, and any file whose content carries a
+NUL byte is refused as binary (no readable text diff possible).
+Applying a reviewed patch is a deliberately separate, later phase.
 
 See ``docs/dev-workspace.md`` for the operator walkthrough, the
 explicit non-goals, and the Phase 2-6 roadmap.
@@ -74,7 +76,9 @@ import logging
 import os
 import shutil
 import subprocess
+import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Optional, Sequence
 
@@ -614,6 +618,10 @@ def read_status(
 #     secret/private file (``.env``, ``*.db``/``nova.db``, SSH keys,
 #     tokens, credentials, logs, backups, exports, ``.git`` internals,
 #     …), and contained inside the validated linked repo.
+#   * Binary blobs are refused outright (a NUL byte in either
+#     ``old_content`` or ``new_content`` means the file is not text and
+#     has no useful unified-diff preview); reviewing binary changes is a
+#     deliberately later phase.
 #   * The diff is produced locally with :mod:`difflib` from the
 #     model-supplied before/after text — Nova does not read the working
 #     tree to build it, so a proposal cannot leak file contents the
@@ -621,6 +629,11 @@ def read_status(
 #     deliberately separate, later (apply) phase.
 #   * Every field is capped so a runaway model reply cannot balloon the
 #     payload, and the result restates that nothing was applied.
+#   * Each built proposal carries a transient ``id`` (random UUID) and a
+#     UTC ``created_at`` ISO timestamp so the review UI can pin a
+#     preview to the exact build it is looking at. No proposal is
+#     persisted in this phase — the values are recomputed on every
+#     call.
 
 
 class PatchProposalError(ValueError):
@@ -634,6 +647,7 @@ class PatchProposalError(ValueError):
 
 # Caps. A patch proposal is model-produced text; every list and blob is
 # bounded so a runaway reply cannot wedge a request or bloat the JSON.
+_MAX_PROPOSAL_TITLE_CHARS = 120
 _MAX_PROPOSAL_SUMMARY_CHARS = 300
 _MAX_PROPOSAL_PLAN_STEPS = 40
 _MAX_PROPOSAL_FILES = 50
@@ -731,6 +745,18 @@ _PROPOSAL_SAFETY_NOTES = (
     "Review it, then apply it yourself. A later phase will add an "
     "explicit, per-patch approval step before anything is written.",
 )
+
+
+def _looks_binary(content: str) -> bool:
+    """True when ``content`` is not safe to preview as a text patch.
+
+    A real text source file never contains a NUL byte, so a NUL is the
+    cheapest, most reliable binary signal — and the same heuristic git
+    itself uses to flag a file as "Binary". The diff preview is pure
+    text, so a binary blob is refused outright in this phase rather than
+    surfacing a broken or huge diff. Empty content is trivially text.
+    """
+    return "\x00" in content
 
 
 def _is_secret_path(rel_posix: str) -> bool:
@@ -875,26 +901,42 @@ class PatchProposal:
     checklist. Nothing here has been applied; ``as_dict`` always reports
     ``review_only`` / ``applied`` and the standing safety notes so the
     contract travels with the data.
+
+    ``id`` and ``created_at`` are transient metadata stamped when the
+    proposal is built (random UUID + UTC ISO timestamp). No proposal is
+    persisted in this phase — these fields exist so the UI can keep the
+    preview pinned to a specific build while the user reviews it. The
+    ``risks`` data is additionally surfaced as ``warnings`` in
+    :meth:`as_dict` so the JSON contract matches both the spec wording
+    and the existing Phase 2 endpoint.
     """
 
     repo_path: str
     summary: str = ""
+    title: str = ""
     plan: tuple[str, ...] = field(default_factory=tuple)
     files: tuple[ProposedFileChange, ...] = field(default_factory=tuple)
     suggested_tests: tuple[str, ...] = field(default_factory=tuple)
     risks: tuple[str, ...] = field(default_factory=tuple)
     diff_preview: str = ""
+    id: str = ""
+    created_at: str = ""
 
     def as_dict(self) -> dict:
+        risks = list(self.risks)
         return {
             "review_only": True,
             "applied": False,
+            "id": self.id,
+            "created_at": self.created_at,
             "repo_path": self.repo_path,
+            "title": self.title,
             "summary": self.summary,
             "plan": list(self.plan),
             "files": [f.as_dict() for f in self.files],
             "suggested_tests": list(self.suggested_tests),
-            "risks": list(self.risks),
+            "risks": risks,
+            "warnings": list(risks),
             "diff_preview": self.diff_preview,
             "safety": list(_PROPOSAL_SAFETY_NOTES),
         }
@@ -974,6 +1016,7 @@ def build_patch_proposal(
     ``proposal`` is the model's structured description::
 
         {
+          "title": "<short label>",
           "summary": "<one line>",
           "plan": ["step", ...],
           "changes": [
@@ -982,14 +1025,18 @@ def build_patch_proposal(
             ...
           ],
           "tests": ["pytest ...", ...],
-          "risks": ["touches auth", ...],
+          "risks": ["touches auth", ...],     # alias: "warnings"
         }
 
     Every change's path is validated by :func:`validate_proposed_path`
-    (repo-relative, no traversal, non-secret, inside the repo) and the
-    diff is computed locally. **Nothing is applied**; this never writes,
-    spawns a process, or touches git. Raises :class:`PatchProposalError`
-    (short, safe message) on any validation failure.
+    (repo-relative, no traversal, non-secret, inside the repo), a binary
+    blob (NUL-bearing content) is refused, and the diff is computed
+    locally. ``title`` is optional and collapsed to a single safe line;
+    ``warnings`` is accepted as a synonym for ``risks``. The built
+    proposal is stamped with a transient random ``id`` and UTC
+    ``created_at``. **Nothing is applied**; this never writes, spawns a
+    process, or touches git. Raises :class:`PatchProposalError` (short,
+    safe message) on any validation failure.
     """
     try:
         resolved = validate_repo_path(repo_path, roots=roots)
@@ -1001,6 +1048,12 @@ def build_patch_proposal(
     if not isinstance(proposal, dict):
         raise PatchProposalError("patch proposal must be an object")
 
+    title_raw = proposal.get("title") or ""
+    if not isinstance(title_raw, str):
+        raise PatchProposalError("title must be a string")
+    # Collapse whitespace so the title stays a single safe line.
+    title = " ".join(title_raw.split())[:_MAX_PROPOSAL_TITLE_CHARS]
+
     summary_raw = proposal.get("summary") or ""
     if not isinstance(summary_raw, str):
         raise PatchProposalError("summary must be a string")
@@ -1009,7 +1062,13 @@ def build_patch_proposal(
 
     plan = _string_list(proposal.get("plan"), _MAX_PROPOSAL_PLAN_STEPS)
     tests = _string_list(proposal.get("tests"), _MAX_PROPOSAL_TESTS)
-    risks = _string_list(proposal.get("risks"), _MAX_PROPOSAL_RISKS)
+    # Accept ``risks`` and ``warnings`` interchangeably so a model that
+    # follows the spec wording lands in the same field as one that
+    # follows the Phase 2 endpoint shape; both are surfaced on output.
+    risks_raw = proposal.get("risks")
+    if risks_raw is None:
+        risks_raw = proposal.get("warnings")
+    risks = _string_list(risks_raw, _MAX_PROPOSAL_RISKS)
 
     raw_changes = proposal.get("changes")
     if not isinstance(raw_changes, (list, tuple)) or not raw_changes:
@@ -1038,6 +1097,13 @@ def build_patch_proposal(
         new = "" if (new is None or action == "delete") else new
         if not isinstance(old, str) or not isinstance(new, str):
             raise PatchProposalError("file content must be a string")
+        if _looks_binary(old) or _looks_binary(new):
+            # Binary patches are out of scope for the text preview: their
+            # diff would be unreadable or huge, and reviewing a binary
+            # change as text is unsafe. Refuse outright in this phase.
+            raise PatchProposalError(
+                f"binary content is not supported for {rel}"
+            )
         if (
             len(old) > _MAX_PROPOSAL_CONTENT_CHARS
             or len(new) > _MAX_PROPOSAL_CONTENT_CHARS
@@ -1086,10 +1152,13 @@ def build_patch_proposal(
 
     return PatchProposal(
         repo_path=str(resolved),
+        title=title,
         summary=summary,
         plan=plan,
         files=tuple(files),
         suggested_tests=tests,
         risks=risks,
         diff_preview="\n".join(preview_parts),
+        id=uuid.uuid4().hex,
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )

--- a/docs/dev-workspace.md
+++ b/docs/dev-workspace.md
@@ -51,22 +51,45 @@ structured change description from the model, the
 `core.dev_workspace.build_patch_proposal` helper returns a calm,
 validated, **review-only** object containing:
 
-- a short **summary** and an **implementation plan**,
-- the **files likely to change** (repo-relative paths),
+- an optional short **title** and a one-line **summary**,
+- an **implementation plan**,
+- the **files likely to change** (repo-relative paths) with a per-file
+  added / removed line count,
 - a **unified-diff preview** per file plus a combined preview,
 - **suggested tests**, and
-- a **risk checklist**.
+- a **risk / warning checklist**.
+
+Every built proposal additionally carries a transient `id` (random
+UUID) and a UTC `created_at` ISO timestamp so the review UI can pin a
+preview to the exact build it is rendering. **No proposal is stored**
+in this phase — the values are recomputed on every call, and there is
+no read-back endpoint.
 
 The diff is computed locally with Python's `difflib` from the
 before/after text the model supplies; Nova does not read your working
 tree to build it, so a proposal cannot surface file contents the model
-was not already given. The result always carries `review_only: true`,
-`applied: false`, and a fixed safety note restating that nothing was
-written. You review it and apply it yourself — an explicit,
-per-patch *apply* step is a deliberately separate, later phase.
+was not already given. **Binary content is refused**: any change whose
+`old_content` or `new_content` contains a NUL byte fails validation
+with a short reason — there is no readable text diff for a binary
+blob, and reviewing binary changes is a deliberately later phase. The
+result always carries `review_only: true`, `applied: false`, and a
+fixed safety note restating that nothing was written. You review it
+and apply it yourself — an explicit, per-patch *apply* step is a
+deliberately separate, later phase.
 
-It is reachable per linked project at
-`POST /projects/{id}/repo/patch-proposal`.
+A linked project surfaces a **Patch proposal preview** section inside
+the Dev Workspace panel (`⎇`) where you can paste a structured
+proposal, validate it through the same backend logic, and review the
+resulting title, summary, plan, affected files, diff, tests, and
+warnings side by side. Two buttons — **Copy patch** and
+**Copy test plan** — copy the combined unified diff and the suggested
+tests to your clipboard so you can apply them yourself in your editor
+or terminal. There is intentionally no "Apply" button in this phase.
+
+It is reachable per linked project at either
+`POST /projects/{id}/repo/patch-proposal` (the original Phase 2 path)
+or `POST /projects/{id}/patch-proposals/validate` (the spec-suggested
+"validate-only" alias). Both share the same body, scope, and response.
 
 ## What Phase 1 and Phase 2 deliberately do NOT do
 
@@ -136,11 +159,21 @@ These are enforced in `core/dev_workspace.py` and covered by
      `logs`, `.git`, `__pycache__`, `.venv`, `node_modules`);
    - the path must still resolve **inside** the linked repo (a
      symlinked subdir pointing outside it is refused);
+   - **binary content is refused** — any `old_content` /
+     `new_content` carrying a NUL byte fails validation, since there
+     is no readable text diff for a binary blob;
    - the diff is built locally with `difflib` from the model-supplied
      before/after text — **no git, no subprocess, no file I/O, no
      network**; nothing is applied, staged, committed, pushed, or
      branched, and every field is capped. The result restates
-     `review_only: true` / `applied: false`.
+     `review_only: true` / `applied: false`, and includes a transient
+     random `id` + UTC `created_at` so the UI can pin a preview to a
+     specific build (no proposal is persisted in this phase).
+8. **No "Apply" affordance in the UI.** The patch proposal preview
+   surface inside the Dev Workspace panel only renders the result and
+   offers **Copy patch** / **Copy test plan** clipboard helpers.
+   There is no button, endpoint, or code path in this phase that
+   could write the proposed diff to disk.
 
 The linked path **and any patch proposal** are **contextual data
 only** — they confer no write power. They are surfaced to the model
@@ -173,7 +206,8 @@ never touches the repository.
 | ------ | ---- | ------- |
 | `PUT` | `/projects/{id}/repo` | Body `{ "path": "<abs path>" \| null }`. A non-empty path is validated then stored (resolved); `null` / empty unlinks. Invalid path → `400` with a short reason; foreign project → `404`. |
 | `GET` | `/projects/{id}/repo/status` | `{ "linked": false }` when no repo; otherwise a calm read-only snapshot (`state`, `branch`, `clean`, `status_short`, `recent_commits`, `changed_files`, `diff_stat`, `detail`). Foreign project → `404`. |
-| `POST` | `/projects/{id}/repo/patch-proposal` | Body is the model's structured change description: `{ "summary"?, "plan"?: [str], "changes": [{ "path", "action"?: "modify"\|"add"\|"delete", "old_content"?, "new_content"? }], "tests"?: [str], "risks"?: [str] }`. Returns a **review-only** `PatchProposal` (`review_only`, `applied:false`, `summary`, `plan`, `files[].diff`, `diff_preview`, `suggested_tests`, `risks`, `safety`). Nothing is written. No linked repo → `400`; any invalid path / proposal → `400` with a short reason; foreign project → `404`; an extra body field → `422`. |
+| `POST` | `/projects/{id}/repo/patch-proposal` | Body is the model's structured change description: `{ "title"?, "summary"?, "plan"?: [str], "changes": [{ "path", "action"?: "modify"\|"add"\|"delete", "old_content"?, "new_content"? }], "tests"?: [str], "risks"?: [str], "warnings"?: [str] }`. Returns a **review-only** `PatchProposal` (`review_only`, `applied:false`, `id`, `created_at`, `title`, `summary`, `plan`, `files[].diff`, `diff_preview`, `suggested_tests`, `risks`, `warnings`, `safety`). Nothing is written. No linked repo → `400`; any invalid path / proposal → `400` with a short reason; foreign project → `404`; an extra body field → `422`. |
+| `POST` | `/projects/{id}/patch-proposals/validate` | Spec-suggested alias of the row above: same body, same per-project / per-user scope, same response. Naming the path `.../validate` makes the "we are only validating, nothing is applied" intent explicit at the URL level. |
 
 `GET /projects` and the other project endpoints additionally report
 `local_repo_path` and `has_local_repo` so the UI can show which
@@ -187,8 +221,14 @@ nothing below is enabled until its phase ships.
 - **Phase 1 — read-only Git context.** *Shipped.* Observe a linked
   repo's state; never modify it.
 - **Phase 2 — patch proposal mode.** *Shipped.* Nova may *propose* a
-  validated unified diff (plan, files, tests, risks); it is shown for
-  review only and **never applied** — no writes, no git, no process.
+  validated unified diff (title, summary, plan, files, tests,
+  warnings/risks, transient `id` + `created_at`); it is shown for
+  review only — backed by a Dev Workspace preview surface with
+  **Copy patch** / **Copy test plan** clipboard helpers, and reachable
+  at either `POST /projects/{id}/repo/patch-proposal` or
+  `POST /projects/{id}/patch-proposals/validate`. Binary content is
+  refused. Patches are **never applied** — no writes, no git, no
+  process, no persistence.
 - **Phase 3 — apply patch with approval.** *Not yet.* Apply a reviewed
   patch to the working tree only after an explicit, per-patch approval;
   still no commit / push / branch.

--- a/static/index.html
+++ b/static/index.html
@@ -491,6 +491,56 @@
             color: var(--text-dim); white-space: pre-wrap; word-break: break-all;
             max-height: 220px; overflow-y: auto;
         }
+        .repo-patch-section {
+            margin-top: 22px; padding-top: 16px;
+            border-top: 1px solid var(--border);
+        }
+        .repo-patch-input {
+            width: 100%; box-sizing: border-box; padding: 9px 12px;
+            background: rgba(255,255,255,0.025);
+            border: 1px solid var(--border); border-radius: 10px;
+            color: var(--text); font-size: 0.78rem; outline: none;
+            font-family: var(--mono, monospace); resize: vertical;
+            min-height: 110px;
+        }
+        .repo-patch-input:focus {
+            border-color: var(--cyan-glow); box-shadow: 0 0 0 3px var(--cyan-soft);
+        }
+        .repo-patch-result { margin-top: 16px; }
+        .repo-patch-badges {
+            display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 10px;
+        }
+        .repo-patch-badge {
+            display: inline-block; padding: 2px 10px; border-radius: 999px;
+            font-size: 0.7rem; font-weight: 600; letter-spacing: 0.02em;
+        }
+        .repo-patch-badge.review { color: var(--cyan-glow); background: var(--cyan-soft); }
+        .repo-patch-badge.applied { color: #7fe0a8; background: rgba(80,200,140,0.12); }
+        .repo-patch-text {
+            font-size: 0.82rem; color: var(--text); line-height: 1.45;
+            word-break: break-word;
+        }
+        .repo-patch-ol { list-style: decimal inside; }
+        .repo-patch-ol li { padding-left: 4px; }
+        .repo-patch-diff {
+            max-height: 320px; font-size: 0.72rem;
+            white-space: pre; word-break: normal; overflow-x: auto;
+        }
+        .repo-patch-warnings li { color: #f0c479; }
+        .repo-patch-file-action {
+            display: inline-block; margin-right: 8px; padding: 1px 7px;
+            border-radius: 6px; font-size: 0.66rem; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.04em;
+        }
+        .repo-patch-file-action.add { color: #7fe0a8; background: rgba(80,200,140,0.12); }
+        .repo-patch-file-action.modify { color: var(--cyan-glow); background: var(--cyan-soft); }
+        .repo-patch-file-action.delete { color: #f0a0a0; background: rgba(220,90,90,0.10); }
+        .repo-patch-file-stats {
+            margin-left: 8px; color: var(--text-dim); font-size: 0.7rem;
+        }
+        .repo-patch-actions {
+            display: flex; gap: 8px; margin-top: 14px; flex-wrap: wrap;
+        }
 
         .conv-group-header {
             font-size: 0.66rem;
@@ -3307,6 +3357,69 @@
                     <pre class="repo-pre" id="repo-diffstat-pre"></pre>
                 </div>
             </div>
+
+            <!-- ── PATCH PROPOSAL PREVIEW (Phase 2, review-only) ──
+                 Renders a validated PatchProposal returned by
+                 ``POST /projects/{id}/patch-proposals/validate``. The
+                 entire surface is review-only: no Apply button, no edit
+                 of the working tree, no commit/push. All dynamic text
+                 from the server (diffs, paths, plan steps) is written
+                 with textContent — never innerHTML — so a proposal can
+                 never inject markup. -->
+            <div id="patch-section" class="repo-patch-section" style="display:none;">
+                <div class="repo-block-title" id="patch-section-title">Patch proposal preview</div>
+                <p class="repo-note" id="patch-intro-text"></p>
+                <label class="repo-label" id="patch-input-label" for="patch-input">Proposal JSON</label>
+                <textarea id="patch-input" class="repo-patch-input" spellcheck="false" autocomplete="off" rows="6"></textarea>
+                <div class="repo-actions">
+                    <button id="patch-preview-btn" class="repo-btn repo-btn-primary" type="button" onclick="previewPatchProposal()">Preview proposal</button>
+                    <button id="patch-clear-btn" class="repo-btn" type="button" onclick="clearPatchPreview()" style="display:none;">Clear</button>
+                </div>
+                <div id="patch-msg" class="repo-msg" style="display:none;"></div>
+
+                <div id="patch-result" class="repo-patch-result" style="display:none;">
+                    <div class="repo-patch-badges">
+                        <span class="repo-patch-badge review">Review-only</span>
+                        <span class="repo-patch-badge applied">Not applied</span>
+                    </div>
+                    <div class="repo-block" id="patch-title-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-title-label">Title</div>
+                        <div class="repo-patch-text" id="patch-title-val"></div>
+                    </div>
+                    <div class="repo-block" id="patch-summary-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-summary-label">Summary</div>
+                        <div class="repo-patch-text" id="patch-summary-val"></div>
+                    </div>
+                    <div class="repo-block" id="patch-plan-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-plan-label">Plan</div>
+                        <ol class="repo-list repo-patch-ol" id="patch-plan-list"></ol>
+                    </div>
+                    <div class="repo-block" id="patch-files-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-files-label">Affected files</div>
+                        <ul class="repo-list" id="patch-files-list"></ul>
+                    </div>
+                    <div class="repo-block" id="patch-diff-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-diff-label">Proposed diff</div>
+                        <pre class="repo-pre repo-patch-diff" id="patch-diff-pre"></pre>
+                    </div>
+                    <div class="repo-block" id="patch-tests-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-tests-label">Suggested tests</div>
+                        <ul class="repo-list" id="patch-tests-list"></ul>
+                    </div>
+                    <div class="repo-block" id="patch-warnings-block" style="display:none;">
+                        <div class="repo-block-title" id="patch-warnings-label">Warnings</div>
+                        <ul class="repo-list repo-patch-warnings" id="patch-warnings-list"></ul>
+                    </div>
+                    <div class="repo-block" id="patch-safety-block">
+                        <div class="repo-block-title" id="patch-safety-label">Safety</div>
+                        <ul class="repo-list" id="patch-safety-list"></ul>
+                    </div>
+                    <div class="repo-patch-actions">
+                        <button id="patch-copy-diff-btn" class="repo-btn" type="button" onclick="copyPatchDiff()">Copy patch</button>
+                        <button id="patch-copy-tests-btn" class="repo-btn" type="button" onclick="copyPatchTests()">Copy test plan</button>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>
@@ -3796,6 +3909,30 @@
             repo_error: "Impossible de lire l'état Git du dépôt.",
             repo_saved: "Dépôt lié.",
             repo_unlinked: "Dépôt délié.",
+            patch_section_title: "Aperçu de proposition de patch",
+            patch_intro: "Collez une proposition structurée pour la prévisualiser. Nova ne modifie aucun fichier — l'aperçu est strictement en lecture seule.",
+            patch_input_label: "Proposition (JSON)",
+            patch_input_ph: "{\n  \"title\": \"\",\n  \"summary\": \"\",\n  \"plan\": [],\n  \"changes\": [\n    {\"path\": \"core/foo.py\", \"action\": \"modify\", \"old_content\": \"\", \"new_content\": \"\"}\n  ],\n  \"tests\": [],\n  \"warnings\": []\n}",
+            patch_preview: "Prévisualiser",
+            patch_clear: "Effacer",
+            patch_title: "Titre",
+            patch_summary: "Résumé",
+            patch_plan: "Plan",
+            patch_files: "Fichiers concernés",
+            patch_diff: "Diff proposé",
+            patch_tests: "Tests suggérés",
+            patch_warnings: "Avertissements",
+            patch_safety: "Sécurité",
+            patch_review_only: "Lecture seule",
+            patch_not_applied: "Non appliqué",
+            patch_copy_diff: "Copier le patch",
+            patch_copy_tests: "Copier le plan de tests",
+            patch_copy_done: "Copié.",
+            patch_copy_fail: "La copie a échoué.",
+            patch_invalid_json: "JSON invalide.",
+            patch_error: "Impossible de prévalider la proposition.",
+            patch_no_diff: "Aucun diff à copier.",
+            patch_no_tests: "Aucun test à copier.",
             no_match: "Aucun résultat",
             search_placeholder: "Rechercher...",
             group_today: "AUJOURD'HUI",
@@ -4012,6 +4149,30 @@
             repo_error: "Could not read the repository's Git status.",
             repo_saved: "Repository linked.",
             repo_unlinked: "Repository unlinked.",
+            patch_section_title: "Patch proposal preview",
+            patch_intro: "Paste a structured proposal to preview it. Nova does not modify any file — the preview is strictly read-only.",
+            patch_input_label: "Proposal (JSON)",
+            patch_input_ph: "{\n  \"title\": \"\",\n  \"summary\": \"\",\n  \"plan\": [],\n  \"changes\": [\n    {\"path\": \"core/foo.py\", \"action\": \"modify\", \"old_content\": \"\", \"new_content\": \"\"}\n  ],\n  \"tests\": [],\n  \"warnings\": []\n}",
+            patch_preview: "Preview proposal",
+            patch_clear: "Clear",
+            patch_title: "Title",
+            patch_summary: "Summary",
+            patch_plan: "Plan",
+            patch_files: "Affected files",
+            patch_diff: "Proposed diff",
+            patch_tests: "Suggested tests",
+            patch_warnings: "Warnings",
+            patch_safety: "Safety",
+            patch_review_only: "Review-only",
+            patch_not_applied: "Not applied",
+            patch_copy_diff: "Copy patch",
+            patch_copy_tests: "Copy test plan",
+            patch_copy_done: "Copied.",
+            patch_copy_fail: "Copy failed.",
+            patch_invalid_json: "Invalid JSON.",
+            patch_error: "Could not validate the proposal.",
+            patch_no_diff: "No diff to copy.",
+            patch_no_tests: "No tests to copy.",
             no_match: "No matches",
             search_placeholder: "Search...",
             group_today: "TODAY",
@@ -4931,6 +5092,28 @@
         if (input) input.placeholder = t("repo_path_ph");
         const repoBtn = document.getElementById("repo-settings-btn");
         if (repoBtn) repoBtn.title = t("repo_settings");
+        // Patch proposal preview.
+        set("patch-section-title", "patch_section_title");
+        set("patch-intro-text", "patch_intro");
+        set("patch-input-label", "patch_input_label");
+        set("patch-preview-btn", "patch_preview");
+        set("patch-clear-btn", "patch_clear");
+        set("patch-title-label", "patch_title");
+        set("patch-summary-label", "patch_summary");
+        set("patch-plan-label", "patch_plan");
+        set("patch-files-label", "patch_files");
+        set("patch-diff-label", "patch_diff");
+        set("patch-tests-label", "patch_tests");
+        set("patch-warnings-label", "patch_warnings");
+        set("patch-safety-label", "patch_safety");
+        set("patch-copy-diff-btn", "patch_copy_diff");
+        set("patch-copy-tests-btn", "patch_copy_tests");
+        const patchInput = document.getElementById("patch-input");
+        if (patchInput) patchInput.placeholder = t("patch_input_ph");
+        const reviewBadge = document.querySelector("#patch-result .repo-patch-badge.review");
+        if (reviewBadge) reviewBadge.textContent = t("patch_review_only");
+        const appliedBadge = document.querySelector("#patch-result .repo-patch-badge.applied");
+        if (appliedBadge) appliedBadge.textContent = t("patch_not_applied");
     }
 
     function openRepoSettings() {
@@ -4940,6 +5123,8 @@
         document.getElementById("repo-status").style.display = "none";
         document.getElementById("repo-path-input").value = "";
         document.getElementById("repo-overlay").classList.add("open");
+        _hidePatchSection();
+        clearPatchPreview();
         closeSidebar();
         loadRepoStatus();
     }
@@ -4989,6 +5174,7 @@
         if (!data || data.linked === false) {
             statusBox.style.display = "none";
             unlinkBtn.style.display = "none";
+            _hidePatchSection();
             if (!input.value) _repoMsg(t("repo_none"), "ok");
             return;
         }
@@ -4998,10 +5184,13 @@
         unlinkBtn.style.display = "";
 
         const state = data.state || "error";
-        if (state === "disabled") { _repoMsg(t("repo_disabled"), "err"); statusBox.style.display = "none"; return; }
-        if (state === "invalid_path") { _repoMsg((t("repo_invalid") + ": " + (data.detail || "")).trim(), "err"); statusBox.style.display = "none"; return; }
-        if (state === "git_unavailable") { _repoMsg(t("repo_git_missing"), "err"); statusBox.style.display = "none"; return; }
-        if (state === "error") { _repoMsg(t("repo_error"), "err"); statusBox.style.display = "none"; return; }
+        if (state === "disabled") { _repoMsg(t("repo_disabled"), "err"); statusBox.style.display = "none"; _hidePatchSection(); return; }
+        if (state === "invalid_path") { _repoMsg((t("repo_invalid") + ": " + (data.detail || "")).trim(), "err"); statusBox.style.display = "none"; _hidePatchSection(); return; }
+        if (state === "git_unavailable") { _repoMsg(t("repo_git_missing"), "err"); statusBox.style.display = "none"; _hidePatchSection(); return; }
+        if (state === "error") { _repoMsg(t("repo_error"), "err"); statusBox.style.display = "none"; _hidePatchSection(); return; }
+
+        // Ready: expose the patch-proposal preview surface.
+        _showPatchSection();
 
         // state === "ready"
         _repoMsg("", null);
@@ -5114,8 +5303,216 @@
         document.getElementById("repo-path-input").value = "";
         document.getElementById("repo-status").style.display = "none";
         document.getElementById("repo-unlink-btn").style.display = "none";
+        _hidePatchSection();
+        clearPatchPreview();
         _repoMsg(t("repo_unlinked"), "ok");
         await loadProjects();
+    }
+
+    // ── PATCH PROPOSAL PREVIEW (Phase 2, review-only) ──
+    //
+    // The preview surface is strictly client-side rendering: it POSTs a
+    // structured proposal to the per-project validate endpoint and shows
+    // the calm, validated reply. No Apply button, no commit, no push —
+    // the backend already enforces those invariants in
+    // ``core/dev_workspace.build_patch_proposal``; the UI never claims
+    // otherwise. All dynamic text (diffs, paths, titles, plans) is
+    // written with ``textContent``, never ``innerHTML``, so a proposal
+    // that happens to contain HTML metacharacters cannot inject markup.
+
+    // Most recently rendered proposal so the Copy buttons can serialise
+    // it without re-parsing the DOM. Reset on every preview / clear.
+    let _lastPatchProposal = null;
+
+    function _showPatchSection() {
+        const sec = document.getElementById("patch-section");
+        if (sec) sec.style.display = "";
+    }
+
+    function _hidePatchSection() {
+        const sec = document.getElementById("patch-section");
+        if (sec) sec.style.display = "none";
+    }
+
+    function _patchMsg(text, kind) {
+        const box = document.getElementById("patch-msg");
+        if (!box) return;
+        if (!text) { box.style.display = "none"; box.textContent = ""; return; }
+        box.textContent = text;
+        box.className = "repo-msg " + (kind === "ok" ? "ok" : "err");
+        box.style.display = "";
+    }
+
+    function clearPatchPreview() {
+        _lastPatchProposal = null;
+        _patchMsg("", null);
+        const input = document.getElementById("patch-input");
+        if (input) input.value = "";
+        const result = document.getElementById("patch-result");
+        if (result) result.style.display = "none";
+        const clearBtn = document.getElementById("patch-clear-btn");
+        if (clearBtn) clearBtn.style.display = "none";
+    }
+
+    async function previewPatchProposal() {
+        if (activeProjectId === "") return;
+        const input = document.getElementById("patch-input");
+        const raw = (input && input.value || "").trim();
+        if (!raw) { _patchMsg(t("patch_invalid_json"), "err"); return; }
+        let parsed;
+        try { parsed = JSON.parse(raw); }
+        catch { _patchMsg(t("patch_invalid_json"), "err"); return; }
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            _patchMsg(t("patch_invalid_json"), "err"); return;
+        }
+
+        let res;
+        try {
+            res = await fetch(
+                `/projects/${encodeURIComponent(activeProjectId)}/patch-proposals/validate`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Authorization": `Bearer ${token}`
+                    },
+                    body: JSON.stringify(parsed)
+                }
+            );
+        } catch { _patchMsg(t("patch_error"), "err"); return; }
+
+        if (res.status === 401) { logout(); return; }
+        if (res.status === 404) { closeRepoSettings(); return; }
+        if (res.status === 422) {
+            _patchMsg(t("patch_invalid_json"), "err"); return;
+        }
+        if (res.status === 400) {
+            let detail = t("patch_error");
+            try { const j = await res.json(); if (j && j.detail) detail = j.detail; } catch {}
+            _patchMsg(detail, "err");
+            return;
+        }
+        if (!res.ok) { _patchMsg(t("patch_error"), "err"); return; }
+
+        let proposal;
+        try { proposal = await res.json(); }
+        catch { _patchMsg(t("patch_error"), "err"); return; }
+        renderPatchProposal(proposal);
+    }
+
+    function _setTextBlock(blockId, valId, value) {
+        const block = document.getElementById(blockId);
+        const target = document.getElementById(valId);
+        if (!block || !target) return;
+        const text = (value || "").trim();
+        if (!text) { block.style.display = "none"; target.textContent = ""; return; }
+        target.textContent = text;
+        block.style.display = "";
+    }
+
+    function _setListBlock(blockId, listId, values, decorate) {
+        const block = document.getElementById(blockId);
+        const list = document.getElementById(listId);
+        if (!block || !list) return;
+        _clearList(list);
+        const items = Array.isArray(values) ? values.filter(v => v != null) : [];
+        if (!items.length) { block.style.display = "none"; return; }
+        items.forEach(v => {
+            const li = document.createElement("li");
+            if (typeof decorate === "function") decorate(li, v);
+            else li.textContent = String(v);
+            list.appendChild(li);
+        });
+        block.style.display = "";
+    }
+
+    function renderPatchProposal(proposal) {
+        if (!proposal || typeof proposal !== "object") {
+            _patchMsg(t("patch_error"), "err"); return;
+        }
+        _lastPatchProposal = proposal;
+        _patchMsg("", null);
+        document.getElementById("patch-result").style.display = "";
+        const clearBtn = document.getElementById("patch-clear-btn");
+        if (clearBtn) clearBtn.style.display = "";
+
+        _setTextBlock("patch-title-block", "patch-title-val", proposal.title);
+        _setTextBlock("patch-summary-block", "patch-summary-val", proposal.summary);
+        _setListBlock("patch-plan-block", "patch-plan-list", proposal.plan);
+
+        _setListBlock("patch-files-block", "patch-files-list",
+            Array.isArray(proposal.files) ? proposal.files : [],
+            (li, f) => {
+                const action = (f && f.action) || "modify";
+                const tag = document.createElement("span");
+                tag.className = "repo-patch-file-action " + action;
+                tag.textContent = action;
+                const p = document.createElement("span");
+                p.textContent = (f && f.path) || "";
+                li.appendChild(tag);
+                li.appendChild(p);
+                const added = Number((f && f.added) || 0);
+                const removed = Number((f && f.removed) || 0);
+                if (added || removed) {
+                    const stats = document.createElement("span");
+                    stats.className = "repo-patch-file-stats";
+                    stats.textContent = `+${added} −${removed}`;
+                    li.appendChild(stats);
+                }
+            }
+        );
+
+        const diffBlock = document.getElementById("patch-diff-block");
+        const diffPre = document.getElementById("patch-diff-pre");
+        const diff = (proposal.diff_preview || "").trim();
+        if (diff) { diffPre.textContent = diff; diffBlock.style.display = ""; }
+        else { diffPre.textContent = ""; diffBlock.style.display = "none"; }
+
+        _setListBlock("patch-tests-block", "patch-tests-list", proposal.suggested_tests);
+        const warnings = Array.isArray(proposal.warnings) && proposal.warnings.length
+            ? proposal.warnings
+            : (Array.isArray(proposal.risks) ? proposal.risks : []);
+        _setListBlock("patch-warnings-block", "patch-warnings-list", warnings);
+        _setListBlock("patch-safety-block", "patch-safety-list", proposal.safety);
+    }
+
+    async function _writeClipboardOrFallback(text) {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(text);
+                return true;
+            }
+        } catch {}
+        try {
+            const ta = document.createElement("textarea");
+            ta.value = text;
+            ta.style.position = "fixed";
+            ta.style.opacity = "0";
+            document.body.appendChild(ta);
+            ta.select();
+            const ok = document.execCommand("copy");
+            document.body.removeChild(ta);
+            return ok;
+        } catch { return false; }
+    }
+
+    async function copyPatchDiff() {
+        if (!_lastPatchProposal) { _patchMsg(t("patch_no_diff"), "err"); return; }
+        const text = (_lastPatchProposal.diff_preview || "").trim();
+        if (!text) { _patchMsg(t("patch_no_diff"), "err"); return; }
+        const ok = await _writeClipboardOrFallback(text);
+        _patchMsg(t(ok ? "patch_copy_done" : "patch_copy_fail"), ok ? "ok" : "err");
+    }
+
+    async function copyPatchTests() {
+        if (!_lastPatchProposal) { _patchMsg(t("patch_no_tests"), "err"); return; }
+        const tests = Array.isArray(_lastPatchProposal.suggested_tests)
+            ? _lastPatchProposal.suggested_tests : [];
+        const clean = tests.filter(line => typeof line === "string" && line.trim());
+        if (!clean.length) { _patchMsg(t("patch_no_tests"), "err"); return; }
+        const text = clean.map((line, i) => `${i + 1}. ${line.trim()}`).join("\n");
+        const ok = await _writeClipboardOrFallback(text);
+        _patchMsg(t(ok ? "patch_copy_done" : "patch_copy_fail"), ok ? "ok" : "err");
     }
 
     // ── CONVERSATIONS ──

--- a/tests/test_dev_workspace.py
+++ b/tests/test_dev_workspace.py
@@ -1116,3 +1116,318 @@ class TestPatchProposalEndpoint:
             headers=_h(tok),
         )
         assert resp.status_code == 422
+
+
+# ════════════════════════════════════════════════════════════════════
+# Phase 2 — title, warnings alias, binary rejection, transient stamps
+# ════════════════════════════════════════════════════════════════════
+#
+# These cover the additive surface on top of the original Phase 2 PR:
+# a ``title`` field, ``warnings`` accepted as a synonym for ``risks``,
+# binary content refused (NUL byte in either side of a change), and the
+# transient ``id`` + ``created_at`` stamps every built proposal carries.
+# A second alias endpoint (``POST .../patch-proposals/validate``) shares
+# the same per-project / per-user scoping as the original path.
+
+
+@_needs_git
+class TestProposalTitleAndWarnings:
+    def test_title_is_optional_and_defaults_empty(self, real_repo):
+        repo, root = real_repo
+        prop = dw.build_patch_proposal(
+            str(repo), _safe_proposal(), roots=[root]
+        )
+        d = prop.as_dict()
+        assert d["title"] == ""
+
+    def test_title_is_collapsed_and_capped(self, real_repo):
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec["title"] = "  Add\n\n  greet()  helper   "
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        # Whitespace collapsed to one safe line.
+        assert prop.title == "Add greet() helper"
+
+        spec["title"] = "x" * (dw._MAX_PROPOSAL_TITLE_CHARS + 50)
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        assert len(prop.title) == dw._MAX_PROPOSAL_TITLE_CHARS
+
+    def test_non_string_title_rejected(self, real_repo):
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec["title"] = 42
+        with pytest.raises(dw.PatchProposalError, match="title"):
+            dw.build_patch_proposal(str(repo), spec, roots=[root])
+
+    def test_warnings_accepted_as_synonym_for_risks(self, real_repo):
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec.pop("risks", None)
+        spec["warnings"] = ["touches auth", "review carefully"]
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        # Lands in the risks field (and is mirrored to ``warnings`` in
+        # the JSON for downstream UI / spec readers).
+        assert list(prop.risks) == ["touches auth", "review carefully"]
+        d = prop.as_dict()
+        assert d["risks"] == d["warnings"] == [
+            "touches auth", "review carefully"
+        ]
+
+    def test_risks_field_wins_over_warnings_alias(self, real_repo):
+        # If a model fills both, ``risks`` is the canonical Phase 2
+        # field and the alias is ignored. (The endpoint forbids unknown
+        # fields elsewhere; both are recognised here.)
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec["risks"] = ["primary risk"]
+        spec["warnings"] = ["should be ignored"]
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        assert list(prop.risks) == ["primary risk"]
+
+    def test_proposal_is_stamped_with_id_and_timestamp(self, real_repo):
+        repo, root = real_repo
+        a = dw.build_patch_proposal(
+            str(repo), _safe_proposal(), roots=[root]
+        )
+        b = dw.build_patch_proposal(
+            str(repo), _safe_proposal(), roots=[root]
+        )
+        # Two separate builds get two separate ids.
+        assert a.id and b.id and a.id != b.id
+        # UUID4 hex is 32 chars.
+        assert len(a.id) == 32 and all(c in "0123456789abcdef" for c in a.id)
+        # ISO timestamp ends with Z (UTC).
+        assert a.created_at.endswith("Z")
+        # Same in the serialised payload.
+        d = a.as_dict()
+        assert d["id"] == a.id
+        assert d["created_at"] == a.created_at
+
+
+@_needs_git
+class TestBinaryPatchRejection:
+    def test_nul_in_new_content_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": "blob.bin",
+                    "action": "add",
+                    "new_content": "binary\x00data\n",
+                }
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="binary"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_nul_in_old_content_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": "blob.bin",
+                    "action": "modify",
+                    "old_content": "before\x00trail\n",
+                    "new_content": "after\n",
+                }
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="binary"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_delete_of_binary_old_content_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": "blob.bin",
+                    "action": "delete",
+                    "old_content": "\x89PNG\r\n\x1a\n\x00fake-png",
+                }
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="binary"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_pure_text_with_high_unicode_still_allowed(self, real_repo):
+        # Defence against a too-aggressive heuristic: emoji / CJK / RTL
+        # text contains no NUL and must remain valid as a text patch.
+        repo, root = real_repo
+        spec = {
+            "changes": [
+                {
+                    "path": "README.md",
+                    "action": "modify",
+                    "old_content": "hello\n",
+                    "new_content": "hello 🌟 مرحبا 你好\n",
+                }
+            ]
+        }
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        assert prop.files
+
+
+@_needs_git
+class TestPatchProposalValidateEndpoint:
+    """``POST /projects/{id}/patch-proposals/validate`` (spec alias)."""
+
+    def test_full_link_then_validate(
+        self, db_path, web_client, real_repo, monkeypatch
+    ):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": str(repo)},
+            headers=_h(tok),
+        )
+        before = _tree_snapshot(repo)
+        resp = web_client.post(
+            f"/projects/{pid}/patch-proposals/validate",
+            json=_safe_proposal(),
+            headers=_h(tok),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["review_only"] is True
+        assert body["applied"] is False
+        assert {f["path"] for f in body["files"]} == {
+            "core/greet.py",
+            "README.md",
+        }
+        assert body["id"] and body["created_at"].endswith("Z")
+        # Validation must be read-only on the working tree.
+        assert _tree_snapshot(repo) == before
+
+    def test_validate_accepts_title_and_warnings(
+        self, db_path, web_client, real_repo, monkeypatch
+    ):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": str(repo)},
+            headers=_h(tok),
+        )
+        spec = _safe_proposal()
+        spec["title"] = "Add greet helper"
+        spec.pop("risks", None)
+        spec["warnings"] = ["new public helper"]
+        resp = web_client.post(
+            f"/projects/{pid}/patch-proposals/validate",
+            json=spec,
+            headers=_h(tok),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["title"] == "Add greet helper"
+        assert body["risks"] == ["new public helper"]
+        assert body["warnings"] == ["new public helper"]
+
+    def test_validate_rejects_binary_content(
+        self, db_path, web_client, real_repo, monkeypatch
+    ):
+        repo, root = real_repo
+        monkeypatch.setenv(dw.ENV_ROOTS, str(root))
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        web_client.put(
+            f"/projects/{pid}/repo",
+            json={"path": str(repo)},
+            headers=_h(tok),
+        )
+        resp = web_client.post(
+            f"/projects/{pid}/patch-proposals/validate",
+            json={
+                "changes": [
+                    {
+                        "path": "blob.bin",
+                        "action": "add",
+                        "new_content": "x\x00y",
+                    }
+                ]
+            },
+            headers=_h(tok),
+        )
+        assert resp.status_code == 400
+        assert "binary" in resp.json()["detail"]
+
+    def test_validate_foreign_project_is_404(
+        self, db_path, web_client
+    ):
+        _make_user(db_path, "alice")
+        _make_user(db_path, "bob")
+        a = _login(web_client, "alice")
+        b = _login(web_client, "bob")
+        pid = web_client.post(
+            "/projects", json={"name": "Priv"}, headers=_h(a)
+        ).json()["id"]
+        resp = web_client.post(
+            f"/projects/{pid}/patch-proposals/validate",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ]
+            },
+            headers=_h(b),
+        )
+        assert resp.status_code == 404
+
+    def test_validate_unlinked_project_is_400(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.post(
+            f"/projects/{pid}/patch-proposals/validate",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ]
+            },
+            headers=_h(tok),
+        )
+        assert resp.status_code == 400
+
+    def test_validate_unauthorised_is_401(self, db_path, web_client):
+        resp = web_client.post(
+            "/projects/1/patch-proposals/validate",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ]
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_validate_extra_field_is_422(self, db_path, web_client):
+        _make_user(db_path, "alice")
+        tok = _login(web_client, "alice")
+        pid = web_client.post(
+            "/projects", json={"name": "Nova"}, headers=_h(tok)
+        ).json()["id"]
+        resp = web_client.post(
+            f"/projects/{pid}/patch-proposals/validate",
+            json={
+                "changes": [
+                    {"path": "a.py", "action": "add", "new_content": "x\n"}
+                ],
+                "apply": True,
+            },
+            headers=_h(tok),
+        )
+        assert resp.status_code == 422

--- a/web.py
+++ b/web.py
@@ -342,14 +342,20 @@ class PatchProposalRequest(BaseModel):
     A structured, model-produced change description. The endpoint turns
     it into a calm, validated, **review-only** patch preview — it never
     writes files, commits, pushes, branches, or runs a command.
+
+    ``warnings`` is accepted as a synonym for ``risks`` so callers may
+    follow either the Phase 2 spec wording or the original endpoint
+    shape; both surface in the response.
     """
     model_config = {"extra": "forbid"}
 
+    title: str | None = None
     summary: str | None = None
     plan: list[str] | None = None
     changes: list[PatchProposalChange]
     tests: list[str] | None = None
     risks: list[str] | None = None
+    warnings: list[str] | None = None
 
 
 class MemoryUpdateRequest(BaseModel):
@@ -724,23 +730,18 @@ def get_project_repo_status_endpoint(
     return snapshot
 
 
-@app.post("/projects/{project_id}/repo/patch-proposal")
-def create_project_repo_patch_proposal_endpoint(
+def _build_patch_proposal_response(
     project_id: int,
     request: PatchProposalRequest,
-    user: CurrentUser = Depends(get_current_user),
-):
-    """Build a **review-only** patch proposal for a linked repo (Phase 2).
+    user: CurrentUser,
+) -> dict:
+    """Shared body for the two Phase 2 patch-proposal endpoints.
 
-    Turns the model's structured change description into a validated,
-    calm :class:`core.dev_workspace.PatchProposal` (plan, likely files,
-    a unified-diff preview, suggested tests, risk checklist). This is a
-    pure transform: it never writes files, stages, commits, pushes,
-    branches, or runs a command — the repo is not touched.
-
-    A foreign / unknown project id is a 404 (existence not leaked); a
-    project with no linked repo, or any proposal/path that fails
-    validation, is a 400 with a short, safe reason.
+    Both ``POST /projects/{id}/repo/patch-proposal`` (the original Phase
+    2 path) and ``POST /projects/{id}/patch-proposals/validate`` (the
+    spec-suggested validate path) share the same per-project, per-user
+    scope and the same read-only validation; this helper keeps them in
+    sync so the two paths can never drift.
     """
     project = _projects.get_project(project_id, user.id)
     if project is None:
@@ -760,6 +761,44 @@ def create_project_repo_patch_proposal_endpoint(
     except dev_workspace.PatchProposalError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return proposal.as_dict()
+
+
+@app.post("/projects/{project_id}/repo/patch-proposal")
+def create_project_repo_patch_proposal_endpoint(
+    project_id: int,
+    request: PatchProposalRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Build a **review-only** patch proposal for a linked repo (Phase 2).
+
+    Turns the model's structured change description into a validated,
+    calm :class:`core.dev_workspace.PatchProposal` (plan, likely files,
+    a unified-diff preview, suggested tests, risk checklist). This is a
+    pure transform: it never writes files, stages, commits, pushes,
+    branches, or runs a command — the repo is not touched.
+
+    A foreign / unknown project id is a 404 (existence not leaked); a
+    project with no linked repo, or any proposal/path that fails
+    validation, is a 400 with a short, safe reason.
+    """
+    return _build_patch_proposal_response(project_id, request, user)
+
+
+@app.post("/projects/{project_id}/patch-proposals/validate")
+def validate_project_patch_proposal_endpoint(
+    project_id: int,
+    request: PatchProposalRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Validate a patch proposal and return its review-only preview.
+
+    Spec-suggested alias of ``POST /projects/{id}/repo/patch-proposal``:
+    same body, same per-project / per-user scoping, same response shape.
+    Naming this endpoint ``.../patch-proposals/validate`` makes the
+    intent — *we are only validating, nothing is applied* — explicit at
+    the URL level. Phase 2 has no persistence and no apply step.
+    """
+    return _build_patch_proposal_response(project_id, request, user)
 
 
 @app.get("/conversations/{conversation_id}/messages")


### PR DESCRIPTION
## Summary

Extends the review-only Phase 2 patch-proposal foundation that landed in #200 with the missing pieces from the Dev Workspace Phase 2 spec — a UI preview surface, binary-patch rejection, an optional `title` field, transient `id` + UTC `created_at` metadata, a `warnings` synonym for `risks`, and the spec-suggested `POST /projects/{id}/patch-proposals/validate` endpoint alias. The repository is still **never written to**: no commits, no pushes, no branches, no shell commands, no persistence.

### Backend (`core/dev_workspace.py`, `web.py`)

- `PatchProposal` gains an optional `title` (single-line, length-capped at 120 chars), a transient random `id` (UUID hex), and a UTC `created_at` ISO timestamp — none of which are persisted; Phase 2 stays transient.
- `build_patch_proposal` accepts `warnings` as a synonym for `risks` (mirrored on output) and refuses any change whose `old_content` or `new_content` carries a NUL byte as binary (`"binary content is not supported for <path>"`). Emoji / CJK / RTL text stays valid.
- New `POST /projects/{project_id}/patch-proposals/validate` endpoint shares the same body, scope, and response as the original `POST /projects/{project_id}/repo/patch-proposal`. Both route through a shared `_build_patch_proposal_response` helper so the paths can never drift. Foreign project → 404, no linked repo → 400, invalid path / proposal / binary → 400, extra body field → 422, missing auth → 401.

### UI (`static/index.html`)

- The Dev Workspace panel (`⎇`) now exposes a "Patch proposal preview" section whenever a linked project's repo is in the `ready` state. Paste a structured proposal as JSON, click **Preview proposal**, and the panel renders the validated reply side by side:
  - title, one-line summary, implementation plan
  - affected files with action badges (add / modify / delete) and per-file `+/−` line counts
  - the proposed unified diff in a scrollable monospace block
  - suggested tests, warnings, and the standing safety notes
- **Copy patch** copies the combined unified diff; **Copy test plan** copies the suggested tests as a numbered list. No "Apply" button, no commit / push / branch affordance.
- Every dynamic value (diff lines, file paths, plan steps, title) is written via `textContent`, never `innerHTML`, so a proposal that happens to contain HTML metacharacters cannot inject markup. Bilingual labels (FR/EN) match the rest of the Dev Workspace UI.

### Tests (`tests/test_dev_workspace.py`)

- `title` accepted, whitespace-collapsed, length-capped, rejected when non-string
- `warnings` recognised as an alias for `risks`; `risks` wins when both are present; both surface on output
- Transient `id` is unique per build (UUID4 hex); `created_at` ends with `Z`
- Binary content refused in `new_content`, `old_content`, and delete's `old_content`; emoji / CJK / RTL text stays valid
- `/patch-proposals/validate` validates end-to-end without touching the working tree, surfaces `title`/`warnings`, refuses binary, returns 404 / 400 / 401 / 422 in the same places as the original endpoint
- All 153 dev-workspace tests pass (17 new); plus 154 auth/scoping/identity tests and 518 project/chat/provider/memory tests pass — no regressions in any sibling suite.

### Docs (`docs/dev-workspace.md`, `CHANGELOG.md`)

- Documents the new fields (`title`, `id`, `created_at`), binary-content refusal, the validate-endpoint alias, and the UI preview surface; adds an explicit "no Apply affordance in the UI" guarantee to the safety boundaries; updates the Phase 2 roadmap entry; CHANGELOG gets a detailed Unreleased entry under `Added`.

## Out of scope (deferred to later phases)

- Applying a reviewed patch to the working tree → Phase 3
- Branch + local commit → Phase 4
- PR draft assistant → Phase 5
- Optional push → Phase 6
- Persistence of past proposals → revisit when there is a safe local mechanism
- Model integration that produces a proposal from chat → separate work

## Test plan

- [x] `tests/test_dev_workspace.py` (153 passed, 17 new)
- [x] `tests/test_projects.py`, `tests/test_paths.py`, `tests/test_relationship_coach.py`, `tests/test_chat_stream.py`, `tests/test_model_providers.py`, `tests/test_provider_status.py`, `tests/test_model_settings.py`, `tests/test_memory.py`, `tests/test_memory_command.py`, `tests/test_message_edit_delete.py`, `tests/test_provider_endpoints.py`, `tests/test_provider_default_model_endpoints.py`, `tests/test_personalization_chat_wiring.py`, `tests/test_feedback.py`, `tests/test_feedback_endpoints.py` (518 passed, 1 unrelated skip)
- [x] `tests/test_auth.py`, `tests/test_alpha_auth.py`, `tests/test_admin_users.py`, `tests/test_conversation_scoping.py`, `tests/test_identity.py`, `tests/test_memory_scoping.py`, `tests/test_memory_parsing.py` (154 passed)
- [ ] Manual: link a local repo via `⎇`, paste a `_safe_proposal`-shaped JSON, confirm the preview renders title / summary / plan / files / diff / tests / warnings + safety notes, and **Copy patch** / **Copy test plan** populate the clipboard.

https://claude.ai/code/session_01Cd92jAGuoDzTkiRaT5tVSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cd92jAGuoDzTkiRaT5tVSa)_