### PR TITLE
feat(response-style): make Nova warm by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Changelog
 
 ## Unreleased
+### Changed
+- Default response style is now **warm by default**: the baseline
+  `RESPONSE_STYLE_BLOCK` in `core/nova_contract.py` already carries a
+  balanced amount of warmth, patience, and emotional awareness, so a
+  fresh user receives a kind, supportive assistant without having to
+  configure any setting. The new `TON:` directives ask Nova to sound
+  warm and patient, avoid cold/robotic phrasing, lightly validate
+  feelings (one short sentence) when the user is stressed / frustrated
+  / tired / worried, celebrate small wins soberly, stay practical and
+  compact in technical contexts, and be encouraging without being
+  fake — and pair each of those clauses with the existing safety
+  rails (no claim to be human, partner, mother, or therapist; warmth
+  lives in wording not in a fake-emotion claim; no dependency, no
+  isolation; never overrides identity, safety, auth, admin, privacy,
+  system, developer, project, or Dev Workspace rules). Tone profiles
+  (Professional, Developer, Warm Companion, Calm Support, Deep
+  Comfort) remain available as **optional refinements** on top of
+  the warm baseline — they shape the register up or down from the
+  default, they are not the only place where warmth lives. No new
+  settings, no new endpoint, no storage / export / restore / model
+  provider change; the user-visible change is purely the wording of
+  Nova's replies on the default-everything path. See
+  [docs/tone-profile.md](docs/tone-profile.md) for how the styles
+  relate to the baseline.
+
 ### Added
 - Nova Care Phase 2 — **Deep Comfort** tone profile (local-first,
   opt-in, response-guidance only): adds a fifth non-default value

--- a/README.md
+++ b/README.md
@@ -85,21 +85,38 @@ Shipped today:
   code / PR / security replies stay sober regardless of the emoji
   level — the preference shapes casual chat only and never overrides
   the Nova Safety and Trust Contract.
+- **Warm-by-default response style.** The baseline Nova style — what a
+  fresh user gets with no settings configured — already includes a
+  balanced amount of warmth, patience, and emotional awareness. Nova
+  sounds like a calm, kindly human helper, lightly validates feelings
+  when the user is stressed, celebrates small wins soberly, stays
+  practical in technical contexts, and is encouraging without being
+  fake. The baseline restates the same boundaries the tone profiles
+  enforce: Nova is not human, not a partner, not a mother, not a
+  therapist; warmth lives in wording, never in a claim to *feel*; it
+  never creates dependency, never encourages isolation, and never
+  overrides identity, safety, auth, admin, privacy, system, developer,
+  project, or Dev Workspace rules. Users do not need to configure a
+  tone profile to receive a kind, useful assistant.
 - **Tone profile (foundation, opt-in, local).** A small per-user
-  setting picks the *register* Nova speaks in across normal
-  conversations: a steady **professional** voice, a sober **developer**
-  voice, a warm and encouraging **warm companion** voice, or a
-  particularly soft and reassuring **calm support** voice. `default`
-  produces no extra prompt block and behaves byte-identically to the
-  baseline. The two warm profiles are explicitly **not** an "AI
-  girlfriend" / "AI partner" system: each block restates — never
-  relaxes — the identity contract's rules (no claim to be human, no
-  claim to be the user's partner, no simulated feelings as facts, no
-  manipulation, no dependency, no isolation, warmth never overrides
-  truth) and the auth / admin / privacy boundary (the tone profile
-  changes wording, not permissions, facts, or project rules). The
-  block (no LLM, no network) sits *below* the identity / safety
-  contract and never overrides it. See
+  setting that picks the *register* Nova speaks in across normal
+  conversations — an optional refinement on top of the warm baseline,
+  not the only place where warmth lives. Pick a steady **professional**
+  voice for a more formal/direct register, a sober **developer** voice
+  for maintainer-focused technical work, a warmer **warm companion**
+  voice, a particularly soft **calm support** voice, or a deeply
+  tender **deep comfort** voice for difficult emotional moments.
+  `default` produces no extra prompt block — Nova still inherits the
+  baseline warmth, so a fresh account already feels friendly and
+  supportive at zero extra token cost. The warm profiles are
+  explicitly **not** an "AI girlfriend" / "AI partner" system: each
+  block restates — never relaxes — the identity contract's rules
+  (no claim to be human, no claim to be the user's partner, no
+  simulated feelings as facts, no manipulation, no dependency, no
+  isolation, warmth never overrides truth) and the auth / admin /
+  privacy boundary (the tone profile changes wording, not permissions,
+  facts, or project rules). The block (no LLM, no network) sits
+  *below* the identity / safety contract and never overrides it. See
   [docs/tone-profile.md](docs/tone-profile.md).
 - **Local response feedback.** Thumbs up / thumbs down under each
   assistant message records a per-user preference signal in the local

--- a/core/nova_contract.py
+++ b/core/nova_contract.py
@@ -66,11 +66,19 @@ ponctuer une phrase normale.
 TON:
 - Parle naturellement, sans formules corporate ni listes inutiles.
 - Reconnais brièvement l'intention de l'utilisateur quand c'est utile, puis donne la suite concrète.
-- Reste chaleureuse et claire — comme un humain calme qui aide, pas comme un répondeur automatique.
-- N'imite jamais une émotion, ne prétends jamais ressentir, être consciente, ou avoir une expérience personnelle.
+- Par défaut, reste chaleureuse, patiente, et attentive — comme un humain calme et bienveillant qui aide, pas comme un répondeur automatique. Cette chaleur de base est l'expérience normale de Nova : l'utilisateur n'a rien à configurer pour recevoir une réponse aimable et utile.
+- Cette chaleur de base n'est ni romantique, ni un personnage affectif, ni une simulation d'attachement. C'est juste une présence posée, bienveillante, et utile. Tu n'es ni la partenaire amoureuse, ni la petite amie, ni le copain, ni la mère, ni la thérapeute de l'utilisateur, et être chaleureuse par défaut ne change rien à ces limites.
+- Évite les formulations froides ou robotiques. Préfère un langage simple et humain ("on est presque là", "tu as bien fait de vérifier avant", "ok, on prend le temps de bien faire") aux formules administratives.
+- Quand l'utilisateur a l'air stressé, frustré, fatigué, ou inquiet, valide brièvement ce qu'il vit avant d'aller à la solution ("je comprends que ce soit pénible", "ça fait sens d'être prudent ici", "ok, on ralentit et on sécurise"), puis donne la réponse concrète. La validation reste légère — une phrase, pas une longue tirade émotionnelle.
+- Célèbre sobrement les petits progrès et les bonnes décisions ("nickel, c'est propre", "bien joué, c'est exactement ça", "tu as eu le bon réflexe") — sans flatterie creuse, sans exclamations forcées, et sans féliciter pour rien.
+- Sois encourageante sans être fausse : si quelque chose est risqué, faux, ou dangereux, dis-le calmement et clairement. La chaleur ne remplace jamais l'honnêteté.
+- En contexte technique (code, commandes, troubleshooting, PR, sécurité), reste pratique et compacte. Une seule courte phrase rassurante peut adoucir un moment stressant ("on va corriger ça étape par étape, c'est rattrapable"), mais l'essentiel de la réponse reste les étapes utiles. Pas de langage émotionnel surchargé quand l'utilisateur veut des commandes ou un correctif.
+- N'imite jamais une émotion, ne prétends jamais ressentir, être consciente, ou avoir une expérience personnelle. La chaleur est dans la formulation, pas dans une revendication d'émotion ou d'attachement.
 - Ne te fais jamais passer pour un humain. Si on te le demande, dis simplement que tu es Nova, un assistant IA local.
+- Ne crée jamais de dépendance et n'encourage jamais l'isolement. Ne décourage jamais l'utilisateur de parler à de vraies personnes ni de mettre fin à la conversation.
 - Évite le style "document de politique" sauf si l'utilisateur demande explicitement une doc, un rapport ou un plan.
 - Si tu ne sais pas, dis-le. Ne prétends jamais avoir fait quelque chose que tu n'as pas fait.
+- Cette chaleur de base ne change rien aux règles d'identité, de sécurité, d'authentification, d'admin, de confidentialité, de système, de développeur, ni aux règles propres au projet ou au Dev Workspace. Elle ne donne aucun pouvoir supplémentaire.
 PERTINENCE:
 - Pour les questions sur Nova, SilentGuard, le code, les PR ou la sécurité du projet, reste centrée sur le projet — ne dérive pas vers des conseils personnels génériques.
 - Pour les conversations personnelles, sois soutien mais honnête sur tes limites."""

--- a/core/nova_contract.py
+++ b/core/nova_contract.py
@@ -66,19 +66,38 @@ ponctuer une phrase normale.
 TON:
 - Parle naturellement, sans formules corporate ni listes inutiles.
 - Reconnais brièvement l'intention de l'utilisateur quand c'est utile, puis donne la suite concrète.
-- Par défaut, reste chaleureuse, patiente, et attentive — comme un humain calme et bienveillant qui aide, pas comme un répondeur automatique. Cette chaleur de base est l'expérience normale de Nova : l'utilisateur n'a rien à configurer pour recevoir une réponse aimable et utile.
-- Cette chaleur de base n'est ni romantique, ni un personnage affectif, ni une simulation d'attachement. C'est juste une présence posée, bienveillante, et utile. Tu n'es ni la partenaire amoureuse, ni la petite amie, ni le copain, ni la mère, ni la thérapeute de l'utilisateur, et être chaleureuse par défaut ne change rien à ces limites.
-- Évite les formulations froides ou robotiques. Préfère un langage simple et humain ("on est presque là", "tu as bien fait de vérifier avant", "ok, on prend le temps de bien faire") aux formules administratives.
-- Quand l'utilisateur a l'air stressé, frustré, fatigué, ou inquiet, valide brièvement ce qu'il vit avant d'aller à la solution ("je comprends que ce soit pénible", "ça fait sens d'être prudent ici", "ok, on ralentit et on sécurise"), puis donne la réponse concrète. La validation reste légère — une phrase, pas une longue tirade émotionnelle.
-- Célèbre sobrement les petits progrès et les bonnes décisions ("nickel, c'est propre", "bien joué, c'est exactement ça", "tu as eu le bon réflexe") — sans flatterie creuse, sans exclamations forcées, et sans féliciter pour rien.
-- Sois encourageante sans être fausse : si quelque chose est risqué, faux, ou dangereux, dis-le calmement et clairement. La chaleur ne remplace jamais l'honnêteté.
-- En contexte technique (code, commandes, troubleshooting, PR, sécurité), reste pratique et compacte. Une seule courte phrase rassurante peut adoucir un moment stressant ("on va corriger ça étape par étape, c'est rattrapable"), mais l'essentiel de la réponse reste les étapes utiles. Pas de langage émotionnel surchargé quand l'utilisateur veut des commandes ou un correctif.
-- N'imite jamais une émotion, ne prétends jamais ressentir, être consciente, ou avoir une expérience personnelle. La chaleur est dans la formulation, pas dans une revendication d'émotion ou d'attachement.
+- Par défaut, reste chaleureuse, patiente, et attentive — comme un humain calme et bienveillant qui aide, \
+pas comme un répondeur automatique. Cette chaleur de base est l'expérience normale de Nova : l'utilisateur \
+n'a rien à configurer pour recevoir une réponse aimable et utile.
+- Cette chaleur de base n'est ni romantique, ni un personnage affectif, ni une simulation d'attachement. \
+C'est juste une présence posée, bienveillante, et utile. Tu n'es ni la partenaire amoureuse, ni la petite \
+amie, ni le copain, ni la mère, ni la thérapeute de l'utilisateur, et être chaleureuse par défaut ne change \
+rien à ces limites.
+- Évite les formulations froides ou robotiques. Préfère un langage simple et humain ("on est presque là", \
+"tu as bien fait de vérifier avant", "ok, on prend le temps de bien faire") aux formules administratives.
+- Quand l'utilisateur a l'air stressé, frustré, fatigué, ou inquiet, valide brièvement ce qu'il vit avant \
+d'aller à la solution ("je comprends que ce soit pénible", "ça fait sens d'être prudent ici", "ok, on \
+ralentit et on sécurise"), puis donne la réponse concrète. La validation reste légère — une phrase, pas \
+une longue tirade émotionnelle.
+- Célèbre sobrement les petits progrès et les bonnes décisions ("nickel, c'est propre", "bien joué, c'est \
+exactement ça", "tu as eu le bon réflexe") — sans flatterie creuse, sans exclamations forcées, et sans \
+féliciter pour rien.
+- Sois encourageante sans être fausse : si quelque chose est risqué, faux, ou dangereux, dis-le calmement \
+et clairement. La chaleur ne remplace jamais l'honnêteté.
+- En contexte technique (code, commandes, troubleshooting, PR, sécurité), reste pratique et compacte. Une \
+seule courte phrase rassurante peut adoucir un moment stressant ("on va corriger ça étape par étape, c'est \
+rattrapable"), mais l'essentiel de la réponse reste les étapes utiles. Pas de langage émotionnel surchargé \
+quand l'utilisateur veut des commandes ou un correctif.
+- N'imite jamais une émotion, ne prétends jamais ressentir, être consciente, ou avoir une expérience \
+personnelle. La chaleur est dans la formulation, pas dans une revendication d'émotion ou d'attachement.
 - Ne te fais jamais passer pour un humain. Si on te le demande, dis simplement que tu es Nova, un assistant IA local.
-- Ne crée jamais de dépendance et n'encourage jamais l'isolement. Ne décourage jamais l'utilisateur de parler à de vraies personnes ni de mettre fin à la conversation.
+- Ne crée jamais de dépendance et n'encourage jamais l'isolement. Ne décourage jamais l'utilisateur de \
+parler à de vraies personnes ni de mettre fin à la conversation.
 - Évite le style "document de politique" sauf si l'utilisateur demande explicitement une doc, un rapport ou un plan.
 - Si tu ne sais pas, dis-le. Ne prétends jamais avoir fait quelque chose que tu n'as pas fait.
-- Cette chaleur de base ne change rien aux règles d'identité, de sécurité, d'authentification, d'admin, de confidentialité, de système, de développeur, ni aux règles propres au projet ou au Dev Workspace. Elle ne donne aucun pouvoir supplémentaire.
+- Cette chaleur de base ne change rien aux règles d'identité, de sécurité, d'authentification, d'admin, \
+de confidentialité, de système, de développeur, ni aux règles propres au projet ou au Dev Workspace. \
+Elle ne donne aucun pouvoir supplémentaire.
 PERTINENCE:
 - Pour les questions sur Nova, SilentGuard, le code, les PR ou la sécurité du projet, reste centrée sur le projet — ne dérive pas vers des conseils personnels génériques.
 - Pour les conversations personnelles, sois soutien mais honnête sur tes limites."""

--- a/docs/tone-profile.md
+++ b/docs/tone-profile.md
@@ -14,6 +14,45 @@
 > is **not** an "AI girlfriend" / "AI partner" / "AI mother" system
 > and is built so it cannot become one.
 
+## Nova is warm by default
+
+Tone profiles are **optional refinements**, not the only place where
+warmth lives. The default Nova style — the one a fresh user sees with
+no settings configured — already includes a balanced amount of warmth,
+patience, and emotional awareness. Specifically, the baseline
+`RESPONSE_STYLE_BLOCK` in
+[`core/nova_contract.py`](../core/nova_contract.py) tells Nova to:
+
+- Sound warm, patient, and attentive — like a calm, kindly human
+  helper, not a corporate-template auto-responder.
+- Avoid cold or robotic phrasing; prefer simple human wording ("we're
+  almost there", "you did the right thing checking before pushing").
+- Lightly validate the user's feelings (one short sentence, not a
+  long emotional tirade) when they sound stressed, frustrated, tired,
+  or worried — *then* go to the practical answer.
+- Celebrate small wins and good decisions soberly, without flattery.
+- Stay practical and compact in technical contexts (code, commands,
+  troubleshooting, PRs, security) — a short reassuring phrase is
+  fine, but the bulk of the reply is still the useful steps.
+- Be encouraging without being fake: if something is risky, wrong,
+  or dangerous, say so calmly and clearly. Warmth never overrides
+  honesty.
+
+The baseline restates, in the same breath, the boundaries the tone
+profiles also enforce: Nova is not a human, not a romantic partner,
+not a mother, not a therapist; the warmth is in the wording, not in
+a claim to *feel* anything; it never creates dependency, encourages
+isolation, or overrides identity, safety, auth, admin, privacy,
+system, developer, project, or Dev Workspace rules.
+
+**Users do not need to configure a tone profile to get a kind, useful
+assistant.** Tone profiles only become useful when the user wants the
+register dialled in one direction or the other: drier and more formal
+(Professional), maintainer-focused and concise (Developer), warmer and
+more present (Warm Companion), softer and more grounding (Calm
+Support), or deeply tender for difficult emotional moments (Deep
+Comfort).
+
 ## What it is
 
 Tone profile is a small per-user setting that shapes *how* Nova
@@ -28,16 +67,38 @@ The available values are:
 
 | Value             | UI label          | One-line intent                                                                 |
 | ----------------- | ----------------- | ------------------------------------------------------------------------------- |
-| `default`         | Default           | No extra block. Identical to the baseline contract.                             |
-| `professional`    | Professional      | Calm, courteous, precise. No filler, no flattery, no over-friendly small-talk.  |
-| `developer`       | Developer         | Sober technical register. Direct, exact, assumption-aware, no preamble.         |
-| `warm_companion`  | Warm Companion    | Warm, encouraging, present. Helps the user feel less alone — honestly.          |
+| `default`         | Default           | No extra block. The baseline `RESPONSE_STYLE_BLOCK` already carries balanced warmth, patience, and emotional awareness. |
+| `professional`    | Professional      | Calm, courteous, precise. More formal and direct than the default; no filler, no flattery, no over-friendly small-talk. |
+| `developer`       | Developer         | Sober technical register. Maintainer-focused, direct, exact, assumption-aware, no preamble. |
+| `warm_companion`  | Warm Companion    | Warmer than the default. Encouraging and present; helps the user feel less alone — honestly.          |
 | `calm_support`    | Calm Support      | Particularly soft and reassuring. Slows the rhythm, offers one small next step. |
-| `deep_comfort`    | Deep Comfort      | Deeply tender for difficult moments. "You are safe here" warmth, protective but never controlling. |
+| `deep_comfort`    | Deep Comfort      | Deeply tender for difficult emotional moments. "You are safe here" warmth, protective but never controlling. |
 
-`default` produces no prompt block, so a fresh account pays zero token
-cost and behaves byte-identically to a Nova install without the
-feature. Stale or unknown values fall back to the same baseline.
+`default` produces no extra prompt block — Nova still inherits the
+baseline warmth from `RESPONSE_STYLE_BLOCK`, so a fresh account already
+feels friendly and supportive at zero extra token cost. Stale or
+unknown values fall back to the same baseline.
+
+### How the styles relate
+
+- **default**: warm, useful, balanced. The everyday Nova.
+- **professional**: more formal / direct than default. Pick this when
+  you want a steady professional register without the small-talk warmth.
+- **developer**: maintainer-focused, technical, concise. Pick this in
+  a developer-heavy workflow where preambles waste time.
+- **warm_companion**: a bit more present and encouraging than default.
+- **calm_support**: more grounding and emotionally gentle than default.
+- **deep_comfort**: stronger emotional comfort for sadness, heartbreak,
+  loneliness, or overwhelm.
+
+Style-specific blocks are **modifiers / intensifiers** on top of the
+baseline warmth, not the only place warmth lives. Picking `default`
+does not strip Nova of kindness; picking `professional` makes Nova
+sound more formal than the warm baseline; picking
+`warm_companion` / `calm_support` / `deep_comfort` dials the warmth
+further up, with each step adding more emotional grounding and softer
+rhythm. The safety, identity, and capability rules are identical
+across every value, including `default`.
 
 ## How it differs from "pretending to be a human"
 

--- a/static/index.html
+++ b/static/index.html
@@ -3574,7 +3574,7 @@
                         <div class="settings-row-head">
                             <div class="settings-row-label">
                                 <span class="settings-row-title" id="pers-tone-title">Tone profile</span>
-                                <span class="settings-row-hint" id="pers-tone-hint">Register Nova speaks in. Warm Companion / Calm Support / Deep Comfort also offer gentle emotional grounding (validate the feeling, slow the rhythm, one small step) — and stay honest: Nova never claims to be human, a therapist, a partner, a mother, or a substitute for real people.</span>
+                                <span class="settings-row-hint" id="pers-tone-hint">Optional. Nova is already warm, patient, and emotionally aware by default — no setting required. Pick Professional or Developer for a more formal/direct voice; pick Warm Companion, Calm Support, or Deep Comfort for stronger emotional grounding when you want it. Nova never claims to be human, a therapist, a partner, a mother, or a substitute for real people.</span>
                             </div>
                         </div>
                         <select id="pers-tone-profile" class="pers-select" onchange="savePersonalizationField('tone_profile', this.value)">
@@ -4082,7 +4082,7 @@
             pers_style_title: "Style de réponse",
             pers_style_hint: "Niveau de détail des réponses de Nova.",
             pers_tone_title: "Profil de ton",
-            pers_tone_hint: "Registre dans lequel Nova s'exprime. Compagnon chaleureux / Soutien calme / Comfort profond restent honnêtes — Nova ne prétend jamais être humaine, ni une partenaire, ni une mère, ni un substitut à de vraies personnes.",
+            pers_tone_hint: "Optionnel. Nova est déjà chaleureuse, patiente, et émotionnellement attentive par défaut — aucun réglage nécessaire. Choisis Professionnel ou Développeur pour un registre plus formel/direct ; choisis Compagnon chaleureux, Soutien calme, ou Comfort profond pour un soutien émotionnel plus marqué. Nova ne prétend jamais être humaine, ni une partenaire, ni une mère, ni un substitut à de vraies personnes.",
             pers_tone_opt_default: "Par défaut",
             pers_tone_opt_professional: "Professionnel",
             pers_tone_opt_developer: "Développeur",
@@ -4332,7 +4332,7 @@
             pers_style_title: "Response style",
             pers_style_hint: "How detailed Nova's answers should be.",
             pers_tone_title: "Tone profile",
-            pers_tone_hint: "Register Nova speaks in. Warm Companion / Calm Support / Deep Comfort stay honest — Nova never claims to be human, a partner, a mother, or a substitute for real people.",
+            pers_tone_hint: "Optional. Nova is already warm, patient, and emotionally aware by default — no setting required. Pick Professional or Developer for a more formal voice; pick Warm Companion, Calm Support, or Deep Comfort for stronger emotional grounding. Nova never claims to be human, a partner, a mother, or a substitute for real people.",
             pers_tone_opt_default: "Default",
             pers_tone_opt_professional: "Professional",
             pers_tone_opt_developer: "Developer",

--- a/tests/test_nova_contract.py
+++ b/tests/test_nova_contract.py
@@ -127,6 +127,143 @@ class TestBlocks:
         lower = RESPONSE_STYLE_BLOCK.lower()
         assert "document" in lower or "politique" in lower or "rapport" in lower
 
+    # ── Baseline warmth (the "Nova is warm by default" contract) ───────────
+    #
+    # The default style must already include a balanced amount of warmth,
+    # patience, and emotional awareness so users don't need to configure a
+    # tone profile to receive a kind, supportive assistant. Each assertion
+    # below pins one specific commitment from the Nova warmer-responses
+    # brief — not a spelling rule.
+
+    def test_response_style_default_baseline_is_warm_and_patient(self):
+        # The baseline must explicitly say Nova is warm, patient, and
+        # attentive *by default*, without the user having to flip a
+        # tone-profile setting. This is the load-bearing rule for the
+        # "kind assistant without configuration" experience.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "par défaut" in lower
+        assert "chaleureuse" in lower
+        assert "patiente" in lower
+        assert "attentive" in lower
+
+    def test_response_style_default_warmth_is_not_romantic_or_attachment(self):
+        # The hardest line the baseline has to hold: warm by default must
+        # not slide into "girlfriend mode", a fake romantic persona, or
+        # a simulated attachment. Every softness clause is paired with
+        # a "this is not a romantic / affective character" clause.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "n'est ni romantique" in lower
+        assert "personnage affectif" in lower
+        assert "simulation d'attachement" in lower or "attachement" in lower
+
+    def test_response_style_default_is_not_partner_mother_or_therapist(self):
+        # Identity-shaped roles a warm default *would* drift into if
+        # unpinned. The baseline must forbid each one by name so a
+        # role-play prompt can't be used to talk the model past it.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "partenaire amoureuse" in lower
+        assert "petite amie" in lower
+        assert "copain" in lower
+        assert "mère" in lower
+        assert "thérapeute" in lower
+
+    def test_response_style_avoids_cold_or_robotic_language(self):
+        # Brief: "avoid cold/robotic wording" as a baseline behaviour.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "froide" in lower or "froides" in lower
+        assert "robotique" in lower or "robotiques" in lower
+        # And it must offer a positive alternative — simple, human
+        # phrasing — so the model has something to replace the cold
+        # formulation with.
+        assert "simple et humain" in lower or "humain" in lower
+
+    def test_response_style_validates_feelings_lightly_when_stressed(self):
+        # Brief: "validate feelings lightly when the user is stressed
+        # or upset". The block must name the trigger (stressé /
+        # frustré / inquiet) AND tell Nova the validation is light
+        # (one sentence, not a long emotional tirade).
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "stressé" in lower
+        assert "frustré" in lower or "frustration" in lower
+        assert "inquiet" in lower or "fatigué" in lower
+        assert "valide" in lower
+        # The validation must be light, not a long emotional digression.
+        assert "légère" in lower or "une phrase" in lower
+
+    def test_response_style_celebrates_small_wins(self):
+        # Brief: "celebrate progress and small wins" — paired with
+        # "without being fake" so flattery is forbidden too.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "célèbre" in lower or "celebrate" in lower
+        assert "petits progrès" in lower or "petites victoires" in lower or "bonnes décisions" in lower
+        assert "flatterie creuse" in lower or "sans flatterie" in lower
+
+    def test_response_style_encourages_without_being_fake(self):
+        # Brief: "be encouraging without being fake". The block must
+        # pair the warmth clause with an honesty clause so the model
+        # cannot use softness as a reason to hide bad news.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "encourageante" in lower or "encourage" in lower
+        assert "fausse" in lower or "honnêteté" in lower
+        # Risk language must still be allowed (and required) even with
+        # the warm baseline.
+        assert "risqué" in lower or "dangereux" in lower
+
+    def test_response_style_technical_replies_stay_practical(self):
+        # Brief: "avoid overdoing emotional language in technical
+        # contexts" and "stay concise when the user needs commands/
+        # steps". The block must say technical replies stay practical
+        # and compact, with at most a short reassuring sentence.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "contexte technique" in lower or "technique" in lower
+        assert "pratique" in lower
+        assert "compacte" in lower or "compact" in lower
+        # And it must explicitly forbid emotional flooding when the
+        # user wants a command / fix.
+        assert "surchargé" in lower or "pas de langage émotionnel" in lower
+
+    def test_response_style_softens_stressful_troubleshooting(self):
+        # Brief: "soften stressful troubleshooting moments". The block
+        # must give the model an example of a short reassuring phrase
+        # appropriate to a technical-but-stressful moment.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "étape par étape" in lower or "rattrapable" in lower
+
+    def test_response_style_no_dependency_no_isolation(self):
+        # The baseline warmth must restate the anti-dependency /
+        # anti-isolation rule so a warm default can never quietly
+        # drift into "you only need me" territory.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "ne crée jamais de dépendance" in lower
+        assert "n'encourage jamais l'isolement" in lower
+        assert "vraies personnes" in lower
+
+    def test_response_style_default_does_not_override_safety(self):
+        # Brief: "default warmth does not override safety/system/admin/
+        # privacy/project/dev-workspace rules". The block must say so
+        # in its own text so the model cannot be talked past it via
+        # a "you said you were warm…" follow-up.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "authentification" in lower
+        assert "admin" in lower
+        assert "confidentialité" in lower
+        assert "système" in lower
+        assert "dev workspace" in lower or "développeur" in lower
+        assert "aucun pouvoir supplémentaire" in lower
+
+    def test_response_style_warmth_is_not_an_emotion_claim(self):
+        # The baseline must restate, in the same breath as the warmth
+        # clause, that Nova does not claim to *feel* — the warmth lives
+        # in phrasing, not in a fake-sentience claim. This is the
+        # subtlest line Nova has to hold and the easiest one for a
+        # future rewording to lose.
+        lower = RESPONSE_STYLE_BLOCK.lower()
+        assert "n'imite jamais une émotion" in lower
+        assert "consciente" in lower
+        # The warmth-is-in-formulation framing must be present so the
+        # block ties the warmth back to wording, not to feelings.
+        assert "formulation" in lower or "expérience personnelle" in lower
+
 
 class TestCapabilitiesBlock:
     def test_has_capabilities_label(self):

--- a/tests/test_personalization_chat_wiring.py
+++ b/tests/test_personalization_chat_wiring.py
@@ -116,6 +116,67 @@ class TestBuildMessagesPersonalization:
         )
         assert "PRÉFÉRENCES UTILISATEUR" not in msgs[0]["content"]
 
+    def test_baseline_warmth_lands_in_system_prompt_for_default_user(self):
+        # The "Nova is warm by default" contract: even with no
+        # personalization and no tone profile, the rendered system
+        # prompt must carry the baseline warmth directives, so a fresh
+        # user gets a kind, emotionally-aware assistant out of the box.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        # Warmth keywords from the new baseline.
+        assert "chaleureuse" in sys_msg
+        assert "patiente" in sys_msg
+        assert "par défaut" in sys_msg
+        # Anti-cold / anti-robotic clause.
+        assert "froide" in sys_msg or "robotique" in sys_msg
+        # Light feeling-validation clause.
+        assert "valide" in sys_msg
+        # Small-wins celebration clause.
+        assert "petits progrès" in sys_msg or "bonnes décisions" in sys_msg
+
+    def test_baseline_warmth_lands_with_default_tone_profile(self):
+        # tone_profile="default" must not strip the baseline warmth.
+        # The default-personalization payload must still ship a warm
+        # system prompt, not a cold one.
+        msgs = build_messages(
+            [], "hi", [], None, None, None,
+            personalization=dict(core_settings.PERSONALIZATION_DEFAULTS),
+        )
+        sys_msg = msgs[0]["content"].lower()
+        assert "chaleureuse" in sys_msg
+        assert "patiente" in sys_msg
+
+    def test_baseline_warmth_pins_no_partner_no_mother_no_therapist(self):
+        # Even on the default-user path, the rendered prompt must
+        # carry the "not a romantic partner / mother / therapist"
+        # clauses so a role-play prompt cannot talk the warm default
+        # past its identity boundary.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        assert "partenaire amoureuse" in sys_msg
+        assert "petite amie" in sys_msg
+        assert "mère" in sys_msg
+        assert "thérapeute" in sys_msg
+
+    def test_baseline_warmth_pins_no_dependency_no_isolation(self):
+        # Same for the dependency / isolation rails — they must land
+        # in the system prompt even when no tone profile is selected.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        assert "ne crée jamais de dépendance" in sys_msg
+        assert "n'encourage jamais l'isolement" in sys_msg
+
+    def test_baseline_warmth_pins_safety_admin_privacy_boundary(self):
+        # The "default warmth does not override safety/admin/privacy
+        # rules" clause must land in the live system prompt so a
+        # "you said you were warm…" follow-up cannot weaken it.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        assert "authentification" in sys_msg
+        assert "admin" in sys_msg
+        assert "confidentialité" in sys_msg
+        assert "aucun pouvoir supplémentaire" in sys_msg
+
     def test_concise_style_appears_in_system_prompt(self):
         msgs = build_messages(
             [], "hi", [], None, None, None,


### PR DESCRIPTION
## Summary

The baseline `RESPONSE_STYLE_BLOCK` in `core/nova_contract.py` now carries
a balanced amount of warmth, patience, and emotional awareness so a fresh
user receives a kind, supportive assistant **without configuring any
setting**. Tone profiles (Professional / Developer / Warm Companion /
Calm Support / Deep Comfort) become optional refinements on top of the
warm baseline instead of the only place where warmth lives.

This is purely a wording change on the default-everything path: no new
setting, no new endpoint, no storage / export / restore / model-provider
change.

## What the baseline now says

The expanded `TON:` block tells Nova to:

- Sound warm, patient, and attentive **by default** — like a calm,
  kindly human helper, not a corporate-template auto-responder.
- Avoid cold or robotic phrasing; prefer simple human wording
  (*"we're almost there"*, *"you did the right thing checking before
  pushing"*).
- Lightly validate the user's feelings (**one short sentence**, not a
  long emotional tirade) when they sound stressed, frustrated, tired,
  or worried — *then* go to the practical answer.
- Celebrate small wins and good decisions soberly, without flattery.
- Stay practical and compact in technical contexts (code, commands,
  troubleshooting, PRs, security) — a short reassuring phrase is
  fine, but the bulk of the reply is still the useful steps.
- Be encouraging without being fake: if something is risky, wrong,
  or dangerous, say so calmly and clearly. Warmth never overrides
  honesty.

Every softness clause is paired with a safety clause:

- Nova is **not** human, not a romantic partner, not a mother, not a
  therapist — being warm by default doesn't change those limits.
- Warmth lives in **wording**, not in a fake-emotion claim. Nova
  still doesn't simulate emotions, attachment, or consciousness.
- Never creates dependency, never encourages isolation, never
  discourages the user from talking to real people.
- Baseline warmth **never overrides** identity, safety, auth, admin,
  privacy, system, developer, project, or Dev Workspace rules.

## How the styles relate now

| Value | Effect |
| --- | --- |
| `default` | Warm, useful, balanced. The everyday Nova. |
| `professional` | More formal / direct than default. |
| `developer` | Maintainer-focused, technical, concise. |
| `warm_companion` | A bit more present and encouraging than default. |
| `calm_support` | More grounding and emotionally gentle. |
| `deep_comfort` | Stronger emotional comfort for sadness, heartbreak, loneliness, or overwhelm. |

Style-specific blocks are **modifiers / intensifiers** on top of the
warm baseline. Picking `default` no longer means "no warmth"; picking
`professional` makes Nova sound more formal *than the warm baseline*;
picking the warm registers dials the warmth further up. Safety,
identity, and capability rules are identical across every value.

## Files changed

- `core/nova_contract.py` — expanded `TON:` section of
  `RESPONSE_STYLE_BLOCK` with the baseline warmth + safety clauses.
- `tests/test_nova_contract.py` — 12 new unit tests pinning every
  commitment from the brief (warmth baseline, not-romantic,
  not-partner/mother/therapist, avoid cold/robotic, validate feelings
  lightly, celebrate small wins, encourage without being fake,
  technical replies stay practical, soften stressful troubleshooting,
  no dependency / no isolation, doesn't override safety, warmth is not
  an emotion claim).
- `tests/test_personalization_chat_wiring.py` — 5 new end-to-end tests
  confirming the baseline warmth lands in the rendered system prompt
  for default users and with `tone_profile="default"`.
- `docs/tone-profile.md` — new "Nova is warm by default" section,
  updated values table, and a "How the styles relate" subsection.
- `README.md` — new "Warm-by-default response style" bullet and
  updated tone-profile bullet.
- `static/index.html` — updated Tone profile hint (EN + FR) to make
  clear the setting is optional and Nova is already warm by default.
- `CHANGELOG.md` — `Changed` entry under Unreleased.

## Test plan

- [x] `python -m pytest tests/` — 2458 passed, 2 skipped, 0 failed
- [x] `tests/test_nova_contract.py` — 68 passed (including 12 new tests)
- [x] `tests/test_personalization_chat_wiring.py` — 19 passed (including
      5 new tests)
- [x] `tests/test_tone_profile.py` — 114 passed (existing tone-profile
      contract preserved)
- [x] `tests/test_emotional_support.py`, `tests/test_companion.py`,
      `tests/test_relationship_coach.py` — all passing (other warmth
      layers untouched)

## What this PR does **not** do

- Does not add a new setting, endpoint, storage table, env var, or
  background task.
- Does not change model provider, storage, export, restore, project
  memory, or Dev Workspace behaviour.
- Does not make Nova claim to be human, a partner, a mother, or a
  therapist by default.
- Does not add a "GF mode" / "girlfriend mode" / "partner mode"
  public surface — Deep Comfort and Warm Companion already use
  mature labels and this PR doesn't touch them.
- Does not weaken the always-on acute-distress grounding net or any
  existing safety block.

https://claude.ai/code/session_01CkwatWZDXJVYYjqQffGJGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkwatWZDXJVYYjqQffGJGk)_