### PR TITLE
feat(dev-workspace): harden patch-proposal preview against control-byte injection (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 ### Added
+- Dev Workspace Phase 2 — control-character hardening for the patch
+  proposal preview. The text-only refusal in `core.dev_workspace`
+  (previously NUL-only) now also refuses any C0 byte other than tab /
+  newline / carriage return — BEL (`\x07`), ESC (`\x1b`), backspace,
+  DEL, and the rest of the C0 range — in both `old_content` and
+  `new_content`, since those bytes would survive into the diff preview
+  and the clipboard via **Copy patch** and beep, colorise, or rewrite a
+  real terminal on paste. Model-supplied display strings (title,
+  summary, plan steps, suggested tests, risks / warnings) are stripped
+  of the same unsafe controls before they leave the builder, so a
+  **Copy test plan** payload is plain text too. Tab / newline / CR
+  remain valid in proposed content (Python indentation, CRLF line
+  endings); emoji / CJK / RTL text was already unaffected. The UI also
+  clamps the file-action CSS class to the known `{modify, add, delete}`
+  set so a future schema change cannot widen the class surface. New
+  tests cover BEL / ESC / backspace / DEL refusal in `new_content` and
+  `old_content`, the tab+CR/LF allow-list, and stripping across title /
+  summary / plan / tests / warnings (including a control-only title
+  collapsing to empty); 163 dev-workspace tests pass.
 - Dev Workspace Phase 2 — patch proposal preview surface (review-only):
   the Dev Workspace panel (`⎇`) gains a "Patch proposal preview"
   section that appears whenever a project's linked repo is in the

--- a/core/dev_workspace.py
+++ b/core/dev_workspace.py
@@ -62,8 +62,14 @@ calls, **no** file writes, and **no** subprocess work — it never
 applies, stages, commits, pushes, or branches anything. Every proposed
 path is validated to be repo-relative, traversal-free, non-secret, and
 contained inside the linked repo, and any file whose content carries a
-NUL byte is refused as binary (no readable text diff possible).
-Applying a reviewed patch is a deliberately separate, later phase.
+NUL byte or any other unsafe C0 / DEL control character (ANSI escapes,
+BEL, backspace, …) is refused as binary — those bytes would survive
+into the diff preview and the clipboard payload of "Copy patch" and
+beep, colorise, or rewrite a real terminal on paste. Model-supplied
+display strings (title, summary, plan steps, suggested tests, risks /
+warnings) are stripped of the same unsafe controls before they leave
+the builder. Applying a reviewed patch is a deliberately separate,
+later phase.
 
 See ``docs/dev-workspace.md`` for the operator walkthrough, the
 explicit non-goals, and the Phase 2-6 roadmap.
@@ -747,16 +753,54 @@ _PROPOSAL_SAFETY_NOTES = (
 )
 
 
+# C0 control characters (and DEL) that real source files never carry as
+# bytes. Tab / newline / carriage return are the only whitespace controls
+# that legitimately appear in text; everything else (NUL, BEL, ESC, …) is
+# either a binary signal or a terminal-escape vector that would *survive*
+# a "Copy patch" into a real terminal. Refusing them keeps the text
+# preview honest and the clipboard payload safe to paste.
+_UNSAFE_CONTROL_CHARS = frozenset(
+    chr(c) for c in range(0x20) if chr(c) not in ("\t", "\n", "\r")
+) | {"\x7f"}
+
+
 def _looks_binary(content: str) -> bool:
     """True when ``content`` is not safe to preview as a text patch.
 
-    A real text source file never contains a NUL byte, so a NUL is the
-    cheapest, most reliable binary signal — and the same heuristic git
-    itself uses to flag a file as "Binary". The diff preview is pure
-    text, so a binary blob is refused outright in this phase rather than
-    surfacing a broken or huge diff. Empty content is trivially text.
+    A real text source file never contains a NUL byte (git's own "Binary"
+    heuristic), and the broader C0 / DEL range (BEL, ESC, …) does not
+    appear in well-formed text either — those bytes would survive into
+    the diff preview, and from there into the user's clipboard, where
+    pasting them into a terminal could colorise output, beep, or run an
+    escape-driven trick. Tab / newline / carriage return are the only
+    whitespace controls that legitimately appear in source; everything
+    else 0x00–0x1f plus 0x7f is treated as binary. Empty content is
+    trivially text.
     """
-    return "\x00" in content
+    if not content:
+        return False
+    for ch in _UNSAFE_CONTROL_CHARS:
+        if ch in content:
+            return True
+    return False
+
+
+def _strip_controls(text: str) -> str:
+    """Drop C0 / DEL controls (keeping tab/newline/CR) from a metadata string.
+
+    Used on model-supplied display text — title, summary, plan steps,
+    suggested tests, risk/warning items. The Phase 2 preview renders
+    these directly, and they also ride along in the clipboard payload
+    via "Copy test plan"; stripping unsafe controls keeps that output
+    plain text even when the model misbehaves. ``_truncate`` and the
+    whitespace-collapse step still run afterwards, so the visible cap is
+    unchanged.
+    """
+    if not text:
+        return text
+    if not any(ch in text for ch in _UNSAFE_CONTROL_CHARS):
+        return text
+    return "".join(ch for ch in text if ch not in _UNSAFE_CONTROL_CHARS)
 
 
 def _is_secret_path(rel_posix: str) -> bool:
@@ -959,7 +1003,9 @@ def _string_list(value: object, cap: int) -> tuple[str, ...]:
     for item in value:
         if not isinstance(item, str):
             raise PatchProposalError("list items must be strings")
-        cleaned = item.strip()
+        # Strip C0/DEL controls before trimming so a sneaky model cannot
+        # smuggle BEL/ESC bytes into the clipboard via "Copy test plan".
+        cleaned = _strip_controls(item).strip()
         if not cleaned:
             continue
         out.append(_truncate(cleaned))
@@ -1051,14 +1097,19 @@ def build_patch_proposal(
     title_raw = proposal.get("title") or ""
     if not isinstance(title_raw, str):
         raise PatchProposalError("title must be a string")
-    # Collapse whitespace so the title stays a single safe line.
-    title = " ".join(title_raw.split())[:_MAX_PROPOSAL_TITLE_CHARS]
+    # Drop C0/DEL controls (BEL/ESC/…) then collapse whitespace so the
+    # title stays a single safe line that is also safe to copy.
+    title = " ".join(
+        _strip_controls(title_raw).split()
+    )[:_MAX_PROPOSAL_TITLE_CHARS]
 
     summary_raw = proposal.get("summary") or ""
     if not isinstance(summary_raw, str):
         raise PatchProposalError("summary must be a string")
-    # Collapse whitespace so the summary stays a single safe line.
-    summary = " ".join(summary_raw.split())[:_MAX_PROPOSAL_SUMMARY_CHARS]
+    # Same hardening for the one-line summary.
+    summary = " ".join(
+        _strip_controls(summary_raw).split()
+    )[:_MAX_PROPOSAL_SUMMARY_CHARS]
 
     plan = _string_list(proposal.get("plan"), _MAX_PROPOSAL_PLAN_STEPS)
     tests = _string_list(proposal.get("tests"), _MAX_PROPOSAL_TESTS)

--- a/docs/dev-workspace.md
+++ b/docs/dev-workspace.md
@@ -159,9 +159,17 @@ These are enforced in `core/dev_workspace.py` and covered by
      `logs`, `.git`, `__pycache__`, `.venv`, `node_modules`);
    - the path must still resolve **inside** the linked repo (a
      symlinked subdir pointing outside it is refused);
-   - **binary content is refused** — any `old_content` /
-     `new_content` carrying a NUL byte fails validation, since there
-     is no readable text diff for a binary blob;
+   - **binary / non-text content is refused** — any `old_content` /
+     `new_content` carrying a NUL byte, an ANSI escape (`ESC`,
+     `\x1b[…m`), a BEL (`\x07`), or any other C0 / DEL control byte
+     other than `\t` / `\n` / `\r` fails validation. The diff preview
+     is plain text that the user may copy into a terminal via
+     **Copy patch**, so terminal-escape vectors must not survive into
+     it; reviewing binary changes is a deliberately later phase.
+     Model-supplied display strings (title, summary, plan steps,
+     suggested tests, risks / warnings) are stripped of the same
+     unsafe controls before they are returned, so a **Copy test plan**
+     payload is plain text too;
    - the diff is built locally with `difflib` from the model-supplied
      before/after text — **no git, no subprocess, no file I/O, no
      network**; nothing is applied, staged, committed, pushed, or

--- a/static/index.html
+++ b/static/index.html
@@ -5461,7 +5461,14 @@
         _setListBlock("patch-files-block", "patch-files-list",
             Array.isArray(proposal.files) ? proposal.files : [],
             (li, f) => {
-                const action = (f && f.action) || "modify";
+                // The server constrains action to {modify, add, delete}
+                // (``_PATCH_ACTIONS`` in core/dev_workspace.py); clamp
+                // here too so a future schema change cannot widen the
+                // CSS-class surface, and so an unexpected value renders
+                // calmly instead of leaking through as a raw class.
+                const rawAction = (f && f.action) || "modify";
+                const action = (rawAction === "add" || rawAction === "delete")
+                    ? rawAction : "modify";
                 const tag = document.createElement("span");
                 tag.className = "repo-patch-file-action " + action;
                 tag.textContent = action;

--- a/tests/test_dev_workspace.py
+++ b/tests/test_dev_workspace.py
@@ -1266,6 +1266,119 @@ class TestBinaryPatchRejection:
         prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
         assert prop.files
 
+    @pytest.mark.parametrize(
+        "ctrl",
+        [
+            "\x07",   # BEL — beeps a real terminal on paste
+            "\x1b",   # ESC — root of the ANSI escape attack family
+            "\x1b[31m",  # ANSI red, full sequence
+            "\x08",   # backspace — can rewrite displayed paths
+            "\x7f",   # DEL — another non-text byte
+        ],
+    )
+    def test_unsafe_controls_in_new_content_rejected(self, real_repo, ctrl):
+        # Tightens the existing NUL-only refusal: any C0 / DEL byte in
+        # proposed content would survive into the diff preview (and the
+        # clipboard via "Copy patch") and is treated as binary.
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": "core/foo.py",
+                    "action": "add",
+                    "new_content": f"alert{ctrl}here\n",
+                }
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="binary"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_unsafe_controls_in_old_content_rejected(self, real_repo):
+        repo, root = real_repo
+        bad = {
+            "changes": [
+                {
+                    "path": "README.md",
+                    "action": "modify",
+                    "old_content": "hello\x1b[2J\n",
+                    "new_content": "hello\n",
+                }
+            ]
+        }
+        with pytest.raises(dw.PatchProposalError, match="binary"):
+            dw.build_patch_proposal(str(repo), bad, roots=[root])
+
+    def test_tab_cr_and_lf_allowed_in_content(self, real_repo):
+        # Defence-in-depth that the broadened check did not over-block
+        # the only whitespace control characters that real source files
+        # legitimately carry: TAB (indent), LF (line break), CR (CRLF).
+        repo, root = real_repo
+        spec = {
+            "changes": [
+                {
+                    "path": "core/foo.py",
+                    "action": "add",
+                    "new_content": "def f():\r\n\treturn 1\r\n",
+                }
+            ]
+        }
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        assert prop.files
+        # The whitespace controls survive untouched into the diff.
+        assert "\treturn 1" in prop.files[0].diff
+
+
+@_needs_git
+class TestProposalMetadataControlStripping:
+    """Control-character hardening for model-supplied display text."""
+
+    def test_controls_stripped_from_title_and_summary(self, real_repo):
+        # A model that smuggles BEL / ESC into a title would, otherwise,
+        # ride along into the clipboard via "Copy test plan" or appear
+        # in copy-pasted log output. They must not survive the build.
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec["title"] = "Add\x07bell\x1b[31mred"
+        spec["summary"] = "Has\x07a\x1b[1mbold\x1b[0mword"
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        for ch in ("\x07", "\x1b"):
+            assert ch not in prop.title
+            assert ch not in prop.summary
+        # The visible words still survive — only the controls are gone.
+        assert "Add" in prop.title and "bell" in prop.title
+        assert "Has" in prop.summary and "bold" in prop.summary
+
+    def test_controls_stripped_from_plan_tests_and_warnings(self, real_repo):
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec["plan"] = ["step\x07one", "\x1b[31mstep two"]
+        spec["tests"] = ["pytest\x07tests/test_x.py"]
+        # ``risks`` wins over the ``warnings`` alias; drop risks first so
+        # we are clearly testing the warnings code path. (Both feed into
+        # the same ``_string_list``, so either path validates the strip.)
+        spec.pop("risks", None)
+        spec["warnings"] = ["risk\x1b[31mhere"]
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        d = prop.as_dict()
+        for field in ("plan", "suggested_tests", "warnings", "risks"):
+            joined = "".join(d[field])
+            assert "\x07" not in joined
+            assert "\x1b" not in joined
+        # Content survives, only the unsafe bytes are dropped.
+        assert any("step" in s for s in d["plan"])
+        assert any("pytest" in s for s in d["suggested_tests"])
+        assert any("risk" in s for s in d["warnings"])
+
+    def test_control_only_metadata_collapses_to_empty(self, real_repo):
+        # A title that is *entirely* control bytes has nothing left to
+        # display; it must collapse to an empty string (which the UI
+        # then hides) rather than rendering invisible bytes.
+        repo, root = real_repo
+        spec = _safe_proposal()
+        spec["title"] = "\x07\x1b\x08"
+        prop = dw.build_patch_proposal(str(repo), spec, roots=[root])
+        assert prop.title == ""
+
 
 @_needs_git
 class TestPatchProposalValidateEndpoint:


### PR DESCRIPTION
## Summary

Audit + harden pass over the review-only Dev Workspace Phase 2 patch-proposal surface that landed in #200/#203. The functional scope (UI preview, copy buttons, binary refusal, title field, transient `id` + `created_at`, `…/patch-proposals/validate` alias, docs) was already merged — this PR tightens the text-only contract behind that surface so model-supplied bytes cannot ride along into the diff preview and the clipboard via **Copy patch** / **Copy test plan** and beep, colorise, or rewrite a real terminal on paste.

Repo behaviour is unchanged: **no apply, no commit, no push, no branch, no file writes, no git, no network**.

### What changes

**Backend (`core/dev_workspace.py`)**

- `_looks_binary` now refuses any C0 / DEL control character other than `\t` / `\n` / `\r` in `old_content` and `new_content`, not just NUL. BEL (`\x07`), ESC (`\x1b`), backspace, DEL, and the rest of the C0 range are all refused with the same `binary content is not supported for <path>` message. Real source text (Python indentation, CRLF line endings, emoji / CJK / RTL) is unaffected.
- New `_strip_controls` helper drops the same unsafe bytes from model-supplied display strings (`title`, `summary`, plan steps, suggested tests, risks / warnings) before they leave `build_patch_proposal`. Whitespace-collapse + length caps still run afterwards, so well-behaved proposals look identical.

**UI (`static/index.html`)**

- `renderPatchProposal` clamps the file-action CSS class to the known `{add, modify, delete}` set so a future schema change cannot widen the class surface — defence-in-depth on top of the server-side `_PATCH_ACTIONS` allowlist.

**Tests (`tests/test_dev_workspace.py`, +10)**

- BEL / ESC / `\x1b[31m` / backspace / DEL in `new_content` rejected (parametrised); ESC also rejected in `old_content`.
- Defence against over-blocking: tab + CRLF in proposed content stays valid and lands in the diff verbatim.
- Control characters stripped from title / summary / plan / tests / warnings while visible words survive; a title that is *entirely* control bytes collapses to empty.

**Docs**

- `docs/dev-workspace.md` safety-boundaries section + the module docstring restate the broader unsafe-control refusal and the metadata stripping; `CHANGELOG.md` gets a new Unreleased Added entry.

### Out of scope (deferred)

- Applying a reviewed patch → Phase 3
- Branch + local commit → Phase 4
- PR draft assistant → Phase 5
- Optional push → Phase 6
- Persistence of past proposals → revisit when there is a safe local mechanism

## Test plan

- [x] `tests/test_dev_workspace.py` — 163 passed (10 new)
- [x] `tests/test_projects.py`, `tests/test_storage_endpoints.py`, `tests/test_storage_status.py`, `tests/test_provider_endpoints.py`, `tests/test_provider_status.py`, `tests/test_provider_default_model_endpoints.py`, `tests/test_chat_stream.py`, `tests/test_memory.py`, `tests/test_memory_command.py`, `tests/test_memory_scoping.py`, `tests/test_memory_parsing.py`, `tests/test_memory_importer.py`, `tests/test_natural_memory.py` — 366 passed (1 pre-existing skip)
- [x] `tests/test_auth.py`, `tests/test_alpha_auth.py`, `tests/test_admin_users.py`, `tests/test_conversation_scoping.py`, `tests/test_identity.py`, `tests/test_personalization_chat_wiring.py`, `tests/test_personalization_settings.py`, `tests/test_settings_scoping.py`, `tests/test_model_providers.py`, `tests/test_model_settings.py`, `tests/test_model_pulls.py`, `tests/test_model_registry.py`, `tests/test_model_access.py`, `tests/test_local_models.py`, `tests/test_paths.py`, `tests/test_data_export.py`, `tests/test_migration.py`, `tests/test_users.py`, `tests/test_feedback.py`, `tests/test_feedback_endpoints.py`, `tests/test_message_edit_delete.py`, `tests/test_session_continuity.py` — 665 passed (1 pre-existing skip)
- [x] `flake8 core/dev_workspace.py tests/test_dev_workspace.py web.py` — clean
- [x] Static `<script>` blocks in `static/index.html` parse with Node

https://claude.ai/code/session_01SntkSPsHac2X6bAZG8Cheo


---
_Generated by [Claude Code](https://claude.ai/code/session_01SntkSPsHac2X6bAZG8Cheo)_