### PR TITLE
feat(model-providers): add optional local GGUF provider (llama.cpp), Phase 1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -305,6 +305,33 @@ NOVA_JELLYFIN_TIMEOUT_SECONDS=5.0
 # Falls back to the system timezone (/etc/timezone) when not set.
 NOVA_TIMEZONE=
 
+# ── Model provider: optional local GGUF backend (llama.cpp) ───────────
+# Nova talks to a model backend through a replaceable provider. Ollama
+# is the default and recommended local backend; leave NOVA_MODEL_PROVIDER
+# unset (or =ollama) to keep current behaviour exactly.
+#
+# Set NOVA_MODEL_PROVIDER=llamacpp to run a local .gguf model directly via
+# llama-cpp-python, with no Ollama. This is opt-in and non-destructive —
+# it never migrates data and never changes Ollama's config. The
+# llama-cpp-python wheel is NOT in requirements.txt; install it yourself
+# (`pip install llama-cpp-python`). If it is missing, Nova does not crash:
+# the provider reports a clean health failure. Nova NEVER downloads a
+# model — point NOVA_GGUF_MODEL_PATH at a .gguf file you already have.
+# See docs/local-gguf.md (recommended dir: /mnt/archive/nova-models).
+#
+# NOVA_MODEL_PROVIDER: ollama (default) | llamacpp.
+# NOVA_GGUF_MODEL_PATH: absolute path to a local .gguf model file. Empty
+#   leaves the provider unconfigured (a clean health failure, not a crash).
+# NOVA_GGUF_CONTEXT_SIZE: context window (n_ctx). Default 4096.
+# NOVA_GGUF_THREADS: CPU threads (n_threads). 0 = let llama.cpp decide.
+# NOVA_GGUF_GPU_LAYERS: layers to offload to GPU (n_gpu_layers). 0 = CPU
+#   only; >0 needs a GPU-enabled llama-cpp-python build.
+NOVA_MODEL_PROVIDER=ollama
+NOVA_GGUF_MODEL_PATH=
+NOVA_GGUF_CONTEXT_SIZE=4096
+NOVA_GGUF_THREADS=0
+NOVA_GGUF_GPU_LAYERS=0
+
 # ── Optional local TTS: Piper ─────────────────────────────────────────
 # Browser speechSynthesis is the default and requires no configuration.
 # On Linux hosts where the platform voices sound robotic, install Piper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,31 @@
   relate to the baseline.
 
 ### Added
+- **Local GGUF model provider (llama.cpp) — Phase 1, opt-in.** Adds
+  `LlamaCppProvider` (`core/model_providers/llamacpp.py`, registered as
+  `llamacpp`, with a `GGUFProvider` alias) so Nova can generate text from
+  a local `.gguf` model directly via the optional `llama-cpp-python`
+  wheel, **without Ollama** — making Ollama no longer architecturally
+  required. **Ollama remains the default and is unchanged**; the new
+  backend is used only when `NOVA_MODEL_PROVIDER=llamacpp`. The provider
+  implements the existing `generate()` / `stream()` / `health()` contract
+  (non-streaming and a simple serialised token stream), imports
+  `llama_cpp` lazily so the registry still loads cleanly when the wheel
+  is absent, and degrades gracefully: a missing dependency or a
+  missing/invalid model path is a clean `ModelProviderError` / health
+  failure, never a crash. It never downloads a model, never runs a shell
+  command, never scans the filesystem, and validates exactly the one
+  configured path (a readable regular `.gguf` file); operator-facing
+  errors are sanitised (no absolute path or raw backend exception, and
+  `health()` surfaces only the model basename). New config:
+  `NOVA_GGUF_MODEL_PATH`, `NOVA_GGUF_CONTEXT_SIZE` (default 4096),
+  `NOVA_GGUF_THREADS` (0 = auto), `NOVA_GGUF_GPU_LAYERS` (0 = CPU). The
+  provider appears automatically in the read-only provider-status /
+  default-model surfaces (no new endpoint, no model-manager UI). New
+  suite `tests/test_llamacpp_provider.py`; memory / projects / storage /
+  export / restore / Dev Workspace paths are untouched. See
+  [docs/local-gguf.md](docs/local-gguf.md) and
+  [docs/model-providers.md](docs/model-providers.md).
 - Nova Care Phase 2 — **Deep Comfort** tone profile (local-first,
   opt-in, response-guidance only): adds a fifth non-default value
   `deep_comfort` to the existing Tone Profile enum so the user can

--- a/README.md
+++ b/README.md
@@ -851,7 +851,9 @@ feature exists.
 
 - Linux (tested on Fedora).
 - Python 3.11+.
-- [Ollama](https://ollama.com) installed and running.
+- [Ollama](https://ollama.com) installed and running. (Optional
+  alternative: run a local `.gguf` model directly via llama.cpp with no
+  Ollama — see [`docs/local-gguf.md`](docs/local-gguf.md).)
 - AMD GPU with ROCm (optional — falls back to CPU).
 
 ### 1. Clone the repository
@@ -966,6 +968,11 @@ All configuration is read from `.env` at startup. Key variables:
 | `NOVA_DATA_DIR` | — | Optional absolute path that holds `nova.db`, backups, and reserved subdirectories. Blank = legacy layout (DB next to the checkout). See [`docs/data-directory.md`](docs/data-directory.md), or [`docs/portable-workspace.md`](docs/portable-workspace.md) for a self-contained parent layout that works for both systemd and Docker. |
 | `NOVA_DEV_WORKSPACE_ROOTS` | — | OS-path-separator- or comma-separated absolute directories that may contain repos a Project can link (read-only Phase 1). Blank = the Dev Workspace feature is off. Never set to `/`, `/home`, or a broad system path. See [`docs/dev-workspace.md`](docs/dev-workspace.md). |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
+| `NOVA_MODEL_PROVIDER` | `ollama` | Model backend: `ollama` (default) or `llamacpp` (local GGUF, no Ollama). See [`docs/local-gguf.md`](docs/local-gguf.md). |
+| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file (only used when `NOVA_MODEL_PROVIDER=llamacpp`). Nova never downloads it. Blank = provider unconfigured. |
+| `NOVA_GGUF_CONTEXT_SIZE` | `4096` | GGUF context window (`n_ctx`) |
+| `NOVA_GGUF_THREADS` | `0` | GGUF CPU threads (`n_threads`); `0` = auto |
+| `NOVA_GGUF_GPU_LAYERS` | `0` | GGUF layers offloaded to GPU (`n_gpu_layers`); `0` = CPU only |
 | `NOVA_AUTO_WEB_LEARNING` | `false` | Enable background RSS/web learning |
 | `LOGIN_RATE_LIMIT_MAX` | `5` | Max login attempts per window |
 | `LOGIN_RATE_LIMIT_WINDOW` | `60` | Rate limit window in seconds (sliding) |

--- a/config.py
+++ b/config.py
@@ -13,6 +13,45 @@ OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 # name here without Nova core changing.
 MODEL_PROVIDER = os.getenv("NOVA_MODEL_PROVIDER", "ollama").strip() or "ollama"
 
+# ── Optional local GGUF backend (llama.cpp via llama-cpp-python) ──────
+# A direct local model provider so Nova can run a `.gguf` model without
+# Ollama. Opt-in: it is only used when NOVA_MODEL_PROVIDER=llamacpp.
+# Ollama remains the default. Nova never downloads a model — the
+# operator points NOVA_GGUF_MODEL_PATH at a file they already have, and
+# the provider validates it is a readable .gguf before loading. The
+# optional `llama-cpp-python` wheel is imported lazily; when it is
+# missing the provider fails gracefully (see core/model_providers/llamacpp.py).
+#
+#   NOVA_GGUF_MODEL_PATH    — absolute path to a local .gguf model file.
+#                             Empty leaves the provider unconfigured (a
+#                             clean health failure, never a crash).
+#   NOVA_GGUF_CONTEXT_SIZE  — context window (n_ctx). Default 4096; a
+#                             non-positive / unparseable value falls back
+#                             to 4096.
+#   NOVA_GGUF_THREADS       — CPU threads (n_threads). 0 (default) lets
+#                             llama.cpp pick.
+#   NOVA_GGUF_GPU_LAYERS    — layers to offload to GPU (n_gpu_layers).
+#                             0 (default) keeps inference on CPU.
+NOVA_GGUF_MODEL_PATH = os.getenv("NOVA_GGUF_MODEL_PATH", "").strip()
+try:
+    NOVA_GGUF_CONTEXT_SIZE = int(os.getenv("NOVA_GGUF_CONTEXT_SIZE", "4096"))
+except ValueError:
+    NOVA_GGUF_CONTEXT_SIZE = 4096
+if NOVA_GGUF_CONTEXT_SIZE <= 0:
+    NOVA_GGUF_CONTEXT_SIZE = 4096
+try:
+    NOVA_GGUF_THREADS = int(os.getenv("NOVA_GGUF_THREADS", "0"))
+except ValueError:
+    NOVA_GGUF_THREADS = 0
+if NOVA_GGUF_THREADS < 0:
+    NOVA_GGUF_THREADS = 0
+try:
+    NOVA_GGUF_GPU_LAYERS = int(os.getenv("NOVA_GGUF_GPU_LAYERS", "0"))
+except ValueError:
+    NOVA_GGUF_GPU_LAYERS = 0
+if NOVA_GGUF_GPU_LAYERS < 0:
+    NOVA_GGUF_GPU_LAYERS = 0
+
 _raw_channel = os.getenv("NOVA_CHANNEL", "stable").lower()
 NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else "stable"
 NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")

--- a/core/model_providers/__init__.py
+++ b/core/model_providers/__init__.py
@@ -18,6 +18,7 @@ from .base import (
     ModelResponse,
     ProviderHealth,
 )
+from .llamacpp import GGUFProvider, LlamaCppProvider, get_llamacpp_provider
 from .mock import MockProvider
 from .ollama import OllamaProvider, get_ollama_provider
 from .registry import (
@@ -38,6 +39,9 @@ __all__ = [
     "ProviderHealth",
     "OllamaProvider",
     "get_ollama_provider",
+    "LlamaCppProvider",
+    "GGUFProvider",
+    "get_llamacpp_provider",
     "MockProvider",
     "get_provider",
     "register_provider",

--- a/core/model_providers/llamacpp.py
+++ b/core/model_providers/llamacpp.py
@@ -1,0 +1,351 @@
+"""Direct local GGUF model provider (llama.cpp via ``llama-cpp-python``).
+
+This is the first provider that lets Nova generate text **without
+Ollama** — it loads a single local ``.gguf`` model file through
+``llama-cpp-python`` and serves it behind the same
+:class:`~core.model_providers.base.ModelProvider` contract every other
+backend implements. Ollama remains Nova's default; this is an opt-in
+alternative selected with ``NOVA_MODEL_PROVIDER=llamacpp``.
+
+Design rules baked in here (all flow from Nova's safety/trust contract):
+
+  * **Optional dependency, graceful absence.** ``llama_cpp`` is imported
+    lazily inside the methods that need it — never at module import — so
+    the registry can import this file on a host that does not have the
+    wheel installed. When the dependency is missing, :meth:`health`
+    reports ``ok=False`` with a clear, fixed message and
+    :meth:`generate` / :meth:`stream` raise :class:`ModelProviderError`.
+  * **No downloads, ever.** Nova never fetches a model. The operator
+    points ``NOVA_GGUF_MODEL_PATH`` at a file they already have.
+  * **Safe path validation.** The configured path is accepted only if it
+    is a readable regular ``.gguf`` file. No globbing, no directory walk,
+    no filesystem scan, no shell.
+  * **Cheap construction, lazy load.** Constructing the provider only
+    validates config and the path; the (potentially multi-GB) model is
+    loaded on first use and cached. This honours the base contract that
+    providers are "safe to construct cheaply and repeatedly" and that
+    construction performs no heavy I/O.
+  * **Sanitised errors.** User/operator-facing messages name the
+    relevant env var and the problem; they never echo a raw backend
+    exception or the absolute model path. The full detail is logged
+    server-side only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Iterator, Optional
+
+from .base import (
+    ModelChunk,
+    ModelProvider,
+    ModelProviderError,
+    ModelRequest,
+    ModelResponse,
+    ProviderHealth,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fixed, non-sensitive operator-facing messages. Kept as constants so the
+# same wording is reported by ``health()`` and raised by generation, and
+# so tests can pin the contract without matching a backend's raw error.
+_DEP_MISSING_MSG = (
+    "llama-cpp-python is not installed. Install it to use the local GGUF "
+    "provider, e.g. `pip install llama-cpp-python`."
+)
+_NO_MODEL_MSG = (
+    "No GGUF model configured. Set NOVA_GGUF_MODEL_PATH to a local .gguf "
+    "model file."
+)
+_LOAD_FAILED_MSG = (
+    "Failed to load the GGUF model. Check NOVA_GGUF_MODEL_PATH and that the "
+    "host has enough memory for this model."
+)
+_GENERATE_FAILED_MSG = "GGUF model generation failed."
+_STREAM_FAILED_MSG = "GGUF model streaming failed."
+
+# Sensible context window when the operator does not set one. llama.cpp's
+# own default (512) is too small for Nova's assembled prompts.
+_DEFAULT_CONTEXT_SIZE = 4096
+
+
+def _validate_model_path(configured: str) -> tuple[Optional[str], str]:
+    """Resolve ``configured`` to a usable model path, or explain why not.
+
+    Returns ``(path, "")`` when the value points at a readable regular
+    ``.gguf`` file, else ``(None, reason)`` with a short, non-sensitive
+    reason. An empty ``configured`` returns ``(None, "")`` — "not
+    configured" is a distinct, caller-handled state, not a validation
+    failure. Best-effort and never raises: a path that trips an ``OSError``
+    on ``stat`` is treated as unusable, not propagated.
+    """
+    value = (configured or "").strip()
+    if not value:
+        return None, ""
+    try:
+        path = Path(value)
+        if path.suffix.lower() != ".gguf":
+            return None, (
+                "NOVA_GGUF_MODEL_PATH must point at a .gguf model file."
+            )
+        if not path.is_file():
+            return None, (
+                "GGUF model file not found. Check NOVA_GGUF_MODEL_PATH."
+            )
+        if not os.access(value, os.R_OK):
+            return None, (
+                "GGUF model file is not readable. Check its permissions."
+            )
+        return str(path), ""
+    except OSError:
+        return None, "GGUF model path could not be read."
+
+
+class LlamaCppProvider(ModelProvider):
+    """Run a local ``.gguf`` model directly via ``llama-cpp-python``.
+
+    Constructed cheaply: it reads config (or explicit overrides) and
+    validates the model path, but does **not** import ``llama_cpp`` or
+    load the model until the first :meth:`generate` / :meth:`stream`.
+    Access to the loaded model is serialised with a lock because a single
+    ``llama_cpp.Llama`` handle is not safe to call concurrently.
+    """
+
+    name = "llamacpp"
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        context_size: Optional[int] = None,
+        threads: Optional[int] = None,
+        gpu_layers: Optional[int] = None,
+        llama_class: Optional[type] = None,
+    ) -> None:
+        # Defer config import so this module has no import-time config
+        # dependency and tests can monkeypatch config before constructing.
+        if (
+            model_path is None
+            or context_size is None
+            or threads is None
+            or gpu_layers is None
+        ):
+            from config import (
+                NOVA_GGUF_CONTEXT_SIZE,
+                NOVA_GGUF_GPU_LAYERS,
+                NOVA_GGUF_MODEL_PATH,
+                NOVA_GGUF_THREADS,
+            )
+
+            if model_path is None:
+                model_path = NOVA_GGUF_MODEL_PATH
+            if context_size is None:
+                context_size = NOVA_GGUF_CONTEXT_SIZE
+            if threads is None:
+                threads = NOVA_GGUF_THREADS
+            if gpu_layers is None:
+                gpu_layers = NOVA_GGUF_GPU_LAYERS
+
+        self._configured_path = (model_path or "").strip()
+        self._model_path, self._path_problem = _validate_model_path(
+            self._configured_path
+        )
+
+        ctx = int(context_size) if context_size else 0
+        self._context_size = ctx if ctx > 0 else _DEFAULT_CONTEXT_SIZE
+        thr = int(threads) if threads else 0
+        self._threads = thr if thr > 0 else 0
+        gpu = int(gpu_layers) if gpu_layers else 0
+        self._gpu_layers = gpu if gpu > 0 else 0
+
+        # Injected only by tests that want a fake ``Llama`` without the
+        # real wheel; ``None`` => import the genuine class on first use.
+        self._llama_class_override = llama_class
+        self._llama = None
+        self._lock = threading.Lock()
+
+    # ── internals ───────────────────────────────────────────────────
+
+    def _get_llama_class(self) -> type:
+        """Return ``llama_cpp.Llama`` (or an injected double).
+
+        Raises :class:`ImportError` when the optional wheel is absent so
+        callers can translate it into the fixed dependency message.
+        """
+        if self._llama_class_override is not None:
+            return self._llama_class_override
+        from llama_cpp import Llama  # optional dep; may raise ImportError
+
+        return Llama
+
+    def _prepare(self):
+        """Return a loaded model handle. Caller must hold ``self._lock``.
+
+        Maps every failure mode — missing dependency, missing/invalid
+        path, load failure — to :class:`ModelProviderError` with a fixed,
+        non-sensitive message.
+        """
+        if self._llama is not None:
+            return self._llama
+        try:
+            llama_class = self._get_llama_class()
+        except ImportError as exc:
+            raise ModelProviderError(_DEP_MISSING_MSG) from exc
+        if self._model_path is None:
+            raise ModelProviderError(self._path_problem or _NO_MODEL_MSG)
+
+        kwargs: dict = {
+            "model_path": self._model_path,
+            "n_ctx": self._context_size,
+            "n_gpu_layers": self._gpu_layers,
+            "verbose": False,
+        }
+        if self._threads:
+            kwargs["n_threads"] = self._threads
+        try:
+            self._llama = llama_class(**kwargs)
+        except Exception as exc:  # noqa: BLE001 — sanitised below
+            logger.warning("GGUF model load failed: %s", exc)
+            raise ModelProviderError(_LOAD_FAILED_MSG) from exc
+        return self._llama
+
+    # ── generation ──────────────────────────────────────────────────
+
+    def generate(self, request: ModelRequest) -> ModelResponse:
+        with self._lock:
+            llama = self._prepare()
+            try:
+                result = llama.create_chat_completion(messages=request.messages)
+            except Exception as exc:  # noqa: BLE001 — sanitised below
+                logger.warning("GGUF generation failed: %s", exc)
+                raise ModelProviderError(_GENERATE_FAILED_MSG) from exc
+        content = _message_content(result)
+        return ModelResponse(content=content or "", model=request.model)
+
+    def stream(self, request: ModelRequest) -> Iterator[ModelChunk]:
+        # The whole body runs while iterated, so the lock is held for the
+        # duration of the stream — serialising access to the single,
+        # non-concurrent llama.cpp handle. Nova's chat path consumes the
+        # generator fully, so the lock is always released.
+        with self._lock:
+            llama = self._prepare()
+            try:
+                upstream = llama.create_chat_completion(
+                    messages=request.messages, stream=True
+                )
+                for chunk in upstream:
+                    fragment = _delta_content(chunk)
+                    if fragment:
+                        yield ModelChunk(content=fragment)
+            except ModelProviderError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — sanitised below
+                logger.warning("GGUF streaming failed: %s", exc)
+                raise ModelProviderError(_STREAM_FAILED_MSG) from exc
+
+    # ── health ──────────────────────────────────────────────────────
+
+    def health(self) -> ProviderHealth:
+        """Cheap, read-only probe. Never raises; never loads the model.
+
+        Reports ``ok=False`` with a clear reason when the dependency is
+        missing or the configured path is absent/invalid, and ``ok=True``
+        with the model's filename (basename only — never the full path)
+        when everything needed to load is in place.
+        """
+        try:
+            self._get_llama_class()
+        except ImportError:
+            return ProviderHealth(
+                ok=False, provider=self.name, detail=_DEP_MISSING_MSG
+            )
+        except Exception as exc:  # never raise from health()
+            logger.warning("GGUF health: backend import failed: %s", exc)
+            return ProviderHealth(
+                ok=False,
+                provider=self.name,
+                detail="llama-cpp backend could not be loaded.",
+            )
+
+        if not self._configured_path:
+            return ProviderHealth(
+                ok=False, provider=self.name, detail=_NO_MODEL_MSG
+            )
+        if self._model_path is None:
+            return ProviderHealth(
+                ok=False,
+                provider=self.name,
+                detail=self._path_problem or _NO_MODEL_MSG,
+            )
+
+        # Surface only the basename so the model is selectable in the
+        # default-model UI without leaking the directory layout.
+        return ProviderHealth(
+            ok=True,
+            provider=self.name,
+            models=[os.path.basename(self._model_path)],
+        )
+
+
+# ── response shape helpers ──────────────────────────────────────────
+# ``create_chat_completion`` returns OpenAI-style dicts. We read them
+# defensively (``.get`` with isinstance guards) so an unexpected shape
+# degrades to empty text rather than raising.
+
+
+def _first_choice(payload) -> dict:
+    if not isinstance(payload, dict):
+        return {}
+    choices = payload.get("choices")
+    if not isinstance(choices, (list, tuple)) or not choices:
+        return {}
+    first = choices[0]
+    return first if isinstance(first, dict) else {}
+
+
+def _message_content(payload) -> str:
+    message = _first_choice(payload).get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    return content if isinstance(content, str) else ""
+
+
+def _delta_content(chunk) -> str:
+    delta = _first_choice(chunk).get("delta")
+    if not isinstance(delta, dict):
+        return ""
+    content = delta.get("content")
+    return content if isinstance(content, str) else ""
+
+
+_default: Optional[LlamaCppProvider] = None
+_default_lock = threading.Lock()
+
+
+def get_llamacpp_provider() -> LlamaCppProvider:
+    """Process-wide singleton factory used by the registry.
+
+    Cheap: construction only validates config and the model path — the
+    model itself is loaded lazily on first generation.
+    """
+    global _default
+    if _default is None:
+        with _default_lock:
+            if _default is None:
+                _default = LlamaCppProvider()
+    return _default
+
+
+# Friendly alias: the backend is "llama.cpp", the model format is "GGUF".
+GGUFProvider = LlamaCppProvider
+
+
+__all__ = [
+    "LlamaCppProvider",
+    "GGUFProvider",
+    "get_llamacpp_provider",
+]

--- a/core/model_providers/registry.py
+++ b/core/model_providers/registry.py
@@ -24,6 +24,7 @@ import threading
 from typing import Callable, Dict, Iterator, Optional
 
 from .base import ModelProvider, ModelProviderError
+from .llamacpp import get_llamacpp_provider
 from .mock import MockProvider
 from .ollama import get_ollama_provider
 
@@ -32,6 +33,7 @@ ProviderFactory = Callable[[], ModelProvider]
 _lock = threading.Lock()
 _factories: Dict[str, ProviderFactory] = {
     "ollama": get_ollama_provider,
+    "llamacpp": get_llamacpp_provider,
     "mock": MockProvider,
 }
 _instances: Dict[str, ModelProvider] = {}

--- a/docs/local-gguf.md
+++ b/docs/local-gguf.md
@@ -1,0 +1,168 @@
+# Running Nova with a local GGUF model (llama.cpp)
+
+> **Status: shipped (Phase 1, optional, local-first).**
+> This document describes the optional `llamacpp` model provider, which
+> lets Nova generate text from a local `.gguf` model **without Ollama**.
+> It lives inside the boundaries set by
+> [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md)
+> and complements [`docs/model-providers.md`](model-providers.md), which
+> explains the provider seam itself. **Ollama remains Nova's default and
+> is fully supported** — this provider is opt-in and changes nothing
+> until you select it.
+
+## Why this exists
+
+Until now Nova needed [Ollama](https://ollama.com) to turn a prompt into
+tokens. The model backend is a [replaceable provider](model-providers.md),
+so Nova can instead load a quantised `.gguf` model directly through
+[`llama-cpp-python`](https://github.com/abetlen/llama-cpp-python) (Python
+bindings for [llama.cpp](https://github.com/ggml-org/llama.cpp)). This
+makes Ollama **no longer architecturally required**: you can run Nova on
+a host that has only a model file and the `llama-cpp-python` wheel.
+
+What this phase deliberately does **not** do:
+
+- it does **not** remove or replace Ollama (still the default),
+- it does **not** download, fetch, or auto-convert any model,
+- it does **not** add a cloud provider, an API key, or a model-manager UI,
+- it does **not** change memory, projects, storage, export/restore, or
+  the Dev Workspace.
+
+## Ollama is still supported
+
+Nothing about the default deployment changes. Leave `NOVA_MODEL_PROVIDER`
+unset (or `=ollama`) and Nova behaves exactly as before — same Ollama
+client, same models, same streaming. The GGUF provider is only used when
+you explicitly set `NOVA_MODEL_PROVIDER=llamacpp`. You can switch back at
+any time by changing the one environment variable and restarting Nova; no
+data is migrated and nothing is deleted.
+
+## Prerequisites
+
+1. **The `llama-cpp-python` wheel.** It is intentionally *not* in Nova's
+   `requirements.txt` — Nova must install and import cleanly on hosts
+   that will only ever use Ollama. Install it yourself:
+
+   ```bash
+   pip install llama-cpp-python
+   ```
+
+   Prebuilt CPU wheels exist for common platforms. For GPU offload
+   (CUDA, Metal, ROCm, Vulkan) follow the project's build instructions —
+   the wheel must be compiled with the matching backend before
+   `NOVA_GGUF_GPU_LAYERS` has any effect. If the wheel is missing, Nova
+   does not crash: the provider reports a clean "not installed" health
+   failure and chat degrades to the usual "backend unreachable" reply.
+
+2. **A local `.gguf` model file that you already have.** Nova never
+   downloads one. Obtain a quantised model (for example from a model hub
+   you trust) out of band and place it on disk yourself. A 7–8B model
+   quantised to `Q4_K_M` is a sensible starting point for CPU hosts.
+
+### Recommended model directory
+
+Keep models out of the Nova checkout and the data directory, on storage
+with room to spare:
+
+```
+/mnt/archive/nova-models/
+└── mistral-7b-instruct-v0.2.Q4_K_M.gguf
+```
+
+Use a stable mount path defined in `/etc/fstab` (not a transient
+`/run/media/...` desktop mount) so a long-running service can always
+find the file. This directory is **only** read by the GGUF provider when
+you point `NOVA_GGUF_MODEL_PATH` at a file inside it; Nova never lists,
+scans, or browses it, and never exposes its contents through the UI.
+
+## Configuration
+
+All knobs are environment variables (read at startup, like the rest of
+Nova's config). Only `NOVA_GGUF_MODEL_PATH` is required.
+
+| Variable | Default | Description |
+|---|---|---|
+| `NOVA_MODEL_PROVIDER` | `ollama` | Set to `llamacpp` to use this provider. Any other value (or unset) keeps Ollama. |
+| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file. Empty leaves the provider unconfigured (a clean health failure, never a crash). |
+| `NOVA_GGUF_CONTEXT_SIZE` | `4096` | Context window (`n_ctx`). A non-positive or unparseable value falls back to `4096`. |
+| `NOVA_GGUF_THREADS` | `0` | CPU threads (`n_threads`). `0` lets llama.cpp choose. |
+| `NOVA_GGUF_GPU_LAYERS` | `0` | Layers to offload to GPU (`n_gpu_layers`). `0` keeps inference on CPU. Requires a GPU-enabled `llama-cpp-python` build. |
+
+Example `.env`:
+
+```bash
+NOVA_MODEL_PROVIDER=llamacpp
+NOVA_GGUF_MODEL_PATH=/mnt/archive/nova-models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
+NOVA_GGUF_CONTEXT_SIZE=4096
+# NOVA_GGUF_THREADS=8         # optional; 0 = auto
+# NOVA_GGUF_GPU_LAYERS=35     # optional; needs a GPU build of llama-cpp-python
+```
+
+After editing `.env`, restart Nova. To confirm the backend, open
+**Settings → Models** (admin) and click **Test connection** — it runs a
+cheap, read-only liveness probe. With the GGUF provider configured the
+probe reports the model's filename when the dependency and path are in
+place, or a clear reason when either is missing.
+
+## How model selection interacts
+
+The GGUF provider serves a *single* model — the file at
+`NOVA_GGUF_MODEL_PATH`. llama.cpp ignores the per-request model name, so
+Nova's routing (`simple` / `normal` / `code` / `advanced`) and the
+admin "default model" selection do not change which weights answer; they
+all resolve to the one loaded file. The provider reports that file's
+basename through the standard health probe, so it appears (and is
+selectable) in the default-model surface without any provider-specific
+UI code.
+
+## Hardware expectations
+
+llama.cpp runs on CPU by default; a GPU only helps if you installed a
+GPU-enabled wheel and set `NOVA_GGUF_GPU_LAYERS`. Rough guidance for
+common quantisations:
+
+| Model size | Quant | Approx. RAM (CPU) | Notes |
+|---|---|---|---|
+| 7–8B | `Q4_K_M` | ~6–8 GB | Comfortable on a 16 GB host; good first choice. |
+| 7–8B | `Q5_K_M` / `Q6_K` | ~8–10 GB | Higher quality, more memory. |
+| 13–14B | `Q4_K_M` | ~10–12 GB | Wants 16–32 GB; slower on CPU. |
+| 30B+ | `Q4_K_M` | 24 GB+ | Practical only with a capable GPU or a large-RAM host. |
+
+These are approximate — actual footprint depends on the model,
+quantisation, and `NOVA_GGUF_CONTEXT_SIZE` (a larger context costs more
+memory). The model is loaded **lazily on the first message** and then
+kept in memory, so the first reply after a restart is slower while
+weights load. If a host lacks the memory for the configured model, the
+load fails with a sanitised error and chat falls back to the standard
+"backend unreachable" reply — Nova stays up.
+
+## Safety notes
+
+- **No downloads.** Nova never fetches a model in this phase. You provide
+  the file.
+- **No shell, no scan.** The provider never runs a shell command and
+  never walks the filesystem. It validates exactly the one path you
+  configured (readable regular `.gguf` file) and refuses anything else.
+- **Sanitised errors.** Operator-facing messages name the relevant
+  environment variable and the problem; they never echo the absolute
+  model path or a raw backend exception. Full detail is in the server
+  logs only.
+- **Ollama untouched.** Selecting `llamacpp` is a non-destructive runtime
+  switch. It never writes settings, never migrates data, and never
+  changes Ollama's configuration.
+- **Identity still wins.** Like every provider, the GGUF backend only
+  turns the messages Nova assembled into text. It cannot reorder or
+  override Nova's identity / safety contract — that ordering is owned
+  upstream in `core.chat.build_messages`. See
+  [`docs/model-providers.md`](model-providers.md).
+
+## Troubleshooting
+
+| Symptom (Test connection / chat) | Likely cause | Fix |
+|---|---|---|
+| "llama-cpp-python is not installed" | The optional wheel is missing | `pip install llama-cpp-python` in Nova's environment |
+| "No GGUF model configured" | `NOVA_GGUF_MODEL_PATH` is empty | Set it to your `.gguf` file |
+| "must point at a .gguf model file" | Wrong extension | Point at the actual `.gguf` file, not a directory or other format |
+| "GGUF model file not found" | Path typo / file moved / disk not mounted | Check the path; confirm the mount is up |
+| "model file is not readable" | Permissions | Make the file readable by the Nova service user |
+| "Failed to load the GGUF model" | Corrupt file or not enough memory | Re-download the model out of band; try a smaller quant; check free RAM |

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -41,8 +41,8 @@ Nova Core  (identity · memory · projects · context · safety · routing · se
    ▼
 Model Provider Interface          core/model_providers/base.py
    ├── OllamaProvider   (default)  core/model_providers/ollama.py
+   ├── LlamaCppProvider (opt-in)   core/model_providers/llamacpp.py
    ├── MockProvider     (tests)    core/model_providers/mock.py
-   ├── future LlamaCppProvider
    ├── future TransformersProvider
    └── future NovaModelProvider
 ```
@@ -232,15 +232,56 @@ admin-only on the server.
 - **No downloads, no new runtime.** Listing is read-only; nothing here
   pulls, imports, or runs a model. `MockProvider` stays test-only.
 
+## Running without Ollama: the local GGUF provider (opt-in)
+
+`LlamaCppProvider` (`core/model_providers/llamacpp.py`, registered as
+`llamacpp`) is the first provider that lets Nova generate text **without
+Ollama**. It loads a single local `.gguf` model file through the optional
+[`llama-cpp-python`](https://github.com/abetlen/llama-cpp-python) wheel
+and serves it behind the same `generate()` / `stream()` / `health()`
+contract. This makes Ollama *no longer architecturally required* — but
+**Ollama remains the default**; the GGUF provider is used only when you
+set `NOVA_MODEL_PROVIDER=llamacpp`.
+
+Phase-1 behaviour and guardrails:
+
+- **Optional dependency, graceful absence.** `llama_cpp` is imported
+  lazily inside the methods that need it — never at module import — so
+  the registry imports cleanly on a host without the wheel. When it is
+  missing, `health()` reports a clear `ok=false` and `generate()` /
+  `stream()` raise `ModelProviderError` (the usual "backend unreachable"
+  reply), never an `ImportError` and never a crash.
+- **No downloads.** Nova never fetches a model. The operator points
+  `NOVA_GGUF_MODEL_PATH` at a `.gguf` file they already have.
+- **Safe path validation.** The path is accepted only if it is a
+  readable regular `.gguf` file — no globbing, no directory walk, no
+  filesystem scan, no shell.
+- **Cheap construction, lazy load.** Constructing the provider only
+  validates config and the path; the model is loaded on first use and
+  cached, so the registry stays cheap and the first reply after a restart
+  is the only slow one.
+- **Sanitised errors.** Operator-facing messages name the relevant env
+  var and the problem; they never echo the absolute model path or a raw
+  backend exception. `health()` reports only the model's *basename* so it
+  is selectable in the default-model surface without leaking the
+  directory layout.
+- **Non-streaming and streaming.** Both `generate()` and a simple
+  token-by-token `stream()` are implemented; access to the single,
+  non-concurrent llama.cpp handle is serialised with a lock.
+
+Configuration (`NOVA_GGUF_MODEL_PATH`, `NOVA_GGUF_CONTEXT_SIZE`,
+`NOVA_GGUF_THREADS`, `NOVA_GGUF_GPU_LAYERS`), the recommended model
+directory, and hardware expectations are documented in
+[`docs/local-gguf.md`](local-gguf.md).
+
 ## Future providers
 
-New **local** runtimes can be added cleanly in later phases — for
-example a `LlamaCppProvider` (GGUF via llama.cpp), a
-`TransformersProvider` (Hugging Face Transformers), or a Nova-owned
-runtime (`NovaModelProvider`). Each only implements `generate()`,
-`stream()`, and `health()` and registers a name. **This phase adds none
-of them**, performs no model downloads, and adds no cloud providers and
-no API keys — those are explicitly out of scope.
+More **local** runtimes can be added cleanly in later phases — for
+example a `TransformersProvider` (Hugging Face Transformers) or a
+Nova-owned runtime (`NovaModelProvider`). Each only implements
+`generate()`, `stream()`, and `health()` and registers a name. **This
+phase adds neither of those**, performs no model downloads, and adds no
+cloud providers and no API keys — those are explicitly out of scope.
 
 The default-model surface needs **no per-provider code** to support a
 future backend: model listing flows through the same `health()` the
@@ -309,3 +350,15 @@ persists). The existing chat / streaming / routing / model-access /
 registry / pull suites continue to pass unchanged — with nothing
 persisted, every default-model lookup returns the same
 `config.MODELS["default"]` as before.
+
+The opt-in GGUF provider has its own suite,
+`tests/test_llamacpp_provider.py`, which pins the contract without the
+real wheel or real weights (a fake `Llama` class is injected and a tiny
+dummy `.gguf` file stands in): the provider implements the base
+interface; a missing `llama-cpp-python` dependency is a clean health
+failure and raises `ModelProviderError` (never `ImportError`); a
+missing / wrong-extension / not-found model path is a clean failure; the
+model is loaded lazily and cached; config knobs reach the backend;
+generation and streaming return content; load and backend errors are
+sanitised (no path / raw-exception leakage); and the registry can select
+`llamacpp` while Ollama stays the default.

--- a/tests/test_llamacpp_provider.py
+++ b/tests/test_llamacpp_provider.py
@@ -1,0 +1,376 @@
+"""Tests for the optional local GGUF provider (llama.cpp).
+
+Pinned contracts (see ``core/model_providers/llamacpp.py``):
+
+* the provider implements the :class:`ModelProvider` base interface;
+* when the optional ``llama-cpp-python`` wheel is missing, ``health()``
+  reports a clean ``ok=False`` and ``generate`` / ``stream`` raise
+  :class:`ModelProviderError` — never an ``ImportError`` and never a
+  crash;
+* a missing model path is a clean health failure (not an exception);
+* an invalid model path (wrong extension / not found / unreadable) is
+  reported clearly and raised as a sanitised ``ModelProviderError``;
+* the model is loaded lazily (construction is cheap) and cached;
+* config knobs (context size / threads / gpu layers) reach the backend;
+* the happy path returns content and streams fragments;
+* operator-facing errors never leak the absolute model path or a raw
+  backend exception;
+* the registry can select ``llamacpp`` while Ollama stays the default.
+
+No real ``llama-cpp-python`` wheel and no real ``.gguf`` weights are
+needed: a fake ``Llama`` class is injected through the constructor, and
+the path validator only checks for a readable ``.gguf`` file (it never
+parses the model), so a tiny dummy file stands in for one.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Match the rest of the suite: stub optional wheels so the package
+# imports on a minimal host (``ollama`` is imported by the provider
+# package's ``__init__``). ``llama_cpp`` is intentionally NOT stubbed —
+# the dependency-missing tests rely on it being absent / forced absent.
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import provider_status as ps  # noqa: E402
+from core.model_providers import (  # noqa: E402
+    GGUFProvider,
+    LlamaCppProvider,
+    ModelProvider,
+    ModelProviderError,
+    ModelRequest,
+    OllamaProvider,
+    available_providers,
+    get_provider,
+    reset,
+)
+from core.model_providers import llamacpp as llamacpp_mod  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """No override / cached instance / singleton leaks between tests."""
+    reset()
+    llamacpp_mod._default = None
+    yield
+    reset()
+    llamacpp_mod._default = None
+
+
+# ── Fake backend ────────────────────────────────────────────────────
+
+
+def _make_fake_llama(
+    *,
+    response: str = "hello from gguf",
+    chunks=("Hel", "lo"),
+    init_error: Exception | None = None,
+    generate_error: Exception | None = None,
+):
+    """Build a fresh fake ``Llama`` class (isolated per test).
+
+    Tracks constructed instances on ``cls.instances`` so tests can assert
+    lazy loading and the kwargs Nova forwarded.
+    """
+
+    class _FakeLlama:
+        instances: list = []
+
+        def __init__(self, **kwargs):
+            if init_error is not None:
+                raise init_error
+            self.kwargs = kwargs
+            type(self).instances.append(self)
+
+        def create_chat_completion(self, messages, stream=False):
+            if generate_error is not None:
+                raise generate_error
+            if stream:
+                events = [{"choices": [{"delta": {"role": "assistant"}}]}]
+                events += [
+                    {"choices": [{"delta": {"content": c}}]} for c in chunks
+                ]
+                events.append({"choices": [{"delta": {}}]})  # final, empty
+                return iter(events)
+            return {
+                "choices": [
+                    {"message": {"role": "assistant", "content": response}}
+                ]
+            }
+
+    return _FakeLlama
+
+
+@pytest.fixture
+def gguf_file(tmp_path):
+    """A readable dummy ``.gguf`` file (contents are never parsed)."""
+    path = tmp_path / "model.gguf"
+    path.write_bytes(b"GGUF\x00 not real weights")
+    return str(path)
+
+
+# ── Base interface ──────────────────────────────────────────────────
+
+
+class TestInterface:
+    def test_implements_base_interface(self, gguf_file):
+        provider = LlamaCppProvider(
+            model_path=gguf_file,
+            context_size=2048,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(),
+        )
+        assert isinstance(provider, ModelProvider)
+        assert provider.name == "llamacpp"
+        assert callable(provider.generate)
+        assert callable(provider.stream)
+        assert callable(provider.health)
+
+    def test_gguf_alias_is_the_same_class(self):
+        assert GGUFProvider is LlamaCppProvider
+
+
+# ── Optional dependency missing ─────────────────────────────────────
+
+
+class TestDependencyMissing:
+    @pytest.fixture(autouse=True)
+    def _force_missing(self, monkeypatch):
+        # Setting the module to None makes ``import llama_cpp`` raise
+        # ImportError deterministically, even on a host that has the
+        # wheel installed.
+        monkeypatch.setitem(sys.modules, "llama_cpp", None)
+
+    def _provider(self, model_path=""):
+        # No llama_class override → the provider imports the real module,
+        # which we have forced to be absent.
+        return LlamaCppProvider(
+            model_path=model_path, context_size=4096, threads=0, gpu_layers=0
+        )
+
+    def test_health_reports_missing_dependency(self, gguf_file):
+        # Dependency is checked before the path, so a valid path still
+        # surfaces the dependency problem (and never raises).
+        health = self._provider(model_path=gguf_file).health()
+        assert health.ok is False
+        assert health.provider == "llamacpp"
+        assert "llama-cpp-python" in health.detail
+        assert health.models == []
+
+    def test_generate_raises_model_provider_error(self):
+        with pytest.raises(ModelProviderError) as exc:
+            self._provider().generate(ModelRequest("m", []))
+        assert "llama-cpp-python" in str(exc.value)
+
+    def test_stream_raises_model_provider_error(self):
+        with pytest.raises(ModelProviderError):
+            list(self._provider().stream(ModelRequest("m", [], stream=True)))
+
+
+# ── Missing / invalid model path (dependency present) ───────────────
+
+
+class TestModelPathValidation:
+    def test_missing_path_is_clean_health_failure(self):
+        provider = LlamaCppProvider(
+            model_path="",
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(),
+        )
+        health = provider.health()
+        assert health.ok is False
+        assert "NOVA_GGUF_MODEL_PATH" in health.detail
+        assert health.models == []
+
+    def test_nonexistent_path_is_clean_health_failure(self, tmp_path):
+        missing = str(tmp_path / "absent.gguf")
+        provider = LlamaCppProvider(
+            model_path=missing,
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(),
+        )
+        health = provider.health()
+        assert health.ok is False
+        assert health.detail
+        # The absolute path must not be echoed back.
+        assert missing not in health.detail
+
+    def test_wrong_extension_is_rejected(self, tmp_path):
+        wrong = tmp_path / "model.bin"
+        wrong.write_bytes(b"not gguf")
+        provider = LlamaCppProvider(
+            model_path=str(wrong),
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(),
+        )
+        health = provider.health()
+        assert health.ok is False
+        assert ".gguf" in health.detail
+
+    def test_generate_invalid_path_raises_sanitised_error(self, tmp_path):
+        missing = str(tmp_path / "absent.gguf")
+        provider = LlamaCppProvider(
+            model_path=missing,
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(),
+        )
+        with pytest.raises(ModelProviderError) as exc:
+            provider.generate(ModelRequest("m", []))
+        # Clean, operator-facing reason — never the raw absolute path.
+        assert missing not in str(exc.value)
+
+
+# ── Happy path ──────────────────────────────────────────────────────
+
+
+class TestGeneration:
+    def _provider(self, gguf_file, **kw):
+        return LlamaCppProvider(
+            model_path=gguf_file,
+            context_size=kw.pop("context_size", 2048),
+            threads=kw.pop("threads", 0),
+            gpu_layers=kw.pop("gpu_layers", 0),
+            llama_class=kw.pop("llama_class", _make_fake_llama()),
+        )
+
+    def test_generate_returns_content(self, gguf_file):
+        provider = self._provider(
+            gguf_file, llama_class=_make_fake_llama(response="bonjour")
+        )
+        out = provider.generate(
+            ModelRequest("ignored-name", [{"role": "user", "content": "hi"}])
+        )
+        assert out.content == "bonjour"
+        # Echoes the requested model label even though llama.cpp ignores it.
+        assert out.model == "ignored-name"
+
+    def test_stream_yields_fragments_and_skips_empty_deltas(self, gguf_file):
+        provider = self._provider(
+            gguf_file, llama_class=_make_fake_llama(chunks=("Hel", "lo", "!"))
+        )
+        chunks = list(provider.stream(ModelRequest("m", [], stream=True)))
+        assert [c.content for c in chunks] == ["Hel", "lo", "!"]
+
+    def test_health_ok_lists_only_basename(self, gguf_file):
+        provider = self._provider(gguf_file)
+        health = provider.health()
+        assert health.ok is True
+        assert health.provider == "llamacpp"
+        assert health.models == ["model.gguf"]
+        # The directory must not leak through the models list.
+        assert gguf_file not in health.models
+
+    def test_model_is_loaded_lazily_and_cached(self, gguf_file):
+        fake = _make_fake_llama()
+        provider = self._provider(gguf_file, llama_class=fake)
+        # Construction must not load the model.
+        assert fake.instances == []
+        provider.generate(ModelRequest("m", []))
+        provider.generate(ModelRequest("m", []))
+        # Loaded exactly once and reused.
+        assert len(fake.instances) == 1
+
+    def test_config_knobs_reach_backend(self, gguf_file):
+        fake = _make_fake_llama()
+        provider = LlamaCppProvider(
+            model_path=gguf_file,
+            context_size=8192,
+            threads=6,
+            gpu_layers=20,
+            llama_class=fake,
+        )
+        provider.generate(ModelRequest("m", []))
+        kwargs = fake.instances[0].kwargs
+        assert kwargs["model_path"] == gguf_file
+        assert kwargs["n_ctx"] == 8192
+        assert kwargs["n_threads"] == 6
+        assert kwargs["n_gpu_layers"] == 20
+        assert kwargs["verbose"] is False
+
+    def test_threads_zero_is_not_forwarded(self, gguf_file):
+        fake = _make_fake_llama()
+        provider = LlamaCppProvider(
+            model_path=gguf_file,
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=fake,
+        )
+        provider.generate(ModelRequest("m", []))
+        # 0 threads => let llama.cpp decide (kwarg omitted).
+        assert "n_threads" not in fake.instances[0].kwargs
+
+
+# ── Error sanitisation ──────────────────────────────────────────────
+
+
+class TestErrorSanitisation:
+    def test_load_failure_is_sanitised(self, gguf_file):
+        secret = "/mnt/secret/path/leak.gguf boom"
+        provider = LlamaCppProvider(
+            model_path=gguf_file,
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(init_error=RuntimeError(secret)),
+        )
+        with pytest.raises(ModelProviderError) as exc:
+            provider.generate(ModelRequest("m", []))
+        assert "/mnt/secret" not in str(exc.value)
+        assert "boom" not in str(exc.value)
+
+    def test_generation_backend_error_is_sanitised(self, gguf_file):
+        secret = "internal cuda assert at 0xdeadbeef"
+        provider = LlamaCppProvider(
+            model_path=gguf_file,
+            context_size=4096,
+            threads=0,
+            gpu_layers=0,
+            llama_class=_make_fake_llama(
+                generate_error=RuntimeError(secret)
+            ),
+        )
+        with pytest.raises(ModelProviderError) as exc:
+            provider.generate(ModelRequest("m", []))
+        assert "0xdeadbeef" not in str(exc.value)
+
+
+# ── Registry integration ────────────────────────────────────────────
+
+
+class TestRegistry:
+    def test_registry_can_select_llamacpp(self):
+        assert "llamacpp" in available_providers()
+        assert isinstance(get_provider("llamacpp"), LlamaCppProvider)
+
+    def test_ollama_remains_default(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        reset()
+        assert isinstance(get_provider(), OllamaProvider)
+
+    def test_config_can_select_llamacpp_as_default(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        reset()
+        llamacpp_mod._default = None
+        assert isinstance(get_provider(), LlamaCppProvider)
+
+    def test_llamacpp_is_selectable_not_test_only(self, monkeypatch):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        status = ps.get_provider_status()
+        assert "llamacpp" in status.selectable_providers
+        assert "llamacpp" not in status.test_only_providers


### PR DESCRIPTION
## Summary

Starts making Ollama optional by adding a **direct local GGUF model provider** behind the existing provider seam. Nova can now generate text from a local `.gguf` model via the optional `llama-cpp-python` wheel **without Ollama** — so Ollama is no longer architecturally required.

**Ollama remains the default and is unchanged.** The new backend is used only when `NOVA_MODEL_PROVIDER=llamacpp`.

- New `LlamaCppProvider` (`core/model_providers/llamacpp.py`, registered as `llamacpp`, with a `GGUFProvider` alias) implementing the existing `generate()` / `stream()` / `health()` contract — non-streaming generation plus a simple, lock-serialised token stream.
- **Graceful by design:** `llama_cpp` is imported lazily, so the registry still loads cleanly when the wheel is absent. A missing dependency or a missing/invalid model path is a clean `ModelProviderError` / `health()` failure, never a crash.
- **Safety:** no model downloads, no shell, no filesystem scan; validates exactly the one configured path (a readable regular `.gguf` file); sanitised operator-facing errors (no absolute path or raw backend exception leaked — `health()` surfaces only the model basename). Memory / projects / storage / export / restore / Dev Workspace are untouched.
- Appears automatically in the existing read-only provider-status / default-model surfaces — **no new endpoint, no model-manager UI**.

### Configuration (all opt-in)

| Variable | Default | Purpose |
|---|---|---|
| `NOVA_MODEL_PROVIDER` | `ollama` | `llamacpp` selects the GGUF backend |
| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` file (never downloaded) |
| `NOVA_GGUF_CONTEXT_SIZE` | `4096` | `n_ctx` |
| `NOVA_GGUF_THREADS` | `0` | `n_threads` (0 = auto) |
| `NOVA_GGUF_GPU_LAYERS` | `0` | `n_gpu_layers` (0 = CPU) |

### Docs
- New `docs/local-gguf.md` (Ollama still supported, how to configure, recommended dir `/mnt/archive/nova-models`, no auto-downloads, hardware expectations, troubleshooting).
- Updates to `docs/model-providers.md`, `README.md`, `.env.example`, `CHANGELOG.md`.

## Test plan

- [x] `tests/test_llamacpp_provider.py` (21 tests): base interface; dependency-missing → clean health failure + `ModelProviderError` (never `ImportError`); missing / wrong-extension / not-found path → clean failure; lazy load + caching; config knobs reach backend; generate + stream return content; load/backend errors sanitised (no path/exception leak); registry selects `llamacpp` while Ollama stays default.
- [x] Existing provider/model/chat suites pass: `test_model_providers`, `test_provider_status`, `test_provider_endpoints`, `test_provider_default_model_endpoints`, `test_model_settings`, `test_model_registry`, `test_chat_stream` (163 passed locally).
- [x] `flake8` clean on changed files.
- [x] Verified the registry imports and resolves `llamacpp` with `llama_cpp` absent (lazy-import guarantee), degrading to a clean "not installed" health failure.
- [ ] Manual end-to-end with a real `.gguf` model + `llama-cpp-python` wheel (not available in CI; see `docs/local-gguf.md`).

https://claude.ai/code/session_01RD5LBogRmCEoEHuL8Nckmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RD5LBogRmCEoEHuL8Nckmj)_