### PR TITLE
Remove Tone Profile selector from Settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 ### Changed
+- **Removed the Tone Profile selector from the Settings UI.** Because
+  Nova is now warm, patient, and emotionally aware by default (the
+  baseline `RESPONSE_STYLE_BLOCK` in `core/nova_contract.py` already
+  carries that warmth), the visible "Tone profile / Profil de ton"
+  card in Personalization is unnecessary user-facing complexity and
+  has been removed. The `<select id="pers-tone-profile">` card, its
+  explanatory paragraph, its FR/EN translation strings, the
+  `_setText` calls that re-rendered them on language switch, and the
+  `tone_profile` entry in the `PERSONALIZATION_FIELDS` JS map are all
+  gone from `static/index.html`. The deterministic prompt fragments
+  (`TONE_PROFESSIONAL_BLOCK`, `TONE_DEVELOPER_BLOCK`,
+  `TONE_WARM_COMPANION_BLOCK`, `TONE_CALM_SUPPORT_BLOCK`,
+  `TONE_DEEP_COMFORT_BLOCK`), `TONE_PROFILE_VALUES`,
+  `is_valid_tone_profile`, `build_tone_profile_block`, the
+  `tone_profile` key in `PERSONALIZATION_ENUMS` /
+  `PERSONALIZATION_DEFAULTS` / `USER_SETTING_KEYS`, and the
+  Pydantic / `/settings` API field stay in place so any
+  previously-saved per-user value still loads cleanly, the
+  `user_settings` rows are not deleted, and the storage / export /
+  restore / model-provider / Dev Workspace / project-memory paths
+  are unchanged. Stronger emotional behaviour is handled
+  automatically — the Emotional Support Layer activates on
+  emotionally-sensitive wording, and the always-on acute-distress
+  grounding net runs regardless of any setting — or through future
+  focused features, never through a user-facing register dropdown.
+  Nova still never claims to be human, a girlfriend, a mother, or a
+  replacement for real people. See
+  [docs/tone-profile.md](docs/tone-profile.md).
 - Default response style is now **warm by default**: the baseline
   `RESPONSE_STYLE_BLOCK` in `core/nova_contract.py` already carries a
   balanced amount of warmth, patience, and emotional awareness, so a

--- a/README.md
+++ b/README.md
@@ -78,13 +78,12 @@ Shipped today:
   admin-managed user list, per-user settings, and an optional
   family-controls layer for restricted roles.
 - **Personalization preferences.** Response length, warmth,
-  enthusiasm, emoji density (none / low / medium / expressive), tone
-  profile (default / professional / developer / warm companion / calm
-  support), and free-text custom instructions are stored per user and
-  shape Nova's tone without leaking into other accounts. Technical /
-  code / PR / security replies stay sober regardless of the emoji
-  level — the preference shapes casual chat only and never overrides
-  the Nova Safety and Trust Contract.
+  enthusiasm, emoji density (none / low / medium / expressive), and
+  free-text custom instructions are stored per user and shape Nova's
+  tone without leaking into other accounts. Technical / code / PR /
+  security replies stay sober regardless of the emoji level — the
+  preference shapes casual chat only and never overrides the Nova
+  Safety and Trust Contract.
 - **Warm-by-default response style.** The baseline Nova style — what a
   fresh user gets with no settings configured — already includes a
   balanced amount of warmth, patience, and emotional awareness. Nova
@@ -98,25 +97,20 @@ Shipped today:
   overrides identity, safety, auth, admin, privacy, system, developer,
   project, or Dev Workspace rules. Users do not need to configure a
   tone profile to receive a kind, useful assistant.
-- **Tone profile (foundation, opt-in, local).** A small per-user
-  setting that picks the *register* Nova speaks in across normal
-  conversations — an optional refinement on top of the warm baseline,
-  not the only place where warmth lives. Pick a steady **professional**
-  voice for a more formal/direct register, a sober **developer** voice
-  for maintainer-focused technical work, a warmer **warm companion**
-  voice, a particularly soft **calm support** voice, or a deeply
-  tender **deep comfort** voice for difficult emotional moments.
-  `default` produces no extra prompt block — Nova still inherits the
-  baseline warmth, so a fresh account already feels friendly and
-  supportive at zero extra token cost. The warm profiles are
-  explicitly **not** an "AI girlfriend" / "AI partner" system: each
-  block restates — never relaxes — the identity contract's rules
-  (no claim to be human, no claim to be the user's partner, no
-  simulated feelings as facts, no manipulation, no dependency, no
-  isolation, warmth never overrides truth) and the auth / admin /
-  privacy boundary (the tone profile changes wording, not permissions,
-  facts, or project rules). The block (no LLM, no network) sits
-  *below* the identity / safety contract and never overrides it. See
+- **Tone profile (internal-only).** The tone-profile selector is **no
+  longer exposed in the Settings UI** — Nova is warm, patient, and
+  emotionally aware by default, and the user does not need to pick a
+  register to receive a kind, useful assistant. The deterministic
+  prompt fragments (professional / developer / warm companion / calm
+  support / deep comfort) and the `tone_profile` field remain in
+  `core/tone_profile.py`, `core/settings.py`, `web.py`, and
+  `core/chat.py` so any previously-saved per-user value still loads
+  cleanly and the storage / export / restore paths are unchanged.
+  Stronger emotional behaviour is handled automatically — the
+  Emotional Support Layer activates on emotionally-sensitive wording,
+  and the always-on acute-distress grounding net runs regardless of
+  any setting — or through future focused features, never through a
+  user-facing register dropdown. See
   [docs/tone-profile.md](docs/tone-profile.md).
 - **Local response feedback.** Thumbs up / thumbs down under each
   assistant message records a per-user preference signal in the local
@@ -239,8 +233,10 @@ core/
   feedback.py         Local response feedback (thumbs up/down) → preference block
   relationship_coach.py  Non-clinical situation-coach prompt block (local)
   companion.py        Opt-in calm-presence + acute-distress grounding blocks (local)
-  tone_profile.py     Opt-in per-user tone-profile prompt blocks (professional /
-                      developer / warm companion / calm support; local)
+  tone_profile.py     Internal-only tone-profile prompt blocks (professional /
+                      developer / warm companion / calm support / deep comfort).
+                      No longer exposed in the Settings UI; Nova is warm by
+                      default and the warm baseline lives in nova_contract.py.
   emotional_support.py  Emotional-support layer prompt block + detector (local)
   identity.py         Identity contract constant
   auth.py             JWT creation and verification

--- a/docs/emotional-support.md
+++ b/docs/emotional-support.md
@@ -204,15 +204,18 @@ message carries emotionally-sensitive wording, regardless of the
 toggle state. To consistently *avoid* the warm framing on neutral
 chat:
 
-- **Pick a sober tone profile.** Settings → Personalization →
-  *Tone profile* → **Default** / **Professional** / **Developer**. On
-  neutral messages those profiles do not auto-add the Emotional
-  Support Layer. The three warm profiles (**Warm Companion**, **Calm
-  Support**, **Deep Comfort**) do auto-add it on every turn, by
-  design. On a genuinely emotional message the layer still activates
-  regardless of the chosen profile — the safety contract is
-  intentionally not behind the toggle, so the warm framing cannot be
-  traded against a sober register.
+- **The tone profile selector has been removed from the Settings UI.**
+  A fresh user lands on `tone_profile = "default"`, which does not
+  auto-add the Emotional Support Layer on neutral messages. Any
+  previously-saved per-user value (the warm profiles **Warm
+  Companion**, **Calm Support**, **Deep Comfort**) still loads and is
+  still honoured by the chat layer if it was selected before the UI
+  removal; to reset it back to the warm baseline, `POST /settings`
+  with `{"tone_profile": "default"}` or remove the row directly. On
+  a genuinely emotional message the layer still activates regardless
+  of the stored profile — the safety contract is intentionally not
+  behind any toggle, so the warm framing cannot be traded against a
+  sober register.
 - **Phrase requests neutrally.** "Help me draft a difficult email"
   is treated as a writing task; "I'm heartbroken about this email I
   have to send" activates the layer.

--- a/docs/tone-profile.md
+++ b/docs/tone-profile.md
@@ -1,18 +1,22 @@
 # Tone Profile (Warm Companion / Calm Support / Deep Comfort / Professional / Developer)
 
-> **Status: shipped (foundation + Phase 2 Deep Comfort), opt-in,
-> local-first.** This document describes the deterministic
-> *tone-profile* prompt layer that lets a user pick the **register**
-> Nova speaks in across normal conversations: a steady professional
-> voice, a sober developer voice, a warm and encouraging voice (*Warm
-> Companion*), a particularly soft and reassuring one (*Calm Support*),
-> or a deeply tender, "you are safe here" voice for difficult moments
-> (*Deep Comfort*). It lives strictly inside the boundaries set by
-> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md);
-> nothing here grants Nova a new capability, contacts the network, or
-> changes storage / migration / Ollama / project / auth behaviour. It
-> is **not** an "AI girlfriend" / "AI partner" / "AI mother" system
-> and is built so it cannot become one.
+> **Status: internal-only.** The Tone Profile selector is **no longer
+> exposed in the Settings UI.** Nova is warm, patient, and emotionally
+> aware **by default** — there is no setting the user needs to
+> configure to receive a kind, supportive assistant. The deterministic
+> prompt fragments (`TONE_PROFESSIONAL_BLOCK`, `TONE_DEVELOPER_BLOCK`,
+> `TONE_WARM_COMPANION_BLOCK`, `TONE_CALM_SUPPORT_BLOCK`,
+> `TONE_DEEP_COMFORT_BLOCK`) and the `tone_profile` field stay in
+> `core/tone_profile.py`, `core/settings.py`, `web.py`, and `core/chat.py`
+> so any previously-saved per-user values still load cleanly and the
+> existing storage / export / restore paths are unchanged. Stronger
+> emotional behaviour is handled automatically (the Emotional Support
+> Layer activates on emotionally-sensitive wording, the always-on
+> acute-distress grounding net runs regardless of any setting) or
+> through future focused features — never through a user-facing
+> register dropdown. The remainder of this document describes the
+> still-present prompt layer for completeness and for the API /
+> backward-compatibility surface.
 
 ## Nova is warm by default
 
@@ -46,12 +50,14 @@ isolation, or overrides identity, safety, auth, admin, privacy,
 system, developer, project, or Dev Workspace rules.
 
 **Users do not need to configure a tone profile to get a kind, useful
-assistant.** Tone profiles only become useful when the user wants the
-register dialled in one direction or the other: drier and more formal
-(Professional), maintainer-focused and concise (Developer), warmer and
-more present (Warm Companion), softer and more grounding (Calm
-Support), or deeply tender for difficult emotional moments (Deep
-Comfort).
+assistant.** Because the warm baseline is sufficient on its own, the
+tone-profile dropdown has been removed from the Settings UI. The
+register values (Professional, Developer, Warm Companion, Calm Support,
+Deep Comfort) remain available internally in `core/tone_profile.py`,
+and the `tone_profile` field still flows through the `user_settings`
+table and the `/settings` API so any previously-saved value loads
+without error — but normal users no longer pick a register; they get
+the warm default.
 
 ## What it is
 
@@ -143,9 +149,9 @@ said you were warm…" follow-up.
 
 | Concern | Where |
 | --- | --- |
-| Setting (storage) | `core/settings.py` → `PERSONALIZATION_ENUMS["tone_profile"]`, `PERSONALIZATION_DEFAULTS["tone_profile"]` |
-| Setting (API) | `web.py` → `SettingsUpdateRequest.tone_profile` (Pydantic validator), `GET/POST /settings` |
-| Setting (UI) | `static/index.html` → Personalization pane, `<select id="pers-tone-profile">` |
+| Setting (storage) | `core/settings.py` → `PERSONALIZATION_ENUMS["tone_profile"]`, `PERSONALIZATION_DEFAULTS["tone_profile"]` (kept for backward-compatibility loading of older saved values) |
+| Setting (API) | `web.py` → `SettingsUpdateRequest.tone_profile` (Pydantic validator), `GET/POST /settings` (kept for backward compatibility; the UI no longer sends it) |
+| Setting (UI) | **Removed.** The Personalization pane no longer renders a tone-profile selector. The warm baseline in `RESPONSE_STYLE_BLOCK` already gives a fresh user a kind, supportive Nova. |
 | Allowed values | `core/tone_profile.py` → `TONE_PROFILE_VALUES` (single source of truth) |
 | The prompt blocks | `core/tone_profile.py` → `TONE_PROFESSIONAL_BLOCK`, `TONE_DEVELOPER_BLOCK`, `TONE_WARM_COMPANION_BLOCK`, `TONE_CALM_SUPPORT_BLOCK`, `TONE_DEEP_COMFORT_BLOCK` |
 | Resolver | `core/tone_profile.py` → `build_tone_profile_block(profile)` |
@@ -191,14 +197,17 @@ relationship-coach, and companion-mode blocks.
 
 The setting is **off by default**: a fresh account has `tone_profile`
 unset and `get_personalization` returns `"default"`, which produces no
-prompt block.
+prompt block. The Settings UI no longer exposes the selector, so a
+fresh user never picks a register — they get the warm baseline.
 
-To turn it off after enabling it:
+Users who had previously selected a non-default tone profile keep
+that value in their `user_settings` row; it is read by the prompt
+builder exactly as before. To reset it back to the warm baseline:
 
-- **In the UI.** Settings → Personalization → *Tone profile* →
-  select **Default**. The change is saved immediately.
 - **Via API.** `POST /settings` with `{"tone_profile": "default"}`
-  (auth-gated, scoped to the calling user).
+  (auth-gated, scoped to the calling user). The endpoint still
+  accepts every previously-valid value, including `default`, so
+  older clients keep working.
 - **Via SQL (manual).** `DELETE FROM user_settings WHERE user_id = ?
   AND key = 'tone_profile'` removes the row entirely; the next read
   falls back to `"default"`.

--- a/static/index.html
+++ b/static/index.html
@@ -3573,23 +3573,6 @@
                     <div class="settings-row">
                         <div class="settings-row-head">
                             <div class="settings-row-label">
-                                <span class="settings-row-title" id="pers-tone-title">Tone profile</span>
-                                <span class="settings-row-hint" id="pers-tone-hint">Optional. Nova is already warm, patient, and emotionally aware by default — no setting required. Pick Professional or Developer for a more formal/direct voice; pick Warm Companion, Calm Support, or Deep Comfort for stronger emotional grounding when you want it. Nova never claims to be human, a therapist, a partner, a mother, or a substitute for real people.</span>
-                            </div>
-                        </div>
-                        <select id="pers-tone-profile" class="pers-select" onchange="savePersonalizationField('tone_profile', this.value)">
-                            <option value="default" id="pers-tone-opt-default">Default</option>
-                            <option value="professional" id="pers-tone-opt-professional">Professional</option>
-                            <option value="developer" id="pers-tone-opt-developer">Developer</option>
-                            <option value="warm_companion" id="pers-tone-opt-warm-companion">Warm Companion</option>
-                            <option value="calm_support" id="pers-tone-opt-calm-support">Calm Support</option>
-                            <option value="deep_comfort" id="pers-tone-opt-deep-comfort">Deep Comfort</option>
-                        </select>
-                    </div>
-
-                    <div class="settings-row">
-                        <div class="settings-row-head">
-                            <div class="settings-row-label">
                                 <span class="settings-row-title" id="pers-warmth-title">Warmth</span>
                                 <span class="settings-row-hint" id="pers-warmth-hint">How warm or neutral Nova should sound.</span>
                             </div>
@@ -4081,14 +4064,6 @@
             personalization_note: "Ces préférences ajusteront le ton de Nova dans tes conversations. Stockées par utilisateur, visibles uniquement par toi.",
             pers_style_title: "Style de réponse",
             pers_style_hint: "Niveau de détail des réponses de Nova.",
-            pers_tone_title: "Profil de ton",
-            pers_tone_hint: "Optionnel. Nova est déjà chaleureuse, patiente, et émotionnellement attentive par défaut — aucun réglage nécessaire. Choisis Professionnel ou Développeur pour un registre plus formel/direct ; choisis Compagnon chaleureux, Soutien calme, ou Comfort profond pour un soutien émotionnel plus marqué. Nova ne prétend jamais être humaine, ni une partenaire, ni une mère, ni un substitut à de vraies personnes.",
-            pers_tone_opt_default: "Par défaut",
-            pers_tone_opt_professional: "Professionnel",
-            pers_tone_opt_developer: "Développeur",
-            pers_tone_opt_warm_companion: "Compagnon chaleureux",
-            pers_tone_opt_calm_support: "Soutien calme",
-            pers_tone_opt_deep_comfort: "Comfort profond",
             pers_warmth_title: "Chaleur",
             pers_warmth_hint: "Ton chaleureux ou neutre.",
             pers_enth_title: "Enthousiasme",
@@ -4331,14 +4306,6 @@
             personalization_note: "These preferences will shape Nova's tone in your conversations. Saved per-user; visible only to you.",
             pers_style_title: "Response style",
             pers_style_hint: "How detailed Nova's answers should be.",
-            pers_tone_title: "Tone profile",
-            pers_tone_hint: "Optional. Nova is already warm, patient, and emotionally aware by default — no setting required. Pick Professional or Developer for a more formal voice; pick Warm Companion, Calm Support, or Deep Comfort for stronger emotional grounding. Nova never claims to be human, a partner, a mother, or a substitute for real people.",
-            pers_tone_opt_default: "Default",
-            pers_tone_opt_professional: "Professional",
-            pers_tone_opt_developer: "Developer",
-            pers_tone_opt_warm_companion: "Warm Companion",
-            pers_tone_opt_calm_support: "Calm Support",
-            pers_tone_opt_deep_comfort: "Deep Comfort",
             pers_warmth_title: "Warmth",
             pers_warmth_hint: "How warm or neutral Nova should sound.",
             pers_enth_title: "Enthusiasm",
@@ -4531,14 +4498,6 @@
         _setText("settings-personalization-note", t("personalization_note"));
         _setText("pers-style-title", t("pers_style_title"));
         _setText("pers-style-hint", t("pers_style_hint"));
-        _setText("pers-tone-title", t("pers_tone_title"));
-        _setText("pers-tone-hint", t("pers_tone_hint"));
-        _setText("pers-tone-opt-default", t("pers_tone_opt_default"));
-        _setText("pers-tone-opt-professional", t("pers_tone_opt_professional"));
-        _setText("pers-tone-opt-developer", t("pers_tone_opt_developer"));
-        _setText("pers-tone-opt-warm-companion", t("pers_tone_opt_warm_companion"));
-        _setText("pers-tone-opt-calm-support", t("pers_tone_opt_calm_support"));
-        _setText("pers-tone-opt-deep-comfort", t("pers_tone_opt_deep_comfort"));
         _setText("pers-warmth-title", t("pers_warmth_title"));
         _setText("pers-warmth-hint", t("pers_warmth_hint"));
         _setText("pers-enth-title", t("pers_enth_title"));
@@ -8656,7 +8615,6 @@
         warmth_level: "pers-warmth",
         enthusiasm_level: "pers-enthusiasm",
         emoji_level: "pers-emoji",
-        tone_profile: "pers-tone-profile",
         custom_instructions: "pers-custom-instructions",
     };
 

--- a/tests/test_tone_selector_ui_removed.py
+++ b/tests/test_tone_selector_ui_removed.py
@@ -1,0 +1,380 @@
+"""
+Tests for the Tone Profile selector being removed from the Settings UI.
+
+Nova is now warm, patient, and emotionally aware by default — the
+baseline `RESPONSE_STYLE_BLOCK` already carries that warmth — so the
+visible "Tone profile / Profil de ton" selector in Personalization is
+unnecessary user-facing complexity and has been removed.
+
+This file pins the *visible-UI* contract:
+
+  * the `<select id="pers-tone-profile">` and its option rows are not
+    rendered in `static/index.html`;
+  * the explanatory paragraph (FR + EN) is gone from the i18n table
+    and from the `_setText` re-render path;
+  * the `tone_profile` key is no longer in the `PERSONALIZATION_FIELDS`
+    JS map, so the load / save path never tries to read or write a
+    selector that doesn't exist;
+  * the remaining personalization controls (response style, warmth,
+    enthusiasm, emoji, custom instructions, companion mode) are
+    untouched;
+
+The *backend* surface stays intact for backward compatibility:
+
+  * `tone_profile` is still in `PERSONALIZATION_ENUMS`,
+    `PERSONALIZATION_DEFAULTS`, and `USER_SETTING_KEYS`, so a
+    previously-saved row continues to load cleanly;
+  * `build_tone_profile_block` still returns the right block for any
+    saved non-default value, so the chat-side wiring is unchanged;
+  * `get_personalization` still returns `"default"` for a fresh user
+    and the saved value for a returning user;
+  * the warm baseline is still in every default-user system prompt,
+    so a user with no settings still gets a kind, emotionally-aware
+    Nova — no setting required.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Heavy network deps the chat module imports at module load. Stub them
+# before the import so a missing wheel never blocks this test file.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import memory as core_memory, settings as core_settings, users  # noqa: E402
+from core.chat import build_messages  # noqa: E402
+from core.identity import IDENTITY_CONTRACT  # noqa: E402
+from core.tone_profile import (  # noqa: E402
+    TONE_DEEP_COMFORT_BLOCK,
+    TONE_PROFILE_VALUES,
+    TONE_WARM_COMPANION_BLOCK,
+    build_tone_profile_block,
+)
+from memory import store as natural_store  # noqa: E402
+
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "static" / "index.html"
+
+
+@pytest.fixture(scope="module")
+def html() -> str:
+    return INDEX_HTML.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def script(html: str) -> str:
+    """Return the largest <script> block, where the app code lives."""
+    blocks = re.findall(r"<script[^>]*>(.*?)</script>", html, flags=re.S)
+    assert blocks, "expected at least one inline <script> in index.html"
+    return max(blocks, key=len)
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw"):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password)
+
+
+# ── Visible-UI contract: the selector is gone ───────────────────────────────
+
+
+class TestToneProfileSelectorIsNotRendered:
+    def test_no_tone_profile_select_element(self, html: str) -> None:
+        # The dropdown the JS used to query by id must not be in the
+        # static HTML at all — not commented out, not hidden, not present.
+        assert 'id="pers-tone-profile"' not in html
+
+    def test_no_tone_profile_title_span(self, html: str) -> None:
+        # The row's title span is the anchor for the i18n update;
+        # removing the select without removing the span would leave an
+        # orphan "Tone profile" label visible to the user.
+        assert 'id="pers-tone-title"' not in html
+
+    def test_no_tone_profile_hint_span(self, html: str) -> None:
+        assert 'id="pers-tone-hint"' not in html
+
+    @pytest.mark.parametrize("opt_id", [
+        "pers-tone-opt-default",
+        "pers-tone-opt-professional",
+        "pers-tone-opt-developer",
+        "pers-tone-opt-warm-companion",
+        "pers-tone-opt-calm-support",
+        "pers-tone-opt-deep-comfort",
+    ])
+    def test_no_tone_profile_option_ids(self, html: str, opt_id: str) -> None:
+        assert f'id="{opt_id}"' not in html
+
+    def test_no_english_tone_profile_label(self, html: str) -> None:
+        # The English settings-row title.
+        assert "Tone profile" not in html
+
+    def test_no_french_tone_profile_label(self, html: str) -> None:
+        # The French settings-row title.
+        assert "Profil de ton" not in html
+
+    def test_no_savePersonalizationField_call_for_tone_profile(
+        self, html: str,
+    ) -> None:
+        # The old onchange="savePersonalizationField('tone_profile', …)"
+        # call would only be present if the <select> were too. Pin its
+        # absence so a regression cannot quietly re-introduce the wiring.
+        assert "savePersonalizationField('tone_profile'" not in html
+        assert 'savePersonalizationField("tone_profile"' not in html
+
+
+# ── i18n contract: translation keys are gone ────────────────────────────────
+
+
+class TestToneProfileTranslationsAreRemoved:
+    @pytest.mark.parametrize("key", [
+        "pers_tone_title",
+        "pers_tone_hint",
+        "pers_tone_opt_default",
+        "pers_tone_opt_professional",
+        "pers_tone_opt_developer",
+        "pers_tone_opt_warm_companion",
+        "pers_tone_opt_calm_support",
+        "pers_tone_opt_deep_comfort",
+    ])
+    def test_translation_key_not_in_table(self, html: str, key: str) -> None:
+        # The FR and EN i18n tables previously carried these keys; the
+        # _setText calls that read them have also been removed. If the
+        # key reappears, either the dictionary or the render path has
+        # regressed.
+        assert f"{key}:" not in html
+        assert f't("{key}")' not in html
+        assert f"t('{key}')" not in html
+
+
+# ── JS field-map contract: PERSONALIZATION_FIELDS no longer carries tone ──
+
+
+class TestPersonalizationFieldsMapDoesNotLeakToneProfile:
+    def test_tone_profile_key_not_in_personalization_fields_object(
+        self, script: str,
+    ) -> None:
+        # Slice the PERSONALIZATION_FIELDS object literal and assert the
+        # tone_profile entry is gone. A naive substring search would also
+        # match the unrelated "tone_profile" string in /settings POST
+        # bodies elsewhere; scoping to the object is the precise check.
+        decl = re.search(
+            r"const\s+PERSONALIZATION_FIELDS\s*=\s*{([^}]*)}",
+            script,
+        )
+        assert decl, "PERSONALIZATION_FIELDS object literal not found"
+        body = decl.group(1)
+        assert "tone_profile" not in body
+        assert "pers-tone-profile" not in body
+
+    def test_remaining_personalization_fields_are_intact(
+        self, script: str,
+    ) -> None:
+        # The other rows must keep their JS↔DOM wiring exactly as
+        # before — removing tone_profile must not collateral-damage them.
+        decl = re.search(
+            r"const\s+PERSONALIZATION_FIELDS\s*=\s*{([^}]*)}",
+            script,
+        )
+        assert decl, "PERSONALIZATION_FIELDS object literal not found"
+        body = decl.group(1)
+        for key, dom_id in [
+            ("response_style", "pers-response-style"),
+            ("warmth_level", "pers-warmth"),
+            ("enthusiasm_level", "pers-enthusiasm"),
+            ("emoji_level", "pers-emoji"),
+            ("custom_instructions", "pers-custom-instructions"),
+        ]:
+            assert key in body, key
+            assert dom_id in body, dom_id
+
+
+# ── Default-style contract: warmth still lands without any setting ──────────
+
+
+class TestWarmthBaselineStillInDefaultPrompt:
+    def test_default_prompt_contains_baseline_warmth_directives(self):
+        # No personalization, no companion mode, no tone profile — the
+        # rendered system prompt must still tell Nova to sound warm and
+        # emotionally aware. That is the whole point of removing the
+        # selector: the baseline already does the right thing.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        assert "chaleureuse" in sys_msg
+        assert "patiente" in sys_msg
+        # Anti-cold-and-robotic clause is part of the default warmth.
+        assert "froide" in sys_msg or "robotique" in sys_msg
+        # Light feeling-validation clause is part of the default warmth.
+        assert "valide" in sys_msg
+
+    def test_default_prompt_starts_with_identity_contract(self):
+        # The warm baseline must never sit *above* the identity / safety
+        # contract — ordering is what keeps the warmth subordinate to
+        # safety rules. Pin it on the no-personalization path.
+        msgs = build_messages([], "hi", [], None, None, None)
+        assert msgs[0]["content"].startswith(IDENTITY_CONTRACT)
+
+    def test_default_prompt_still_pins_no_human_no_partner_no_mother(self):
+        # The "warmth is in wording, not in identity" rails must land in
+        # every default-user prompt so a "you said you were warm…"
+        # follow-up cannot weaken them.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        assert "humain" in sys_msg
+        assert "partenaire amoureuse" in sys_msg
+        assert "mère" in sys_msg
+        assert "thérapeute" in sys_msg
+
+    def test_default_prompt_still_pins_no_dependency_no_isolation(self):
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        assert "ne crée jamais de dépendance" in sys_msg
+        assert "n'encourage jamais l'isolement" in sys_msg
+
+    def test_default_prompt_still_pins_honesty_over_warmth(self):
+        # "Warmth never overrides truth" — the baseline must still tell
+        # Nova to say risky / wrong / dangerous things plainly even
+        # without any tone profile selected.
+        msgs = build_messages([], "hi", [], None, None, None)
+        sys_msg = msgs[0]["content"].lower()
+        # The baseline carries the honesty clause as
+        # "La chaleur ne remplace jamais l'honnêteté."
+        assert (
+            "ne remplace jamais l'honnêteté" in sys_msg
+            or "honnêteté" in sys_msg
+        )
+
+
+# ── Backward-compat contract: old saved values still work ───────────────────
+
+
+class TestStaleSavedToneProfileDoesNotCrash:
+    def test_get_personalization_returns_default_for_fresh_user(
+        self, db_path,
+    ):
+        # A fresh user has no row — `get_personalization` falls back to
+        # `"default"` and the chat layer renders no tone block.
+        alice = _make_user(db_path, "alice")
+        prefs = core_settings.get_personalization(alice)
+        assert prefs["tone_profile"] == "default"
+        assert build_tone_profile_block(prefs["tone_profile"]) == ""
+
+    def test_old_warm_companion_value_still_loads_cleanly(self, db_path):
+        # A user who selected "Warm Companion" before the UI removal
+        # keeps that row in `user_settings`. Reading it must not raise
+        # and the block must still be applied to their chat — the
+        # destructive migration the brief forbids is exactly what
+        # would have stripped it.
+        alice = _make_user(db_path, "alice")
+        core_settings.save_user_setting(alice, "tone_profile", "warm_companion")
+        prefs = core_settings.get_personalization(alice)
+        assert prefs["tone_profile"] == "warm_companion"
+        # The chat-side build path still resolves the block, so the
+        # user keeps the wording they had previously chosen.
+        assert build_tone_profile_block(prefs["tone_profile"]) == (
+            TONE_WARM_COMPANION_BLOCK
+        )
+
+    def test_old_deep_comfort_value_still_loads_cleanly(self, db_path):
+        alice = _make_user(db_path, "alice")
+        core_settings.save_user_setting(alice, "tone_profile", "deep_comfort")
+        prefs = core_settings.get_personalization(alice)
+        assert prefs["tone_profile"] == "deep_comfort"
+        assert build_tone_profile_block(prefs["tone_profile"]) == (
+            TONE_DEEP_COMFORT_BLOCK
+        )
+
+    def test_every_known_value_round_trips_through_storage(self, db_path):
+        # Defensive sweep: every value the UI used to expose must keep
+        # round-tripping through `user_settings` so older clients (or
+        # raw API calls) never trip the loader.
+        alice = _make_user(db_path, "alice")
+        for value in TONE_PROFILE_VALUES:
+            core_settings.save_user_setting(alice, "tone_profile", value)
+            prefs = core_settings.get_personalization(alice)
+            assert prefs["tone_profile"] == value
+
+    def test_completely_stale_value_falls_back_silently(self, db_path):
+        # A directly-written row whose value is no longer in the enum
+        # (e.g. an experimental profile shipped on a side-branch) must
+        # not crash the loader. ``get_user_setting`` is a raw read, so
+        # the resilience contract is at ``build_tone_profile_block``:
+        # unknown values resolve to "" and the chat path skips the
+        # block, falling back to the warm baseline.
+        alice = _make_user(db_path, "alice")
+        core_settings.save_user_setting(
+            alice, "tone_profile", "experimental_unknown"
+        )
+        # Raw read returns the stale string — that is the "don't run a
+        # destructive migration" guarantee.
+        raw = core_settings.get_user_setting(alice, "tone_profile", "default")
+        assert raw == "experimental_unknown"
+        # But the prompt builder treats it as no profile, so chat is
+        # unaffected: the warm baseline still carries the response.
+        assert build_tone_profile_block(raw) == ""
+
+    def test_tone_profile_is_still_a_user_setting(self):
+        # The settings router uses `is_user_setting` to decide whether a
+        # POST belongs in `user_settings` or in the global table. Even
+        # though the UI no longer sends `tone_profile`, the backend must
+        # still treat any direct API call as a per-user write — never a
+        # host-wide one. Removing it from `USER_SETTING_KEYS` would
+        # silently re-route legacy clients to the global table.
+        assert core_settings.is_user_setting("tone_profile")
+
+    def test_tone_profile_default_is_registered(self):
+        # `get_personalization` is the single read path; if `default`
+        # disappears from `PERSONALIZATION_DEFAULTS` the fresh-user
+        # payload loses a key and any client that reads `tone_profile`
+        # crashes with KeyError. Pin the fallback explicitly.
+        assert core_settings.PERSONALIZATION_DEFAULTS["tone_profile"] == "default"
+
+
+# ── Unrelated-settings contract: nothing else regressed ─────────────────────
+
+
+class TestOtherPersonalizationSettingsUnchanged:
+    def test_other_enums_still_present(self):
+        # Removing the tone-profile UI must not collateral-damage the
+        # other personalization knobs — response style, warmth,
+        # enthusiasm, emoji level all keep their enum surface.
+        enums = core_settings.PERSONALIZATION_ENUMS
+        assert enums["response_style"] == frozenset(
+            {"default", "concise", "detailed", "technical"}
+        )
+        assert enums["warmth_level"] == frozenset({"low", "normal", "high"})
+        assert enums["enthusiasm_level"] == frozenset({"low", "normal", "high"})
+        assert enums["emoji_level"] == frozenset(
+            {"none", "low", "medium", "expressive"}
+        )
+
+    def test_other_defaults_unchanged(self):
+        defaults = core_settings.PERSONALIZATION_DEFAULTS
+        assert defaults["response_style"] == "default"
+        assert defaults["warmth_level"] == "normal"
+        assert defaults["enthusiasm_level"] == "normal"
+        assert defaults["emoji_level"] == "low"
+        assert defaults["custom_instructions"] == ""
+
+    def test_companion_mode_setting_still_registered(self):
+        # Companion mode is the *other* opt-in tone layer — independent
+        # from tone profile and untouched by this change. Pin that the
+        # setting key is still per-user so a regression cannot also
+        # remove it by accident.
+        assert core_settings.is_user_setting("companion_mode_enabled")


### PR DESCRIPTION
## Summary

Nova is now warm, patient, and emotionally aware **by default** (the baseline `RESPONSE_STYLE_BLOCK` in `core/nova_contract.py` already carries that warmth), so the visible **Tone profile / Profil de ton** selector in Settings → Personalization is unnecessary user-facing complexity. This PR removes it from the UI while keeping the underlying response-style logic fully intact for backward compatibility.

### What changed (UI only)
- Removed the `<select id="pers-tone-profile">` card, its explanatory hint paragraph, and its six option rows from `static/index.html`.
- Removed the FR + EN i18n strings (`pers_tone_title`, `pers_tone_hint`, `pers_tone_opt_*`) and the `_setText` calls that re-rendered them on language switch.
- Removed the `tone_profile` entry from the `PERSONALIZATION_FIELDS` JS map so the load/save path never touches a control that no longer exists.

### What deliberately did **not** change (backward compatibility)
- `core/tone_profile.py` keeps every prompt fragment (`TONE_PROFESSIONAL_BLOCK`, `TONE_DEVELOPER_BLOCK`, `TONE_WARM_COMPANION_BLOCK`, `TONE_CALM_SUPPORT_BLOCK`, `TONE_DEEP_COMFORT_BLOCK`), `TONE_PROFILE_VALUES`, and the resolver.
- `tone_profile` stays in `PERSONALIZATION_ENUMS` / `PERSONALIZATION_DEFAULTS` / `USER_SETTING_KEYS`, and the Pydantic + `/settings` API field still validates and persists.
- `core/chat.py` still appends the tone block when a non-default value is loaded.
- **No destructive migration.** Any previously-saved per-user `tone_profile` row continues to load cleanly and is still honoured by the chat layer.

### Behavior
- Users no longer configure tone to get a kind Nova — the warm default does it.
- Technical/dev responses stay practical and concise; emotional support still activates automatically via the Emotional Support Layer and the always-on acute-distress grounding net.
- Nova still never claims to be human, a girlfriend, a mother, or a substitute for real people.
- No new replacement setting was added; no model-provider / storage / export / restore / Dev Workspace / project-memory behavior changed.

### Docs
Updated `docs/tone-profile.md`, `docs/emotional-support.md`, `README.md`, and `CHANGELOG.md` to state Nova is warm by default, the selector is no longer exposed in the UI, and stronger emotional behaviour is handled automatically or via future focused features.

## Test plan
- [x] New `tests/test_tone_selector_ui_removed.py` (37 tests) pins: the selector/options/labels/`savePersonalizationField` call are gone from `index.html`; the FR/EN i18n keys are gone; `tone_profile` is no longer in `PERSONALIZATION_FIELDS` while the other rows stay intact; the warm baseline (warm directives + no-human/partner/mother rails + dependency/isolation rails + honesty clause) still lands in the default-user system prompt; old saved values (`warm_companion`, `deep_comfort`, every enum value) still round-trip through `user_settings`; a completely-stale value falls back to no block; `tone_profile` is still a user setting; other personalization enums/defaults and companion mode are unchanged.
- [x] Existing suites still green: `test_tone_profile.py`, `test_personalization_settings.py`, `test_personalization_chat_wiring.py`, `test_emotional_support.py`, `test_companion.py`, `test_relationship_coach.py`, `test_chat_stream.py`, `test_feedback*.py`, `test_nova_contract.py` (496 passed combined with the new file).
- [ ] Manual UI check in a browser (not performed in this environment — Settings → Personalization should now show Response style → Warmth → Enthusiasm → Emoji → Custom instructions → Companion mode, with no Tone profile row).

https://claude.ai/code/session_01UcAgX96dK23AqH72s2WmmY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcAgX96dK23AqH72s2WmmY)_