### PR TITLE
feat(model-providers): admin GGUF model-path config + model dir (Phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -322,12 +322,20 @@ NOVA_TIMEZONE=
 # NOVA_MODEL_PROVIDER: ollama (default) | llamacpp.
 # NOVA_GGUF_MODEL_PATH: absolute path to a local .gguf model file. Empty
 #   leaves the provider unconfigured (a clean health failure, not a crash).
+#   An admin can also set this from Settings → Models → "Local GGUF model"
+#   (persisted in the database; the pasted path must live inside
+#   NOVA_MODEL_DIR). The persisted value takes precedence over this one.
+# NOVA_MODEL_DIR: directory that local .gguf files must live inside.
+#   Default /mnt/archive/nova-models. The admin UI only accepts a model
+#   path that resolves inside this directory (no arbitrary files, no path
+#   traversal). Nova never lists, scans, or downloads into it.
 # NOVA_GGUF_CONTEXT_SIZE: context window (n_ctx). Default 4096.
 # NOVA_GGUF_THREADS: CPU threads (n_threads). 0 = let llama.cpp decide.
 # NOVA_GGUF_GPU_LAYERS: layers to offload to GPU (n_gpu_layers). 0 = CPU
 #   only; >0 needs a GPU-enabled llama-cpp-python build.
 NOVA_MODEL_PROVIDER=ollama
 NOVA_GGUF_MODEL_PATH=
+NOVA_MODEL_DIR=/mnt/archive/nova-models
 NOVA_GGUF_CONTEXT_SIZE=4096
 NOVA_GGUF_THREADS=0
 NOVA_GGUF_GPU_LAYERS=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,34 @@
   relate to the baseline.
 
 ### Added
+- **Local GGUF model path UI + model directory — Phase 2, admin-only.**
+  Makes the optional `llamacpp` provider configurable without editing
+  `.env`. A new `core/gguf_settings.py` adds a directory-confined path
+  validator (`validate_gguf_model_path`): a model path is accepted only
+  when it is an absolute, traversal-free (`..`/`~`-rejected) `.gguf` file
+  that resolves — symlinks included — **inside** the allowed model
+  directory `NOVA_MODEL_DIR` (new config, default
+  `/mnt/archive/nova-models`), exists, is a regular readable file. The
+  chosen path is persisted host-wide via `save_system_setting`
+  (`gguf_model_path`, deliberately outside `USER_SETTING_KEYS` /
+  `ALLOWED_SETTINGS`), takes precedence over `NOVA_GGUF_MODEL_PATH`, and
+  takes effect without a restart — `set_gguf_model_path` drops the cached
+  provider via the new `evict_provider` (registry) and
+  `reset_llamacpp_provider`, and the factory now resolves its path from
+  the persisted setting (falling back to env). Three admin-only endpoints
+  back a "Local GGUF model" card in **Settings → Models**: `GET
+  /admin/provider/gguf` (status: provider, model dir + existence,
+  configured path + source + validity), `POST
+  /admin/provider/gguf/model-path` (validate then persist; a refusal is a
+  sanitised 400 that writes nothing), and `POST /admin/provider/gguf/test`
+  (checks the path is valid *and* `llama-cpp-python` is installed —
+  "valid enough to attempt loading" — without loading the multi-GB
+  weights). No filesystem browser, no scan, no shell, no download, no
+  deletion, no overwrite; errors are sanitised and the card is hidden for
+  non-admins. **Ollama remains the default and is untouched** — a GGUF
+  path is harmless until `NOVA_MODEL_PROVIDER=llamacpp`. Tests:
+  `tests/test_gguf_settings.py`, `tests/test_gguf_endpoints.py`. See
+  [docs/local-gguf.md](docs/local-gguf.md).
 - **Local GGUF model provider (llama.cpp) — Phase 1, opt-in.** Adds
   `LlamaCppProvider` (`core/model_providers/llamacpp.py`, registered as
   `llamacpp`, with a `GGUFProvider` alias) so Nova can generate text from

--- a/README.md
+++ b/README.md
@@ -969,7 +969,8 @@ All configuration is read from `.env` at startup. Key variables:
 | `NOVA_DEV_WORKSPACE_ROOTS` | — | OS-path-separator- or comma-separated absolute directories that may contain repos a Project can link (read-only Phase 1). Blank = the Dev Workspace feature is off. Never set to `/`, `/home`, or a broad system path. See [`docs/dev-workspace.md`](docs/dev-workspace.md). |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
 | `NOVA_MODEL_PROVIDER` | `ollama` | Model backend: `ollama` (default) or `llamacpp` (local GGUF, no Ollama). See [`docs/local-gguf.md`](docs/local-gguf.md). |
-| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file (only used when `NOVA_MODEL_PROVIDER=llamacpp`). Nova never downloads it. Blank = provider unconfigured. |
+| `NOVA_MODEL_DIR` | `/mnt/archive/nova-models` | Directory local `.gguf` files must live inside. Admins can set the model path from Settings → Models; only paths inside this directory are accepted (no traversal, no arbitrary files). |
+| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file (only used when `NOVA_MODEL_PROVIDER=llamacpp`). Nova never downloads it. Blank = provider unconfigured. An admin-set path (Settings → Models) takes precedence. |
 | `NOVA_GGUF_CONTEXT_SIZE` | `4096` | GGUF context window (`n_ctx`) |
 | `NOVA_GGUF_THREADS` | `0` | GGUF CPU threads (`n_threads`); `0` = auto |
 | `NOVA_GGUF_GPU_LAYERS` | `0` | GGUF layers offloaded to GPU (`n_gpu_layers`); `0` = CPU only |

--- a/config.py
+++ b/config.py
@@ -52,6 +52,18 @@ except ValueError:
 if NOVA_GGUF_GPU_LAYERS < 0:
     NOVA_GGUF_GPU_LAYERS = 0
 
+# Directory that local GGUF model files must live inside. The admin-only
+# GGUF settings surface (Settings → Models → "Local GGUF model") only
+# accepts a model path that resolves *inside* this directory, which
+# defeats path traversal and keeps Nova from ever being pointed at an
+# arbitrary file. Nova never lists, scans, or browses it — it only
+# validates the one path an admin configures. Default is the recommended
+# out-of-checkout location; override with NOVA_MODEL_DIR.
+NOVA_MODEL_DIR = (
+    os.getenv("NOVA_MODEL_DIR", "/mnt/archive/nova-models").strip()
+    or "/mnt/archive/nova-models"
+)
+
 _raw_channel = os.getenv("NOVA_CHANNEL", "stable").lower()
 NOVA_CHANNEL = _raw_channel if _raw_channel in ("stable", "beta", "alpha") else "stable"
 NOVA_BRANCH = os.getenv("NOVA_BRANCH", "main")

--- a/core/gguf_settings.py
+++ b/core/gguf_settings.py
@@ -1,0 +1,444 @@
+"""Admin-configurable local GGUF model path (GGUF provider, Phase 2).
+
+Phase 1 shipped the optional ``llamacpp`` provider — Nova can run a local
+``.gguf`` model without Ollama — but the *only* way to point it at a model
+file was editing ``NOVA_GGUF_MODEL_PATH`` in the environment and
+restarting. This module adds a small, safe, admin-only configuration
+surface so the model path can be set, validated, and tested from
+**Settings → Models** without touching ``.env``.
+
+Scope / safety contract (Phase 2):
+
+* **Directory-confined, never arbitrary.** A model path is accepted only
+  when it resolves (symlinks included) **inside** the configured model
+  directory (``config.NOVA_MODEL_DIR``, default ``/mnt/archive/nova-models``),
+  is an existing readable regular ``.gguf`` file, and contains no ``..``
+  traversal. Anything else is refused with a short, sanitised reason and
+  **nothing is written**. There is no filesystem browsing, no globbing,
+  no directory walk, no shell — Nova validates exactly the one path an
+  admin pastes.
+* **Persisted like the Phase-2 default model.** The chosen path is a
+  single host-wide row in the ``settings`` table via
+  :func:`core.settings.save_system_setting` — an operator decision, not a
+  per-user preference. It is deliberately **not** in
+  ``core.settings.USER_SETTING_KEYS`` or ``config.ALLOWED_SETTINGS`` so it
+  can never be written through the generic ``/settings`` path that would
+  bypass the validation here.
+* **Read path is cheap and never raises.**
+  :func:`resolve_gguf_model_path` returns the persisted path if one is set
+  (and a DB exists), else ``config.NOVA_GGUF_MODEL_PATH``. It performs no
+  network I/O, never loads a model, and swallows every error so provider
+  construction stays cheap and offline-safe.
+* **Takes effect without a restart.** A successful write invalidates the
+  cached ``llamacpp`` provider so the next generation rebuilds it against
+  the new path — but nothing is loaded eagerly and nothing else changes.
+* **No downloads, no deletion, no overwrite.** Nova never fetches,
+  removes, or replaces a model. The operator supplies the file; this
+  module only records which one to use.
+* **Ollama is untouched and stays the default.** Configuring a GGUF path
+  is harmless when ``NOVA_MODEL_PROVIDER`` is still ``ollama`` — it simply
+  takes effect if/when the operator selects ``llamacpp``.
+* **Sanitised errors.** Operator-facing messages name the relevant
+  environment variable and the problem; they never echo a raw backend
+  exception. Full detail is logged server-side only.
+
+It is the foundation under the admin-only ``GET /admin/provider/gguf``,
+``POST /admin/provider/gguf/model-path`` and ``POST
+/admin/provider/gguf/test`` endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Host-wide ``settings`` key holding the admin-selected GGUF model path.
+#: Kept out of ``USER_SETTING_KEYS`` / ``ALLOWED_SETTINGS`` on purpose so
+#: it can only ever be written through :func:`set_gguf_model_path`, which
+#: validates the path against the allowed model directory first.
+GGUF_MODEL_PATH_SETTING_KEY = "gguf_model_path"
+
+#: Defensive cap on a pasted path. PATH_MAX on Linux is 4096; we accept up
+#: to that so a crafted client can't smuggle a huge blob into the settings
+#: row even though the value is also validated as a real file.
+MAX_PATH_LEN = 4096
+
+#: The backend label this surface configures. The GGUF provider is always
+#: ``llamacpp`` regardless of which provider is currently the default.
+PROVIDER_NAME = "llamacpp"
+
+# Fixed, non-sensitive operator-facing message reused by status + test so
+# the wording never drifts.
+_NO_PATH_MSG = (
+    "No GGUF model is configured. Paste the path to a .gguf file inside "
+    "the model directory, or set NOVA_GGUF_MODEL_PATH."
+)
+
+
+class GgufModelPathError(Exception):
+    """A requested GGUF model path was refused.
+
+    Carries a short, **sanitised** reason safe to surface to the admin UI:
+    it never echoes a raw backend exception or a path outside the one the
+    caller supplied.
+    """
+
+
+# ── Config / persisted reads ─────────────────────────────────────────
+
+
+def resolve_model_dir() -> str:
+    """The directory GGUF model files must live inside (``NOVA_MODEL_DIR``).
+
+    Best-effort and never raises: a missing / oddly-shaped config degrades
+    to the recommended default rather than turning a read into a failure.
+    """
+    try:
+        from config import NOVA_MODEL_DIR
+
+        value = (NOVA_MODEL_DIR or "").strip()
+        return value or "/mnt/archive/nova-models"
+    except Exception as exc:  # pragma: no cover - config is stable
+        logger.warning("gguf: model-dir lookup failed: %s", exc)
+        return "/mnt/archive/nova-models"
+
+
+def _config_model_path() -> str:
+    """The env-provided GGUF model path (``NOVA_GGUF_MODEL_PATH``)."""
+    try:
+        from config import NOVA_GGUF_MODEL_PATH
+
+        return (NOVA_GGUF_MODEL_PATH or "").strip()
+    except Exception as exc:  # pragma: no cover - config is stable
+        logger.warning("gguf: config path lookup failed: %s", exc)
+        return ""
+
+
+def _persisted_model_path() -> str:
+    """The admin-persisted GGUF model path, or ``""`` if none / unavailable.
+
+    Guards on the DB file existing before connecting so a read on a host
+    that has not initialised its database yet (or a test that never set
+    one up) neither raises nor creates a stray empty database file. Any
+    error degrades to ``""``.
+    """
+    try:
+        from core.memory import DB_PATH
+
+        if not os.path.exists(DB_PATH):
+            return ""
+        from core.settings import get_system_setting
+
+        return (get_system_setting(GGUF_MODEL_PATH_SETTING_KEY, "") or "").strip()
+    except Exception as exc:  # never block construction on a settings read
+        logger.debug("gguf: persisted path read failed: %s", exc)
+        return ""
+
+
+def resolve_gguf_model_path() -> str:
+    """The GGUF model path Nova uses: persisted admin choice, else env.
+
+    Safe to call from provider construction and from any thread: it
+    performs **no** network I/O, never loads a model, and never raises. A
+    blank persisted setting (the default for every existing install)
+    transparently falls back to ``config.NOVA_GGUF_MODEL_PATH`` so Phase-1
+    deployments behave exactly as before.
+    """
+    return _persisted_model_path() or _config_model_path()
+
+
+# ── Path validation (the safety boundary) ────────────────────────────
+
+
+def validate_gguf_model_path(raw, model_dir: str) -> str:
+    """Validate a candidate model path, returning its resolved form.
+
+    Enforces, in order: a non-empty clean string → no NUL/newlines → no
+    ``~`` expansion → absolute → no ``..`` traversal → a ``.gguf``
+    extension → resolves (symlinks included) inside ``model_dir`` → exists
+    → is a regular file → is readable. Raises :class:`GgufModelPathError`
+    with a short, safe message on the first failure; returns the fully
+    resolved absolute path string on success.
+
+    The containment check uses :meth:`pathlib.Path.resolve` on both the
+    candidate and ``model_dir`` so a symlink that points outside the
+    allowed directory is refused — not just literal ``..`` traversal.
+    """
+    if raw is None or isinstance(raw, bool):
+        raise GgufModelPathError("A model path is required.")
+    try:
+        text = os.fspath(raw)
+    except TypeError:
+        raise GgufModelPathError("The model path must be a string.")
+    if not isinstance(text, str):
+        raise GgufModelPathError("The model path must be a string.")
+    text = text.strip()
+    if not text:
+        raise GgufModelPathError("A model path is required.")
+    if len(text) > MAX_PATH_LEN:
+        raise GgufModelPathError("That model path is too long.")
+    if "\x00" in text or "\n" in text or "\r" in text:
+        raise GgufModelPathError("That model path contains invalid characters.")
+    if "~" in text:
+        # No home-directory expansion: keep the containment check honest.
+        raise GgufModelPathError("The model path must be an absolute path.")
+
+    candidate = Path(text)
+    if not candidate.is_absolute():
+        raise GgufModelPathError("The model path must be an absolute path.")
+    if ".." in candidate.parts:
+        raise GgufModelPathError("The model path must not contain '..'.")
+    if candidate.suffix.lower() != ".gguf":
+        raise GgufModelPathError("The model file must be a .gguf file.")
+
+    allowed_raw = (model_dir or "").strip()
+    if not allowed_raw:
+        raise GgufModelPathError(
+            "No model directory is configured. Set NOVA_MODEL_DIR."
+        )
+    try:
+        allowed = Path(allowed_raw).resolve()
+    except (OSError, RuntimeError, ValueError):
+        raise GgufModelPathError(
+            "The configured model directory could not be resolved."
+        )
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError, ValueError):
+        raise GgufModelPathError("That model path could not be resolved.")
+
+    try:
+        within = resolved == allowed or resolved.is_relative_to(allowed)
+    except ValueError:
+        within = False
+    if not within:
+        raise GgufModelPathError(
+            "The model file must be inside the configured model directory."
+        )
+
+    try:
+        if not resolved.exists():
+            raise GgufModelPathError(
+                "No file exists at that path inside the model directory."
+            )
+        if not resolved.is_file():
+            raise GgufModelPathError("That path is not a file.")
+    except OSError:
+        raise GgufModelPathError("That model path could not be read.")
+    if not os.access(str(resolved), os.R_OK):
+        raise GgufModelPathError(
+            "That model file is not readable. Check its permissions."
+        )
+
+    return str(resolved)
+
+
+# ── Status (read-only) ───────────────────────────────────────────────
+
+
+def _configured_provider() -> str:
+    """The provider Nova is configured to use (``NOVA_MODEL_PROVIDER``)."""
+    try:
+        from config import MODEL_PROVIDER
+
+        return (MODEL_PROVIDER or "ollama").strip().lower() or "ollama"
+    except Exception as exc:  # pragma: no cover - config is stable
+        logger.warning("gguf: provider lookup failed: %s", exc)
+        return "ollama"
+
+
+def _dir_state(model_dir: str) -> tuple[bool, bool]:
+    """``(exists, is_dir)`` for ``model_dir``. Never raises."""
+    try:
+        p = Path(model_dir)
+        return p.exists(), p.is_dir()
+    except OSError:
+        return False, False
+
+
+def gguf_status() -> dict:
+    """Calm, read-only snapshot of the local-GGUF configuration.
+
+    Returns a JSON-serialisable dict the admin UI renders verbatim::
+
+        {
+          "provider": str,            # configured provider (NOVA_MODEL_PROVIDER)
+          "is_llamacpp": bool,        # is the GGUF provider the active one?
+          "default_provider": str,    # always "ollama"
+          "model_dir": str,           # NOVA_MODEL_DIR
+          "model_dir_exists": bool,
+          "model_dir_is_dir": bool,
+          "configured_path": str,     # resolved model path ("" if unset)
+          "path_source": str,         # "custom" | "env" | "unset"
+          "path_valid": bool,         # passes validation against model_dir
+          "path_detail": str,         # sanitised reason when not valid
+          "filename": str,            # basename of the configured path
+        }
+
+    Never raises and never loads a model. ``configured_path`` is the one
+    operator-set value (admin-only endpoint); no other filesystem paths
+    are surfaced.
+    """
+    provider = _configured_provider()
+    model_dir = resolve_model_dir()
+    exists, is_dir = _dir_state(model_dir)
+
+    persisted = _persisted_model_path()
+    env_path = _config_model_path()
+    resolved = persisted or env_path
+    source = "custom" if persisted else ("env" if env_path else "unset")
+
+    path_valid = False
+    path_detail = ""
+    filename = ""
+    if resolved:
+        filename = os.path.basename(resolved)
+        try:
+            validate_gguf_model_path(resolved, model_dir)
+            path_valid = True
+        except GgufModelPathError as exc:
+            path_detail = str(exc)
+
+    return {
+        "provider": provider,
+        "is_llamacpp": provider == PROVIDER_NAME,
+        "default_provider": "ollama",
+        "model_dir": model_dir,
+        "model_dir_exists": exists,
+        "model_dir_is_dir": is_dir,
+        "configured_path": resolved,
+        "path_source": source,
+        "path_valid": path_valid,
+        "path_detail": path_detail,
+        "filename": filename,
+    }
+
+
+# ── Write (validated) ────────────────────────────────────────────────
+
+
+def _invalidate_llamacpp_cache() -> None:
+    """Drop the cached ``llamacpp`` provider so the new path takes effect.
+
+    Best-effort: a failure to evict only means the change waits for the
+    next restart, so it is logged and swallowed rather than raised after a
+    successful persist.
+    """
+    try:
+        from core.model_providers import evict_provider
+        from core.model_providers.llamacpp import reset_llamacpp_provider
+
+        reset_llamacpp_provider()
+        evict_provider(PROVIDER_NAME)
+    except Exception as exc:  # never fail the write on a cache miss
+        logger.debug("gguf: provider cache invalidation failed: %s", exc)
+
+
+def set_gguf_model_path(path) -> dict:
+    """Validate ``path`` against the model directory, then persist it.
+
+    On success the resolved path is written to the global ``settings``
+    table, the cached ``llamacpp`` provider is dropped so the change takes
+    effect on the next generation, and the new :func:`gguf_status` is
+    returned. Any validation failure raises :class:`GgufModelPathError`
+    with a sanitised message and **writes nothing**.
+    """
+    model_dir = resolve_model_dir()
+    validated = validate_gguf_model_path(path, model_dir)
+
+    from core.settings import save_system_setting
+
+    save_system_setting(GGUF_MODEL_PATH_SETTING_KEY, validated)
+    _invalidate_llamacpp_cache()
+    return gguf_status()
+
+
+# ── Test / health (read-only, never loads the model) ─────────────────
+
+
+def test_gguf_provider() -> dict:
+    """Check the configured GGUF model is *valid enough to attempt loading*.
+
+    Read-only and cheap: it confirms a path is configured, that it passes
+    the directory-confined validation (exists, readable, ``.gguf``, inside
+    ``NOVA_MODEL_DIR``), and that the ``llama-cpp-python`` backend is
+    importable — but it never loads the (potentially multi-GB) weights.
+    Always returns a stable, JSON-serialisable shape and never raises::
+
+        {"ok": bool, "provider": "llamacpp", "detail": str,
+         "filename": str, "path_valid": bool}
+
+    ``ok`` is ``True`` only when the path is valid *and* the backend is
+    installed; otherwise ``detail`` carries a short, sanitised reason.
+    """
+    model_dir = resolve_model_dir()
+    resolved = resolve_gguf_model_path()
+    if not resolved:
+        return {
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "detail": _NO_PATH_MSG,
+            "filename": "",
+            "path_valid": False,
+        }
+
+    try:
+        validated = validate_gguf_model_path(resolved, model_dir)
+    except GgufModelPathError as exc:
+        return {
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "detail": str(exc),
+            "filename": os.path.basename(resolved),
+            "path_valid": False,
+        }
+
+    # Cheap, read-only probe: the provider's own health() checks the
+    # dependency and re-validates the path as a readable .gguf — it never
+    # loads the model. Construct a fresh provider against the validated
+    # path so the probe reflects exactly what was configured.
+    try:
+        from core.model_providers.llamacpp import LlamaCppProvider
+
+        health = LlamaCppProvider(model_path=validated).health()
+        ok = bool(health.ok)
+        detail = health.detail or ""
+    except Exception as exc:  # never raise into the endpoint
+        logger.warning("gguf test: provider probe failed: %s", exc)
+        return {
+            "ok": False,
+            "provider": PROVIDER_NAME,
+            "detail": "The GGUF provider could not be probed.",
+            "filename": os.path.basename(validated),
+            "path_valid": True,
+        }
+
+    if ok and not detail:
+        detail = (
+            "The GGUF model path is valid and llama-cpp-python is "
+            "installed. Nova will load the model on first use."
+        )
+    return {
+        "ok": ok,
+        "provider": PROVIDER_NAME,
+        "detail": detail,
+        "filename": os.path.basename(validated),
+        "path_valid": True,
+    }
+
+
+__all__ = [
+    "GGUF_MODEL_PATH_SETTING_KEY",
+    "MAX_PATH_LEN",
+    "PROVIDER_NAME",
+    "GgufModelPathError",
+    "resolve_model_dir",
+    "resolve_gguf_model_path",
+    "validate_gguf_model_path",
+    "gguf_status",
+    "set_gguf_model_path",
+    "test_gguf_provider",
+]

--- a/core/model_providers/__init__.py
+++ b/core/model_providers/__init__.py
@@ -18,11 +18,17 @@ from .base import (
     ModelResponse,
     ProviderHealth,
 )
-from .llamacpp import GGUFProvider, LlamaCppProvider, get_llamacpp_provider
+from .llamacpp import (
+    GGUFProvider,
+    LlamaCppProvider,
+    get_llamacpp_provider,
+    reset_llamacpp_provider,
+)
 from .mock import MockProvider
 from .ollama import OllamaProvider, get_ollama_provider
 from .registry import (
     available_providers,
+    evict_provider,
     get_provider,
     register_provider,
     reset,
@@ -42,10 +48,12 @@ __all__ = [
     "LlamaCppProvider",
     "GGUFProvider",
     "get_llamacpp_provider",
+    "reset_llamacpp_provider",
     "MockProvider",
     "get_provider",
     "register_provider",
     "available_providers",
+    "evict_provider",
     "use_provider",
     "set_override",
     "reset",

--- a/core/model_providers/llamacpp.py
+++ b/core/model_providers/llamacpp.py
@@ -326,18 +326,51 @@ _default: Optional[LlamaCppProvider] = None
 _default_lock = threading.Lock()
 
 
+def _resolve_configured_path() -> Optional[str]:
+    """The model path to build the singleton with: persisted choice, else env.
+
+    The admin-configurable path (Phase 2) lives in the settings DB and
+    falls back to ``NOVA_GGUF_MODEL_PATH``. Resolved here — never raises,
+    never loads a model — so construction stays cheap. ``None`` lets
+    :class:`LlamaCppProvider` read ``config`` itself (the Phase-1
+    behaviour) if the resolver is somehow unavailable.
+    """
+    try:
+        from core.gguf_settings import resolve_gguf_model_path
+
+        return resolve_gguf_model_path()
+    except Exception as exc:  # pragma: no cover - resolver is defensive
+        logger.debug("GGUF path resolve failed; using config: %s", exc)
+        return None
+
+
 def get_llamacpp_provider() -> LlamaCppProvider:
     """Process-wide singleton factory used by the registry.
 
     Cheap: construction only validates config and the model path — the
-    model itself is loaded lazily on first generation.
+    model itself is loaded lazily on first generation. The model path is
+    resolved from the admin-persisted setting (falling back to
+    ``NOVA_GGUF_MODEL_PATH``), so an admin change takes effect once the
+    cached instance is dropped (see :func:`reset_llamacpp_provider`).
     """
     global _default
     if _default is None:
         with _default_lock:
             if _default is None:
-                _default = LlamaCppProvider()
+                _default = LlamaCppProvider(model_path=_resolve_configured_path())
     return _default
+
+
+def reset_llamacpp_provider() -> None:
+    """Drop the cached singleton so the next factory call rebuilds it.
+
+    Called after the admin updates the configured model path so the new
+    file is picked up (and the previously-loaded model released) on the
+    next generation, without a process restart.
+    """
+    global _default
+    with _default_lock:
+        _default = None
 
 
 # Friendly alias: the backend is "llama.cpp", the model format is "GGUF".

--- a/core/model_providers/registry.py
+++ b/core/model_providers/registry.py
@@ -97,6 +97,21 @@ def get_provider(name: Optional[str] = None) -> ModelProvider:
         return instance
 
 
+def evict_provider(name: str) -> None:
+    """Drop the cached instance for ``name`` so the next resolve rebuilds it.
+
+    Used when a provider's *resolved configuration* changes at runtime —
+    e.g. an admin updates the GGUF model path — so the change takes effect
+    on the next :func:`get_provider` without a process restart. Unknown /
+    blank names are a no-op; the factory itself is left registered.
+    """
+    key = (name or "").strip().lower()
+    if not key:
+        return
+    with _lock:
+        _instances.pop(key, None)
+
+
 def set_override(provider: Optional[ModelProvider]) -> None:
     """Force :func:`get_provider` to return ``provider`` (tests only).
 

--- a/docs/local-gguf.md
+++ b/docs/local-gguf.md
@@ -1,9 +1,12 @@
 # Running Nova with a local GGUF model (llama.cpp)
 
-> **Status: shipped (Phase 1, optional, local-first).**
+> **Status: shipped (Phase 1 + Phase 2, optional, local-first).**
 > This document describes the optional `llamacpp` model provider, which
 > lets Nova generate text from a local `.gguf` model **without Ollama**.
-> It lives inside the boundaries set by
+> Phase 1 added the provider itself; **Phase 2 adds a small admin-only UI
+> for setting and validating the model path** (Settings → Models → "Local
+> GGUF model") so you no longer have to edit `.env` by hand. It lives
+> inside the boundaries set by
 > [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md)
 > and complements [`docs/model-providers.md`](model-providers.md), which
 > explains the provider seam itself. **Ollama remains Nova's default and
@@ -20,11 +23,14 @@ bindings for [llama.cpp](https://github.com/ggml-org/llama.cpp)). This
 makes Ollama **no longer architecturally required**: you can run Nova on
 a host that has only a model file and the `llama-cpp-python` wheel.
 
-What this phase deliberately does **not** do:
+What this provider deliberately does **not** do:
 
 - it does **not** remove or replace Ollama (still the default),
 - it does **not** download, fetch, or auto-convert any model,
-- it does **not** add a cloud provider, an API key, or a model-manager UI,
+- it does **not** add a cloud provider, an API key, or a model-download manager,
+- it does **not** add a filesystem browser — the Phase-2 UI validates the
+  one path you paste, it never lists or scans a directory,
+- it does **not** delete or overwrite any model file,
 - it does **not** change memory, projects, storage, export/restore, or
   the Dev Workspace.
 
@@ -62,7 +68,17 @@ data is migrated and nothing is deleted.
 ### Recommended model directory
 
 Keep models out of the Nova checkout and the data directory, on storage
-with room to spare:
+with room to spare. Create the directory and drop your `.gguf` file in:
+
+```bash
+# Create the recommended directory (or set NOVA_MODEL_DIR to your own).
+sudo mkdir -p /mnt/archive/nova-models
+# Make it readable by the user Nova runs as (adjust the user/group).
+sudo chown "$USER" /mnt/archive/nova-models
+
+# Place a .gguf model you already have inside it (Nova never downloads one).
+cp ~/Downloads/mistral-7b-instruct-v0.2.Q4_K_M.gguf /mnt/archive/nova-models/
+```
 
 ```
 /mnt/archive/nova-models/
@@ -71,9 +87,15 @@ with room to spare:
 
 Use a stable mount path defined in `/etc/fstab` (not a transient
 `/run/media/...` desktop mount) so a long-running service can always
-find the file. This directory is **only** read by the GGUF provider when
-you point `NOVA_GGUF_MODEL_PATH` at a file inside it; Nova never lists,
-scans, or browses it, and never exposes its contents through the UI.
+find the file. Override the location with `NOVA_MODEL_DIR` if
+`/mnt/archive/nova-models` does not suit your host.
+
+This directory is the **allowed model directory**: the admin UI (and the
+configured path) only accept a model file that resolves *inside* it. Nova
+never lists, scans, browses, or downloads into it, and never exposes its
+contents through the UI — it validates exactly the one path you point it
+at. Putting your model here is what makes the Phase-2 "set the path from
+Settings" flow work.
 
 ## Configuration
 
@@ -83,7 +105,8 @@ Nova's config). Only `NOVA_GGUF_MODEL_PATH` is required.
 | Variable | Default | Description |
 |---|---|---|
 | `NOVA_MODEL_PROVIDER` | `ollama` | Set to `llamacpp` to use this provider. Any other value (or unset) keeps Ollama. |
-| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file. Empty leaves the provider unconfigured (a clean health failure, never a crash). |
+| `NOVA_MODEL_DIR` | `/mnt/archive/nova-models` | Directory local `.gguf` files must live inside. The admin UI only accepts a model path that resolves inside this directory (no arbitrary files, no path traversal). |
+| `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file. Empty leaves the provider unconfigured (a clean health failure, never a crash). An admin-set path (below) takes precedence over this. |
 | `NOVA_GGUF_CONTEXT_SIZE` | `4096` | Context window (`n_ctx`). A non-positive or unparseable value falls back to `4096`. |
 | `NOVA_GGUF_THREADS` | `0` | CPU threads (`n_threads`). `0` lets llama.cpp choose. |
 | `NOVA_GGUF_GPU_LAYERS` | `0` | Layers to offload to GPU (`n_gpu_layers`). `0` keeps inference on CPU. Requires a GPU-enabled `llama-cpp-python` build. |
@@ -92,6 +115,7 @@ Example `.env`:
 
 ```bash
 NOVA_MODEL_PROVIDER=llamacpp
+NOVA_MODEL_DIR=/mnt/archive/nova-models
 NOVA_GGUF_MODEL_PATH=/mnt/archive/nova-models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
 NOVA_GGUF_CONTEXT_SIZE=4096
 # NOVA_GGUF_THREADS=8         # optional; 0 = auto
@@ -103,6 +127,39 @@ After editing `.env`, restart Nova. To confirm the backend, open
 cheap, read-only liveness probe. With the GGUF provider configured the
 probe reports the model's filename when the dependency and path are in
 place, or a clear reason when either is missing.
+
+## Setting the model path from the UI (no `.env` edit) — Phase 2
+
+You do not have to edit `.env` to point Nova at a model. As an admin,
+open **Settings → Models → "Local GGUF model"**. The card shows:
+
+- the **configured provider** (and whether the GGUF provider is active),
+- the **model directory** (`NOVA_MODEL_DIR`) and whether it exists,
+- the **configured model path**, where it came from (saved here, from the
+  environment, or not set), and whether it currently passes validation.
+
+Paste an absolute path to a `.gguf` file **inside the model directory**
+and click **Validate & save path**. The server validates the path before
+storing it; the saved value is kept in Nova's database and **takes
+precedence** over `NOVA_GGUF_MODEL_PATH`, taking effect on the next
+message without a restart. Click **Test GGUF provider** to check the
+model is valid enough to attempt loading (path is valid *and*
+`llama-cpp-python` is installed) — it never loads the multi-GB weights.
+
+A path is accepted only when **all** of these hold; otherwise the save is
+refused with a short, sanitised reason and nothing is written:
+
+- it is an **absolute** path containing no `..` and no `~`,
+- it ends in **`.gguf`**,
+- it resolves (symlinks included) **inside** `NOVA_MODEL_DIR`,
+- the file **exists**, is a **regular file** (not a directory), and is
+  **readable** by the Nova service user.
+
+There is **no file browser**: Nova validates exactly the one path you
+paste and never lists or scans the directory. The setting is host-wide
+(an operator decision, like the default model), admin-only, and never
+reachable through the per-user settings path. It never downloads,
+deletes, or overwrites a model.
 
 ## How model selection interacts
 
@@ -138,11 +195,20 @@ load fails with a sanitised error and chat falls back to the standard
 
 ## Safety notes
 
-- **No downloads.** Nova never fetches a model in this phase. You provide
-  the file.
-- **No shell, no scan.** The provider never runs a shell command and
-  never walks the filesystem. It validates exactly the one path you
-  configured (readable regular `.gguf` file) and refuses anything else.
+- **No downloads.** Nova never fetches a model. You provide the file.
+- **Directory-confined paths.** The admin UI (and the validation behind
+  it) only accepts a model path that resolves inside `NOVA_MODEL_DIR`,
+  defeating path traversal and arbitrary-file exposure. Symlinks are
+  resolved before the containment check, so a link that escapes the
+  directory is refused.
+- **No file browser, no scan.** The UI validates exactly the one path you
+  paste — it never lists, scans, or walks the directory, and the provider
+  never runs a shell command.
+- **No deletion, no overwrite.** Configuring a path only records *which*
+  file to use; Nova never removes or replaces a model file.
+- **Admin-only, host-wide.** The model path is an operator decision (a
+  single global setting), gated to admins, and never reachable through
+  the per-user settings path.
 - **Sanitised errors.** Operator-facing messages name the relevant
   environment variable and the problem; they never echo the absolute
   model path or a raw backend exception. Full detail is in the server
@@ -161,8 +227,10 @@ load fails with a sanitised error and chat falls back to the standard
 | Symptom (Test connection / chat) | Likely cause | Fix |
 |---|---|---|
 | "llama-cpp-python is not installed" | The optional wheel is missing | `pip install llama-cpp-python` in Nova's environment |
-| "No GGUF model configured" | `NOVA_GGUF_MODEL_PATH` is empty | Set it to your `.gguf` file |
-| "must point at a .gguf model file" | Wrong extension | Point at the actual `.gguf` file, not a directory or other format |
-| "GGUF model file not found" | Path typo / file moved / disk not mounted | Check the path; confirm the mount is up |
-| "model file is not readable" | Permissions | Make the file readable by the Nova service user |
-| "Failed to load the GGUF model" | Corrupt file or not enough memory | Re-download the model out of band; try a smaller quant; check free RAM |
+| "No GGUF model configured" / "No GGUF model is configured" | No path set (env or UI) | Set `NOVA_GGUF_MODEL_PATH`, or paste a path in Settings → Models |
+| "must be a .gguf file" / "must point at a .gguf model file" | Wrong extension | Point at the actual `.gguf` file, not a directory or other format |
+| "must be inside the configured model directory" | Path is outside `NOVA_MODEL_DIR` | Move the model into the model directory, or set `NOVA_MODEL_DIR` to where it lives |
+| "must not contain '..'" / "must be an absolute path" | Relative or traversal path pasted in the UI | Paste a full absolute path inside the model directory |
+| "No file exists at that path" / "GGUF model file not found" | Path typo / file moved / disk not mounted | Check the path; confirm the mount is up |
+| "not readable" | Permissions | Make the file readable by the Nova service user |
+| "Failed to load the GGUF model" | Corrupt file or not enough memory | Replace the model out of band; try a smaller quant; check free RAM |

--- a/static/index.html
+++ b/static/index.html
@@ -3786,6 +3786,44 @@
                         <div id="settings-default-model-error" style="color:var(--danger);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
                         <div id="settings-default-model-ok" style="color:var(--text-dim);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
                     </div>
+
+                    <!--
+                      Local GGUF model (admin-only). Configures the .gguf
+                      model the optional llama.cpp provider serves, without
+                      editing .env. The pasted path is validated on the
+                      server — it must resolve inside the configured model
+                      directory (NOVA_MODEL_DIR) and be an existing readable
+                      .gguf file — before anything is persisted. Nothing is
+                      downloaded, scanned, deleted, or overwritten, and no
+                      file browser is exposed: Nova validates exactly the one
+                      path. Ollama stays the default; this only takes effect
+                      when NOVA_MODEL_PROVIDER=llamacpp. Hidden for non-admins
+                      (the endpoints are admin-only and would 403).
+                    -->
+                    <div class="settings-row" id="settings-gguf-row" style="display:none;">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="settings-gguf-title">Local GGUF model</span>
+                                <span class="settings-row-hint" id="settings-gguf-hint">Point the local llama.cpp provider at a .gguf file inside the model directory. Validated · admin-only.</span>
+                            </div>
+                            <button class="memory-btn" id="settings-gguf-refresh-btn" onclick="loadGgufCard()" style="white-space:nowrap;">Refresh</button>
+                        </div>
+                        <div id="settings-gguf-summary" style="margin-top:10px;">
+                            <div class="admin-empty">Loading…</div>
+                        </div>
+                        <div id="settings-gguf-editor" style="margin-top:10px;display:none;flex-direction:column;gap:8px;">
+                            <input id="settings-gguf-path-input" type="text" placeholder="/mnt/archive/nova-models/model.gguf"
+                                style="width:100%;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:monospace;font-size:0.8rem;padding:6px 10px;outline:none;box-sizing:border-box;"
+                                onkeydown="if(event.key==='Enter')saveGgufModelPath()" />
+                            <div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;">
+                                <button class="memory-btn" id="settings-gguf-save-btn" onclick="saveGgufModelPath()" style="white-space:nowrap;">Validate &amp; save path</button>
+                                <button class="memory-btn" id="settings-gguf-test-btn" onclick="testGgufProvider()" style="white-space:nowrap;">Test GGUF provider</button>
+                            </div>
+                        </div>
+                        <div id="settings-gguf-error" style="color:var(--danger);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
+                        <div id="settings-gguf-ok" style="color:var(--text-dim);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
+                        <div id="settings-gguf-test-result" style="margin-top:8px;"></div>
+                    </div>
                 </section>
 
                 <!-- ADMIN (admin-only) -->
@@ -8816,6 +8854,7 @@
         if (pane === "models") {
             loadModelsProviderCard().catch(() => {});
             loadDefaultModelCard().catch(() => {});
+            loadGgufCard().catch(() => {});
         }
     }
 
@@ -10828,6 +10867,244 @@
             loadDefaultModelCard().catch(() => {});
         } catch (e) {
             if (errEl) errEl.textContent = "Network error while saving the default model.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    }
+
+    // ── Settings → Models: local GGUF model path (admin-only) ─────
+    //
+    // Configures the .gguf model the optional llama.cpp provider serves
+    // without editing .env. Admin-gated on the client (the row is hidden
+    // for non-admins) and on the server (the endpoints are
+    // require_admin). The pasted path is validated on the server — it
+    // must resolve inside NOVA_MODEL_DIR and be an existing readable
+    // .gguf file — before it is persisted. Nothing is downloaded,
+    // scanned, deleted, or overwritten; there is no file browser.
+    async function loadGgufCard() {
+        const row = document.getElementById("settings-gguf-row");
+        if (!row) return;
+        const isAdmin = !!(currentUser && currentUser.role === "admin");
+        if (!isAdmin) { row.style.display = "none"; return; }
+        row.style.display = "";
+        const summary = document.getElementById("settings-gguf-summary");
+        const errEl = document.getElementById("settings-gguf-error");
+        const okEl = document.getElementById("settings-gguf-ok");
+        const resEl = document.getElementById("settings-gguf-test-result");
+        if (errEl) errEl.textContent = "";
+        if (okEl) okEl.textContent = "";
+        if (resEl) resEl.innerHTML = "";
+        if (summary) summary.innerHTML = '<div class="admin-empty">Loading…</div>';
+        try {
+            const res = await fetch("/admin/provider/gguf", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) { row.style.display = "none"; return; }
+            if (!res.ok) {
+                if (summary) summary.innerHTML = '<div class="admin-empty">Failed to load GGUF settings.</div>';
+                return;
+            }
+            renderGgufCard(await res.json());
+        } catch (e) {
+            if (summary) summary.innerHTML = '<div class="admin-empty">Failed to load GGUF settings.</div>';
+        }
+    }
+
+    function renderGgufCard(status) {
+        const summary = document.getElementById("settings-gguf-summary");
+        const editor = document.getElementById("settings-gguf-editor");
+        const input = document.getElementById("settings-gguf-path-input");
+        if (!summary) return;
+        const provider = escapeHtml(status.provider || "ollama");
+        const providerTag = status.is_llamacpp
+            ? `<span class="admin-tag installed">active</span>`
+            : `<span class="admin-tag">inactive</span>`;
+        const dirTag = status.model_dir_is_dir
+            ? `<span class="admin-tag installed">present</span>`
+            : `<span class="admin-tag error">missing</span>`;
+        const pathStr = status.configured_path
+            ? escapeHtml(status.configured_path) : "—";
+        const sourceLabel = ({ custom: "saved here", env: "from environment", unset: "not set" })[status.path_source] || status.path_source || "";
+        let pathTag;
+        if (status.path_source === "unset") {
+            pathTag = `<span class="admin-tag">not set</span>`;
+        } else if (status.path_valid) {
+            pathTag = `<span class="admin-tag installed">valid</span>`;
+        } else {
+            pathTag = `<span class="admin-tag error">invalid</span>`;
+        }
+        const parts = [];
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">GGUF provider (llama.cpp)</span>` +
+            providerTag +
+            `</div>` +
+            `<div class="admin-progress-meta">configured provider: <code>${provider}</code> · default: <code>${escapeHtml(status.default_provider || "ollama")}</code></div>` +
+            `</div>`
+        );
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">model directory</span>` +
+            dirTag +
+            `</div>` +
+            `<div class="admin-model-name">${escapeHtml(status.model_dir || "—")}</div>` +
+            `</div>`
+        );
+        parts.push(
+            `<div class="admin-model-row">` +
+            `<div class="admin-model-head">` +
+            `<span class="admin-model-display">configured model path</span>` +
+            pathTag +
+            `</div>` +
+            `<div class="admin-model-name">${pathStr}</div>` +
+            (sourceLabel ? `<div class="admin-progress-meta">source: <code>${escapeHtml(sourceLabel)}</code></div>` : "") +
+            `</div>`
+        );
+        if (!status.model_dir_is_dir) {
+            parts.push(
+                `<div class="admin-warning warning">` +
+                `<span class="admin-warning-level">warning</span>` +
+                `<span class="admin-warning-msg">The model directory does not exist yet. Create it (or set NOVA_MODEL_DIR) and place your .gguf file inside it.</span>` +
+                `</div>`
+            );
+        }
+        if (status.configured_path && !status.path_valid && status.path_detail) {
+            parts.push(
+                `<div class="admin-warning error">` +
+                `<span class="admin-warning-level">error</span>` +
+                `<span class="admin-warning-msg">${escapeHtml(status.path_detail)}</span>` +
+                `</div>`
+            );
+        }
+        if (!status.is_llamacpp) {
+            parts.push(
+                `<div class="admin-warning info">` +
+                `<span class="admin-warning-level">info</span>` +
+                `<span class="admin-warning-msg">Ollama is the active provider. This GGUF configuration takes effect when NOVA_MODEL_PROVIDER=llamacpp.</span>` +
+                `</div>`
+            );
+        }
+        summary.innerHTML = parts.join("");
+        // Pre-fill the editor with the current path so an admin can tweak
+        // it rather than retype the whole thing.
+        if (input && document.activeElement !== input) {
+            input.value = status.configured_path || "";
+        }
+        if (editor) editor.style.display = "flex";
+    }
+
+    async function saveGgufModelPath() {
+        const input = document.getElementById("settings-gguf-path-input");
+        const btn = document.getElementById("settings-gguf-save-btn");
+        const errEl = document.getElementById("settings-gguf-error");
+        const okEl = document.getElementById("settings-gguf-ok");
+        const resEl = document.getElementById("settings-gguf-test-result");
+        if (errEl) errEl.textContent = "";
+        if (okEl) okEl.textContent = "";
+        if (resEl) resEl.innerHTML = "";
+        if (!input || !btn) return;
+        const path = (input.value || "").trim();
+        if (!path) {
+            if (errEl) errEl.textContent = "Paste the path to a .gguf file inside the model directory.";
+            return;
+        }
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Saving…";
+        try {
+            const res = await fetch("/admin/provider/gguf/model-path", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ path }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                if (errEl) errEl.textContent = "Access denied.";
+                return;
+            }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const b = await res.json();
+                    if (b && b.detail) detail = b.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            if (okEl) okEl.textContent = `Saved. Nova will use ${body.filename || "this model"} when the GGUF provider is active.`;
+            renderGgufCard(body);
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while saving the model path.";
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    }
+
+    async function testGgufProvider() {
+        const btn = document.getElementById("settings-gguf-test-btn");
+        const errEl = document.getElementById("settings-gguf-error");
+        const resEl = document.getElementById("settings-gguf-test-result");
+        if (errEl) errEl.textContent = "";
+        if (resEl) resEl.innerHTML = "";
+        if (!btn) return;
+        const original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = "Testing…";
+        try {
+            const res = await fetch("/admin/provider/gguf/test", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: "{}",
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                if (errEl) errEl.textContent = "Access denied.";
+                return;
+            }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const b = await res.json();
+                    if (b && b.detail) detail = b.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            const ok = body && body.ok === true;
+            const tag = ok
+                ? `<span class="admin-tag installed">ready</span>`
+                : `<span class="admin-tag error">not ready</span>`;
+            const fileLine = body.filename
+                ? `<div class="admin-progress-meta">model: <code>${escapeHtml(body.filename)}</code></div>`
+                : "";
+            const detailLine = body.detail
+                ? `<div class="admin-warning ${ok ? "info" : "error"}"><span class="admin-warning-level">${ok ? "info" : "error"}</span><span class="admin-warning-msg">${escapeHtml(body.detail)}</span></div>`
+                : "";
+            if (resEl) resEl.innerHTML =
+                `<div class="admin-section-title">GGUF provider test result</div>` +
+                `<div class="admin-model-row">` +
+                `<div class="admin-model-head">` +
+                `<span class="admin-model-display">backend: ${escapeHtml(body.provider || "llamacpp")}</span>` +
+                tag +
+                `</div>` +
+                fileLine +
+                `</div>` +
+                detailLine;
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while testing the GGUF provider.";
         } finally {
             btn.disabled = false;
             btn.textContent = original;

--- a/tests/test_gguf_endpoints.py
+++ b/tests/test_gguf_endpoints.py
@@ -1,0 +1,310 @@
+"""Wire-level tests for the admin-only ``/admin/provider/gguf*`` endpoints.
+
+Pins the contract of the GGUF Phase-2 surface:
+
+* all three endpoints are admin-only — non-admin and restricted users get
+  403, unauthenticated callers get 401 / 403;
+* ``GET /admin/provider/gguf`` returns the stable status shape and shows
+  the configured GGUF path safely (the model directory + the one
+  operator-set path, never an arbitrary file listing);
+* ``POST /admin/provider/gguf/model-path`` validates the pasted path
+  against the model directory before persisting — a path outside the dir
+  / a non-``.gguf`` file / a missing file is a sanitised 400 and a
+  follow-up status shows nothing was written; a valid path persists;
+* ``POST /admin/provider/gguf/test`` is a calm 200 with the
+  ``{ok, provider, detail, filename, path_valid}`` shape even when no
+  path is configured;
+* Ollama remains the default provider throughout.
+
+Mirrors ``tests/test_provider_endpoints.py`` fixtures so the provider
+suites stay consistent.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod in ("ddgs", "duckduckgo_search", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core import memory as core_memory, users  # noqa: E402
+from core.model_providers import reset as reset_registry  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+@pytest.fixture
+def model_dir(tmp_path):
+    d = tmp_path / "nova-models"
+    d.mkdir()
+    return d
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+# ── Auth gating ─────────────────────────────────────────────────────
+
+
+_ENDPOINTS = [
+    ("GET", "/admin/provider/gguf", None),
+    ("POST", "/admin/provider/gguf/model-path", {"path": "/x/m.gguf"}),
+    ("POST", "/admin/provider/gguf/test", {}),
+]
+
+
+class TestGgufEndpointsAuth:
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_non_admin_forbidden(self, web_client, user_token, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(user_token))
+        else:
+            resp = web_client.post(path, headers=_h(user_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_restricted_forbidden(self, web_client, restricted_token, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(restricted_token))
+        else:
+            resp = web_client.post(path, headers=_h(restricted_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_unauthenticated_blocked(self, web_client, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path)
+        else:
+            resp = web_client.post(path, json=body)
+        assert resp.status_code in (401, 403)
+
+
+# ── GET /admin/provider/gguf ────────────────────────────────────────
+
+
+class TestGgufStatusEndpoint:
+    def test_status_shape_defaults(self, web_client, admin_token, monkeypatch, model_dir):
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.get("/admin/provider/gguf", headers=_h(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["provider"] == "ollama"
+        assert body["is_llamacpp"] is False
+        assert body["default_provider"] == "ollama"
+        assert body["model_dir"] == str(model_dir)
+        assert body["configured_path"] == ""
+        assert body["path_source"] == "unset"
+        assert body["path_valid"] is False
+
+    def test_status_shows_configured_path_safely(
+        self, web_client, admin_token, monkeypatch, model_dir,
+    ):
+        f = model_dir / "model.gguf"
+        f.write_bytes(b"GGUF\x00")
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(f))
+        resp = web_client.get("/admin/provider/gguf", headers=_h(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_llamacpp"] is True
+        assert body["configured_path"] == str(f.resolve())
+        assert body["filename"] == "model.gguf"
+        assert body["path_valid"] is True
+        assert body["path_source"] == "env"
+
+
+# ── POST /admin/provider/gguf/model-path ────────────────────────────
+
+
+class TestGgufSetPathEndpoint:
+    def test_valid_path_persists(self, web_client, admin_token, monkeypatch, model_dir):
+        f = model_dir / "model.gguf"
+        f.write_bytes(b"GGUF\x00")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": str(f)},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["configured_path"] == str(f.resolve())
+        assert body["path_source"] == "custom"
+        assert body["path_valid"] is True
+        # A follow-up status reflects the persisted choice.
+        status = web_client.get("/admin/provider/gguf", headers=_h(admin_token)).json()
+        assert status["configured_path"] == str(f.resolve())
+        assert status["path_source"] == "custom"
+
+    def test_path_outside_model_dir_is_400(self, web_client, admin_token, monkeypatch, tmp_path, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        outside = tmp_path / "evil.gguf"
+        outside.write_bytes(b"GGUF\x00")
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": str(outside)},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "inside the configured model directory" in resp.json()["detail"]
+        # Nothing was written.
+        status = web_client.get("/admin/provider/gguf", headers=_h(admin_token)).json()
+        assert status["configured_path"] == ""
+
+    def test_non_gguf_file_is_400(self, web_client, admin_token, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        bad = model_dir / "model.bin"
+        bad.write_bytes(b"nope")
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": str(bad)},
+        )
+        assert resp.status_code == 400, resp.text
+        assert ".gguf" in resp.json()["detail"]
+
+    def test_missing_file_is_400(self, web_client, admin_token, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": str(model_dir / "absent.gguf")},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "No file exists" in resp.json()["detail"]
+
+    def test_traversal_is_400(self, web_client, admin_token, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": str(model_dir / ".." / "secret.gguf")},
+        )
+        assert resp.status_code == 400, resp.text
+        assert ".." in resp.json()["detail"]
+
+    def test_empty_path_is_422(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_extra_field_is_rejected(self, web_client, admin_token, model_dir):
+        resp = web_client.post(
+            "/admin/provider/gguf/model-path",
+            headers=_h(admin_token),
+            json={"path": "/x/m.gguf", "provider": "evil"},
+        )
+        assert resp.status_code == 422
+
+
+# ── POST /admin/provider/gguf/test ──────────────────────────────────
+
+
+class TestGgufTestEndpoint:
+    def test_no_path_is_calm_200(self, web_client, admin_token, monkeypatch):
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post("/admin/provider/gguf/test", headers=_h(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["provider"] == "llamacpp"
+        assert body["path_valid"] is False
+        assert body["detail"]
+
+    def test_invalid_path_is_calm_200(self, web_client, admin_token, monkeypatch, tmp_path, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        outside = tmp_path / "outside.gguf"
+        outside.write_bytes(b"GGUF\x00")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(outside))
+        resp = web_client.post("/admin/provider/gguf/test", headers=_h(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["path_valid"] is False
+        assert "inside the configured model directory" in body["detail"]

--- a/tests/test_gguf_settings.py
+++ b/tests/test_gguf_settings.py
@@ -30,7 +30,6 @@ tiny dummy file stands in for one.
 
 from __future__ import annotations
 
-import sqlite3
 import sys
 from unittest.mock import MagicMock
 

--- a/tests/test_gguf_settings.py
+++ b/tests/test_gguf_settings.py
@@ -1,0 +1,337 @@
+"""Tests for the admin-configurable local GGUF model path (Phase 2).
+
+Pinned contracts (see ``core/gguf_settings.py``):
+
+* :func:`validate_gguf_model_path` accepts a readable ``.gguf`` file that
+  resolves inside the allowed model directory, and refuses everything
+  else with a sanitised :class:`GgufModelPathError`:
+
+    - a non-``.gguf`` file,
+    - a missing file,
+    - a directory,
+    - a path outside the model directory,
+    - ``..`` traversal,
+    - a symlink that escapes the model directory,
+    - a relative path / ``~`` expansion / empty / NUL-bearing input;
+
+* :func:`resolve_gguf_model_path` prefers the persisted setting over the
+  env value and never raises (no DB → env fallback);
+* :func:`gguf_status` reports the configured path + directory state
+  without loading a model;
+* :func:`set_gguf_model_path` validates before persisting and writes
+  nothing on failure;
+* :func:`test_gguf_provider` reports a missing path / invalid path as a
+  calm ``ok=False`` with a sanitised detail (no real wheel needed).
+
+No real ``llama-cpp-python`` wheel and no real ``.gguf`` weights are
+needed — the validator only checks for a readable ``.gguf`` file, so a
+tiny dummy file stands in for one.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub optional wheels so importing the provider package (pulled in by
+# the cache-invalidation / probe helpers) works on a minimal host.
+for _mod in ("ddgs", "duckduckgo_search", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import gguf_settings as gs  # noqa: E402
+from core import memory as core_memory  # noqa: E402
+from core.gguf_settings import GgufModelPathError  # noqa: E402
+from core.model_providers import reset as reset_registry  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+@pytest.fixture
+def model_dir(tmp_path):
+    d = tmp_path / "nova-models"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def gguf_file(model_dir):
+    """A readable dummy ``.gguf`` file inside the model directory."""
+    path = model_dir / "model.gguf"
+    path.write_bytes(b"GGUF\x00 not real weights")
+    return path
+
+
+# ── validate_gguf_model_path ─────────────────────────────────────────
+
+
+class TestValidatePathAccepts:
+    def test_accepts_gguf_inside_model_dir(self, model_dir, gguf_file):
+        result = gs.validate_gguf_model_path(str(gguf_file), str(model_dir))
+        # Returns the fully resolved absolute path (canonical form).
+        assert result == str(gguf_file.resolve())
+
+    def test_accepts_gguf_in_subdir_of_model_dir(self, model_dir):
+        sub = model_dir / "team-a"
+        sub.mkdir()
+        f = sub / "m.gguf"
+        f.write_bytes(b"GGUF\x00")
+        result = gs.validate_gguf_model_path(str(f), str(model_dir))
+        assert result == str(f.resolve())
+
+    def test_uppercase_extension_is_accepted(self, model_dir):
+        f = model_dir / "Model.GGUF"
+        f.write_bytes(b"GGUF\x00")
+        result = gs.validate_gguf_model_path(str(f), str(model_dir))
+        assert result == str(f.resolve())
+
+
+class TestValidatePathRejects:
+    def test_rejects_non_gguf_file(self, model_dir):
+        bad = model_dir / "model.bin"
+        bad.write_bytes(b"not gguf")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(bad), str(model_dir))
+        assert ".gguf" in str(exc.value)
+
+    def test_rejects_missing_file(self, model_dir):
+        missing = model_dir / "absent.gguf"
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(missing), str(model_dir))
+        assert "No file exists" in str(exc.value)
+        # The absolute path must not be echoed back.
+        assert str(missing) not in str(exc.value)
+
+    def test_rejects_directory(self, model_dir):
+        # A directory named with a .gguf suffix passes the extension gate
+        # but must be refused by the is-file check.
+        d = model_dir / "weights.gguf"
+        d.mkdir()
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(d), str(model_dir))
+        assert "not a file" in str(exc.value)
+
+    def test_rejects_path_outside_model_dir(self, tmp_path, model_dir):
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        f = outside / "model.gguf"
+        f.write_bytes(b"GGUF\x00")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(f), str(model_dir))
+        assert "inside the configured model directory" in str(exc.value)
+
+    def test_rejects_sibling_prefix_directory(self, tmp_path):
+        # "/x/nova-models-evil" must not be treated as inside
+        # "/x/nova-models" just because of the shared string prefix.
+        allowed = tmp_path / "nova-models"
+        allowed.mkdir()
+        evil = tmp_path / "nova-models-evil"
+        evil.mkdir()
+        f = evil / "model.gguf"
+        f.write_bytes(b"GGUF\x00")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(f), str(allowed))
+        assert "inside the configured model directory" in str(exc.value)
+
+    def test_rejects_dotdot_traversal(self, model_dir):
+        traversal = str(model_dir / ".." / "secret.gguf")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(traversal, str(model_dir))
+        assert ".." in str(exc.value)
+
+    def test_rejects_symlink_escaping_model_dir(self, tmp_path, model_dir):
+        # A symlink *inside* the model dir whose target is *outside* it
+        # must be refused — resolve() follows the link before the
+        # containment check.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = outside / "real.gguf"
+        target.write_bytes(b"GGUF\x00")
+        link = model_dir / "link.gguf"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(link), str(model_dir))
+        assert "inside the configured model directory" in str(exc.value)
+
+    def test_rejects_relative_path(self, model_dir):
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path("model.gguf", str(model_dir))
+        assert "absolute" in str(exc.value)
+
+    def test_rejects_tilde_path(self, model_dir):
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path("~/model.gguf", str(model_dir))
+        assert "absolute" in str(exc.value)
+
+    def test_rejects_empty(self, model_dir):
+        with pytest.raises(GgufModelPathError):
+            gs.validate_gguf_model_path("   ", str(model_dir))
+
+    def test_rejects_nul_byte(self, model_dir):
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path("/x/m\x00.gguf", str(model_dir))
+        assert "invalid characters" in str(exc.value)
+
+    def test_rejects_when_no_model_dir_configured(self, gguf_file):
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.validate_gguf_model_path(str(gguf_file), "")
+        assert "NOVA_MODEL_DIR" in str(exc.value)
+
+    def test_rejects_non_string(self, model_dir):
+        with pytest.raises(GgufModelPathError):
+            gs.validate_gguf_model_path(1234, str(model_dir))
+
+
+# ── resolve_model_dir / resolve_gguf_model_path ──────────────────────
+
+
+class TestResolution:
+    def test_model_dir_defaults_to_recommended(self, monkeypatch):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", "")
+        assert gs.resolve_model_dir() == "/mnt/archive/nova-models"
+
+    def test_model_dir_honours_config(self, monkeypatch):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", "/srv/models")
+        assert gs.resolve_model_dir() == "/srv/models"
+
+    def test_resolve_falls_back_to_env_without_db(self, monkeypatch, tmp_path):
+        # No DB on disk → no persisted value → env path is used and no
+        # stray database file is created.
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "absent.db"))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "/env/model.gguf")
+        assert gs.resolve_gguf_model_path() == "/env/model.gguf"
+        assert not (tmp_path / "absent.db").exists()
+
+    def test_persisted_path_overrides_env(self, monkeypatch, tmp_path):
+        db = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", db)
+        monkeypatch.setattr(natural_store, "DB_PATH", db)
+        core_memory.initialize_db()
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "/env/model.gguf")
+        from core.settings import save_system_setting
+
+        save_system_setting(gs.GGUF_MODEL_PATH_SETTING_KEY, "/custom/m.gguf")
+        assert gs.resolve_gguf_model_path() == "/custom/m.gguf"
+
+
+# ── gguf_status ──────────────────────────────────────────────────────
+
+
+class TestStatus:
+    def test_shape_and_unset_state(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "none.db"))
+        monkeypatch.setattr("config.MODEL_PROVIDER", "ollama")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(tmp_path / "nova-models"))
+        status = gs.gguf_status()
+        assert status["provider"] == "ollama"
+        assert status["is_llamacpp"] is False
+        assert status["default_provider"] == "ollama"
+        assert status["model_dir"] == str(tmp_path / "nova-models")
+        assert status["model_dir_exists"] is False
+        assert status["configured_path"] == ""
+        assert status["path_source"] == "unset"
+        assert status["path_valid"] is False
+        assert status["filename"] == ""
+
+    def test_reports_env_path_validity(self, monkeypatch, tmp_path, gguf_file, model_dir):
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "none.db"))
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(gguf_file))
+        status = gs.gguf_status()
+        assert status["is_llamacpp"] is True
+        assert status["path_source"] == "env"
+        assert status["path_valid"] is True
+        assert status["filename"] == "model.gguf"
+        assert status["configured_path"] == str(gguf_file.resolve())
+
+    def test_reports_invalid_env_path_with_detail(self, monkeypatch, tmp_path, model_dir):
+        # An env path outside the model dir is surfaced as invalid with a
+        # sanitised detail rather than silently accepted.
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "none.db"))
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        outside = tmp_path / "outside.gguf"
+        outside.write_bytes(b"GGUF\x00")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(outside))
+        status = gs.gguf_status()
+        assert status["path_valid"] is False
+        assert status["path_detail"]
+
+
+# ── set_gguf_model_path ──────────────────────────────────────────────
+
+
+class TestSetPath:
+    @pytest.fixture
+    def db(self, monkeypatch, tmp_path):
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        core_memory.initialize_db()
+        reset_registry()
+        yield path
+        reset_registry()
+
+    def test_valid_path_persists(self, db, monkeypatch, model_dir, gguf_file):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.set_gguf_model_path(str(gguf_file))
+        assert out["configured_path"] == str(gguf_file.resolve())
+        assert out["path_source"] == "custom"
+        assert out["path_valid"] is True
+        # A follow-up resolve reflects the persisted choice.
+        assert gs.resolve_gguf_model_path() == str(gguf_file.resolve())
+
+    def test_invalid_path_writes_nothing(self, db, monkeypatch, model_dir, tmp_path):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        outside = tmp_path / "evil.gguf"
+        outside.write_bytes(b"GGUF\x00")
+        with pytest.raises(GgufModelPathError):
+            gs.set_gguf_model_path(str(outside))
+        # Nothing persisted → resolve falls back to the (empty) env value.
+        assert gs.resolve_gguf_model_path() == ""
+
+
+# ── test_gguf_provider ───────────────────────────────────────────────
+
+
+class TestProviderTest:
+    def test_no_path_is_calm_failure(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "none.db"))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        result = gs.test_gguf_provider()
+        assert result["ok"] is False
+        assert result["provider"] == "llamacpp"
+        assert result["path_valid"] is False
+        assert "No GGUF model" in result["detail"]
+
+    def test_invalid_path_is_calm_failure(self, monkeypatch, tmp_path, model_dir):
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "none.db"))
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        outside = tmp_path / "outside.gguf"
+        outside.write_bytes(b"GGUF\x00")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(outside))
+        result = gs.test_gguf_provider()
+        assert result["ok"] is False
+        assert result["path_valid"] is False
+        assert "inside the configured model directory" in result["detail"]
+
+    def test_valid_path_reports_path_valid(self, monkeypatch, tmp_path, model_dir, gguf_file):
+        # The dependency may be absent in CI; either way the path is valid
+        # and the detail is a clean, non-sensitive string.
+        monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "none.db"))
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(gguf_file))
+        result = gs.test_gguf_provider()
+        assert result["path_valid"] is True
+        assert result["filename"] == "model.gguf"
+        assert isinstance(result["detail"], str) and result["detail"]

--- a/web.py
+++ b/web.py
@@ -72,6 +72,7 @@ from core import maintenance as _maintenance
 from core import storage_status as _storage_status
 from core import provider_status as _provider_status
 from core import model_settings as _model_settings
+from core import gguf_settings as _gguf_settings
 from core import data_export as _data_export
 from core import voice as _voice
 import sqlite3 as _sqlite3
@@ -3234,6 +3235,77 @@ def provider_set_default_model_endpoint(
         return _model_settings.set_default_model(req.model)
     except _model_settings.DefaultModelError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+
+# ── ADMIN: LOCAL GGUF MODEL PATH (GGUF provider, Phase 2) ─────────────
+# Lets an admin configure the local ``.gguf`` model the optional
+# ``llamacpp`` provider serves, without editing ``.env``. All three
+# endpoints are ``require_admin``. Safety, enforced in
+# ``core.gguf_settings``:
+#
+#   * status + test are read-only and never load the (multi-GB) model;
+#   * a pasted path is accepted only when it resolves (symlinks included)
+#     **inside** NOVA_MODEL_DIR, is an existing readable ``.gguf`` file,
+#     and contains no ``..`` traversal — anything else is a sanitised 400
+#     and nothing is written;
+#   * the value is a single host-wide ``settings`` row, never per-user,
+#     and never reachable through the generic ``/settings`` path;
+#   * no filesystem browsing, no shell, no download, no deletion, no
+#     overwrite — Nova validates exactly the one path supplied;
+#   * Ollama is untouched: configuring a GGUF path is harmless while
+#     ``ollama`` stays the active provider.
+
+
+@app.get("/admin/provider/gguf")
+def provider_gguf_status_endpoint(_: CurrentUser = Depends(require_admin)):
+    """Read-only snapshot of the local-GGUF configuration.
+
+    Returns the configured provider, the model directory (and whether it
+    exists), the configured model path, where it came from
+    (custom/env/unset), and whether it currently passes validation.
+    Never loads a model, never reaches the network.
+    """
+    return _gguf_settings.gguf_status()
+
+
+class SetGgufModelPathRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    path: str = Field(min_length=1, max_length=_gguf_settings.MAX_PATH_LEN)
+
+
+@app.post("/admin/provider/gguf/model-path")
+def provider_gguf_set_path_endpoint(
+    req: SetGgufModelPathRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Validate the pasted path against NOVA_MODEL_DIR, then persist it.
+
+    The path must resolve inside the configured model directory and be an
+    existing readable ``.gguf`` file. On success the host-wide setting is
+    updated, the cached GGUF provider is dropped so the change takes
+    effect on the next message, and the new status is returned. A refusal
+    (wrong extension, missing file, directory, outside the model dir, or
+    ``..`` traversal) is a 400 with a short, sanitised message and
+    **nothing is written**.
+    """
+    try:
+        return _gguf_settings.set_gguf_model_path(req.path)
+    except _gguf_settings.GgufModelPathError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@app.post("/admin/provider/gguf/test")
+def provider_gguf_test_endpoint(_: CurrentUser = Depends(require_admin)):
+    """Check the configured GGUF model is valid enough to attempt loading.
+
+    Confirms a path is configured, that it passes the directory-confined
+    validation, and that the ``llama-cpp-python`` backend is installed —
+    without loading the weights. Always a calm 200 with a stable
+    ``{ok, provider, detail, filename, path_valid}`` shape; a missing
+    dependency or an invalid path is reported as ``ok=false`` with a
+    sanitised detail, never a 500.
+    """
+    return _gguf_settings.test_gguf_provider()
 
 
 @app.get("/channel")


### PR DESCRIPTION
## Summary

GGUF Provider **Phase 2** — make the optional local GGUF (llama.cpp) provider easy to configure from the UI, without editing `.env`. Ollama remains the default and is untouched; no auto-downloads.

- **`NOVA_MODEL_DIR`** (new config, default `/mnt/archive/nova-models`): the allowed directory local `.gguf` files must live inside.
- **`core/gguf_settings.py`** (new): a directory-confined path validator + resolver + status/set/test helpers.
  - `validate_gguf_model_path` accepts a path only when it is **absolute**, contains no `..`/`~`, ends in **`.gguf`**, resolves (**symlinks included**) **inside** `NOVA_MODEL_DIR`, **exists**, is a **regular readable file**. Everything else is refused with a short, sanitised reason.
  - The chosen path is persisted host-wide (`gguf_model_path`, deliberately outside `USER_SETTING_KEYS`/`ALLOWED_SETTINGS`), **takes precedence** over `NOVA_GGUF_MODEL_PATH`, and **takes effect without a restart** (`evict_provider` + `reset_llamacpp_provider`; the factory now resolves its path from the setting).
- **Three admin-only endpoints** behind a "Local GGUF model" card in **Settings → Models**:
  - `GET /admin/provider/gguf` — status (provider, model dir + existence, configured path + source + validity).
  - `POST /admin/provider/gguf/model-path` — validate then persist; a refusal is a sanitised **400** that writes nothing.
  - `POST /admin/provider/gguf/test` — confirms the path is valid **and** `llama-cpp-python` is installed ("valid enough to attempt loading") **without loading** the multi-GB weights.

### Safety
Admin-only · directory-confined (defeats traversal/symlink escape) · **no file browser, no scan, no shell, no download, no deletion, no overwrite** · sanitised errors · host-wide (never per-user) · **Ollama support unchanged**.

### Out of scope (deliberately not done)
No model-download manager, no Hugging Face scan, no cloud providers, no API keys, no Ollama removal, no chat-behaviour change beyond provider config, no arbitrary filesystem exposure.

## Test plan

- [x] Validator: accepts a `.gguf` inside the model dir; rejects non-`.gguf`, missing files, directories, paths outside the dir, `..` traversal, symlink escapes, sibling-prefix dirs, relative/`~`/empty/NUL inputs.
- [x] Status endpoint shows the configured GGUF path safely; set-path persists / refuses (sanitised 400) / writes nothing on failure; test endpoint is a calm 200.
- [x] Admin-only gating (non-admin/restricted → 403, unauthenticated → 401/403) on all three endpoints.
- [x] Ollama remains the default provider; existing provider/chat/storage/projects/dev-workspace suites still pass.
- [x] New suites: `tests/test_gguf_settings.py`, `tests/test_gguf_endpoints.py`.
- [x] Render logic for the new card verified across all states (unset / valid / invalid / custom / inactive) incl. HTML-escaping.

Tested with `pytest`: the provider/model/llamacpp/settings/gguf suites pass (163/163 targeted). The only full-suite failures were in unrelated files (`test_router.py`, `test_natural_memory.py`, `test_projects.py::TestNaturalMemoryScoping`) and were caused solely by the optional `ollama` wheel being absent in the bare CI container (a `MagicMock` stub isn't a real exception / isn't JSON-serializable); all 80 of those tests pass once `ollama` is installed.

## Docs
`docs/local-gguf.md` (Phase 2 section: creating `/mnt/archive/nova-models`, placing `.gguf` models, configuring via UI, validation rules, hardware expectations, troubleshooting), `.env.example`, `README.md`, `CHANGELOG.md`.

https://claude.ai/code/session_01AzcFvt2ByVCaMjahFNpYeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzcFvt2ByVCaMjahFNpYeR)_