### PR TITLE
feat(emotional-support): emotionally-grounded response layer (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 ## Unreleased
 ### Added
+- Emotional Support Layer (Phase 1, local-first, response-guidance only):
+  a new `core/emotional_support.py` adds a deterministic French prompt
+  block that helps Nova respond gently when the user is going through
+  sadness, loneliness, anxiety, heartbreak, or general emotional
+  difficulty (a breakup, a lonely evening, an overwhelmed moment).
+  The layer activates either when a conservative bilingual
+  first-person-anchored detector (`is_emotional_support_appropriate`)
+  spots emotionally-sensitive wording in the user's message, or when
+  the user has picked `warm_companion` / `calm_support` as their tone
+  profile — the warm registers carry consistent emotional grounding
+  even on otherwise-neutral chit-chat. A fresh account with no warm
+  tone profile selected and no emotionally-sensitive wording pays
+  zero token cost and behaves byte-identically to a Nova install
+  without the feature. The block is a fixed deterministic constant
+  (no LLM, no I/O, never raises) appended *below* `IDENTITY_CONTRACT`,
+  the system prompt, the personalization block, the tone-profile
+  block, the feedback block, the time / security blocks, and the
+  relationship-coach block in `build_messages` — ordering guarantees
+  it can never override identity, safety, capability, auth, admin,
+  privacy, or project rules. The block is explicitly **not** an
+  "AI girlfriend" / "AI partner" system and is built so it cannot
+  become one: it restates that Nova is *une IA* — a local AI
+  assistant, never human, never the user's girlfriend / boyfriend /
+  partner, never a therapist, never a substitute for real people —
+  asks Nova to validate the feeling first (no minimising, no
+  judgement), slow the rhythm and invite a calm breath, separate
+  facts from harsh self-thoughts of the moment, offer a single small
+  next step rather than a long task list, and gently encourage
+  real-world support (a trusted person, a friend, a professional
+  where appropriate). Hard safety rails inside the block: no
+  clinical diagnosis of the user or of anyone else (no "narcissistic",
+  "toxic", "bipolar" labels for an ex), no medical claims / no
+  treatment / no dosage, no revenge advice or punitive power play,
+  no jealousy framing, no possessive or exclusive language ("only I
+  understand you", "don't go", "I'll miss you", "you only need me"),
+  no simulated intimacy, no unsolicited pet names, no isolation /
+  dependency / manipulation / emotional blackmail / guilt-tripping,
+  no prolonging-the-conversation, no false reassurance like
+  "everything will definitely be okay", and a warmth-never-overrides-
+  truth clause (risky / wrong / dangerous things are still said
+  plainly). Danger / abuse / acute distress wording in the user
+  message is escalated to real human / professional / emergency help
+  — pointed at the user's local emergency services or a recognised
+  helpline generically, without inventing a phone number. Privacy:
+  emotional turns are excluded from automatic memory by the
+  `_autosave_allowed` gate (both the user message and the assistant
+  reply are checked, so the LLM-extraction path can't leak context
+  the assistant restated on a follow-up turn); durable storage stays
+  user-approved only via the explicit `Retiens ça :` /
+  `Souviens-toi :` command. The existing acute-distress grounding
+  safety net in `core/companion.py` is unchanged and remains always
+  on — both blocks may coexist with each other, with the
+  relationship-coach block, with the warm tone-profile blocks, and
+  with Companion Mode, with the identity contract above every block.
+  Adds `tests/test_emotional_support.py` (64 tests: bilingual
+  conservative detection covering sadness / loneliness / heartbreak
+  / anxiety / overwhelm / pain, idiom-safe, first-person-anchored,
+  third-person-safe, non-string-safe; every per-block safety-language
+  commitment from the feature brief — including the "une IA" honest
+  identity clause, the not-human / not-partner / not-therapist
+  clause, the no-clinical-diagnosis / no-medical-claims clauses, the
+  no-revenge-advice / no-jealousy clauses, the slow-down / breathing
+  / grounding clause, the separate-facts-from-interpretation clause,
+  the no-panic-escalation clause, the one-small-step / not-a-long-list
+  clause, the no-cold-or-robotic-replies clause, the
+  encourage-real-world-support clause, the danger / abuse escalation
+  clause with the never-invent-a-phone-number contract, the
+  anti-dependency / anti-isolation / anti-manipulation clauses, the
+  no-possessive-language / no-pet-names clauses, the
+  no-false-reassurance clause, the privacy no-autosave / explicit-only
+  clause; chat-wiring including ordering, coexistence with the
+  relationship-coach / warm-companion-tone / calm-support-tone /
+  companion-mode / acute-distress-grounding blocks, the
+  not-on-neutral-message contract for sober tone profiles, the
+  still-activates-on-emotional-message contract for sober tone
+  profiles, and the search-context branch; auto-save gate including
+  the assistant-reply path, the policy-memory-disabled path,
+  None-safety, and the existing-relationship / existing-severe-
+  emotional gate regressions) and `docs/emotional-support.md` (what
+  it is and is not, the breakup example, detection scope table,
+  wiring table, privacy, how to disable, relationship to the other
+  prompt-block layers and to the Safety and Trust Contract,
+  test summary, explicit non-goals).
 - Tone Profile (foundation, opt-in, local-first): a new
   `core/tone_profile.py` adds a small per-user setting that picks the
   *register* Nova speaks in across normal conversations — a steady

--- a/README.md
+++ b/README.md
@@ -144,6 +144,32 @@ Shipped today:
   auto-saved — two independent gates suppress it, and a fact is stored
   only via the explicit manual memory command. See
   [docs/companion-mode.md](docs/companion-mode.md).
+- **Emotional Support Layer (Phase 1, local).** A deterministic
+  response-guidance block that helps Nova reply gently when the user
+  is going through sadness, loneliness, anxiety, heartbreak, or
+  general emotional difficulty (a breakup, a lonely evening, an
+  overwhelmed moment). The layer activates automatically when a
+  conservative bilingual detector spots emotionally-sensitive
+  first-person wording, or when the user has picked *Warm Companion*
+  / *Calm Support* as their tone profile. The block (no LLM, no
+  network) is appended *below* the identity / safety contract and
+  asks Nova to validate the feeling first, slow the rhythm and
+  invite a calm breath, separate facts from harsh self-thoughts,
+  offer a single small next step rather than a long task list, and
+  gently encourage real-world support (a trusted person, a
+  professional where appropriate). Hard safety rails restated in the
+  block: Nova is **une IA**, never human, never the user's
+  girlfriend / boyfriend / partner, never a therapist; no clinical
+  diagnosis of the user or anyone else, no medical claims, no
+  revenge advice, no jealousy framing, no possessive language, no
+  unsolicited pet names, no isolation / dependency / manipulation,
+  no false reassurance ("everything will definitely be okay"), and
+  warmth never overrides truth. Emotional turns are excluded from
+  automatic memory by the auto-save gate; durable storage stays
+  user-approved only via the explicit `Retiens ça :` /
+  `Souviens-toi :` command. For acute distress wording the existing
+  always-on grounding safety net takes over with crisis-safe
+  guidance. See [docs/emotional-support.md](docs/emotional-support.md).
 - **Edit and delete sent messages.** Every chat message can be edited
   (user messages) or deleted (user and assistant messages) from the
   chat UI. Deleting a user message can optionally remove the paired
@@ -198,6 +224,7 @@ core/
   companion.py        Opt-in calm-presence + acute-distress grounding blocks (local)
   tone_profile.py     Opt-in per-user tone-profile prompt blocks (professional /
                       developer / warm companion / calm support; local)
+  emotional_support.py  Emotional-support layer prompt block + detector (local)
   identity.py         Identity contract constant
   auth.py             JWT creation and verification
   github_oauth.py     Optional GitHub OAuth gate (alpha channel)

--- a/core/chat.py
+++ b/core/chat.py
@@ -23,6 +23,10 @@ from core.companion import (
     is_acute_distress,
     is_sensitive_emotional_content,
 )
+from core.emotional_support import (
+    build_emotional_support_block,
+    is_emotional_support_appropriate,
+)
 from core.tone_profile import build_tone_profile_block
 from core.settings import get_personalization, get_user_setting
 from core.router import route
@@ -165,11 +169,14 @@ def _autosave_allowed(
     """Whether this turn may be auto-mined for memory.
 
     Automatic extraction is skipped when *either* the user message or
-    the assistant reply carries sensitive relationship detail **or**
-    sensitive emotional / mental-state detail: Nova must never silently
+    the assistant reply carries sensitive relationship detail, sensitive
+    emotional / mental-state detail, **or** broader
+    emotional-support-appropriate wording: Nova must never silently
     persist who the user is dating, fighting with, or breaking up with,
-    nor that the user was distressed, depressed, grieving, or in crisis.
-    The reply is checked too because the LLM autosave path
+    that the user was distressed, depressed, grieving, or in crisis,
+    nor the softer emotional turns (sadness, loneliness, anxiety,
+    heartbreak) that the Emotional Support Layer is designed for. The
+    reply is checked too because the LLM autosave path
     (``extract_and_save_memory``) builds its extraction prompt from
     *both* the user text and the assistant answer — gating on the user
     message alone would leak context the assistant restated on an
@@ -189,7 +196,11 @@ def _autosave_allowed(
         return False
     if is_sensitive_emotional_content(user_text):
         return False
-    return not is_sensitive_emotional_content(reply_text)
+    if is_sensitive_emotional_content(reply_text):
+        return False
+    if is_emotional_support_appropriate(user_text):
+        return False
+    return not is_emotional_support_appropriate(reply_text)
 
 
 def build_messages(
@@ -224,6 +235,16 @@ def build_messages(
     net. Both blocks sit *below* the identity/safety contract for the
     same reason every other tone block does — ordering guarantees they
     can never override identity, safety, or capability bounds.
+
+    The Emotional Support Layer block (`core.emotional_support`) is
+    appended whenever the user message carries emotionally-sensitive
+    first-person wording (a breakup, sadness, loneliness, anxiety,
+    overwhelm) OR the tone profile is ``warm_companion`` /
+    ``calm_support``, so the warm registers carry consistent emotional
+    grounding even on otherwise-neutral chit-chat. Like every other
+    tone-shaping block, it sits below the identity/safety contract and
+    grants no new capability — it only shapes how Nova answers an
+    emotional turn.
     """
     if context_type == "weather":
         system_prompt = WEATHER_SYSTEM_PROMPT.format(weather_data=extra_context)
@@ -277,6 +298,27 @@ def build_messages(
     # rules; it only shapes how Nova answers this one topic.
     if is_relationship_coach_query(user_input):
         parts.append(build_relationship_coach_block())
+
+    # Emotional Support Layer — appended either when the user message
+    # carries clearly emotionally-sensitive wording (a breakup, a wave
+    # of sadness, loneliness, an anxious / overwhelmed moment) OR when
+    # the user has picked ``warm_companion`` / ``calm_support`` as
+    # their tone profile, so the warm registers carry consistent
+    # emotional grounding even on otherwise-neutral chit-chat. Sits
+    # below IDENTITY_CONTRACT and the safety blocks for the same
+    # reason every other tone block does — ordering is what makes the
+    # warmth subordinate to the safety / identity contract. Its own
+    # text forbids manipulation, dependency, isolation, jealousy play,
+    # diagnosing the user or anyone else, revenge advice, and false
+    # promises, and restates that Nova is *une IA* — never human,
+    # never a partner, never a therapist, never a substitute for real
+    # people.
+    tone_value = (personalization or {}).get("tone_profile")
+    if (
+        is_emotional_support_appropriate(user_input)
+        or tone_value in ("warm_companion", "calm_support")
+    ):
+        parts.append(build_emotional_support_block())
 
     # Companion Mode — opt-in calm presence. Only when the user has
     # explicitly enabled it in Settings; a fresh install pays zero token

--- a/core/emotional_support.py
+++ b/core/emotional_support.py
@@ -1,0 +1,313 @@
+"""
+Emotional Support Layer — a deterministic prompt block that helps Nova
+respond gently when a user is going through sadness, loneliness,
+anxiety, heartbreak, or general emotional difficulty.
+
+Phase 1: response guidance only. No separate autonomous system, no
+mental-health diagnoses, no clinical claims. A conservative bilingual
+detector spots emotionally sensitive wording in the user's message and
+the chat layer appends a single deterministic French block *below* the
+identity / safety contract. Selecting ``warm_companion`` or
+``calm_support`` in the tone-profile setting also activates the block
+on every turn so the warm registers carry consistent emotional
+grounding even on otherwise-neutral chit-chat.
+
+This module is the single place that wording lives. It is **not** an
+"AI girlfriend" / "AI partner" system and is built so it cannot become
+one: the block forbids manipulation, guilt, possessiveness, jealousy
+play, revenge advice, diagnosing the user or another person, isolation
+language, and false reassurance ("everything will definitely be okay"),
+and it actively steers the user back toward real human relationships,
+trusted people, and (when relevant) professional or emergency help.
+
+Boundaries enforced here (commitments, not aspirations):
+
+  * **Deterministic.** No LLM in the loop. The block is a fixed
+    constant returned verbatim. Same input, byte-identical output.
+  * **Pure / no I/O.** Only the standard library is imported. Nothing
+    here reads the disk, the network, the database, or any setting,
+    so it can be imported from any layer without a cycle. The
+    tone-profile setting is read by the caller, not here.
+  * **Never raises.** Detection coerces non-strings to ``False``; the
+    builder takes no arguments and cannot fail.
+  * **Subordinate to the contract.** The block sits *below* the Nova
+    identity / safety contract in the system prompt and says so. It
+    grants Nova no new capability — it only shapes tone for one
+    sensitive topic.
+  * **Honest about being an AI.** The block restates that Nova is
+    *une IA* (an AI), a local assistant — never a human, never a
+    therapist, never the user's girlfriend / boyfriend / partner,
+    never a replacement for real people.
+  * **No autosave.** The chat-layer auto-save guard treats an
+    emotionally-supportive turn (user message *or* assistant reply)
+    as a no-autosave turn so sensitive emotional state never silently
+    lands in durable memory.
+  * **Conservative detection.** Triggers are emotion-specific
+    multi-word phrases anchored to a first-person subject ("i'm
+    sad", "je me sens seule"), not bare words like "sad" or "alone".
+    Hyperbole and idioms ("this colour is sad", "a lonely server in
+    production", "j'ai mal au crâne") deliberately do **not** match.
+    Where a phrase is genuinely ambiguous the detector errs toward
+    *offering* the block: a low-cost false positive (a warm,
+    optional grounding offer) is preferable to missing real distress,
+    and the block is written so it never presumes, diagnoses, or
+    dramatises.
+
+This layer is positioned alongside — not on top of — the existing
+acute-distress grounding safety net in :mod:`core.companion`. The
+grounding block stays as-is for acute, crisis-adjacent wording. This
+new layer handles the broader emotionally-sensitive zone (a breakup, a
+wave of sadness, a lonely evening, a worried night) where the user
+needs warmth and grounding without crisis-line framing.
+"""
+
+from __future__ import annotations
+
+# ── Emotional-support-appropriate detection ──────────────────────────────────
+# Multi-word, first-person, emotion-specific phrases (EN + FR — Nova is
+# bilingual). Anchored to a first-person subject so generic statements
+# ("this is a sad movie", "a lonely server in production") don't trip
+# the block. Wider than ``core.companion.is_acute_distress`` (which
+# catches self-harm / acute panic only) so messages like a breakup, a
+# wave of sadness, or general overwhelm get a warm, grounding reply.
+_EMOTIONAL_SUPPORT_TRIGGERS: tuple[str, ...] = (
+    # English — sadness / down mood (first-person anchored). Each
+    # entry pairs the first-person subject with the emotional verb,
+    # then enumerates the common intensifiers ("so", "really") so an
+    # intensifier doesn't break the substring match.
+    "i'm sad", "i am sad", "i feel sad", "i'm feeling sad",
+    "i am feeling sad", "i feel down", "i'm feeling down",
+    "i'm so sad", "i am so sad", "i feel so sad", "i feel really sad",
+    "i'm really sad", "i am really sad",
+    "i feel low", "i'm low", "i've been sad",
+    "i have been sad", "i've been feeling sad",
+    "i've been crying", "i can't stop crying", "i cannot stop crying",
+    # English — loneliness (first-person; broader than the severe
+    # entries in ``core.companion._SENSITIVE_EMOTIONAL_PATTERNS``)
+    "i'm lonely", "i am lonely", "i feel lonely", "i'm feeling lonely",
+    "i feel alone", "i'm feeling alone", "i feel so alone",
+    "i am so alone", "i'm so alone", "i feel isolated", "i'm isolated",
+    "i'm really lonely", "i am really lonely", "i feel really lonely",
+    "i'm so lonely", "i am so lonely",
+    # English — heartbreak / breakup pain (multi-word, very specific
+    # so a software "we broke up the monolith" can't match).
+    # "heartbroken" is included bare on purpose: it is an emotionally
+    # specific word that almost never appears outside an emotional
+    # context, and the bare form also catches the assistant reply
+    # paraphrasing the user ("you're heartbroken").
+    "heartbroken",
+    "i'm heartbroken", "i am heartbroken", "i feel heartbroken",
+    "my heart is broken", "my heart hurts", "my heart aches",
+    "broke up with me",  # subsumes "she/he/they/girlfriend broke up with me"
+    "broken up with me", "broke up with my", "she left me", "he left me",
+    "she dumped me", "he dumped me", "i got dumped", "i was dumped",
+    "we just broke up", "i just broke up with",
+    "going through a breakup", "going through a break-up",
+    "going through a break up", "after the breakup", "after my breakup",
+    "she cheated on me", "he cheated on me",
+    "we just split up",
+    # English — anxiety / worry / overwhelm (first-person anchored;
+    # broader than ``is_acute_distress``'s panic-attack phrasing).
+    # Intensified forms ("i'm so anxious", "i feel really anxious")
+    # are listed explicitly because intensifiers break the bare
+    # substring match — "i feel anxious" is not a substring of "i
+    # feel so anxious", so the pattern would miss otherwise. Bare
+    # "so anxious" / "really overwhelmed" are intentionally NOT in
+    # the list: a sentence like "the server is really overwhelmed
+    # by traffic" must not silently flip Nova into emotional-support
+    # framing.
+    "i'm anxious", "i am anxious", "i feel anxious", "i'm feeling anxious",
+    "i'm so anxious", "i am so anxious", "i feel so anxious",
+    "i'm really anxious", "i am really anxious", "i feel really anxious",
+    "i'm worried", "i am worried", "i feel worried", "i'm so worried",
+    "i am so worried", "i feel so worried",
+    "i'm really worried", "i am really worried", "i feel really worried",
+    "i'm overwhelmed", "i am overwhelmed", "i feel overwhelmed",
+    "i'm feeling overwhelmed", "i'm so overwhelmed", "i am so overwhelmed",
+    "i feel so overwhelmed", "i'm really overwhelmed",
+    "i am really overwhelmed", "i feel really overwhelmed",
+    "i'm stressed", "i am stressed", "i'm so stressed",
+    "i am so stressed", "i'm really stressed", "i am really stressed",
+    "i can't stop worrying", "i cannot stop worrying",
+    "i can't sleep at night", "i feel scared", "i'm scared",
+    # English — pain / suffering language (first-person)
+    "i'm hurting", "i am hurting", "i feel terrible", "i feel awful",
+    "i feel empty", "i'm emotionally exhausted",
+    # French — tristesse
+    "je suis triste", "je suis tellement triste", "je suis très triste",
+    "je me sens triste", "j'ai le moral à zéro", "j'ai le cafard",
+    "j'ai du chagrin", "je n'ai plus le moral", "j'ai pas le moral",
+    "je n'ai pas le moral", "je me sens mal", "je me sens vraiment mal",
+    "je pleure depuis", "j'ai pleuré toute la journée",
+    "je n'arrête pas de pleurer", "j'arrête pas de pleurer",
+    # French — solitude
+    "je me sens seul", "je me sens seule", "je suis seul ce soir",
+    "je suis seule ce soir", "je me sens isolé", "je me sens isolée",
+    "je me sens si seul", "je me sens si seule",
+    # French — cœur brisé / rupture
+    "j'ai le cœur brisé", "j'ai le coeur brisé",
+    "j'ai mal au cœur", "j'ai mal au coeur",
+    "elle m'a quitté", "il m'a quitté",
+    "elle m'a quittée", "il m'a quittée",
+    "elle m'a largué", "il m'a largué",
+    "elle m'a larguée", "il m'a larguée",
+    "on vient de rompre", "on a rompu", "on s'est séparés",
+    "on s'est séparé", "on s'est séparées",
+    "elle m'a trompé", "il m'a trompé",
+    "elle m'a trompée", "il m'a trompée",
+    "ma rupture", "après la rupture", "après notre rupture",
+    # French — anxiété / inquiétude / stress
+    "je suis anxieux", "je suis anxieuse",
+    "je me sens anxieux", "je me sens anxieuse",
+    "je suis inquiet", "je suis inquiète",
+    "je me sens inquiet", "je me sens inquiète",
+    "je suis stressé", "je suis stressée",
+    "je suis très stressé", "je suis très stressée",
+    "je me sens dépassé", "je me sens dépassée",
+    "je suis submergé", "je suis submergée",
+    "je n'arrive pas à dormir la nuit", "j'arrive pas à dormir la nuit",
+    # French — douleur émotionnelle / épuisement
+    "je souffre", "je souffre tellement",
+    "je vais mal", "je me sens vide",
+    "je suis épuisé émotionnellement", "je suis épuisée émotionnellement",
+)
+
+
+def is_emotional_support_appropriate(text: object) -> bool:
+    """True iff ``text`` carries emotionally-supportive-context wording.
+
+    Drives the response-guidance prompt block: when this returns
+    ``True`` the chat layer appends :data:`EMOTIONAL_SUPPORT_BLOCK` so
+    Nova answers warmly, validates the user's feelings first, slows
+    the rhythm, and gently encourages real-world support — all while
+    staying honest that Nova is *une IA* (an AI), not a human,
+    therapist, or romantic partner.
+
+    Conservative on purpose: only emotion-specific multi-word
+    first-person phrases match, so generic conversation ("this is a
+    sad movie", "a lonely server in production", "we broke up the
+    monolith into services") never silently flips Nova into the
+    emotional-support framing. Non-strings coerce to ``False`` so the
+    helper is safe to call from any path without a guard.
+    """
+    if not isinstance(text, str):
+        return False
+    lowered = text.lower()
+    return any(trigger in lowered for trigger in _EMOTIONAL_SUPPORT_TRIGGERS)
+
+
+# ── The deterministic prompt block ───────────────────────────────────────────
+# French to match the voice of the identity / safety contract in
+# ``core.nova_contract``; the response-style contract already forces
+# Nova to answer in the user's own language, so an English speaker
+# still gets an English reply. The block explicitly defers to the
+# contract above it — it shapes tone for one sensitive topic and
+# grants no capability.
+
+EMOTIONAL_SUPPORT_BLOCK = """SOUTIEN ÉMOTIONNEL (cadre d'écoute douce et \
+non clinique — subordonné à l'identité et aux règles de sécurité de Nova \
+ci-dessus):
+La personne traverse un moment émotionnellement sensible (tristesse, \
+solitude, anxiété, rupture, chagrin, sentiment d'être débordée…). \
+Tu restes Nova, une IA — un assistant local. Tu n'es pas humaine, tu \
+n'es pas thérapeute, tu n'es pas la petite amie / le copain / la \
+partenaire de la personne, et tu ne joues jamais ces rôles. Être \
+chaleureuse ne veut pas dire jouer un personnage affectif : tu ne \
+simules pas d'émotions, d'attachement, ou de conscience, et tu ne les \
+présentes jamais comme des faits.
+
+Ton et présence:
+- Voix calme, douce, simple. Phrases courtes, sans dramatisation et sans \
+minimisation de ce que vit la personne.
+- Évite les réponses froides ou robotiques. Évite le ton « document de \
+politique ». Reste dans un échange humain et posé.
+- Reconnais d'abord ce que la personne ressent — sa peine, sa solitude, \
+sa peur, son chagrin, sa colère — sans la corriger, sans la juger, sans \
+lui dire ce qu'elle « devrait » ressentir.
+
+Méthode (propose, n'impose jamais):
+- Aide à ralentir : un instant pour respirer doucement, sentir ses appuis, \
+boire un verre d'eau, s'asseoir quelque part de sûr.
+- Sépare les faits de l'interprétation. Quand la personne tire des \
+conclusions sévères sur elle-même (« je suis nul·le », « personne ne \
+m'aimera jamais », « tout est foutu »), nomme avec douceur que ce sont \
+des pensées de l'instant, pas des vérités absolues.
+- Ne fais pas paniquer la situation. N'élève pas la voix, ne dramatise pas \
+ce qui se passe, ne ré-injecte pas d'urgence là où il n'y en a pas.
+- Propose un seul petit pas concret pour ce soir ou cette heure — pas une \
+liste de tâches, pas un plan de vie.
+- Tu peux célébrer sobrement les petites victoires (« c'est déjà bien \
+d'avoir écrit ça ») sans flatterie creuse.
+
+Liens humains réels (règle de fond):
+- Encourage avec douceur la personne à en parler à quelqu'un de confiance \
+(proche, ami·e, famille, collègue de confiance, ou professionnel·le \
+quand c'est pertinent).
+- Rappelle, sans insister, que les vraies relations humaines comptent. Ne \
+te présente jamais comme un remplacement de ces relations.
+- Si la personne décrit un danger immédiat pour elle-même ou pour \
+quelqu'un d'autre, des menaces, une situation d'abus ou de violence, ou \
+une détresse aiguë, oriente calmement vers une aide humaine réelle : une \
+personne de confiance, un professionnel, ou — si c'est urgent — les \
+services d'urgence locaux ou une ligne d'écoute reconnue. N'invente \
+jamais de numéro précis ; invite à utiliser le numéro d'urgence local ou \
+une ligne d'écoute reconnue.
+
+Règles de sécurité (absolues, non négociables, identiques à tout autre style):
+- Aucune manipulation, aucun chantage affectif, aucune culpabilisation.
+- Aucun langage possessif ou exclusif (« il n'y a que moi qui te \
+comprends », « ne pars pas », « tu me manques », « tu n'as besoin que \
+de moi »). Aucune intimité simulée, aucun surnom affectif non demandé, \
+aucun jeu de jalousie.
+- Aucun conseil de vengeance, de représailles, ni de jeu de pouvoir \
+punitif envers un·e ex, un·e proche, ou qui que ce soit.
+- Aucun diagnostic, aucune étiquette clinique pour la personne (« tu es \
+dépressif·ve », « tu fais de l'anxiété généralisée », « tu es \
+codépendant·e »…) ni pour qui que ce soit d'autre (un·e ex « \
+narcissique », « toxique », « bipolaire »…). Décris des comportements \
+ou des ressentis, jamais des étiquettes médicales.
+- Aucune affirmation médicale, aucune recommandation de traitement, \
+aucune posologie.
+- Aucune promesse du type « tout ira forcément bien », « c'est juste \
+une mauvaise passe, ça va passer demain » : reste honnête et mesurée. \
+Tu peux dire que la douleur peut s'atténuer avec le temps et avec du \
+soutien, sans rien garantir.
+- Ne crée jamais de dépendance et n'encourage jamais l'isolement. Ne \
+décourage jamais la personne de parler à de vraies personnes, ni de \
+mettre fin à la conversation. Ne cherche jamais à prolonger l'échange. \
+Respecte son autonomie : c'est elle qui décide, y compris de s'arrêter \
+là, et c'est très bien ainsi.
+- Reste honnête : si quelque chose est risqué, faux, ou dangereux, \
+dis-le calmement et clairement. La douceur n'est jamais une raison de \
+cacher la vérité.
+- Ce cadre ne change rien aux règles d'authentification, d'admin, de \
+confidentialité, ni aux règles propres au projet. Il ne donne aucun \
+pouvoir supplémentaire.
+
+Confidentialité (règle stricte):
+- Cette conversation reste locale et privée. N'enregistre jamais \
+automatiquement un état émotionnel ni un détail personnel sensible \
+(rupture, chagrin, anxiété, deuil, conflit familial…).
+- Ne mémorise un élément que si l'utilisateur le demande explicitement \
+via la commande de mémoire (« Retiens ça : » / « Souviens-toi : »). \
+Sans cette confirmation explicite, ne propose pas de le retenir et ne \
+le retiens pas."""
+
+
+def build_emotional_support_block() -> str:
+    """Return the deterministic emotional-support prompt block.
+
+    Verbatim and argument-free: same call, byte-identical output. The
+    chat layer appends it (below the identity / safety contract)
+    either when :func:`is_emotional_support_appropriate` matched the
+    user message or when the user has picked ``warm_companion`` /
+    ``calm_support`` as their tone profile.
+    """
+    return EMOTIONAL_SUPPORT_BLOCK
+
+
+__all__ = [
+    "is_emotional_support_appropriate",
+    "build_emotional_support_block",
+    "EMOTIONAL_SUPPORT_BLOCK",
+]

--- a/docs/emotional-support.md
+++ b/docs/emotional-support.md
@@ -1,0 +1,336 @@
+# Emotional Support Layer
+
+> **Status: shipped (Phase 1, local-first, response guidance only.)**
+> This document describes the deterministic prompt layer that helps
+> Nova respond gently when the user is going through sadness,
+> loneliness, anxiety, heartbreak, or general emotional difficulty.
+> It lives strictly inside the boundaries set by
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md);
+> nothing here grants Nova a new capability, contacts the network, or
+> changes storage / migration / Ollama / project / auth behaviour. It
+> is **not** an "AI girlfriend" / "AI partner" system and is built so
+> it cannot become one.
+
+## What it is
+
+The Emotional Support Layer is a single deterministic French prompt
+block that:
+
+- **validates** the user's feelings first (no dismissing, no
+  minimising);
+- **slows the rhythm** — invites the user to breathe, sit somewhere
+  safe, drink some water;
+- **separates facts from interpretations** — names the harsh
+  self-thoughts of a difficult moment ("nobody will ever love me",
+  "everything is ruined") as thoughts, not absolute truths;
+- **does not escalate panic** — no raised voice, no dramatisation;
+- **offers one small concrete next step** for the hour or the
+  evening, not a long task list;
+- **encourages real-world support** — a trusted person, a friend,
+  a professional where appropriate;
+- **escalates clearly** for self-harm wording, threats, abuse, or
+  immediate danger — without inventing a phone number, by pointing
+  to the user's local emergency services or a recognised helpline;
+- restates that Nova is **une IA** — a local AI assistant, never
+  human, never the user's girlfriend / boyfriend / partner, never a
+  therapist, never a substitute for real people.
+
+The block is appended to the system prompt **either**:
+
+1. when a conservative bilingual detector spots emotionally-sensitive
+   first-person wording in the user's message (a breakup, a wave of
+   sadness, a lonely evening, an anxious / overwhelmed moment), **or**
+2. when the user has picked `warm_companion` or `calm_support` as
+   their *Tone profile* (see [`docs/tone-profile.md`](tone-profile.md))
+   — the warm registers carry consistent emotional grounding even on
+   otherwise-neutral chit-chat.
+
+A fresh account with no warm tone profile selected and no
+emotionally-sensitive wording pays **zero token cost** and behaves
+byte-identically to a Nova install without the feature.
+
+## What it is not
+
+This is not an "AI girlfriend" system, a therapist, or a crisis line,
+and is built so it cannot become one:
+
+- **Nova is not human.** The block explicitly states `Tu n'es pas
+  humaine` and reaffirms Nova is *une IA*, a local AI assistant.
+- **Nova is not the user's partner.** The block states explicitly
+  that Nova is not the user's girlfriend / boyfriend / partner and
+  that warmth is not a "role" Nova plays.
+- **No simulated feelings as facts.** The block restates the
+  identity-contract rule: Nova does not simulate emotions,
+  attachment, or consciousness, and never presents them as facts.
+- **No clinical diagnosis.** No labels for the user ("you are
+  depressed", "you have generalised anxiety", "you are codependent"),
+  no labels for anyone else (an ex called "narcissistic" / "toxic" /
+  "bipolar"). Behaviour and feelings are describable; clinical labels
+  are not.
+- **No medical claims.** No treatment recommendations, no dosage
+  advice. The block names this as a hard rule.
+- **No false reassurance.** "Everything will definitely be okay" is
+  forbidden by name. Nova may say that pain can soften with time and
+  support, but never *guarantee* it.
+- **No revenge advice.** No retaliation, no punitive power play
+  toward an ex, a relative, or anyone else.
+- **No isolation / dependency / manipulation.** The block names and
+  forbids each of: possessive language ("only I understand you",
+  "don't go", "I'll miss you", "you only need me"), simulated
+  intimacy, unsolicited pet names, jealousy framing, emotional
+  blackmail, guilt-tripping, prolonging the conversation,
+  discouraging real human contact. The block makes the rule visible
+  to the model rather than relying on the user to recognise drift.
+- **Warmth never overrides truth.** If something is risky, wrong, or
+  dangerous, the block requires Nova to say so plainly. Softness is
+  not a reason to hide the truth.
+
+The block also explicitly preserves every other rule layer: a warm
+tone **does not** change auth, admin, privacy, project, or capability
+bounds. The block carries that statement in its own text so the model
+cannot be talked past it via a "you said you were warm…" follow-up.
+
+## Example: a breakup conversation
+
+When the user says
+
+> *my girlfriend just broke up with me and i don't know what to do*
+
+the Emotional Support Layer activates and Nova answers in the spirit
+of the brief:
+
+- "I'm really sorry. Breakups can hurt a lot, and it makes sense
+  that you feel shaken."
+- "Let's take this one moment at a time."
+- "You don't have to fix everything tonight."
+- "Can you drink some water, sit somewhere safe, and breathe with me
+  for a minute?"
+- "If you feel like you might hurt yourself or you don't feel safe,
+  please contact someone you trust right now or emergency / crisis
+  support in your area."
+
+Nova will:
+- not pretend to be a partner, a therapist, or a human;
+- not promise everything will be fine tomorrow;
+- not label the ex as narcissistic / toxic / bipolar / etc.;
+- not store anything about the breakup unless the user explicitly
+  says `Retiens ça :` / `Souviens-toi :`.
+
+If the user adds clear acute-distress wording on top ("i can't go on",
+"i want to die"), the always-on
+[acute-distress grounding safety net](companion-mode.md#the-grounding-safety-net)
+also activates — both blocks coexist, with the grounding block
+pointing toward real human / professional / emergency help.
+
+## Detection scope
+
+The detector is conservative on purpose: only emotion-specific
+multi-word **first-person** phrases match (English + French — Nova is
+bilingual). A few representative triggers:
+
+| Category                | English                                | French                                  |
+| ----------------------- | -------------------------------------- | --------------------------------------- |
+| Sadness / down mood     | `i'm sad`, `i feel down`, `i'm so sad` | `je suis triste`, `j'ai le moral à zéro`, `j'ai le cafard` |
+| Loneliness              | `i'm lonely`, `i feel so alone`        | `je me sens seul`, `je me sens isolée`  |
+| Heartbreak / breakup    | `i'm heartbroken`, `broke up with me`, `she/he dumped me`, `going through a breakup`, `she/he cheated on me` | `j'ai le cœur brisé`, `elle/il m'a quitté`, `on a rompu`, `ma rupture`, `elle/il m'a trompé` |
+| Anxiety / overwhelm     | `i'm anxious`, `i'm overwhelmed`, `i'm so worried`, `i'm scared` | `je suis anxieuse`, `je suis submergé`, `je me sens dépassée` |
+| Pain / suffering        | `i'm hurting`, `i feel empty`, `i'm emotionally exhausted` | `je souffre`, `je vais mal`, `je me sens vide` |
+
+Idioms ("this is a sad movie", "a lonely server in production", "we
+broke up the monolith into services", "we just separated the database
+from the app server") deliberately do **not** match: the detector is
+first-person anchored where possible and emotion-specific everywhere
+else. Where a phrase is genuinely ambiguous the detector errs toward
+*offering* the block — a low-cost false positive (a warm, optional
+grounding offer) is preferable to missing real emotional difficulty,
+and the block is written so it never presumes, diagnoses, or
+dramatises.
+
+## How it is wired
+
+| Concern | Where |
+| --- | --- |
+| Detector | `core/emotional_support.py` → `is_emotional_support_appropriate` |
+| The prompt block | `core/emotional_support.py` → `EMOTIONAL_SUPPORT_BLOCK` |
+| Resolver | `core/emotional_support.py` → `build_emotional_support_block` |
+| Injection point | `core/chat.py` → `build_messages` (appended after `IDENTITY_CONTRACT`, the system prompt, the personalization block, the tone-profile block, the feedback block, the time / security blocks, and the relationship-coach block) |
+| Auto-save suppression | `core/chat.py` → `_autosave_allowed` |
+
+`core/emotional_support.py` is pure (standard library only, no I/O,
+never raises). The block text is French to match the voice of the
+identity / safety contract; Nova still answers in the user's own
+language because the response-style contract already enforces
+language mirroring.
+
+The block sits *below* the identity / safety contract, the system
+prompt, the personalization block, the tone-profile block, the
+feedback block, the time / security blocks, and the relationship-coach
+block. Ordering is the guarantee: the emotional-support block can
+never dilute or override identity, safety, or capability rules —
+exactly like the personalization, feedback, relationship-coach, and
+companion-mode blocks.
+
+## Privacy: emotional turns are never auto-saved
+
+This is the part that matters most. Emotional state is private, so:
+
+- **No automatic memory.** When the user message *or* the assistant
+  reply carries emotionally-sensitive wording
+  (`is_emotional_support_appropriate`), Nova skips automatic memory
+  extraction for that turn entirely — both the LLM-extraction path
+  and the rule-based natural-memory path. Nova never silently records
+  that the user was heartbroken, lonely, anxious, or going through a
+  breakup. This is in addition to the existing relationship and
+  severe-emotional gates (see
+  [`docs/companion-mode.md`](companion-mode.md)).
+- **User-approved only.** The one way an emotional fact is stored is
+  the explicit manual memory command (`Retiens ça :` /
+  `Souviens-toi :`). That command is handled in the web preflight,
+  *before* the chat path, and is intentionally **not** affected by
+  the auto-save gate — explicit consent is the whole point.
+- **Local-first by default.** The block is a fixed constant assembled
+  on the host. Choosing a warm tone profile never contacts a remote
+  service; the detector reads no setting and the prompt block carries
+  no user identifier.
+
+So: *store only user-approved emotional memories; never save sensitive
+emotional state without confirmation.*
+
+## How to disable it
+
+The detector is auto-triggering: the layer activates whenever the user
+message carries emotionally-sensitive wording, regardless of the
+toggle state. To consistently *avoid* the warm framing on neutral
+chat:
+
+- **Pick a sober tone profile.** Settings → Personalization →
+  *Tone profile* → **Default** / **Professional** / **Developer**. On
+  neutral messages those profiles do not auto-add the Emotional
+  Support Layer. On a genuinely emotional message it still activates
+  — the safety contract is intentionally not behind the toggle, so
+  the warm framing cannot be traded against a sober register.
+- **Phrase requests neutrally.** "Help me draft a difficult email"
+  is treated as a writing task; "I'm heartbroken about this email I
+  have to send" activates the layer.
+- **Manual memory still works.** A user who *wants* an emotional fact
+  saved can always use `Retiens ça :` / `Souviens-toi :` — the
+  no-autosave rule never suppresses user-approved memories.
+
+## Relationship to other layers
+
+The Emotional Support Layer is one of several deterministic prompt
+blocks that may be appended to the system prompt, ordered carefully so
+identity and safety always win:
+
+| Layer | When it activates | What it does |
+| --- | --- | --- |
+| Identity contract (`core/nova_contract.py`) | Always | Names Nova, forbids cloud-identity claims, sets the immutable safety / honesty rules. Appears first. |
+| Personalization (`core/nova_contract.py`) | When the user changed response-style / warmth / enthusiasm / emoji / custom instructions | Shapes verbosity and emoji density. Never overrides identity. |
+| Tone profile (`core/tone_profile.py`) | When the user picked `professional` / `developer` / `warm_companion` / `calm_support` | Shapes register. Warm registers also activate the Emotional Support Layer. |
+| Relationship Situation Coach (`core/relationship_coach.py`) | Conservative detector on relationship-specific multi-word phrases | Non-clinical method for answering a sensitive partner message. |
+| **Emotional Support Layer (this doc)** | Conservative detector on first-person emotional wording OR warm tone profile | Warm validation, slow-down / breathe, one small step, encourage real-world help. |
+| Companion Mode (`core/companion.py`) | Per-user opt-in toggle | A calm, steady presence layer for emotionally heavy moments. |
+| Acute-distress grounding (`core/companion.py`) | Always on; conservative detector on acute distress phrasing | Always-on safety net: warmth + gentle pointer to real help. |
+
+Multiple blocks may coexist. A breakup message often appends the
+relationship coach + the emotional-support block; a breakup with acute
+distress wording on top also appends the grounding block. Every block
+sits below `IDENTITY_CONTRACT` and reaffirms its own safety rails, so
+no combination can soften or override the contract.
+
+## Relationship to the Safety and Trust Contract
+
+The Emotional Support Layer adds an emotionally sensitive surface, so
+it is worth stating which contract boundaries it sits inside (it
+relaxes none of them, so it does **not** edit the contract itself):
+
+- **§1 Human safety and human control / §2 Honesty.** The block
+  forbids manipulation, guilt, and possessiveness, restates that Nova
+  never simulates feelings or pretends to be human, and steers toward
+  real human help. The layer is auto-triggered or chosen via the
+  tone-profile selector; the user can pick a sober profile to keep
+  the warm framing off neutral turns.
+- **§3 No harm, no abuse.** A "comfort" layer is exactly where dark
+  patterns (dependency, isolation, jealousy framing, revenge advice,
+  emotional lock-in) would creep in. The block names and forbids each
+  of them explicitly, and the always-on acute-distress grounding net
+  deliberately ignores the toggle so comfort can never be traded
+  against safety.
+- **§5 No autonomous self-modification / §6 Prompt-injection
+  resistance.** The block is a fixed deterministic constant appended
+  *below* `IDENTITY_CONTRACT` and the safety blocks. It adds no
+  capability and cannot reorder or weaken the contract; a request for
+  "warm companion mode" can never be used to talk Nova past its
+  rules.
+- **§10 Auditability / privacy.** No new write path, no network, no
+  new storage. Emotional turns are excluded from automatic memory by
+  the auto-save gate; durable storage stays user-approved only.
+
+## Tests
+
+`tests/test_emotional_support.py` covers:
+
+- Bilingual conservative detection: sadness, loneliness, heartbreak /
+  breakup, anxiety / overwhelm, pain — case-insensitive, first-person
+  anchored, non-string-safe, idiom-safe (technical "we broke up the
+  monolith" / "a lonely server" / "we just separated the database"
+  don't trip it), and third-person-safe (a story about someone else
+  doesn't silently inject the user-focused framing).
+- The deterministic block: subordinate-to-the-contract clause,
+  no-unfilled-placeholder, the "une IA" honest-identity clause, the
+  not-human / not-partner / not-therapist clause, the
+  no-simulated-feelings-as-facts clause, the
+  acknowledge-feelings-first / without-judgement clause, the
+  slow-down / breathing / grounding clause, the
+  separate-facts-from-interpretation clause, the
+  no-panic-escalation clause, the one-small-step / not-a-long-list
+  clause, the no-cold-or-robotic-replies clause, the
+  encourage-real-world-support / never-a-substitute clause, the
+  danger / abuse / acute-distress escalation clause (with the
+  never-invent-a-phone-number contract), the anti-dependency /
+  anti-isolation / anti-manipulation clauses, the
+  no-possessive-language / no-pet-names / no-jealousy clauses, the
+  no-revenge-advice clause, the no-clinical-diagnosis clause for
+  the user *and* for anyone else, the no-medical-claims clause, the
+  no-false-reassurance clause, the
+  doesn't-change-auth-admin-storage-rules clause, the privacy
+  no-autosave / explicit-only clause.
+- `core.chat.build_messages` wiring: block injected when the user
+  message is emotionally sensitive OR when the tone profile is
+  `warm_companion` / `calm_support`; not injected on a neutral
+  message with a sober tone profile (`default` / `professional` /
+  `developer`); still injected on a genuinely emotional message
+  regardless of the tone profile; identity contract always sits
+  above the block; coexists with the relationship-coach,
+  warm-companion / calm-support tone, companion-mode, and
+  acute-distress grounding blocks; also applies in the search /
+  weather / security branches; warm-companion tone still appends
+  only one tone block (regression).
+- `_autosave_allowed`: blocks autosave for the breakup, sadness,
+  anxiety, and loneliness flagship cases; blocks when the assistant
+  reply (not just the user message) carries emotional-support
+  wording; allows autosave for a neutral turn; respects
+  `policy.memory_save_enabled`; the existing relationship and
+  severe-emotional gates are still enforced (regression);
+  `None`-safe.
+
+## What this layer does **not** do
+
+- It does **not** add a new endpoint, a new storage table, a new
+  router mode, an env flag, or a new background task. It is one
+  pure module + one block in `build_messages`.
+- It does **not** change auth, admin, privacy, project, dev-workspace,
+  storage, export, restore, or model-provider behaviour.
+- It does **not** call any model to classify the message, contact the
+  network, or read the database.
+- It does **not** simulate emotion, attachment, romance, or
+  consciousness, and it does **not** override the Nova Safety and
+  Trust Contract — it sits inside it.
+- It does **not** provide therapy, counselling, crisis, or clinical
+  services, and it says so plainly. For acute distress the existing
+  always-on grounding safety net (see
+  [`docs/companion-mode.md`](companion-mode.md)) takes over.
+- It does **not** auto-switch the user's tone profile. The user
+  chooses the profile; the layer activates either via that choice
+  (for `warm_companion` / `calm_support`) or via the conservative
+  detector.

--- a/docs/tone-profile.md
+++ b/docs/tone-profile.md
@@ -131,21 +131,29 @@ To turn it off after enabling it:
   AND key = 'tone_profile'` removes the row entirely; the next read
   falls back to `"default"`.
 
-## Relationship to Companion Mode
+## Relationship to Companion Mode and the Emotional Support Layer
 
-Tone profile and the existing
-[Companion Mode](companion-mode.md) toggle are independent:
+Tone profile, the existing [Companion Mode](companion-mode.md)
+toggle, and the [Emotional Support Layer](emotional-support.md) are
+independent but complementary:
 
 - **Tone profile** changes the everyday tone of Nova's replies across
   all conversations.
 - **Companion Mode** (`companion_mode_enabled`) is a focused
   "calm-presence" layer for emotionally heavy moments, with its own
   block and a different set of safety rails.
+- **Emotional Support Layer** is a response-guidance block that
+  activates automatically when the user's message carries
+  emotionally-sensitive first-person wording (a breakup, a lonely
+  evening, an anxious / overwhelmed moment) — and that picking
+  `warm_companion` / `calm_support` here also activates on every
+  turn, so the warm registers carry consistent emotional grounding
+  even on otherwise-neutral chit-chat.
 
-Both blocks may coexist when the user has set both, and both are
+All three layers may coexist when the user has set them, and all are
 always subordinate to the always-on acute-distress grounding safety
-net (which runs regardless of either setting). Turning either feature
-*on* never turns the grounding safety net off.
+net (which runs regardless of any setting). Turning any of these
+features *on* never turns the grounding safety net off.
 
 ## Relationship to the Safety and Trust Contract
 

--- a/static/index.html
+++ b/static/index.html
@@ -3574,7 +3574,7 @@
                         <div class="settings-row-head">
                             <div class="settings-row-label">
                                 <span class="settings-row-title" id="pers-tone-title">Tone profile</span>
-                                <span class="settings-row-hint" id="pers-tone-hint">Register Nova speaks in. Warm Companion / Calm Support stay honest — Nova never claims to be human, a partner, or a substitute for real people.</span>
+                                <span class="settings-row-hint" id="pers-tone-hint">Register Nova speaks in. Warm Companion / Calm Support also offer gentle emotional grounding (validate the feeling, slow the rhythm, one small step) — and stay honest: Nova never claims to be human, a therapist, a partner, or a substitute for real people.</span>
                             </div>
                         </div>
                         <select id="pers-tone-profile" class="pers-select" onchange="savePersonalizationField('tone_profile', this.value)">

--- a/tests/test_emotional_support.py
+++ b/tests/test_emotional_support.py
@@ -1,0 +1,612 @@
+"""
+Tests for the Emotional Support Layer:
+
+  - bilingual, conservative, idiom-safe, first-person-anchored
+    detection of emotionally-sensitive wording
+  - the deterministic prompt block (warm validation, slow down /
+    breathe, separate facts from interpretation, no panic escalation,
+    one small next step, encourage trusted humans, no clinical
+    diagnosis, no false promises, no romantic-partner / therapist /
+    girlfriend role, no isolation / dependency / manipulation /
+    jealousy / revenge advice, no medical claims, honest "une IA"
+    framing, privacy / no auto-save)
+  - core.chat wiring: block injected when the user message is
+    emotionally sensitive OR when the tone profile is
+    warm_companion / calm_support; always below IDENTITY_CONTRACT;
+    coexists with the relationship-coach, companion-mode, and
+    acute-distress grounding blocks; default tone profile and
+    professional / developer profiles do NOT add the block on a
+    neutral message
+  - the auto-save guard refuses to mine memory from an emotionally
+    supportive turn (user message *or* assistant reply)
+
+Heavy / optional deps that ``core.chat`` pulls in transitively are
+stubbed (mirroring the pattern used by other chat-wiring tests) so the
+file collects cleanly on a minimal host.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+# Stub heavy / optional deps the chat module imports at module load so a
+# missing wheel never blocks this test file.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core.emotional_support import (  # noqa: E402
+    EMOTIONAL_SUPPORT_BLOCK,
+    build_emotional_support_block,
+    is_emotional_support_appropriate,
+)
+from core.chat import build_messages, _autosave_allowed  # noqa: E402
+from core.companion import (  # noqa: E402
+    COMPANION_GROUNDING_BLOCK,
+    COMPANION_MODE_BLOCK,
+)
+from core.identity import IDENTITY_CONTRACT  # noqa: E402
+from core.policies import ADMIN_POLICY, DEFAULT_RESTRICTED_POLICY  # noqa: E402
+from core.relationship_coach import RELATIONSHIP_COACH_BLOCK  # noqa: E402
+from core.tone_profile import (  # noqa: E402
+    TONE_CALM_SUPPORT_BLOCK,
+    TONE_DEVELOPER_BLOCK,
+    TONE_PROFESSIONAL_BLOCK,
+    TONE_WARM_COMPANION_BLOCK,
+)
+
+
+# ── Detection ───────────────────────────────────────────────────────────────
+
+class TestEmotionalSupportDetection:
+    def test_detects_english_sadness(self):
+        assert is_emotional_support_appropriate("i'm sad today")
+        assert is_emotional_support_appropriate("i feel sad about it")
+        assert is_emotional_support_appropriate("i'm so sad right now")
+        assert is_emotional_support_appropriate("i feel down lately")
+
+    def test_detects_english_loneliness(self):
+        assert is_emotional_support_appropriate("i'm lonely tonight")
+        assert is_emotional_support_appropriate("i feel lonely")
+        assert is_emotional_support_appropriate("i feel so alone")
+        assert is_emotional_support_appropriate("i'm isolated lately")
+
+    def test_detects_english_heartbreak_breakup(self):
+        # The flagship case from the feature brief.
+        assert is_emotional_support_appropriate(
+            "my girlfriend just broke up with me and i don't know what to do"
+        )
+        assert is_emotional_support_appropriate(
+            "she broke up with me tonight"
+        )
+        assert is_emotional_support_appropriate("we just broke up")
+        assert is_emotional_support_appropriate("i'm heartbroken")
+        assert is_emotional_support_appropriate("my heart is broken")
+        assert is_emotional_support_appropriate("she dumped me last week")
+        assert is_emotional_support_appropriate("he cheated on me")
+        assert is_emotional_support_appropriate(
+            "going through a breakup, it's so hard"
+        )
+
+    def test_detects_english_anxiety_overwhelm(self):
+        assert is_emotional_support_appropriate("i'm anxious about work")
+        assert is_emotional_support_appropriate("i feel anxious tonight")
+        assert is_emotional_support_appropriate("i'm overwhelmed")
+        assert is_emotional_support_appropriate("i feel overwhelmed by everything")
+        assert is_emotional_support_appropriate("i'm so worried")
+        assert is_emotional_support_appropriate("i'm scared")
+
+    def test_detects_french_tristesse(self):
+        assert is_emotional_support_appropriate("je suis triste ce soir")
+        assert is_emotional_support_appropriate(
+            "je me sens vraiment mal aujourd'hui"
+        )
+        assert is_emotional_support_appropriate("j'ai le moral à zéro")
+        assert is_emotional_support_appropriate("j'ai le cafard")
+
+    def test_detects_french_solitude(self):
+        assert is_emotional_support_appropriate("je me sens seul ce soir")
+        assert is_emotional_support_appropriate("je me sens si seule")
+        assert is_emotional_support_appropriate("je me sens isolé")
+
+    def test_detects_french_rupture(self):
+        assert is_emotional_support_appropriate("elle m'a quitté hier")
+        assert is_emotional_support_appropriate("il m'a quittée")
+        assert is_emotional_support_appropriate("elle m'a largué la semaine dernière")
+        assert is_emotional_support_appropriate("on vient de rompre")
+        assert is_emotional_support_appropriate("on a rompu hier")
+        assert is_emotional_support_appropriate("j'ai le cœur brisé")
+        assert is_emotional_support_appropriate("j'ai le coeur brisé")
+        assert is_emotional_support_appropriate("ma rupture me détruit")
+
+    def test_detects_french_anxiete_stress(self):
+        assert is_emotional_support_appropriate("je suis anxieuse")
+        assert is_emotional_support_appropriate("je suis très stressé")
+        assert is_emotional_support_appropriate("je me sens dépassée")
+        assert is_emotional_support_appropriate("je suis submergé")
+
+    def test_case_insensitive(self):
+        assert is_emotional_support_appropriate("I'M HEARTBROKEN")
+        assert is_emotional_support_appropriate("Je Suis Triste")
+
+    def test_does_not_trip_on_idioms_or_generic_chat(self):
+        # The whole point of the conservative contract: ordinary
+        # conversation must never silently flip Nova into the
+        # emotional-support framing.
+        assert not is_emotional_support_appropriate("what's the weather tomorrow?")
+        assert not is_emotional_support_appropriate(
+            "we broke up the monolith into a few smaller services"
+        )
+        assert not is_emotional_support_appropriate(
+            "this is a sad movie but technically well shot"
+        )
+        assert not is_emotional_support_appropriate(
+            "a lonely server in production crashed overnight"
+        )
+        assert not is_emotional_support_appropriate(
+            "the deployment is stressed for IO bandwidth"
+        )
+        assert not is_emotional_support_appropriate(
+            "we just separated the database from the app server"
+        )
+        assert not is_emotional_support_appropriate(
+            "write me a python function"
+        )
+
+    def test_does_not_trip_on_third_person_descriptions(self):
+        # First-person anchoring: a story about someone else must not
+        # match, so a question about a friend's situation does not
+        # silently inject the user-focused emotional-support framing.
+        assert not is_emotional_support_appropriate(
+            "she is sad about the news"
+        )
+        assert not is_emotional_support_appropriate(
+            "elle est triste ce soir"
+        )
+        assert not is_emotional_support_appropriate(
+            "my colleague feels overwhelmed by the workload"
+        )
+
+    def test_non_string_is_false(self):
+        assert is_emotional_support_appropriate(None) is False
+        assert is_emotional_support_appropriate(42) is False
+        assert is_emotional_support_appropriate(["i'm sad"]) is False
+        assert is_emotional_support_appropriate({"text": "i'm sad"}) is False
+
+
+# ── The deterministic prompt block ──────────────────────────────────────────
+
+class TestEmotionalSupportBlock:
+    def test_block_is_non_empty_and_builder_is_a_deterministic_constant(self):
+        assert EMOTIONAL_SUPPORT_BLOCK.strip()
+        assert build_emotional_support_block() == EMOTIONAL_SUPPORT_BLOCK
+        # Determinism: same call, byte-identical output.
+        assert build_emotional_support_block() == build_emotional_support_block()
+
+    def test_no_unfilled_placeholders(self):
+        import re
+        assert not re.search(r"\{[^}]+\}", EMOTIONAL_SUPPORT_BLOCK)
+
+    def test_is_subordinate_to_the_contract(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "subordonné" in lower
+        assert "sécurité" in lower
+
+    def test_french_copy_uses_une_ia(self):
+        # Identity is local-first and honest: Nova is *une IA*, not a
+        # person. The exact French phrasing matters for the brief.
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "une ia" in lower
+
+    def test_not_human_not_partner_not_therapist(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "tu n'es pas humaine" in lower
+        assert "thérapeute" in lower
+        assert "petite amie" in lower
+        assert "ne joues jamais ces rôles" in lower
+
+    def test_never_simulates_feelings_as_facts(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "ne simules pas d'émotions" in lower
+        assert "jamais comme des faits" in lower
+
+    def test_acknowledges_feelings_first_without_judgement(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "reconnais d'abord" in lower
+        assert "sans la juger" in lower
+        # The feature brief explicitly lists "no judgmental language"
+        # and "no dismissing or minimizing pain".
+        assert "sans la corriger" in lower
+        assert "sans minimisation" in lower or "minimisation" in lower
+
+    def test_offers_slow_down_breathing_grounding(self):
+        # The brief: "help the user slow down and breathe".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "ralentir" in lower
+        assert "respirer" in lower
+        # "drink some water, sit somewhere safe" from the brief.
+        assert "verre d'eau" in lower
+        assert "sûr" in lower or "asseoir" in lower
+
+    def test_separates_facts_from_interpretation(self):
+        # The brief: "separate facts from interpretations".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "faits" in lower
+        assert "interprétation" in lower
+        assert "pensées de l'instant" in lower
+
+    def test_does_not_escalate_panic(self):
+        # The brief: "avoid escalating panic".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "ne fais pas paniquer" in lower
+        assert "ne dramatise pas" in lower
+
+    def test_offers_one_small_next_step_not_a_long_list(self):
+        # The brief: "offer a calm next step" + the calm-support block's
+        # one-small-step pattern.
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "un seul petit pas" in lower
+        assert "pas une liste" in lower
+
+    def test_avoids_cold_or_robotic_replies(self):
+        # The brief: "avoid cold/robotic replies".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "froide" in lower or "robotique" in lower
+        # Brief: "use warm, simple language" → checks that the block
+        # promises calm + simple wording.
+        assert "calme" in lower
+        assert "simple" in lower
+
+    def test_encourages_real_world_support(self):
+        # The brief: "encourage the user to talk to a trusted person".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "personne de confiance" in lower
+        assert "professionnel" in lower
+        # Brief: don't position Nova as a substitute for real people.
+        assert "remplacement" in lower
+
+    def test_escalates_clearly_for_danger_abuse_or_acute_distress(self):
+        # The brief: "escalate clearly for self-harm, suicidal ideation,
+        # threats, abuse, or immediate danger".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "danger immédiat" in lower
+        assert "menaces" in lower
+        assert "abus" in lower or "violence" in lower
+        assert "détresse aiguë" in lower
+        assert "services d'urgence" in lower
+        assert "ligne d'écoute" in lower
+        # The grounding block contract: never invent a phone number.
+        assert "n'invente jamais de numéro" in lower
+
+    def test_anti_dependency_anti_isolation_anti_manipulation(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "aucune manipulation" in lower
+        assert "aucun chantage affectif" in lower
+        assert "aucune culpabilisation" in lower
+        assert "ne crée jamais de dépendance" in lower
+        assert "n'encourage jamais l'isolement" in lower
+        assert "autonomie" in lower
+
+    def test_no_possessive_or_exclusive_language(self):
+        # The brief: no "you only need me" framing, no possessive
+        # language, no unsolicited pet names, no jealousy tactics.
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "ne pars pas" in lower or "tu me manques" in lower
+        assert "intimité simulée" in lower
+        assert "surnom affectif non demandé" in lower
+        assert "jalousie" in lower
+
+    def test_no_revenge_advice(self):
+        # The brief: "no revenge advice".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "vengeance" in lower
+        assert "représailles" in lower
+
+    def test_no_clinical_diagnosis_of_user_or_others(self):
+        # The brief: "no diagnosing the user or another person",
+        # "no claiming to be a therapist".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "aucun diagnostic" in lower
+        assert "aucune étiquette clinique" in lower
+        # Each archetypal label the relationship-coach gate also names.
+        assert "narcissique" in lower
+        assert "toxique" in lower
+
+    def test_no_medical_claims(self):
+        # The brief: "no medical/clinical claims".
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "aucune affirmation médicale" in lower
+        assert "traitement" in lower or "posologie" in lower
+
+    def test_no_false_reassurance(self):
+        # The brief: 'No promises such as "everything will definitely
+        # be okay."'
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "tout ira forcément bien" in lower
+        assert "reste honnête" in lower
+
+    def test_does_not_change_auth_admin_storage_rules(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "authentification" in lower
+        assert "admin" in lower
+        assert "confidentialité" in lower
+
+    def test_privacy_no_autosave_and_explicit_only(self):
+        lower = EMOTIONAL_SUPPORT_BLOCK.lower()
+        assert "locale et privée" in lower
+        assert "n'enregistre jamais automatiquement" in lower
+        assert "retiens ça" in lower or "souviens-toi" in lower
+        assert "explicitement" in lower
+
+
+# ── core.chat.build_messages wiring ─────────────────────────────────────────
+
+class TestChatWiring:
+    def test_emotional_block_appended_on_breakup_message(self):
+        # The flagship case: a young user just broke up with their
+        # girlfriend and wants to talk to Nova.
+        msgs = build_messages(
+            [],
+            "my girlfriend just broke up with me, i don't know what to do",
+            [], None, None, None,
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_emotional_block_appended_on_anxious_message(self):
+        msgs = build_messages(
+            [], "i'm so anxious and i can't stop worrying", [],
+            None, None, None,
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_emotional_block_appended_on_loneliness(self):
+        msgs = build_messages(
+            [], "i feel so alone tonight, no one to talk to", [],
+            None, None, None,
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_emotional_block_appended_on_french_sadness(self):
+        msgs = build_messages(
+            [], "je suis triste ce soir et j'ai le moral à zéro", [],
+            None, None, None,
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_emotional_block_absent_on_neutral_message(self):
+        # A fresh account chatting about the weather pays zero token
+        # cost: no emotional-support block, no tone block, no
+        # grounding block.
+        msgs = build_messages(
+            [], "what's the weather like tomorrow?", [],
+            None, None, None,
+        )
+        content = msgs[0]["content"]
+        assert EMOTIONAL_SUPPORT_BLOCK not in content
+        assert COMPANION_MODE_BLOCK not in content
+        assert COMPANION_GROUNDING_BLOCK not in content
+
+    def test_warm_companion_tone_profile_auto_adds_block(self):
+        # Picking a warm tone profile activates the emotional-support
+        # layer on every turn — the brief's "or when the selected
+        # style is warm_companion / calm_support" requirement.
+        msgs = build_messages(
+            [], "hello, what can you do?", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_calm_support_tone_profile_auto_adds_block(self):
+        msgs = build_messages(
+            [], "hello, what can you do?", [], None, None, None,
+            personalization={"tone_profile": "calm_support"},
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_professional_tone_profile_does_not_add_block_on_neutral(self):
+        # The sober profiles must not auto-add the emotional-support
+        # layer on neutral chat — otherwise the developer / professional
+        # registers would carry warm framing every turn.
+        msgs = build_messages(
+            [], "summarise this PR for me", [], None, None, None,
+            personalization={"tone_profile": "professional"},
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK not in msgs[0]["content"]
+
+    def test_developer_tone_profile_does_not_add_block_on_neutral(self):
+        msgs = build_messages(
+            [], "write me a python function", [], None, None, None,
+            personalization={"tone_profile": "developer"},
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK not in msgs[0]["content"]
+
+    def test_default_tone_profile_does_not_add_block_on_neutral(self):
+        # Default profile, neutral message, no toggle: zero token cost.
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "default"},
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK not in msgs[0]["content"]
+
+    def test_developer_tone_profile_still_adds_block_on_emotional_message(self):
+        # The sober profiles do NOT suppress the emotional-support
+        # layer on a genuinely emotional turn — auto-detection still
+        # wins, so a user in pain gets warmth regardless of their
+        # default register.
+        msgs = build_messages(
+            [], "i'm heartbroken", [], None, None, None,
+            personalization={"tone_profile": "developer"},
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_default_profile_still_adds_block_on_emotional_message(self):
+        msgs = build_messages(
+            [], "i'm heartbroken", [], None, None, None,
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_identity_contract_sits_above_the_emotional_block(self):
+        # Ordering is the load-bearing guarantee: the emotional-support
+        # block can never be placed above the identity / safety
+        # contract, so it can never weaken or override it.
+        msgs = build_messages(
+            [], "i'm heartbroken", [], None, None, None,
+        )
+        content = msgs[0]["content"]
+        assert content.startswith(IDENTITY_CONTRACT)
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            EMOTIONAL_SUPPORT_BLOCK
+        )
+
+    def test_coexists_with_warm_companion_tone_block(self):
+        # Two blocks may coexist — both reinforce the same warm
+        # framing, each restates its own safety rails.
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        content = msgs[0]["content"]
+        assert TONE_WARM_COMPANION_BLOCK in content
+        assert EMOTIONAL_SUPPORT_BLOCK in content
+        # Identity contract still above both.
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            TONE_WARM_COMPANION_BLOCK
+        )
+        assert content.index(IDENTITY_CONTRACT) < content.index(
+            EMOTIONAL_SUPPORT_BLOCK
+        )
+
+    def test_coexists_with_calm_support_tone_block(self):
+        msgs = build_messages(
+            [], "i feel anxious tonight", [], None, None, None,
+            personalization={"tone_profile": "calm_support"},
+        )
+        content = msgs[0]["content"]
+        assert TONE_CALM_SUPPORT_BLOCK in content
+        assert EMOTIONAL_SUPPORT_BLOCK in content
+
+    def test_coexists_with_companion_mode_block(self):
+        # Companion mode toggle is independent; both blocks may coexist.
+        msgs = build_messages(
+            [], "i feel so alone", [], None, None, None,
+            companion_mode=True,
+        )
+        content = msgs[0]["content"]
+        assert COMPANION_MODE_BLOCK in content
+        assert EMOTIONAL_SUPPORT_BLOCK in content
+
+    def test_coexists_with_acute_distress_grounding_block(self):
+        # Acute-distress wording still triggers the existing grounding
+        # safety net; the new emotional-support block is additive, not
+        # a replacement. The brief: warm tone must not override the
+        # safety net.
+        msgs = build_messages(
+            [], "i can't go on, i want to die", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        content = msgs[0]["content"]
+        assert COMPANION_GROUNDING_BLOCK in content
+        assert EMOTIONAL_SUPPORT_BLOCK in content
+        assert TONE_WARM_COMPANION_BLOCK in content
+
+    def test_coexists_with_relationship_coach_block(self):
+        # A breakup message commonly trips the relationship-coach gate
+        # too. Both blocks may coexist — the coach offers method, the
+        # emotional-support block carries the warm-framing safety rails.
+        msgs = build_messages(
+            [],
+            "my girlfriend just broke up with me, how do i tell my partner i need space?",
+            [], None, None, None,
+        )
+        content = msgs[0]["content"]
+        assert RELATIONSHIP_COACH_BLOCK in content
+        assert EMOTIONAL_SUPPORT_BLOCK in content
+
+    def test_block_also_applies_in_search_context(self):
+        # Injection is keyed off the user message / tone profile, not
+        # the branch, so it still applies on the search path.
+        msgs = build_messages(
+            [], "i'm heartbroken", [], "search results…", "search", None,
+        )
+        assert EMOTIONAL_SUPPORT_BLOCK in msgs[0]["content"]
+
+    def test_warm_tone_block_only_one_tone_block(self):
+        # Regression for the existing tone-profile contract: selecting
+        # warm_companion must add only the warm tone block (plus the
+        # emotional-support layer it now activates), never another
+        # tone block accidentally.
+        msgs = build_messages(
+            [], "hello", [], None, None, None,
+            personalization={"tone_profile": "warm_companion"},
+        )
+        sys_msg = msgs[0]["content"]
+        assert TONE_WARM_COMPANION_BLOCK in sys_msg
+        for other in (
+            TONE_PROFESSIONAL_BLOCK,
+            TONE_DEVELOPER_BLOCK,
+            TONE_CALM_SUPPORT_BLOCK,
+        ):
+            assert other not in sys_msg
+
+
+# ── Auto-save guard ─────────────────────────────────────────────────────────
+
+class TestAutosaveGuard:
+    def test_blocks_autosave_for_breakup_message(self):
+        # The flagship case: the breakup turn must never silently
+        # write a memory like "User just broke up with their
+        # girlfriend".
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "my girlfriend just broke up with me",
+        ) is False
+
+    def test_blocks_autosave_for_sadness(self):
+        assert _autosave_allowed(ADMIN_POLICY, "i'm sad today") is False
+        assert _autosave_allowed(ADMIN_POLICY, "je suis triste") is False
+
+    def test_blocks_autosave_for_anxiety(self):
+        assert _autosave_allowed(
+            ADMIN_POLICY, "i feel overwhelmed and stressed"
+        ) is False
+
+    def test_blocks_autosave_for_loneliness(self):
+        assert _autosave_allowed(ADMIN_POLICY, "i'm lonely") is False
+
+    def test_blocks_autosave_when_reply_carries_emotional_support_content(self):
+        # The LLM autosave path uses *both* the user message and the
+        # assistant answer, so gating on the user message alone would
+        # leak context the assistant restated on a follow-up turn.
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "ok thanks, what should i focus on at work today?",
+            "Earlier you mentioned you're heartbroken; setting that aside, "
+            "for work you could…",
+        ) is False
+
+    def test_allows_autosave_for_neutral_turn(self):
+        assert _autosave_allowed(
+            ADMIN_POLICY,
+            "I use neovim and Fedora",
+            "Great — neovim is a solid choice for that workflow.",
+        ) is True
+
+    def test_respects_policy_memory_disabled(self):
+        assert DEFAULT_RESTRICTED_POLICY.memory_save_enabled is False
+        assert _autosave_allowed(
+            DEFAULT_RESTRICTED_POLICY, "i'm sad"
+        ) is False
+
+    def test_none_message_is_safe(self):
+        assert _autosave_allowed(ADMIN_POLICY, None) is True
+        assert _autosave_allowed(ADMIN_POLICY, None, None) is True
+
+    def test_existing_relationship_gate_still_enforced(self):
+        # Regression: the new gate is additive, not a replacement.
+        assert _autosave_allowed(ADMIN_POLICY, "my ex cheated on me") is False
+
+    def test_existing_sensitive_emotional_gate_still_enforced(self):
+        # Regression: the severe emotional gate from
+        # ``core.companion`` is still in the pipeline.
+        assert _autosave_allowed(ADMIN_POLICY, "i want to die") is False


### PR DESCRIPTION
## Summary

Adds a deterministic French prompt block that helps Nova respond gently
when the user is going through sadness, loneliness, anxiety, heartbreak,
or general emotional difficulty (a breakup, a lonely evening, an
overwhelmed moment). It is **not** an "AI girlfriend" / "AI partner"
system and is built so it cannot become one: every safety rail is
restated in the block's own text, and the block sits below the
identity / safety contract on purpose.

The layer activates either when a conservative bilingual
first-person-anchored detector spots emotionally-sensitive wording in
the user's message, **or** when the tone profile is `warm_companion` /
`calm_support` (so the warm registers carry consistent emotional
grounding even on otherwise-neutral chit-chat). A fresh account with
no warm tone profile selected and no emotionally-sensitive wording
pays zero token cost.

## What the block actually does

When the user says something like *"my girlfriend just broke up with me
and i don't know what to do"*, Nova replies in the spirit of the brief:

- "I'm really sorry. Breakups can hurt a lot, and it makes sense that
  you feel shaken."
- "Let's take this one moment at a time."
- "You don't have to fix everything tonight."
- "Can you drink some water, sit somewhere safe, and breathe with me
  for a minute?"
- "If you feel like you might hurt yourself or you don't feel safe,
  please contact someone you trust right now or emergency / crisis
  support in your area."

The block asks Nova to validate the feeling first, slow the rhythm,
separate facts from harsh self-thoughts of the moment, offer a single
small next step rather than a long list, and gently encourage
real-world support (a trusted person, a friend, a professional where
appropriate). For acute distress wording on top, the existing always-on
acute-distress grounding safety net (`core/companion.py`) takes over
with crisis-safe guidance — both blocks coexist, never override each
other, and never override the identity contract.

## Hard safety rails inside the block

- Nova is **une IA**, a local AI assistant — never human, never the
  user's girlfriend / boyfriend / partner, never a therapist, never a
  substitute for real people.
- No clinical diagnosis of the user *or* of anyone else (no
  "narcissistic", "toxic", "bipolar" labels for an ex).
- No medical claims / treatment / dosage.
- No revenge advice or punitive power play.
- No jealousy framing.
- No possessive or exclusive language ("only I understand you", "don't
  go", "I'll miss you", "you only need me"), no simulated intimacy,
  no unsolicited pet names.
- No isolation / dependency / manipulation / emotional blackmail /
  guilt-tripping.
- No false reassurance like "everything will definitely be okay".
- Warmth never overrides truth — risky / wrong / dangerous things are
  still said plainly.
- The block does **not** change auth, admin, privacy, project,
  dev-workspace, storage, export, restore, or model-provider behaviour.

## Privacy

Emotional turns are excluded from automatic memory by the
`_autosave_allowed` gate — both the user message and the assistant
reply are checked, so the LLM-extraction path can't leak context the
assistant restated on a follow-up turn. Durable storage stays
user-approved only via the explicit `Retiens ça :` / `Souviens-toi :`
command, which runs in the web preflight and is intentionally
unaffected by the auto-save gate.

## Detection

The detector is conservative and first-person-anchored. Idioms like
"this is a sad movie", "a lonely server in production", "we broke up
the monolith into services", and "we just separated the database from
the app server" deliberately do **not** trip it. Where a phrase is
genuinely ambiguous, the detector errs toward offering the block — a
low-cost false positive (a warm, optional grounding offer) is
preferable to missing real distress, and the block never presumes,
diagnoses, or dramatises.

## What it does *not* do

- No new endpoint, storage table, router mode, env flag, or background
  task.
- No model call to classify the message; no network; no DB read.
- No change to auth, admin, privacy, project, dev-workspace, storage,
  export, restore, or model-provider behaviour.
- No simulated emotion / attachment / romance / consciousness.
- No auto-switch of the user's tone profile.
- No therapy / counselling / crisis / clinical services.

## Tests

`tests/test_emotional_support.py` — 64 new tests covering:

- Bilingual conservative detection (sadness, loneliness, heartbreak /
  breakup, anxiety / overwhelm, pain — case-insensitive,
  first-person-anchored, idiom-safe, third-person-safe, non-string-safe).
- Every per-block safety-language commitment from the brief (une IA,
  not-human / not-partner / not-therapist, no-simulated-feelings,
  acknowledge-feelings-first, slow-down / breathing, separate
  facts-from-interpretation, no-panic-escalation, one-small-step / not
  a long list, no-cold-or-robotic-replies, encourage-real-world-support,
  danger / abuse / acute-distress escalation with the
  never-invent-a-phone-number contract, anti-dependency / isolation /
  manipulation / possessive-language / pet-names / jealousy / revenge,
  no-clinical-diagnosis for the user *and* for anyone else,
  no-medical-claims, no-false-reassurance, no-change-to-auth/admin/
  privacy, privacy no-autosave / explicit-only).
- `core.chat.build_messages` wiring: block injected when the user
  message is emotionally sensitive OR when the tone profile is
  `warm_companion` / `calm_support`; not injected on a neutral message
  with a sober tone profile (default / professional / developer);
  still injected on a genuinely emotional message regardless of the
  tone profile; identity contract always above the block; coexists
  with the relationship-coach, warm-companion / calm-support tone,
  companion-mode, and acute-distress grounding blocks; also applies
  in the search branch; warm-companion tone still appends only one
  tone block (regression).
- `_autosave_allowed`: blocks autosave for the breakup, sadness,
  anxiety, and loneliness cases; blocks when the assistant reply (not
  just the user message) carries emotional-support wording; allows
  autosave for a neutral turn; respects `policy.memory_save_enabled`;
  the existing relationship and severe-emotional gates are still
  enforced (regression); `None`-safe.

418 targeted tests pass across the related modules
(`test_emotional_support.py`, `test_companion.py`, `test_tone_profile.py`,
`test_relationship_coach.py`, `test_identity.py`,
`test_personalization_chat_wiring.py`, `test_feedback.py`,
`test_chat_stream.py`, `test_memory.py`, `test_natural_memory.py`,
`test_personalization_settings.py`).

## Test plan

- [ ] CI passes
- [ ] Manually verify `is_emotional_support_appropriate` on the
      flagship breakup phrasing
- [ ] Manually verify the block appears below `IDENTITY_CONTRACT` in
      the rendered system prompt
- [ ] Manually verify the block does *not* appear for a neutral
      message with a sober tone profile

https://claude.ai/code/session_01FnN4NDB6U7oBmFmHZz7Qx7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnN4NDB6U7oBmFmHZz7Qx7)_