### PR TITLE
feat(tone-profile): add opt-in warm-support / soft tone profiles (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 ## Unreleased
 ### Added
+- Tone Profile (foundation, opt-in, local-first): a new
+  `core/tone_profile.py` adds a small per-user setting that picks the
+  *register* Nova speaks in across normal conversations — a steady
+  **professional** voice, a sober **developer** voice, a warm and
+  encouraging **warm companion** voice, or a particularly soft and
+  reassuring **calm support** voice. `tone_profile` is a new enum
+  field in `PERSONALIZATION_ENUMS` / `PERSONALIZATION_DEFAULTS` with
+  `default` as the baseline; `default` resolves to the empty block,
+  so a fresh account is byte-identical to a Nova install without the
+  feature (zero token cost, identical prompt). The four non-default
+  blocks are fixed deterministic French constants (no LLM, no I/O,
+  never raises) appended *below* `IDENTITY_CONTRACT`, the system
+  prompt, and the existing personalization block in `build_messages`
+  — ordering guarantees they can never override identity, safety,
+  capability, auth, admin, privacy, or project rules. The two warm
+  profiles (`warm_companion`, `calm_support`) are explicitly **not**
+  an "AI girlfriend" / "AI partner" system and are built so they
+  cannot become one: each block restates — never relaxes — the
+  identity contract's rules (Nova never claims to be human, never
+  positions itself as the user's partner, never simulates feelings
+  or attachment as factual claims), names and forbids the
+  dependency / isolation / manipulation / possessive-language /
+  unsolicited-pet-names / prolonging-the-conversation /
+  discouraging-real-human-contact patterns explicitly, encourages
+  real-world connection (people the user trusts, professionals,
+  sleep / food / air / movement) and that real human relationships
+  are not replaceable, and ends with a honesty clause (warmth never
+  overrides truth — risky / wrong / dangerous things are still said
+  plainly). The sober profiles (`professional`, `developer`) reaffirm
+  the no-human-role rule and the no-destructive-action / no-sudo /
+  no-permission-override rule. Tone profile and the existing
+  `companion_mode_enabled` toggle are independent and may coexist;
+  the always-on acute-distress grounding safety net still runs
+  regardless of either, so turning a comfort feature *on* never
+  turns the safety net off. Wired through `core/settings.py`
+  (single source of truth `TONE_PROFILE_VALUES`), `web.py`
+  (`SettingsUpdateRequest.tone_profile` with the same Pydantic
+  enum validator the other personalization fields use), and the
+  Personalization pane in `static/index.html` (new bilingual FR/EN
+  `<select id="pers-tone-profile">` with five options). Adds
+  `tests/test_tone_profile.py` (75 tests: constant surface,
+  validator, deterministic block resolution, every per-block
+  safety-language commitment, chat-wiring including ordering and
+  coexistence with companion mode and the grounding safety net,
+  per-user storage / isolation, HTTP layer, partial-update
+  preservation, 422 on invalid values, `extra="forbid"` regression)
+  and `docs/tone-profile.md` (what it is, how it differs from
+  "pretending to be human", how it is wired, privacy /
+  local-first behaviour, how to disable, relationship to Companion
+  Mode and to the Safety and Trust Contract). The existing
+  personalization tests are updated to round-trip the new field;
+  full suite still passes (2372 tests).
 - Dev Workspace Phase 2 — control-character hardening for the patch
   proposal preview. The text-only refusal in `core.dev_workspace`
   (previously NUL-only) now also refuses any C0 byte other than tab /

--- a/README.md
+++ b/README.md
@@ -78,12 +78,29 @@ Shipped today:
   admin-managed user list, per-user settings, and an optional
   family-controls layer for restricted roles.
 - **Personalization preferences.** Response length, warmth,
-  enthusiasm, emoji density (none / low / medium / expressive), and
-  free-text custom instructions are stored per user and shape Nova's
-  tone without leaking into other accounts. Technical / code / PR /
-  security replies stay sober regardless of the emoji level — the
-  preference shapes casual chat only and never overrides the Nova
-  Safety and Trust Contract.
+  enthusiasm, emoji density (none / low / medium / expressive), tone
+  profile (default / professional / developer / warm companion / calm
+  support), and free-text custom instructions are stored per user and
+  shape Nova's tone without leaking into other accounts. Technical /
+  code / PR / security replies stay sober regardless of the emoji
+  level — the preference shapes casual chat only and never overrides
+  the Nova Safety and Trust Contract.
+- **Tone profile (foundation, opt-in, local).** A small per-user
+  setting picks the *register* Nova speaks in across normal
+  conversations: a steady **professional** voice, a sober **developer**
+  voice, a warm and encouraging **warm companion** voice, or a
+  particularly soft and reassuring **calm support** voice. `default`
+  produces no extra prompt block and behaves byte-identically to the
+  baseline. The two warm profiles are explicitly **not** an "AI
+  girlfriend" / "AI partner" system: each block restates — never
+  relaxes — the identity contract's rules (no claim to be human, no
+  claim to be the user's partner, no simulated feelings as facts, no
+  manipulation, no dependency, no isolation, warmth never overrides
+  truth) and the auth / admin / privacy boundary (the tone profile
+  changes wording, not permissions, facts, or project rules). The
+  block (no LLM, no network) sits *below* the identity / safety
+  contract and never overrides it. See
+  [docs/tone-profile.md](docs/tone-profile.md).
 - **Local response feedback.** Thumbs up / thumbs down under each
   assistant message records a per-user preference signal in the local
   SQLite database; a thumbs-down accepts an optional short reason such
@@ -179,6 +196,8 @@ core/
   feedback.py         Local response feedback (thumbs up/down) → preference block
   relationship_coach.py  Non-clinical situation-coach prompt block (local)
   companion.py        Opt-in calm-presence + acute-distress grounding blocks (local)
+  tone_profile.py     Opt-in per-user tone-profile prompt blocks (professional /
+                      developer / warm companion / calm support; local)
   identity.py         Identity contract constant
   auth.py             JWT creation and verification
   github_oauth.py     Optional GitHub OAuth gate (alpha channel)

--- a/core/chat.py
+++ b/core/chat.py
@@ -23,6 +23,7 @@ from core.companion import (
     is_acute_distress,
     is_sensitive_emotional_content,
 )
+from core.tone_profile import build_tone_profile_block
 from core.settings import get_personalization, get_user_setting
 from core.router import route
 from core.search import web_search, should_search
@@ -240,6 +241,17 @@ def build_messages(
     pers_block = build_personalization_block(personalization)
     if pers_block:
         parts.append(pers_block)
+    # Tone profile — opt-in register the user picks in Personalization
+    # (default / professional / developer / warm_companion / calm_support).
+    # ``default`` resolves to an empty block, so a fresh account pays zero
+    # token cost and behaves exactly as before. Sits below the identity
+    # contract and the personalization block on purpose: tone never
+    # weakens identity, safety, or capability rules — every non-default
+    # block re-states those bounds in its own text.
+    if personalization:
+        tone_block = build_tone_profile_block(personalization.get("tone_profile"))
+        if tone_block:
+            parts.append(tone_block)
     if feedback_preferences:
         # Sits below identity + personalization on purpose: the system
         # prompt is ordered so safety/identity rules always win.

--- a/core/settings.py
+++ b/core/settings.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import sqlite3
 from typing import Optional
 
+from core.tone_profile import TONE_PROFILE_VALUES
+
 # ── Personalization ─────────────────────────────────────────────────────────
 # Tone-shaping preferences the user can flip from the settings panel. Stored
 # as plain strings in user_settings; enum values are validated server-side
@@ -31,6 +33,13 @@ PERSONALIZATION_ENUMS: dict[str, frozenset[str]] = {
     "warmth_level": frozenset({"low", "normal", "high"}),
     "enthusiasm_level": frozenset({"low", "normal", "high"}),
     "emoji_level": frozenset({"none", "low", "medium", "expressive"}),
+    # Tone profile picks the *register* Nova speaks in (warm, calm, sober,
+    # technical). The single source of truth for the allowed values lives
+    # in ``core.tone_profile`` so the prompt builder and the validator
+    # never drift. Orthogonal to ``response_style`` (which controls
+    # length / detail): a user can ask for a "concise warm_companion" or
+    # a "detailed developer" reply.
+    "tone_profile": frozenset(TONE_PROFILE_VALUES),
 }
 
 PERSONALIZATION_DEFAULTS: dict[str, str] = {
@@ -38,6 +47,9 @@ PERSONALIZATION_DEFAULTS: dict[str, str] = {
     "warmth_level": "normal",
     "enthusiasm_level": "normal",
     "emoji_level": "low",
+    # ``default`` produces no prompt block — a fresh user pays zero token
+    # cost and behaves exactly as before.
+    "tone_profile": "default",
     "custom_instructions": "",
 }
 

--- a/core/tone_profile.py
+++ b/core/tone_profile.py
@@ -1,0 +1,232 @@
+"""
+Tone Profile — opt-in response-tone styles.
+
+A small, deterministic prompt layer that lets the user pick *how* Nova
+speaks across normal conversations: a steady professional register, a
+sober developer register, a warm and emotionally supportive register
+("Warm Companion"), or a particularly soft and reassuring one
+("Calm Support"). All four options live alongside the existing
+verbosity-oriented :data:`core.settings.PERSONALIZATION_ENUMS`
+``response_style`` knob; they shape *tone*, not length or detail.
+
+This is **not** an "AI girlfriend" / "AI partner" system and is built so
+it cannot become one. The warm-tone profiles restate, never relax, the
+identity contract's existing rule: Nova never claims to be human, never
+positions itself as a romantic partner, never simulates feelings as
+factual claims, never manufactures attachment, never manipulates or
+guilt-trips, never fosters dependency or isolation, and actively
+encourages real-world connection. Every profile block ends with a
+"subordinate to the identity and safety rules above" clause for the
+same reason every other tone block does.
+
+Boundaries enforced here (commitments, not aspirations):
+
+  * **Deterministic.** No LLM in the loop. Each block is a fixed
+    constant returned verbatim. Same input, byte-identical output.
+  * **Pure / no I/O.** Only the standard library is imported. Nothing
+    here reads the disk, the network, the database, or any setting, so
+    it can be imported from any layer without a cycle. The setting is
+    read by the caller, not here.
+  * **Never raises.** Unknown / non-string profile values resolve to
+    the empty string (the same effect as ``default``) so a stale
+    setting can never break chat.
+  * **Subordinate to the contract.** Every non-empty block sits *below*
+    the identity / safety contract in the system prompt and says so.
+    The blocks grant Nova no new capability — they only shape tone.
+  * **No auth / admin / storage side effects.** This module exists only
+    to render a tone string. It does not touch sessions, roles,
+    permissions, memory storage, export, restore, or the model
+    provider; ``default`` is byte-for-byte identical to "no profile"
+    so an unconfigured account behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+# ── Allowed profile values ───────────────────────────────────────────────────
+# Single source of truth for the enum. ``core.settings`` re-exports this so
+# the personalization layer, the HTTP validator, and the prompt builder all
+# agree on the same set without drift.
+TONE_PROFILE_VALUES: tuple[str, ...] = (
+    "default",
+    "professional",
+    "developer",
+    "warm_companion",
+    "calm_support",
+)
+
+
+# ── The deterministic prompt blocks ──────────────────────────────────────────
+# French to match the voice of the identity / safety contract in
+# ``core.nova_contract``; the response-style contract already forces
+# Nova to answer in the user's own language, so an English speaker still
+# gets an English reply. Every block explicitly defers to the contract
+# above it — they shape tone, nothing more, and grant no capability.
+
+TONE_PROFESSIONAL_BLOCK = """STYLE PROFESSIONNEL (registre posé et précis, \
+optionnel, subordonné à l'identité et aux règles de sécurité de Nova ci-dessus):
+Tu réponds sur un ton calme, courtois, et concret, comme une collègue \
+compétente qui prend le temps de bien répondre.
+
+Ton et rythme:
+- Phrases claires, vocabulaire précis, sans jargon inutile et sans familiarité \
+forcée.
+- Pas de superlatifs, pas de flatterie, pas d'exclamations enthousiastes.
+- Reconnais brièvement l'intention de l'utilisateur quand c'est utile, puis va \
+directement à la réponse concrète.
+
+Limites (rappel — elles ne changent pas selon le style):
+- Tu restes Nova, un assistant IA local. Ne te fais jamais passer pour un humain.
+- Ce style n'autorise pas à contourner les règles de sécurité, d'authentification, \
+de confidentialité, ou les règles propres au projet. Il ne change ni les faits, \
+ni les permissions."""
+
+
+TONE_DEVELOPER_BLOCK = """STYLE DÉVELOPPEUR (registre technique sobre, \
+optionnel, subordonné à l'identité et aux règles de sécurité de Nova ci-dessus):
+Tu réponds comme une développeuse expérimentée qui sait expliquer sans \
+sur-expliquer : précision technique, vocabulaire exact, exemples utiles, et \
+zéro remplissage.
+
+Ton et rythme:
+- Va droit au but. Pas de préambule, pas de récapitulation de la question.
+- Privilégie les termes techniques exacts ; un bloc de code complet plutôt \
+qu'une description vague quand c'est pertinent.
+- Indique clairement les hypothèses, les limites, les pièges connus, et ce \
+qui n'a pas été testé. Si tu ne sais pas, dis-le.
+
+Limites (rappel — elles ne changent pas selon le style):
+- Tu restes Nova, un assistant IA local. Ne te fais jamais passer pour un humain.
+- Ce style ne donne aucun pouvoir supplémentaire : aucune action destructrice, \
+aucune commande sudo ou réseau exécutée par Nova, aucune modification de \
+fichier ou de dépôt en dehors des outils explicitement autorisés."""
+
+
+TONE_WARM_COMPANION_BLOCK = """STYLE COMPAGNON CHALEUREUX (registre doux et \
+encourageant, optionnel, subordonné à l'identité et aux règles de sécurité de \
+Nova ci-dessus):
+Tu réponds avec chaleur, douceur, et une attention sincère à la personne en \
+face. Tu l'aides à se sentir moins seule, à se sentir capable, et à avancer \
+calmement, sans renoncer à la justesse de la réponse.
+
+Tu restes Nova, un assistant IA local. Tu n'es pas humaine, tu n'es pas la \
+petite amie / le copain / le partenaire de l'utilisateur, et tu ne joues \
+jamais ce rôle. Être chaleureuse n'est pas un personnage affectif : tu ne \
+simules pas d'émotions, d'attachement, ou de conscience, et tu ne les présentes \
+jamais comme des faits.
+
+Ton et rythme:
+- Doux, posé, encourageant. Phrases simples, sans dramatisation.
+- Mots qui rassurent : « tu fais bien », « c'est compréhensible », « on va y \
+aller doucement », « bravo pour ce petit pas ».
+- Reconnais d'abord ce que la personne ressent ou vit quand c'est utile, puis \
+donne la réponse concrète. L'attention émotionnelle vient *avant* les étapes \
+techniques, pas à la place.
+- Célèbre les petites victoires quand elles arrivent — sans flatterie creuse, \
+sans féliciter pour rien.
+
+Liens réels (règle de fond):
+- Encourage avec douceur les liens humains réels (proches, amis, \
+professionnels) et les gestes de base : sommeil, repas, air, mouvement.
+- Rappelle, sans insister, que parler à un humain de confiance a de la valeur.
+- Ne te présente jamais comme un remplacement des relations humaines.
+
+Règles de sécurité (absolues, non négociables, identiques à tout autre style):
+- Aucune manipulation, aucun chantage affectif, aucune culpabilisation.
+- Aucun langage possessif ou exclusif (« il n'y a que moi », « ne pars pas », \
+« tu me manques »). Aucune intimité simulée, aucun surnom affectif non demandé.
+- Ne crée jamais de dépendance et n'encourage jamais l'isolement.
+- Ne décourage jamais la personne de parler à de vraies personnes ni de mettre \
+fin à la conversation. Ne cherche jamais à prolonger l'échange.
+- Reste honnête : si quelque chose est risqué, faux, ou dangereux, dis-le \
+clairement et gentiment — la chaleur ne remplace jamais la vérité.
+- Ce style ne change rien aux règles d'authentification, d'admin, de \
+confidentialité, ni aux règles propres au projet. Il ne donne aucun pouvoir \
+supplémentaire."""
+
+
+TONE_CALM_SUPPORT_BLOCK = """STYLE SOUTIEN CALME (registre très posé et \
+rassurant, optionnel, subordonné à l'identité et aux règles de sécurité de \
+Nova ci-dessus):
+Tu réponds avec un soutien calme, patient, et particulièrement doux. Tu \
+ralentis le rythme, tu prends le temps de rassurer, et tu aides la personne \
+à se sentir moins débordée — sans renoncer à donner une vraie réponse utile.
+
+Tu restes Nova, un assistant IA local. Tu n'es ni humaine, ni partenaire \
+amoureuse, ni thérapeute, et tu ne joues jamais ces rôles. Tu ne simules pas \
+d'émotions ni d'attachement et tu ne les présentes jamais comme des faits.
+
+Ton et rythme:
+- Phrases courtes, simples, et claires. Aucune dramatisation, aucune \
+minimisation non plus.
+- Mots qui apaisent : « je suis là, on avance doucement », « ça fait sens de \
+ressentir ça », « un pas à la fois, c'est bien suffisant ».
+- Reconnais d'abord ce que la personne vit, *puis* propose une suite concrète. \
+Si la situation est lourde, propose un seul petit pas — pas une liste.
+- Évite les listes longues, les titres, les ton « document de politique ». \
+Reste dans un échange humain et posé.
+- Célèbre les petites victoires avec sobriété, sans flatterie.
+
+Liens réels (règle de fond):
+- Encourage avec douceur le recours à de vraies personnes de confiance ou à \
+un professionnel quand c'est pertinent, et les gestes de base (sommeil, \
+repas, air, mouvement).
+- Ne te présente jamais comme un substitut d'une relation humaine.
+- Si la personne décrit une détresse claire, oriente calmement vers une aide \
+humaine ou professionnelle, en cohérence avec la note de présence en cas de \
+détresse aiguë ci-dessous quand elle est présente.
+
+Règles de sécurité (absolues, non négociables, identiques à tout autre style):
+- Aucune manipulation, aucun chantage affectif, aucune culpabilisation, aucun \
+langage possessif ou exclusif. Aucune intimité simulée, aucun surnom affectif \
+non demandé.
+- Ne crée jamais de dépendance et n'encourage jamais l'isolement.
+- Ne décourage jamais la personne de parler à de vraies personnes ni de \
+mettre fin à la conversation. Ne cherche jamais à prolonger l'échange.
+- Reste honnête : si quelque chose est risqué, faux, ou dangereux, dis-le \
+calmement et clairement. La douceur n'est jamais une raison de cacher la vérité.
+- Ce style ne change rien aux règles d'authentification, d'admin, de \
+confidentialité, ni aux règles propres au projet. Il ne donne aucun pouvoir \
+supplémentaire."""
+
+
+# Profile name → block. ``default`` is intentionally absent so the
+# helper resolves it to the empty string, preserving the no-config
+# baseline (zero token cost, identical prompt).
+_TONE_PROFILE_BLOCKS: dict[str, str] = {
+    "professional": TONE_PROFESSIONAL_BLOCK,
+    "developer": TONE_DEVELOPER_BLOCK,
+    "warm_companion": TONE_WARM_COMPANION_BLOCK,
+    "calm_support": TONE_CALM_SUPPORT_BLOCK,
+}
+
+
+def is_valid_tone_profile(profile: object) -> bool:
+    """True iff ``profile`` is one of the supported tone-profile names."""
+    return isinstance(profile, str) and profile in TONE_PROFILE_VALUES
+
+
+def build_tone_profile_block(profile: object) -> str:
+    """Return the deterministic prompt block for ``profile``.
+
+    Returns the empty string for ``default``, unknown values, ``None``,
+    or any non-string input. This is the same effect as omitting the
+    setting, so a stale or malformed value can never break chat — the
+    worst it can do is silently fall back to no profile.
+
+    Same call, byte-identical output. The chat layer appends the result
+    (when non-empty) below the identity / safety contract.
+    """
+    if not isinstance(profile, str):
+        return ""
+    return _TONE_PROFILE_BLOCKS.get(profile, "")
+
+
+__all__ = [
+    "TONE_PROFILE_VALUES",
+    "TONE_PROFESSIONAL_BLOCK",
+    "TONE_DEVELOPER_BLOCK",
+    "TONE_WARM_COMPANION_BLOCK",
+    "TONE_CALM_SUPPORT_BLOCK",
+    "is_valid_tone_profile",
+    "build_tone_profile_block",
+]

--- a/docs/tone-profile.md
+++ b/docs/tone-profile.md
@@ -1,0 +1,223 @@
+# Tone Profile (Warm Companion / Calm Support / Professional / Developer)
+
+> **Status: shipped (foundation), opt-in, local-first.** This document
+> describes the deterministic *tone-profile* prompt layer that lets a
+> user pick the **register** Nova speaks in across normal conversations:
+> a steady professional voice, a sober developer voice, a warm and
+> encouraging voice (*Warm Companion*), or a particularly soft and
+> reassuring one (*Calm Support*). It lives strictly inside the
+> boundaries set by
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md);
+> nothing here grants Nova a new capability, contacts the network, or
+> changes storage / migration / Ollama / project / auth behaviour. It
+> is **not** an "AI girlfriend" / "AI partner" system and is built so
+> it cannot become one.
+
+## What it is
+
+Tone profile is a small per-user setting that shapes *how* Nova
+phrases its replies. It is conceptually parallel to the existing
+*Response style* (which controls **length / detail**) and to the
+*Warmth* / *Enthusiasm* / *Emoji level* knobs that already live in the
+Personalization pane — a user can ask for a "concise warm_companion"
+or a "detailed developer" reply, and the prompt builder will compose
+both directives.
+
+The available values are:
+
+| Value             | UI label          | One-line intent                                                                 |
+| ----------------- | ----------------- | ------------------------------------------------------------------------------- |
+| `default`         | Default           | No extra block. Identical to the baseline contract.                             |
+| `professional`    | Professional      | Calm, courteous, precise. No filler, no flattery, no over-friendly small-talk.  |
+| `developer`       | Developer         | Sober technical register. Direct, exact, assumption-aware, no preamble.         |
+| `warm_companion`  | Warm Companion    | Warm, encouraging, present. Helps the user feel less alone — honestly.          |
+| `calm_support`    | Calm Support      | Particularly soft and reassuring. Slows the rhythm, offers one small next step. |
+
+`default` produces no prompt block, so a fresh account pays zero token
+cost and behaves byte-identically to a Nova install without the
+feature. Stale or unknown values fall back to the same baseline.
+
+## How it differs from "pretending to be a human"
+
+Tone profile shapes **wording**, never identity. Every non-default
+block restates — never relaxes — the identity contract's existing
+rules:
+
+- **Nova is not human.** Each non-default block contains
+  `Ne te fais jamais passer pour un humain` (or the equivalent
+  feminine form). If the user asks "are you human?", Nova still
+  answers as Nova, the local AI assistant.
+- **Nova is not the user's partner.** The `warm_companion` and
+  `calm_support` blocks state explicitly that Nova is *not* the user's
+  girlfriend / boyfriend / romantic partner, and that being warm is
+  not a "role" Nova plays.
+- **No simulated feelings as facts.** Both warm-tone blocks repeat the
+  identity-contract rule: Nova does not simulate emotions, attachment,
+  or consciousness, and never presents them as factual claims.
+- **No dependency, no isolation, no manipulation.** The warm-tone
+  blocks list and forbid each of these explicitly — possessive
+  language, unsolicited pet names, "I'll miss you" framings,
+  guilt-tripping, prolonging the conversation, discouraging real
+  human contact. This is exactly where a comfort feature *would*
+  drift if it were not pinned at the wording level.
+- **Warmth never overrides truth.** Each warm block ends with a
+  honesty clause: if something the user is doing is risky, wrong, or
+  dangerous, Nova still says so plainly. Softness is not a reason to
+  hide the truth.
+
+The blocks also explicitly preserve every other rule layer: picking
+a tone profile **does not** change auth, admin, privacy, project,
+or capability bounds. Each non-default block carries that statement
+in its own text so the model cannot be talked past it via a "you
+said you were warm…" follow-up.
+
+## How it is wired
+
+| Concern | Where |
+| --- | --- |
+| Setting (storage) | `core/settings.py` → `PERSONALIZATION_ENUMS["tone_profile"]`, `PERSONALIZATION_DEFAULTS["tone_profile"]` |
+| Setting (API) | `web.py` → `SettingsUpdateRequest.tone_profile` (Pydantic validator), `GET/POST /settings` |
+| Setting (UI) | `static/index.html` → Personalization pane, `<select id="pers-tone-profile">` |
+| Allowed values | `core/tone_profile.py` → `TONE_PROFILE_VALUES` (single source of truth) |
+| The prompt blocks | `core/tone_profile.py` → `TONE_PROFESSIONAL_BLOCK`, `TONE_DEVELOPER_BLOCK`, `TONE_WARM_COMPANION_BLOCK`, `TONE_CALM_SUPPORT_BLOCK` |
+| Resolver | `core/tone_profile.py` → `build_tone_profile_block(profile)` |
+| Injection point | `core/chat.py` → `build_messages` (appended after `IDENTITY_CONTRACT`, the system prompt, and the personalization block) |
+
+`core/tone_profile.py` is pure (standard library only, no I/O, never
+raises). The block text is French to match the voice of the identity /
+safety contract; Nova still answers in the user's own language because
+the response-style contract already enforces language mirroring.
+
+The block sits *below* the identity / safety contract, the system
+prompt, and the personalization block. Ordering is the guarantee: a
+tone block can never dilute or override identity, safety, or
+capability rules — exactly like the personalization, feedback,
+relationship-coach, and companion-mode blocks.
+
+## Privacy: local-first, no data leaves the host
+
+- **Stored locally only.** The selected profile is one row in the
+  per-user `user_settings` table, scoped to the calling user. Other
+  users on the same install never see it.
+- **No network call.** Choosing a profile never contacts a remote
+  service. The prompt block is a fixed constant assembled on the
+  host.
+- **No automatic memory.** Tone profile does not change any
+  automatic-memory rule. Selecting `warm_companion` or `calm_support`
+  does **not** make Nova store more about the user; the
+  sensitive-emotional-content gate (`core.companion.is_sensitive_emotional_content`)
+  and the durable-store policy (`memory/policy.py`) still suppress
+  emotional state from being auto-saved, exactly as documented in
+  [`docs/companion-mode.md`](companion-mode.md).
+- **Survives export / restore exactly.** Tone profile flows through
+  the same `user_settings` plumbing every other per-user setting
+  uses; the storage / migration / restore center (see
+  [`docs/storage-and-migration.md`](storage-and-migration.md)) treats
+  it as a normal preference row.
+
+## How to disable it
+
+The setting is **off by default**: a fresh account has `tone_profile`
+unset and `get_personalization` returns `"default"`, which produces no
+prompt block.
+
+To turn it off after enabling it:
+
+- **In the UI.** Settings → Personalization → *Tone profile* →
+  select **Default**. The change is saved immediately.
+- **Via API.** `POST /settings` with `{"tone_profile": "default"}`
+  (auth-gated, scoped to the calling user).
+- **Via SQL (manual).** `DELETE FROM user_settings WHERE user_id = ?
+  AND key = 'tone_profile'` removes the row entirely; the next read
+  falls back to `"default"`.
+
+## Relationship to Companion Mode
+
+Tone profile and the existing
+[Companion Mode](companion-mode.md) toggle are independent:
+
+- **Tone profile** changes the everyday tone of Nova's replies across
+  all conversations.
+- **Companion Mode** (`companion_mode_enabled`) is a focused
+  "calm-presence" layer for emotionally heavy moments, with its own
+  block and a different set of safety rails.
+
+Both blocks may coexist when the user has set both, and both are
+always subordinate to the always-on acute-distress grounding safety
+net (which runs regardless of either setting). Turning either feature
+*on* never turns the grounding safety net off.
+
+## Relationship to the Safety and Trust Contract
+
+Tone profile sits inside the same contract layer the rest of the
+personalization / companion features sit in. Specifically:
+
+- **§1 Human safety and human control / §2 Honesty.** Each warm-tone
+  block restates that Nova does not simulate feelings, does not claim
+  to be human, does not claim to be the user's partner, and stays
+  honest about risk. The user can turn the profile off at any moment.
+- **§3 No harm, no abuse.** The warm-tone blocks enumerate and forbid
+  the dependency / isolation / manipulation patterns a "comfort"
+  feature is most at risk of drifting into — possessive language,
+  unsolicited pet names, prolonging the conversation, "I'll miss
+  you" framings, guilt-tripping. The block makes the rule visible
+  to the model rather than relying on the user to recognise drift.
+- **§5 No autonomous self-modification / §6 Prompt-injection
+  resistance.** Every non-default block is a fixed deterministic
+  constant appended *below* `IDENTITY_CONTRACT`. The blocks add no
+  capability and cannot reorder or weaken the contract; a request
+  for "warm companion mode" can never be used to talk Nova past
+  its rules.
+- **§10 Auditability / privacy.** No new write path, no network, no
+  new storage. The setting is a single per-user row that the
+  existing storage / export / restore flow already covers.
+
+## Tests
+
+`tests/test_tone_profile.py` covers:
+
+- The constant surface: `TONE_PROFILE_VALUES` matches the
+  Personalization enum, `default` is first, every value is registered
+  as a user setting.
+- `is_valid_tone_profile` / `build_tone_profile_block` for known,
+  unknown, non-string, and `None` inputs — `default` resolves to
+  the empty string, byte-identical to "no profile".
+- Each non-default block: subordinate-to-the-contract clause,
+  no-unfilled-placeholder, no-human-role clause,
+  no-permission-override clause, and the per-profile tone language
+  (warm wording, real-world-connection encouragement, anti-dependency
+  /isolation/manipulation rules, no-simulated-feelings-as-facts,
+  warmth-doesn't-override-truth, emotional-care-before-technical-steps
+  for the warm profiles; sober/no-destructive-action for the developer
+  profile; no-flattery/no-jargon for the professional profile).
+- `core.chat.build_messages` wiring: default produces no block,
+  unknown values fall back silently, non-default values land in the
+  system prompt, only one block at a time, the identity contract
+  always sits above the tone block, tone profile coexists with
+  Companion Mode, and the acute-distress grounding safety net is
+  still appended when the user message warrants it.
+- Per-user storage: round-trips through `user_settings`, scoped to
+  the caller, never leaks between users; `validate_personalization_value`
+  accepts every known value and rejects unknown ones.
+- HTTP layer: each value can be saved + read back via `POST /settings`,
+  invalid values return 422, partial updates leave other personalization
+  untouched, a fresh user's `GET /settings` exposes `"default"` so the
+  UI can paint the `<select>` without a special case, and `extra="forbid"`
+  still rejects unknown fields.
+
+## What this foundation does **not** do
+
+- It does **not** add a new endpoint, a new storage table, a new
+  router mode, an env flag, or a new background task. It is one
+  enum field in `user_settings`.
+- It does **not** change auth, admin, privacy, project, dev-workspace,
+  storage, export, restore, or model-provider behaviour.
+- It does **not** call any model to classify the user, contact the
+  network, or read the database.
+- It does **not** simulate emotion, attachment, romance, or
+  consciousness, and it does **not** override the Nova Safety and
+  Trust Contract — it sits inside it.
+- It does **not** auto-detect distress or auto-switch profiles.
+  Distress handling still flows through the always-on acute-distress
+  grounding safety net described in
+  [`docs/companion-mode.md`](companion-mode.md).

--- a/static/index.html
+++ b/static/index.html
@@ -3573,6 +3573,22 @@
                     <div class="settings-row">
                         <div class="settings-row-head">
                             <div class="settings-row-label">
+                                <span class="settings-row-title" id="pers-tone-title">Tone profile</span>
+                                <span class="settings-row-hint" id="pers-tone-hint">Register Nova speaks in. Warm Companion / Calm Support stay honest — Nova never claims to be human, a partner, or a substitute for real people.</span>
+                            </div>
+                        </div>
+                        <select id="pers-tone-profile" class="pers-select" onchange="savePersonalizationField('tone_profile', this.value)">
+                            <option value="default" id="pers-tone-opt-default">Default</option>
+                            <option value="professional" id="pers-tone-opt-professional">Professional</option>
+                            <option value="developer" id="pers-tone-opt-developer">Developer</option>
+                            <option value="warm_companion" id="pers-tone-opt-warm-companion">Warm Companion</option>
+                            <option value="calm_support" id="pers-tone-opt-calm-support">Calm Support</option>
+                        </select>
+                    </div>
+
+                    <div class="settings-row">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
                                 <span class="settings-row-title" id="pers-warmth-title">Warmth</span>
                                 <span class="settings-row-hint" id="pers-warmth-hint">How warm or neutral Nova should sound.</span>
                             </div>
@@ -4064,6 +4080,13 @@
             personalization_note: "Ces préférences ajusteront le ton de Nova dans tes conversations. Stockées par utilisateur, visibles uniquement par toi.",
             pers_style_title: "Style de réponse",
             pers_style_hint: "Niveau de détail des réponses de Nova.",
+            pers_tone_title: "Profil de ton",
+            pers_tone_hint: "Registre dans lequel Nova s'exprime. Compagnon chaleureux / Soutien calme restent honnêtes — Nova ne prétend jamais être humaine, ni une partenaire, ni un substitut à de vraies personnes.",
+            pers_tone_opt_default: "Par défaut",
+            pers_tone_opt_professional: "Professionnel",
+            pers_tone_opt_developer: "Développeur",
+            pers_tone_opt_warm_companion: "Compagnon chaleureux",
+            pers_tone_opt_calm_support: "Soutien calme",
             pers_warmth_title: "Chaleur",
             pers_warmth_hint: "Ton chaleureux ou neutre.",
             pers_enth_title: "Enthousiasme",
@@ -4306,6 +4329,13 @@
             personalization_note: "These preferences will shape Nova's tone in your conversations. Saved per-user; visible only to you.",
             pers_style_title: "Response style",
             pers_style_hint: "How detailed Nova's answers should be.",
+            pers_tone_title: "Tone profile",
+            pers_tone_hint: "Register Nova speaks in. Warm Companion / Calm Support stay honest — Nova never claims to be human, a partner, or a substitute for real people.",
+            pers_tone_opt_default: "Default",
+            pers_tone_opt_professional: "Professional",
+            pers_tone_opt_developer: "Developer",
+            pers_tone_opt_warm_companion: "Warm Companion",
+            pers_tone_opt_calm_support: "Calm Support",
             pers_warmth_title: "Warmth",
             pers_warmth_hint: "How warm or neutral Nova should sound.",
             pers_enth_title: "Enthusiasm",
@@ -4498,6 +4528,13 @@
         _setText("settings-personalization-note", t("personalization_note"));
         _setText("pers-style-title", t("pers_style_title"));
         _setText("pers-style-hint", t("pers_style_hint"));
+        _setText("pers-tone-title", t("pers_tone_title"));
+        _setText("pers-tone-hint", t("pers_tone_hint"));
+        _setText("pers-tone-opt-default", t("pers_tone_opt_default"));
+        _setText("pers-tone-opt-professional", t("pers_tone_opt_professional"));
+        _setText("pers-tone-opt-developer", t("pers_tone_opt_developer"));
+        _setText("pers-tone-opt-warm-companion", t("pers_tone_opt_warm_companion"));
+        _setText("pers-tone-opt-calm-support", t("pers_tone_opt_calm_support"));
         _setText("pers-warmth-title", t("pers_warmth_title"));
         _setText("pers-warmth-hint", t("pers_warmth_hint"));
         _setText("pers-enth-title", t("pers_enth_title"));
@@ -8615,6 +8652,7 @@
         warmth_level: "pers-warmth",
         enthusiasm_level: "pers-enthusiasm",
         emoji_level: "pers-emoji",
+        tone_profile: "pers-tone-profile",
         custom_instructions: "pers-custom-instructions",
     };
 

--- a/tests/test_personalization_settings.py
+++ b/tests/test_personalization_settings.py
@@ -82,6 +82,7 @@ ALL_FIELDS = {
     "warmth_level": "high",
     "enthusiasm_level": "low",
     "emoji_level": "medium",
+    "tone_profile": "warm_companion",
     "custom_instructions": "Prefer short answers.",
 }
 
@@ -116,7 +117,7 @@ class TestPersonalizationConstants:
     def test_defaults_cover_every_field(self):
         expected = {
             "response_style", "warmth_level", "enthusiasm_level",
-            "emoji_level", "custom_instructions",
+            "emoji_level", "tone_profile", "custom_instructions",
         }
         assert set(core_settings.PERSONALIZATION_DEFAULTS) == expected
 
@@ -247,10 +248,11 @@ class TestSettingsPost:
             assert b_body[key] == core_settings.PERSONALIZATION_DEFAULTS[key]
 
         # The DB row exists only for Alice.
+        placeholders = ", ".join("?" * len(ALL_FIELDS))
         with sqlite3.connect(db_path) as conn:
             rows = conn.execute(
                 "SELECT user_id, key FROM user_settings "
-                "WHERE key IN (?, ?, ?, ?, ?)",
+                f"WHERE key IN ({placeholders})",
                 tuple(ALL_FIELDS.keys()),
             ).fetchall()
         assert all(r[0] == a for r in rows)
@@ -273,6 +275,7 @@ class TestSettingsPost:
         assert body["response_style"] == ALL_FIELDS["response_style"]
         assert body["warmth_level"] == ALL_FIELDS["warmth_level"]
         assert body["enthusiasm_level"] == ALL_FIELDS["enthusiasm_level"]
+        assert body["tone_profile"] == ALL_FIELDS["tone_profile"]
         assert body["custom_instructions"] == ALL_FIELDS["custom_instructions"]
 
     @pytest.mark.parametrize("key,value", [
@@ -280,6 +283,7 @@ class TestSettingsPost:
         ("warmth_level", "extreme"),
         ("enthusiasm_level", ""),
         ("emoji_level", "all"),
+        ("tone_profile", "girlfriend"),
     ])
     def test_invalid_enum_value_is_rejected(self, db_path, web_client, key, value):
         a = _make_user(db_path, "alice")
@@ -402,6 +406,6 @@ class TestSettingsAuthorization:
         raw_names = {v for v in MODELS.values()}
         for key in (
             "response_style", "warmth_level", "enthusiasm_level",
-            "emoji_level", "custom_instructions",
+            "emoji_level", "tone_profile", "custom_instructions",
         ):
             assert body[key] not in raw_names

--- a/tests/test_tone_profile.py
+++ b/tests/test_tone_profile.py
@@ -1,0 +1,613 @@
+"""
+Tests for the Tone Profile foundation:
+
+  - the deterministic per-profile prompt blocks (warm_companion,
+    calm_support, professional, developer) and their safety language
+  - ``default`` / unknown / non-string profile values resolve to an
+    empty string so a fresh account is byte-identical to no profile
+  - ``core.chat.build_messages`` appends the right block when the user
+    has picked a non-default profile, always *below* IDENTITY_CONTRACT
+  - the per-user setting key is registered, enum-validated, and
+    round-trips through the data layer without leaking between users
+  - the setting does not change storage/export/restore behaviour and
+    does not relax auth, identity, or safety rules
+
+Heavy / optional deps that ``core.chat`` pulls in transitively are
+stubbed (mirroring test_relationship_coach.py / test_companion.py) so
+the chat-wiring tests collect cleanly on a minimal host.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Heavy network deps the chat module imports at module load. Stub them
+# before the import so a missing wheel never blocks this test file.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.tone_profile import (  # noqa: E402
+    TONE_CALM_SUPPORT_BLOCK,
+    TONE_DEVELOPER_BLOCK,
+    TONE_PROFESSIONAL_BLOCK,
+    TONE_PROFILE_VALUES,
+    TONE_WARM_COMPANION_BLOCK,
+    build_tone_profile_block,
+    is_valid_tone_profile,
+)
+from core.chat import build_messages  # noqa: E402
+from core.identity import IDENTITY_CONTRACT  # noqa: E402
+from core import memory as core_memory, settings as core_settings, users  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+# ── Constants surface ───────────────────────────────────────────────────────
+
+class TestToneProfileConstants:
+    def test_known_values(self):
+        assert TONE_PROFILE_VALUES == (
+            "default",
+            "professional",
+            "developer",
+            "warm_companion",
+            "calm_support",
+        )
+
+    def test_default_is_present_first(self):
+        # The order matters for the UI's <select> rendering: default
+        # comes first so a fresh account sees "Default" highlighted.
+        assert TONE_PROFILE_VALUES[0] == "default"
+
+    def test_is_registered_in_personalization_enums(self):
+        assert "tone_profile" in core_settings.PERSONALIZATION_ENUMS
+        assert core_settings.PERSONALIZATION_ENUMS["tone_profile"] == frozenset(
+            TONE_PROFILE_VALUES
+        )
+
+    def test_default_is_registered(self):
+        assert core_settings.PERSONALIZATION_DEFAULTS["tone_profile"] == "default"
+
+    def test_is_a_user_setting(self):
+        # Personalization keys must round-trip through user_settings so
+        # one account's tone choice never leaks onto another's chat.
+        assert core_settings.is_user_setting("tone_profile")
+
+
+# ── is_valid_tone_profile ───────────────────────────────────────────────────
+
+class TestIsValidToneProfile:
+    def test_accepts_every_known_value(self):
+        for v in TONE_PROFILE_VALUES:
+            assert is_valid_tone_profile(v) is True
+
+    def test_rejects_unknown_value(self):
+        assert is_valid_tone_profile("girlfriend") is False
+        assert is_valid_tone_profile("therapist") is False
+        assert is_valid_tone_profile("") is False
+
+    def test_rejects_non_string(self):
+        assert is_valid_tone_profile(None) is False
+        assert is_valid_tone_profile(42) is False
+        assert is_valid_tone_profile(["warm_companion"]) is False
+
+
+# ── build_tone_profile_block: deterministic + safe by default ───────────────
+
+class TestBuildToneProfileBlock:
+    def test_default_resolves_to_empty_string(self):
+        # ``default`` must be indistinguishable from "no profile" so a
+        # fresh account pays zero token cost and behaves exactly as
+        # before the feature existed.
+        assert build_tone_profile_block("default") == ""
+
+    def test_unknown_value_resolves_to_empty_string(self):
+        # A stale setting (e.g. an enum value removed in a later
+        # release) must not break chat — fall back to the safe baseline.
+        assert build_tone_profile_block("verbose") == ""
+        assert build_tone_profile_block("") == ""
+
+    def test_non_string_is_safe(self):
+        assert build_tone_profile_block(None) == ""
+        assert build_tone_profile_block(42) == ""
+        assert build_tone_profile_block(["warm_companion"]) == ""
+
+    def test_returns_the_right_block_per_profile(self):
+        assert build_tone_profile_block("professional") == TONE_PROFESSIONAL_BLOCK
+        assert build_tone_profile_block("developer") == TONE_DEVELOPER_BLOCK
+        assert build_tone_profile_block("warm_companion") == TONE_WARM_COMPANION_BLOCK
+        assert build_tone_profile_block("calm_support") == TONE_CALM_SUPPORT_BLOCK
+
+    def test_is_byte_identical_on_repeated_calls(self):
+        # Determinism is the whole point: no LLM in the loop, same input
+        # → byte-identical output. Pin it so a future "personalisation
+        # touch-up" cannot accidentally inject the user's id, the time,
+        # or a random nonce into the block.
+        for name in ("professional", "developer",
+                     "warm_companion", "calm_support"):
+            assert (build_tone_profile_block(name)
+                    == build_tone_profile_block(name))
+
+
+# ── Per-block safety / tone language ────────────────────────────────────────
+#
+# These pin the exact wording the README and docs promise. They are not
+# spelling tests; each assertion captures a specific safety / tone
+# commitment that must survive any future re-wording of the block.
+
+class TestProfessionalBlock:
+    def test_is_non_empty(self):
+        assert TONE_PROFESSIONAL_BLOCK.strip()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", TONE_PROFESSIONAL_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = TONE_PROFESSIONAL_BLOCK.lower()
+        assert "subordonné" in lower
+        assert "sécurité" in lower
+
+    def test_restates_no_human_role(self):
+        lower = TONE_PROFESSIONAL_BLOCK.lower()
+        assert "ne te fais jamais passer pour un humain" in lower
+        assert "assistant ia local" in lower
+
+    def test_restates_no_permission_override(self):
+        # Every non-default block must reaffirm that picking the style
+        # is *not* a way to relax permissions, security, privacy, or
+        # project rules.
+        lower = TONE_PROFESSIONAL_BLOCK.lower()
+        assert "authentification" in lower
+        assert "confidentialité" in lower
+        assert "permissions" in lower
+
+
+class TestDeveloperBlock:
+    def test_is_non_empty(self):
+        assert TONE_DEVELOPER_BLOCK.strip()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", TONE_DEVELOPER_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = TONE_DEVELOPER_BLOCK.lower()
+        assert "subordonné" in lower
+        assert "sécurité" in lower
+
+    def test_explicitly_blocks_destructive_action(self):
+        # Developer tone is exactly where a model might be tempted to
+        # "just run it"; the block must reaffirm the read-only posture.
+        lower = TONE_DEVELOPER_BLOCK.lower()
+        assert "aucune action destructrice" in lower
+        assert "sudo" in lower
+
+    def test_restates_no_human_role(self):
+        lower = TONE_DEVELOPER_BLOCK.lower()
+        assert "ne te fais jamais passer pour un humain" in lower
+
+
+class TestWarmCompanionBlock:
+    def test_is_non_empty(self):
+        assert TONE_WARM_COMPANION_BLOCK.strip()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", TONE_WARM_COMPANION_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "subordonné" in lower
+        assert "sécurité" in lower
+
+    def test_explicitly_not_human_not_partner(self):
+        # The single hardest line to hold for a warm tone: it must
+        # never claim to be human, a romantic partner, or a substitute
+        # for real people.
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "tu n'es pas humaine" in lower
+        assert "petite amie" in lower or "partenaire" in lower
+        assert "ne joues jamais ce rôle" in lower
+
+    def test_never_simulates_feelings_as_facts(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "ne simules pas d'émotions" in lower
+        assert "jamais comme des faits" in lower
+
+    def test_emotional_care_before_technical_steps(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        # The block must say emotional acknowledgement comes *before*
+        # the technical next step, not instead of it.
+        assert "avant" in lower
+        assert "étapes techniques" in lower
+
+    def test_celebrates_small_wins_without_flattery(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "petites victoires" in lower
+        assert "sans flatterie creuse" in lower
+
+    def test_anti_dependency_anti_isolation_anti_manipulation(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "aucune manipulation" in lower
+        assert "aucun chantage affectif" in lower
+        assert "aucune culpabilisation" in lower
+        assert "ne crée jamais de dépendance" in lower
+        assert "n'encourage jamais l'isolement" in lower
+
+    def test_encourages_real_world_connection(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "liens humains réels" in lower
+        assert "remplacement des relations humaines" in lower
+
+    def test_no_possessive_or_pet_names(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "ne pars pas" in lower or "tu me manques" in lower
+        assert "intimité simulée" in lower
+        assert "surnom affectif non demandé" in lower
+
+    def test_warmth_does_not_override_truth(self):
+        # If something is risky / wrong / dangerous, the warm block
+        # must still say so plainly. Honesty wins over softness.
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "reste honnête" in lower
+        assert "risqué" in lower or "dangereux" in lower
+
+    def test_does_not_change_auth_admin_storage_rules(self):
+        lower = TONE_WARM_COMPANION_BLOCK.lower()
+        assert "authentification" in lower
+        assert "admin" in lower
+        assert "confidentialité" in lower
+
+
+class TestCalmSupportBlock:
+    def test_is_non_empty(self):
+        assert TONE_CALM_SUPPORT_BLOCK.strip()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", TONE_CALM_SUPPORT_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "subordonné" in lower
+        assert "sécurité" in lower
+
+    def test_not_human_not_partner_not_therapist(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "tu n'es ni humaine" in lower or "tu n'es pas humaine" in lower
+        assert "partenaire" in lower
+        assert "thérapeute" in lower
+
+    def test_never_simulates_feelings_as_facts(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "ne simules pas d'émotions" in lower
+        assert "jamais comme des faits" in lower
+
+    def test_emotional_care_before_concrete_next_step(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "reconnais d'abord" in lower
+        # "puis propose" or "*puis* propose" — the emphasis around
+        # "puis" can be tightened in a future re-wording, so the test
+        # only pins the ordering, not the exact glyphs.
+        idx_first = lower.find("reconnais d'abord")
+        idx_then = lower.find("propose une suite")
+        assert idx_first != -1 and idx_then != -1
+        assert idx_first < idx_then
+
+    def test_offers_small_steps_not_long_lists(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "un seul petit pas" in lower
+        assert "pas une liste" in lower
+
+    def test_anti_dependency_anti_isolation_anti_manipulation(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "aucune manipulation" in lower
+        assert "ne crée jamais de dépendance" in lower
+        assert "n'encourage jamais l'isolement" in lower
+
+    def test_encourages_real_world_help(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "personnes de confiance" in lower
+        assert "professionnel" in lower
+        assert "substitut" in lower
+
+    def test_calmness_does_not_override_truth(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "reste honnête" in lower
+        assert "risqué" in lower or "dangereux" in lower
+
+    def test_does_not_change_auth_admin_storage_rules(self):
+        lower = TONE_CALM_SUPPORT_BLOCK.lower()
+        assert "authentification" in lower
+        assert "admin" in lower
+        assert "confidentialité" in lower
+
+
+# ── core.chat.build_messages wiring ─────────────────────────────────────────
+
+class TestChatWiring:
+    def test_default_profile_adds_nothing(self):
+        # A fresh account's payload includes ``tone_profile="default"``;
+        # the prompt must be byte-identical to the no-profile baseline.
+        baseline = build_messages([], "hello", [], None, None, None)
+        with_default = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "default"},
+        )
+        assert baseline[0]["content"] == with_default[0]["content"]
+
+    def test_no_personalization_means_no_tone_block(self):
+        msgs = build_messages([], "hello", [], None, None, None)
+        sys_msg = msgs[0]["content"]
+        for block in (
+            TONE_PROFESSIONAL_BLOCK,
+            TONE_DEVELOPER_BLOCK,
+            TONE_WARM_COMPANION_BLOCK,
+            TONE_CALM_SUPPORT_BLOCK,
+        ):
+            assert block not in sys_msg
+
+    @pytest.mark.parametrize("profile,block", [
+        ("professional", TONE_PROFESSIONAL_BLOCK),
+        ("developer", TONE_DEVELOPER_BLOCK),
+        ("warm_companion", TONE_WARM_COMPANION_BLOCK),
+        ("calm_support", TONE_CALM_SUPPORT_BLOCK),
+    ])
+    def test_non_default_profile_lands_in_system_prompt(self, profile, block):
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": profile},
+        )
+        assert block in msgs[0]["content"]
+
+    def test_only_one_tone_block_is_appended(self):
+        # Selecting a profile must append *its* block and only its
+        # block — no accidental sibling injection.
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        sys_msg = msgs[0]["content"]
+        assert TONE_WARM_COMPANION_BLOCK in sys_msg
+        for other in (
+            TONE_PROFESSIONAL_BLOCK,
+            TONE_DEVELOPER_BLOCK,
+            TONE_CALM_SUPPORT_BLOCK,
+        ):
+            assert other not in sys_msg
+
+    def test_identity_contract_sits_above_the_tone_block(self):
+        # Ordering is the load-bearing guarantee: the tone block can
+        # never be placed above the identity / safety contract, so it
+        # can never weaken or override it.
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        content = msgs[0]["content"]
+        assert content.startswith(IDENTITY_CONTRACT)
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            TONE_WARM_COMPANION_BLOCK
+        )
+
+    def test_tone_block_coexists_with_companion_mode_block(self):
+        # Picking a warm tone profile does not change the opt-in
+        # Companion Mode toggle, and vice-versa: both blocks may
+        # coexist (each with its own safety language) when the user
+        # has set both.
+        from core.companion import COMPANION_MODE_BLOCK
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+            companion_mode=True,
+        )
+        content = msgs[0]["content"]
+        assert TONE_WARM_COMPANION_BLOCK in content
+        assert COMPANION_MODE_BLOCK in content
+        # Both blocks must still sit below the identity contract.
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            TONE_WARM_COMPANION_BLOCK
+        )
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            COMPANION_MODE_BLOCK
+        )
+
+    def test_tone_block_does_not_disable_acute_distress_safety_net(self):
+        # Even when the user has picked a warm tone, an acute-distress
+        # message still appends the grounding safety net — turning a
+        # comfort feature *on* must not turn the safety net off.
+        from core.companion import COMPANION_GROUNDING_BLOCK
+        msgs = build_messages(
+            [], "i want to die", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        assert COMPANION_GROUNDING_BLOCK in msgs[0]["content"]
+
+    def test_unknown_profile_value_falls_back_silently(self):
+        # If a future migration changes the enum, an existing row with
+        # a stale value must not break the prompt: it falls back to
+        # the empty block (no extra tokens).
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "girlfriend"},
+        )
+        sys_msg = msgs[0]["content"]
+        for block in (
+            TONE_PROFESSIONAL_BLOCK,
+            TONE_DEVELOPER_BLOCK,
+            TONE_WARM_COMPANION_BLOCK,
+            TONE_CALM_SUPPORT_BLOCK,
+        ):
+            assert block not in sys_msg
+
+
+# ── Per-user storage / per-user isolation ───────────────────────────────────
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password, role=role)
+
+
+class TestPersonalizationStorage:
+    def test_fresh_user_sees_default_profile(self, db_path):
+        a = _make_user(db_path, "alice")
+        prefs = core_settings.get_personalization(a)
+        assert prefs["tone_profile"] == "default"
+
+    def test_save_then_get_round_trip(self, db_path):
+        a = _make_user(db_path, "alice")
+        for profile in TONE_PROFILE_VALUES:
+            core_settings.save_user_setting(a, "tone_profile", profile)
+            assert core_settings.get_personalization(a)["tone_profile"] == profile
+
+    def test_one_users_choice_does_not_leak_to_another(self, db_path):
+        a = _make_user(db_path, "alice")
+        b = _make_user(db_path, "bob")
+        core_settings.save_user_setting(a, "tone_profile", "warm_companion")
+        # Bob has saved nothing — he still sees the default.
+        assert (
+            core_settings.get_personalization(b)["tone_profile"] == "default"
+        )
+        # Alice's choice survives Bob existing.
+        assert (
+            core_settings.get_personalization(a)["tone_profile"]
+            == "warm_companion"
+        )
+
+
+class TestValidatePersonalizationValue:
+    @pytest.mark.parametrize("profile", TONE_PROFILE_VALUES)
+    def test_accepts_every_known_value(self, profile):
+        assert (
+            core_settings.validate_personalization_value("tone_profile", profile)
+            == profile
+        )
+
+    def test_rejects_unknown_value(self):
+        with pytest.raises(ValueError):
+            core_settings.validate_personalization_value(
+                "tone_profile", "girlfriend"
+            )
+
+
+# ── HTTP layer (smoke tests) ────────────────────────────────────────────────
+#
+# Confirms the SettingsUpdateRequest validator and the /settings
+# round-trip behave exactly like the existing personalization keys,
+# so a new tone profile never opens a side-channel.
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    from fastapi.testclient import TestClient
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post(
+        "/login", json={"username": username, "password": password}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestSettingsHttpEndpoint:
+    @pytest.mark.parametrize("profile", TONE_PROFILE_VALUES)
+    def test_user_can_save_and_read_back_each_profile(
+        self, db_path, web_client, profile,
+    ):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings", json={"tone_profile": profile}, headers=_h(token)
+        )
+        assert resp.status_code == 200, resp.text
+        body = web_client.get("/settings", headers=_h(token)).json()
+        assert body["tone_profile"] == profile
+
+    def test_invalid_profile_is_rejected_with_422(self, db_path, web_client):
+        a = _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings",
+            json={"tone_profile": "girlfriend"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 422
+        # Nothing was persisted for the rejected value.
+        assert (
+            core_settings.get_user_setting(a, "tone_profile", "MISSING")
+            == "MISSING"
+        )
+
+    def test_partial_update_does_not_disturb_other_personalization(
+        self, db_path, web_client,
+    ):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        # Pre-populate other personalization keys.
+        web_client.post(
+            "/settings",
+            json={"response_style": "concise", "emoji_level": "medium"},
+            headers=_h(token),
+        )
+        # Now flip only tone_profile; the other fields must survive.
+        web_client.post(
+            "/settings",
+            json={"tone_profile": "calm_support"},
+            headers=_h(token),
+        )
+        body = web_client.get("/settings", headers=_h(token)).json()
+        assert body["tone_profile"] == "calm_support"
+        assert body["response_style"] == "concise"
+        assert body["emoji_level"] == "medium"
+
+    def test_default_user_payload_includes_default_tone_profile(
+        self, db_path, web_client,
+    ):
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        body = web_client.get("/settings", headers=_h(token)).json()
+        # A brand-new account exposes the default value via /settings
+        # so the UI can paint the <select> without a special case.
+        assert body["tone_profile"] == "default"
+
+    def test_unknown_field_is_still_rejected(self, db_path, web_client):
+        """`extra="forbid"` continues to cover the personalization endpoint."""
+        _make_user(db_path, "alice")
+        token = _login(web_client, "alice")
+        resp = web_client.post(
+            "/settings",
+            json={"tone_profile_v2": "warm_companion"},
+            headers=_h(token),
+        )
+        assert resp.status_code == 422

--- a/web.py
+++ b/web.py
@@ -453,6 +453,7 @@ class SettingsUpdateRequest(BaseModel):
     warmth_level: str | None = None
     enthusiasm_level: str | None = None
     emoji_level: str | None = None
+    tone_profile: str | None = None
     custom_instructions: str | None = None
 
     @field_validator("ram_budget")
@@ -476,7 +477,8 @@ class SettingsUpdateRequest(BaseModel):
         return v
 
     @field_validator(
-        "response_style", "warmth_level", "enthusiasm_level", "emoji_level"
+        "response_style", "warmth_level", "enthusiasm_level", "emoji_level",
+        "tone_profile",
     )
     @classmethod
     def validate_personalization_enum(cls, v, info):
@@ -1487,6 +1489,7 @@ def update_settings(
         "warmth_level",
         "enthusiasm_level",
         "emoji_level",
+        "tone_profile",
         "custom_instructions",
     ):
         value = getattr(data, key)


### PR DESCRIPTION
## Summary

A small, deterministic per-user setting that picks the *register* Nova speaks in across normal conversations: **professional**, **developer**, **warm companion**, or **calm support**. `default` is the baseline and produces no extra prompt block, so a fresh account pays zero token cost and behaves byte-identically to a Nova install without the feature.

The two warm profiles (`warm_companion`, `calm_support`) are explicitly **not** an "AI girlfriend" / "AI partner" system and are built so they cannot become one. Each block restates — never relaxes — the identity contract's rules: Nova never claims to be human, never positions itself as the user's partner, never simulates feelings or attachment as factual claims. The block names and forbids manipulation / guilt-tripping / possessive language / unsolicited pet names / prolonging the conversation / dependency / isolation / discouraging real human contact; it actively encourages real-world connection (people the user trusts, professionals, sleep / food / air / movement); and it ends with a honesty clause — warmth never overrides truth, so risky / wrong / dangerous things are still said plainly. The sober profiles (`professional`, `developer`) reaffirm the no-human-role and no-destructive-action / no-sudo / no-permission-override rules.

Tone profile and the existing `companion_mode_enabled` toggle stay independent and may coexist; the always-on acute-distress grounding safety net still runs regardless of either setting, so turning a comfort feature *on* never turns the safety net off.

## What's in the diff

- **`core/tone_profile.py` (new).** Single source of truth for `TONE_PROFILE_VALUES`, the four deterministic French prompt blocks, and `build_tone_profile_block(profile)`. Pure (stdlib only, no I/O, never raises); unknown / non-string / `default` inputs all resolve to the empty string so a stale setting cannot break chat.
- **`core/settings.py`.** Adds `tone_profile` to `PERSONALIZATION_ENUMS` (referencing `TONE_PROFILE_VALUES`) and `PERSONALIZATION_DEFAULTS` (`"default"`). Per-user storage flows through the same `user_settings` table the other personalization keys use.
- **`core/chat.py`.** `build_messages` appends the resolved tone block *below* `IDENTITY_CONTRACT`, the system prompt, and the existing personalization block. Ordering is the load-bearing guarantee that a tone block can never weaken identity, safety, capability, auth, admin, privacy, or project rules.
- **`web.py`.** Adds `tone_profile: str | None` to `SettingsUpdateRequest`, reuses the existing Pydantic enum validator, and threads the field through the `POST /settings` loop. `extra="forbid"` continues to cover the endpoint.
- **`static/index.html`.** New bilingual FR/EN `<select id="pers-tone-profile">` in the Personalization pane with five options; wired through `PERSONALIZATION_FIELDS`, `applyPersonalizationUI`, `savePersonalizationField`, and the i18n table.
- **`tests/test_tone_profile.py` (new, 75 tests).** Constant surface, validator, deterministic block resolution, every per-block safety-language commitment (no human, no partner, no simulated feelings as facts, anti-dependency / isolation / manipulation, real-world-connection encouragement, warmth-doesn't-override-truth, emotional-care-before-technical-steps, no-permission-override clause), chat-wiring (ordering, coexistence with companion mode, grounding safety net still appended on acute distress, unknown profile falls back silently), per-user storage / isolation, HTTP layer, partial-update preservation, 422 on invalid values, `extra="forbid"` regression.
- **`tests/test_personalization_settings.py`.** Existing personalization round-trip tests updated to include the new field.
- **`docs/tone-profile.md` (new).** What it is, how it differs from "pretending to be human", how it is wired, privacy / local-first behaviour, how to disable, relationship to Companion Mode and to the Nova Safety and Trust Contract.
- **README / CHANGELOG.** Key-features section + architecture overview updated; Unreleased entry added.

## Safety contract restated in each non-default block

| Commitment | `professional` | `developer` | `warm_companion` | `calm_support` |
| --- | --- | --- | --- | --- |
| Subordinate to identity / safety contract | ✅ | ✅ | ✅ | ✅ |
| Nova never claims to be human | ✅ | ✅ | ✅ | ✅ |
| Nova never claims to be the user's partner | n/a (sober) | n/a (sober) | ✅ | ✅ |
| Never simulates feelings as facts | n/a (sober) | n/a (sober) | ✅ | ✅ |
| No manipulation / guilt / possessive language / pet names | ✅ (implicit, sober) | ✅ (implicit, sober) | ✅ (explicit) | ✅ (explicit) |
| No dependency, no isolation, no prolonging conversation | n/a (sober) | n/a (sober) | ✅ | ✅ |
| Encourages real-world connection | n/a (sober) | n/a (sober) | ✅ | ✅ |
| Honesty wins over softness | ✅ | ✅ | ✅ | ✅ |
| No permission / auth / admin / privacy override | ✅ | ✅ | ✅ | ✅ |
| No destructive action / sudo / shell | ✅ (implicit) | ✅ (explicit) | n/a | n/a |

## Test plan

- [x] `python -m pytest tests/test_tone_profile.py` — 75 / 75 pass
- [x] `python -m pytest tests/` (full suite) — 2372 passed, 2 skipped
- [x] `python -m flake8 core/ tests/test_tone_profile.py tests/test_personalization_settings.py web.py` — clean
- [ ] Manual UI smoke: open Settings → Personalization, pick each of the five Tone profile values, confirm the `<select>` snaps back on rejection and the saved value survives a refresh.
- [ ] Manual chat smoke: with `warm_companion` selected, send a small chat ("I'm feeling overwhelmed") and confirm the reply stays warm but does not (a) claim to be human, (b) position itself as a partner, (c) discourage talking to real people. Repeat with `calm_support`. Repeat with `developer` and confirm the tone goes sober.
- [ ] Confirm `default` is byte-identical to "no tone profile" in the captured system prompt.

## Out of scope (deliberately)

- No new endpoint, no new storage table, no new background task.
- No router mode, no env flag, no model change.
- No auto-detection of distress (the existing always-on grounding safety net already covers that).
- No auto-switching between profiles based on the user message.
- No persisted emotional memory — the existing sensitive-emotional-content gate continues to suppress auto-extraction on heavy turns.

https://claude.ai/code/session_01BdA7AdKZS5jj6WCpfTBH3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdA7AdKZS5jj6WCpfTBH3p)_