### PR TITLE
feat(model-providers): read-only local GGUF model library (Phase 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -328,7 +328,11 @@ NOVA_TIMEZONE=
 # NOVA_MODEL_DIR: directory that local .gguf files must live inside.
 #   Default /mnt/archive/nova-models. The admin UI only accepts a model
 #   path that resolves inside this directory (no arbitrary files, no path
-#   traversal). Nova never lists, scans, or downloads into it.
+#   traversal, no symlink escape). Admins can also pick from a read-only,
+#   bounded listing of the .gguf files in this directory (the model
+#   library: GET /admin/provider/gguf/models). Nova only lists .gguf files
+#   inside this one directory and never scans the wider filesystem or
+#   downloads into it.
 # NOVA_GGUF_CONTEXT_SIZE: context window (n_ctx). Default 4096.
 # NOVA_GGUF_THREADS: CPU threads (n_threads). 0 = let llama.cpp decide.
 # NOVA_GGUF_GPU_LAYERS: layers to offload to GPU (n_gpu_layers). 0 = CPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,30 @@
   relate to the baseline.
 
 ### Added
+- **Local GGUF model library — Phase 3, admin-only, read-only.** Lets an
+  admin discover and pick a local `.gguf` model instead of typing its full
+  path. `core/gguf_settings.py` gains `list_local_models()`, a read-only
+  listing **confined to `NOVA_MODEL_DIR`**: a bounded walk (capped depth,
+  directory count, and result count — `MAX_SCAN_DEPTH` / `MAX_DIRS_SCANNED`
+  / `MAX_LIBRARY_MODELS`) that skips hidden/system entries, never follows a
+  symlink out of the directory (`followlinks=False`; symlinked files whose
+  target escapes are omitted), lists only `.gguf` files, and returns only
+  relative paths plus safe metadata (`name`, `relative_path`, `size_bytes`,
+  ISO-8601 UTC `modified_at`, `selected`) — never an unrelated absolute
+  path. Each candidate is re-validated through the Phase-2
+  `validate_gguf_model_path`, so **the listed set is exactly the selectable
+  set**. `select_local_model()` resolves a *relative* path against
+  `NOVA_MODEL_DIR` and persists it through the same Phase-2 write boundary
+  (`set_gguf_model_path`), refusing an absolute path, `..`, a missing file,
+  or a non-`.gguf` file with a sanitised error and writing nothing. Two
+  admin-only endpoints back a "Local model library" panel on the existing
+  Settings → Models card: `GET /admin/provider/gguf/models` (the listing; a
+  missing directory is a calm 200 with an empty list + warning) and `POST
+  /admin/provider/gguf/select` (pick one by relative path). No filesystem
+  browser, no recursion without bound, no shell, no download, no deletion,
+  no overwrite; the panel is hidden for non-admins. **Ollama remains the
+  default and is untouched.** Tests: `tests/test_gguf_library.py`. See
+  [docs/local-gguf.md](docs/local-gguf.md).
 - **Local GGUF model path UI + model directory — Phase 2, admin-only.**
   Makes the optional `llamacpp` provider configurable without editing
   `.env`. A new `core/gguf_settings.py` adds a directory-confined path

--- a/README.md
+++ b/README.md
@@ -969,7 +969,7 @@ All configuration is read from `.env` at startup. Key variables:
 | `NOVA_DEV_WORKSPACE_ROOTS` | — | OS-path-separator- or comma-separated absolute directories that may contain repos a Project can link (read-only Phase 1). Blank = the Dev Workspace feature is off. Never set to `/`, `/home`, or a broad system path. See [`docs/dev-workspace.md`](docs/dev-workspace.md). |
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
 | `NOVA_MODEL_PROVIDER` | `ollama` | Model backend: `ollama` (default) or `llamacpp` (local GGUF, no Ollama). See [`docs/local-gguf.md`](docs/local-gguf.md). |
-| `NOVA_MODEL_DIR` | `/mnt/archive/nova-models` | Directory local `.gguf` files must live inside. Admins can set the model path from Settings → Models; only paths inside this directory are accepted (no traversal, no arbitrary files). |
+| `NOVA_MODEL_DIR` | `/mnt/archive/nova-models` | Directory local `.gguf` files must live inside. Admins can set the model path from Settings → Models, or pick from a read-only, bounded listing of the `.gguf` files in this directory (the model library); only paths inside this directory are accepted (no traversal, no arbitrary files, no symlink escape). |
 | `NOVA_GGUF_MODEL_PATH` | — | Absolute path to a local `.gguf` model file (only used when `NOVA_MODEL_PROVIDER=llamacpp`). Nova never downloads it. Blank = provider unconfigured. An admin-set path (Settings → Models) takes precedence. |
 | `NOVA_GGUF_CONTEXT_SIZE` | `4096` | GGUF context window (`n_ctx`) |
 | `NOVA_GGUF_THREADS` | `0` | GGUF CPU threads (`n_threads`); `0` = auto |

--- a/config.py
+++ b/config.py
@@ -56,8 +56,11 @@ if NOVA_GGUF_GPU_LAYERS < 0:
 # GGUF settings surface (Settings → Models → "Local GGUF model") only
 # accepts a model path that resolves *inside* this directory, which
 # defeats path traversal and keeps Nova from ever being pointed at an
-# arbitrary file. Nova never lists, scans, or browses it — it only
-# validates the one path an admin configures. Default is the recommended
+# arbitrary file. Admins may also browse a read-only, bounded listing of
+# the .gguf files in this directory (the Phase-3 model library) and pick
+# one; the listing is confined to this directory, skips hidden entries,
+# never follows a symlink out of it, and only ever surfaces .gguf files —
+# Nova never scans the wider filesystem. Default is the recommended
 # out-of-checkout location; override with NOVA_MODEL_DIR.
 NOVA_MODEL_DIR = (
     os.getenv("NOVA_MODEL_DIR", "/mnt/archive/nova-models").strip()

--- a/core/gguf_settings.py
+++ b/core/gguf_settings.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,17 @@ MAX_PATH_LEN = 4096
 #: The backend label this surface configures. The GGUF provider is always
 #: ``llamacpp`` regardless of which provider is currently the default.
 PROVIDER_NAME = "llamacpp"
+
+#: Bounds on the read-only model-library scan of ``NOVA_MODEL_DIR`` (Phase
+#: 3). The scan is recursive but *strictly* bounded so it can never become
+#: a filesystem-wide walk: it descends at most ``MAX_SCAN_DEPTH`` levels
+#: below the model directory, visits at most ``MAX_DIRS_SCANNED``
+#: directories, and returns at most ``MAX_LIBRARY_MODELS`` files. Hidden /
+#: dot directories are pruned and symlinked directories are never followed
+#: (see :func:`list_local_models`).
+MAX_SCAN_DEPTH = 5
+MAX_DIRS_SCANNED = 2000
+MAX_LIBRARY_MODELS = 500
 
 # Fixed, non-sensitive operator-facing message reused by status + test so
 # the wording never drifts.
@@ -356,6 +368,256 @@ def set_gguf_model_path(path) -> dict:
     return gguf_status()
 
 
+# ── Model library: read-only listing + select (Phase 3) ──────────────
+
+
+def _iso_utc(timestamp: float) -> str:
+    """Format a POSIX mtime as an ISO-8601 UTC string (second precision).
+
+    Returns ``""`` for an unrepresentable timestamp rather than raising,
+    so one odd file never breaks the whole listing.
+    """
+    try:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+def _selected_resolved_path(model_dir: str) -> str:
+    """The resolved path of the currently-configured model, or ``""``.
+
+    Resolves the configured GGUF path the same way a listed entry is
+    resolved (through :func:`validate_gguf_model_path`) so the ``selected``
+    flag is a like-for-like comparison of canonical paths. A missing /
+    invalid configured path simply means "nothing selected" — never an
+    error.
+    """
+    configured = resolve_gguf_model_path()
+    if not configured:
+        return ""
+    try:
+        return validate_gguf_model_path(configured, model_dir)
+    except GgufModelPathError:
+        return ""
+
+
+def list_local_models() -> dict:
+    """Read-only listing of local ``.gguf`` models inside ``NOVA_MODEL_DIR``.
+
+    Returns a JSON-serialisable dict the admin UI renders verbatim::
+
+        {
+          "model_dir": str,          # NOVA_MODEL_DIR (the one allowed dir)
+          "model_dir_exists": bool,
+          "models": [
+            {
+              "name": str,           # file basename, e.g. "model.gguf"
+              "relative_path": str,  # path relative to model_dir
+              "size_bytes": int,
+              "modified_at": str,    # ISO-8601 UTC, e.g. "2026-05-21T12:00:00Z"
+              "selected": bool,      # is this the configured model?
+            },
+            ...
+          ],
+          "count": int,
+          "truncated": bool,         # a bound was hit; not every file shown
+          "warnings": [str],         # calm, non-sensitive notes
+        }
+
+    Safety (the whole point of this surface):
+
+    * **Confined to the one allowed directory.** Only ``NOVA_MODEL_DIR``
+      is scanned — never the wider filesystem, never a caller-supplied
+      path. The directory itself is the only absolute path returned;
+      every model is reported by *relative* path + basename so no
+      unrelated filesystem layout leaks.
+    * **Bounded recursion.** The walk descends at most
+      :data:`MAX_SCAN_DEPTH` levels, visits at most
+      :data:`MAX_DIRS_SCANNED` directories, and returns at most
+      :data:`MAX_LIBRARY_MODELS` files; hitting any bound sets
+      ``truncated`` and stops — it can never become a filesystem-wide
+      scan.
+    * **No hidden/system entries, no symlink escape.** Dot directories
+      and dot files are skipped, symlinked directories are never
+      descended (``followlinks=False``), and every candidate file is
+      re-validated with :func:`validate_gguf_model_path` so a symlinked
+      file whose target escapes the model directory (or is unreadable, or
+      is not a regular ``.gguf`` file) is silently omitted — the listed
+      set is exactly the selectable set.
+    * **Read-only.** Nothing is created, downloaded, moved, deleted, or
+      overwritten and no shell is invoked. Never raises — any problem
+      degrades to an empty list with a sanitised warning.
+    """
+    model_dir = resolve_model_dir()
+    warnings: list[str] = []
+
+    def _result(exists: bool, models: list[dict], truncated: bool) -> dict:
+        return {
+            "model_dir": model_dir,
+            "model_dir_exists": exists,
+            "models": models,
+            "count": len(models),
+            "truncated": truncated,
+            "warnings": warnings,
+        }
+
+    raw = (model_dir or "").strip()
+    if not raw:
+        warnings.append("No model directory is configured. Set NOVA_MODEL_DIR.")
+        return _result(False, [], False)
+
+    try:
+        base = Path(raw).resolve()
+    except (OSError, RuntimeError, ValueError):
+        warnings.append("The configured model directory could not be resolved.")
+        return _result(False, [], False)
+
+    try:
+        if not base.exists():
+            warnings.append(
+                "The model directory does not exist yet. Create it (or set "
+                "NOVA_MODEL_DIR) and place your .gguf files inside it."
+            )
+            return _result(False, [], False)
+        if not base.is_dir():
+            warnings.append("The configured model directory is not a directory.")
+            return _result(True, [], False)
+    except OSError:
+        warnings.append("The model directory could not be read.")
+        return _result(False, [], False)
+
+    selected = _selected_resolved_path(model_dir)
+    base_str = str(base)
+
+    models: list[dict] = []
+    truncated = False
+    dirs_scanned = 0
+
+    for dirpath, dirnames, filenames in os.walk(base_str, followlinks=False):
+        dirs_scanned += 1
+        if dirs_scanned > MAX_DIRS_SCANNED:
+            truncated = True
+            break
+
+        rel_dir = os.path.relpath(dirpath, base_str)
+        depth = 0 if rel_dir in (".", "") else len(rel_dir.split(os.sep))
+        # Prune hidden/system dirs in-place and stop descending past the
+        # depth cap. Sorting makes truncation deterministic.
+        if depth >= MAX_SCAN_DEPTH:
+            dirnames[:] = []
+        else:
+            dirnames[:] = sorted(d for d in dirnames if not d.startswith("."))
+
+        for filename in sorted(filenames):
+            if filename.startswith("."):
+                continue
+            if not filename.lower().endswith(".gguf"):
+                continue
+            abs_path = os.path.join(dirpath, filename)
+            try:
+                resolved = validate_gguf_model_path(abs_path, model_dir)
+            except GgufModelPathError:
+                # Symlink escaping the dir, unreadable, not a regular file,
+                # etc. — not selectable, so deliberately not listed.
+                continue
+            try:
+                st = os.stat(resolved)
+            except OSError:
+                continue
+            try:
+                rel = str(Path(resolved).relative_to(base))
+            except ValueError:
+                rel = os.path.basename(resolved)
+            models.append(
+                {
+                    "name": os.path.basename(resolved),
+                    "relative_path": rel,
+                    "size_bytes": int(st.st_size),
+                    "modified_at": _iso_utc(st.st_mtime),
+                    "selected": bool(selected) and resolved == selected,
+                }
+            )
+            if len(models) >= MAX_LIBRARY_MODELS:
+                truncated = True
+                break
+        if truncated:
+            break
+
+    models.sort(key=lambda m: m["relative_path"].lower())
+
+    if truncated:
+        warnings.append(
+            "The model directory has more files than can be listed at once; "
+            "only the first results are shown."
+        )
+    elif not models:
+        warnings.append("No .gguf model files were found in the model directory.")
+
+    return _result(True, models, truncated)
+
+
+def select_local_model(relative_path) -> dict:
+    """Select a listed local model (by its ``relative_path``) as the GGUF model.
+
+    Resolves ``relative_path`` against ``NOVA_MODEL_DIR`` and hands the
+    joined path to :func:`set_gguf_model_path`, which performs the full
+    Phase-2 validation (``.gguf`` extension, containment inside the model
+    directory with symlinks resolved, existing readable regular file, no
+    ``..``) before persisting it as the single host-wide setting and
+    invalidating the cached provider. Returns the new :func:`gguf_status`.
+
+    ``relative_path`` must be a clean *relative* path (exactly as returned
+    by :func:`list_local_models`): an absolute path, a ``..`` segment, a
+    ``~``, NUL/newline bytes, or an over-long value is refused up front
+    with a sanitised :class:`GgufModelPathError` and **nothing is written**
+    — the containment guarantee never depends on the caller being honest.
+    """
+    if relative_path is None or isinstance(relative_path, bool):
+        raise GgufModelPathError("A model is required.")
+    try:
+        text = os.fspath(relative_path)
+    except TypeError:
+        raise GgufModelPathError("The model selection must be a string.")
+    if not isinstance(text, str):
+        raise GgufModelPathError("The model selection must be a string.")
+    text = text.strip()
+    if not text:
+        raise GgufModelPathError("A model is required.")
+    if len(text) > MAX_PATH_LEN:
+        raise GgufModelPathError("That model selection is too long.")
+    if "\x00" in text or "\n" in text or "\r" in text:
+        raise GgufModelPathError(
+            "That model selection contains invalid characters."
+        )
+    if "~" in text:
+        raise GgufModelPathError("Choose a model from the listed local models.")
+
+    candidate = Path(text)
+    if candidate.is_absolute():
+        raise GgufModelPathError(
+            "Choose a model from the listed local models (use its relative "
+            "path), not an absolute path."
+        )
+    if ".." in candidate.parts:
+        raise GgufModelPathError("The model path must not contain '..'.")
+
+    model_dir = resolve_model_dir()
+    raw_dir = (model_dir or "").strip()
+    if not raw_dir:
+        raise GgufModelPathError(
+            "No model directory is configured. Set NOVA_MODEL_DIR."
+        )
+
+    # Join, then re-validate-and-persist through the Phase-2 boundary:
+    # set_gguf_model_path resolves symlinks and re-checks containment, so
+    # selection inherits exactly the same safety guarantees as a pasted
+    # path — there is no second, weaker code path.
+    full = os.path.join(raw_dir, text)
+    return set_gguf_model_path(full)
+
+
 # ── Test / health (read-only, never loads the model) ─────────────────
 
 
@@ -434,11 +696,16 @@ __all__ = [
     "GGUF_MODEL_PATH_SETTING_KEY",
     "MAX_PATH_LEN",
     "PROVIDER_NAME",
+    "MAX_SCAN_DEPTH",
+    "MAX_DIRS_SCANNED",
+    "MAX_LIBRARY_MODELS",
     "GgufModelPathError",
     "resolve_model_dir",
     "resolve_gguf_model_path",
     "validate_gguf_model_path",
     "gguf_status",
     "set_gguf_model_path",
+    "list_local_models",
+    "select_local_model",
     "test_gguf_provider",
 ]

--- a/docs/local-gguf.md
+++ b/docs/local-gguf.md
@@ -1,12 +1,14 @@
 # Running Nova with a local GGUF model (llama.cpp)
 
-> **Status: shipped (Phase 1 + Phase 2, optional, local-first).**
+> **Status: shipped (Phase 1 + Phase 2 + Phase 3, optional, local-first).**
 > This document describes the optional `llamacpp` model provider, which
 > lets Nova generate text from a local `.gguf` model **without Ollama**.
 > Phase 1 added the provider itself; **Phase 2 adds a small admin-only UI
 > for setting and validating the model path** (Settings → Models → "Local
-> GGUF model") so you no longer have to edit `.env` by hand. It lives
-> inside the boundaries set by
+> GGUF model") so you no longer have to edit `.env` by hand; **Phase 3
+> adds a read-only model library** that discovers the `.gguf` files
+> already inside the model directory so an admin can pick one instead of
+> typing its full path. It lives inside the boundaries set by
 > [`docs/nova-safety-and-trust-contract.md`](nova-safety-and-trust-contract.md)
 > and complements [`docs/model-providers.md`](model-providers.md), which
 > explains the provider seam itself. **Ollama remains Nova's default and
@@ -28,8 +30,11 @@ What this provider deliberately does **not** do:
 - it does **not** remove or replace Ollama (still the default),
 - it does **not** download, fetch, or auto-convert any model,
 - it does **not** add a cloud provider, an API key, or a model-download manager,
-- it does **not** add a filesystem browser — the Phase-2 UI validates the
-  one path you paste, it never lists or scans a directory,
+- it does **not** add a general filesystem browser — the Phase-3 model
+  library is a **read-only**, **bounded** listing confined to the one
+  configured model directory (`NOVA_MODEL_DIR`); it lists only `.gguf`
+  files, never the wider filesystem, never follows symlinks out of the
+  directory, and never browses an arbitrary path,
 - it does **not** delete or overwrite any model file,
 - it does **not** change memory, projects, storage, export/restore, or
   the Dev Workspace.
@@ -155,11 +160,52 @@ refused with a short, sanitised reason and nothing is written:
 - the file **exists**, is a **regular file** (not a directory), and is
   **readable** by the Nova service user.
 
-There is **no file browser**: Nova validates exactly the one path you
-paste and never lists or scans the directory. The setting is host-wide
-(an operator decision, like the default model), admin-only, and never
-reachable through the per-user settings path. It never downloads,
-deletes, or overwrites a model.
+The setting is host-wide (an operator decision, like the default model),
+admin-only, and never reachable through the per-user settings path. It
+never downloads, deletes, or overwrites a model.
+
+## Picking a model from the library (no path typing) — Phase 3
+
+Pasting a full path works, but Phase 3 makes it optional. As an admin,
+open **Settings → Models → "Local GGUF model"** and, under **Local model
+library**, click **List local models**. Nova lists the `.gguf` files it
+finds inside `NOVA_MODEL_DIR`, each with its:
+
+- **file name** and **relative path** (relative to the model directory —
+  never an absolute path),
+- **size** and **last-modified** time,
+- whether it is the **currently selected** model.
+
+Click **Use this model** next to any entry to make it the configured GGUF
+model. Selecting is the same validated, persisted action as pasting the
+path: the chosen relative path is joined to `NOVA_MODEL_DIR` and
+re-validated (it must resolve inside the directory, be a readable regular
+`.gguf` file, contain no `..`) before the host-wide setting is written and
+the provider is rebuilt on the next message. A model only appears in the
+library if it would also pass the paste-a-path validation, so **the listed
+set is exactly the selectable set**.
+
+The listing is deliberately conservative — this is *not* a general file
+browser:
+
+- it is **read-only**: nothing is created, moved, downloaded, deleted, or
+  overwritten, and no shell is ever invoked;
+- it is **confined to `NOVA_MODEL_DIR`**: the wider filesystem is never
+  scanned, and no caller-supplied path is ever listed;
+- the recursion is **bounded**: it descends a limited number of levels,
+  visits a capped number of directories, and returns a capped number of
+  files (hitting a bound is reported as a `truncated` flag plus a
+  warning), so it can never become a filesystem-wide walk;
+- it **skips hidden / dot files and directories** and **never follows a
+  symlink out of the model directory** (symlinked directories are not
+  descended; a symlinked file whose target escapes the directory is
+  omitted);
+- it lists **only `.gguf` files** and returns **only relative paths +
+  safe metadata**, so no unrelated filesystem layout is exposed.
+
+The relevant admin-only endpoints are `GET /admin/provider/gguf/models`
+(the listing) and `POST /admin/provider/gguf/select` (pick one by its
+relative path). Both require the admin role; non-admins never see the card.
 
 ## How model selection interacts
 
@@ -201,9 +247,12 @@ load fails with a sanitised error and chat falls back to the standard
   defeating path traversal and arbitrary-file exposure. Symlinks are
   resolved before the containment check, so a link that escapes the
   directory is refused.
-- **No file browser, no scan.** The UI validates exactly the one path you
-  paste — it never lists, scans, or walks the directory, and the provider
-  never runs a shell command.
+- **No general file browser.** The Phase-3 model library is a read-only,
+  bounded listing confined to `NOVA_MODEL_DIR`: it lists only `.gguf`
+  files, never the wider filesystem, skips hidden/system entries, never
+  follows a symlink out of the directory, caps its depth / breadth /
+  result count, and returns only relative paths and safe metadata. The
+  provider never runs a shell command.
 - **No deletion, no overwrite.** Configuring a path only records *which*
   file to use; Nova never removes or replaces a model file.
 - **Admin-only, host-wide.** The model path is an operator decision (a

--- a/static/index.html
+++ b/static/index.html
@@ -3820,6 +3820,25 @@
                                 <button class="memory-btn" id="settings-gguf-test-btn" onclick="testGgufProvider()" style="white-space:nowrap;">Test GGUF provider</button>
                             </div>
                         </div>
+                        <!--
+                          Local model library (admin-only, read-only). Lists
+                          the .gguf files Nova found inside the model
+                          directory so an admin can pick one instead of
+                          typing its full path. The listing is server-side,
+                          confined to NOVA_MODEL_DIR, never recurses without
+                          bound, never follows symlinks out of it, and never
+                          downloads, deletes, or overwrites anything. "Use"
+                          selects a model through the same validated path the
+                          paste field uses.
+                        -->
+                        <div id="settings-gguf-library" style="margin-top:12px;display:none;flex-direction:column;gap:6px;">
+                            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+                                <span class="settings-row-title" style="font-size:0.84rem;">Local model library</span>
+                                <button class="memory-btn" id="settings-gguf-list-btn" onclick="loadGgufModels()" style="white-space:nowrap;">List local models</button>
+                            </div>
+                            <span class="settings-row-hint" id="settings-gguf-library-hint">Read-only listing of .gguf files inside the model directory. Pick one to set it as the model path. Nothing is downloaded, deleted, or overwritten.</span>
+                            <div id="settings-gguf-models" style="margin-top:4px;"></div>
+                        </div>
                         <div id="settings-gguf-error" style="color:var(--danger);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
                         <div id="settings-gguf-ok" style="color:var(--text-dim);font-size:0.78rem;margin-top:6px;min-height:0;"></div>
                         <div id="settings-gguf-test-result" style="margin-top:8px;"></div>
@@ -10892,9 +10911,11 @@
         const errEl = document.getElementById("settings-gguf-error");
         const okEl = document.getElementById("settings-gguf-ok");
         const resEl = document.getElementById("settings-gguf-test-result");
+        const modelsEl = document.getElementById("settings-gguf-models");
         if (errEl) errEl.textContent = "";
         if (okEl) okEl.textContent = "";
         if (resEl) resEl.innerHTML = "";
+        if (modelsEl) modelsEl.innerHTML = "";
         if (summary) summary.innerHTML = '<div class="admin-empty">Loading…</div>';
         try {
             const res = await fetch("/admin/provider/gguf", {
@@ -10995,6 +11016,8 @@
             input.value = status.configured_path || "";
         }
         if (editor) editor.style.display = "flex";
+        const library = document.getElementById("settings-gguf-library");
+        if (library) library.style.display = "flex";
     }
 
     async function saveGgufModelPath() {
@@ -11108,6 +11131,140 @@
         } finally {
             btn.disabled = false;
             btn.textContent = original;
+        }
+    }
+
+    // ── Settings → Models: local GGUF model library (admin-only) ──
+    //
+    // Lists the .gguf files Nova found inside NOVA_MODEL_DIR (read-only,
+    // server-side, bounded, no symlink escape) so an admin can pick one
+    // instead of typing its full path. "Use" selects a model through the
+    // same validated path the paste field uses — nothing is downloaded,
+    // deleted, or overwritten.
+    async function loadGgufModels() {
+        const isAdmin = !!(currentUser && currentUser.role === "admin");
+        if (!isAdmin) return;
+        const btn = document.getElementById("settings-gguf-list-btn");
+        const modelsEl = document.getElementById("settings-gguf-models");
+        if (!modelsEl) return;
+        const original = btn ? btn.textContent : "";
+        if (btn) { btn.disabled = true; btn.textContent = "Listing…"; }
+        modelsEl.innerHTML = '<div class="admin-empty">Loading…</div>';
+        try {
+            const res = await fetch("/admin/provider/gguf/models", {
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) { modelsEl.innerHTML = ""; return; }
+            if (!res.ok) {
+                modelsEl.innerHTML = '<div class="admin-empty">Failed to list local models.</div>';
+                return;
+            }
+            renderGgufModels(await res.json());
+        } catch (e) {
+            modelsEl.innerHTML = '<div class="admin-empty">Failed to list local models.</div>';
+        } finally {
+            if (btn) { btn.disabled = false; btn.textContent = original || "List local models"; }
+        }
+    }
+
+    function renderGgufModels(body) {
+        const modelsEl = document.getElementById("settings-gguf-models");
+        if (!modelsEl) return;
+        const models = Array.isArray(body.models) ? body.models : [];
+        const parts = [];
+        (body.warnings || []).forEach((w) => {
+            parts.push(
+                `<div class="admin-warning info">` +
+                `<span class="admin-warning-level">info</span>` +
+                `<span class="admin-warning-msg">${escapeHtml(String(w))}</span>` +
+                `</div>`
+            );
+        });
+        if (!models.length) {
+            if (!parts.length) {
+                parts.push('<div class="admin-empty">No .gguf models found in the model directory.</div>');
+            }
+            modelsEl.innerHTML = parts.join("");
+            return;
+        }
+        models.forEach((m) => {
+            const name = escapeHtml(String(m.name || ""));
+            const rel = escapeHtml(String(m.relative_path || ""));
+            const size = (typeof m.size_bytes === "number") ? formatBytes(m.size_bytes) : "—";
+            const when = m.modified_at ? escapeHtml(String(m.modified_at)) : "—";
+            const selected = m.selected === true;
+            const tag = selected
+                ? `<span class="admin-tag installed">selected</span>`
+                : "";
+            // The relative path (never an absolute path) is carried in a
+            // data attribute and read back via getAttribute on click, so a
+            // filename containing quotes / angle brackets can never break
+            // out of an inline handler. Escape & < > " for the attribute.
+            const relAttr = escapeHtml(String(m.relative_path || "")).replace(/"/g, "&quot;");
+            const action = selected
+                ? `<button class="memory-btn" disabled style="white-space:nowrap;opacity:0.6;">In use</button>`
+                : `<button class="memory-btn gguf-use-btn" data-rel="${relAttr}" style="white-space:nowrap;">Use this model</button>`;
+            parts.push(
+                `<div class="admin-model-row">` +
+                `<div class="admin-model-head">` +
+                `<span class="admin-model-display">${name}</span>` +
+                tag +
+                `</div>` +
+                `<div class="admin-model-name">${rel}</div>` +
+                `<div class="admin-progress-meta">size: <code>${size}</code> · modified: <code>${when}</code></div>` +
+                `<div style="margin-top:6px;">${action}</div>` +
+                `</div>`
+            );
+        });
+        modelsEl.innerHTML = parts.join("");
+        modelsEl.querySelectorAll(".gguf-use-btn").forEach((b) => {
+            b.addEventListener("click", () => selectGgufModel(b.getAttribute("data-rel"), b));
+        });
+    }
+
+    async function selectGgufModel(relativePath, btn) {
+        const errEl = document.getElementById("settings-gguf-error");
+        const okEl = document.getElementById("settings-gguf-ok");
+        const resEl = document.getElementById("settings-gguf-test-result");
+        if (errEl) errEl.textContent = "";
+        if (okEl) okEl.textContent = "";
+        if (resEl) resEl.innerHTML = "";
+        if (!relativePath) return;
+        const original = btn ? btn.textContent : "";
+        if (btn) { btn.disabled = true; btn.textContent = "Selecting…"; }
+        try {
+            const res = await fetch("/admin/provider/gguf/select", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ relative_path: relativePath }),
+            });
+            if (res.status === 401) { logout(); return; }
+            if (res.status === 403) {
+                if (errEl) errEl.textContent = "Access denied.";
+                return;
+            }
+            if (!res.ok) {
+                let detail = `Failed (${res.status})`;
+                try {
+                    const b = await res.json();
+                    if (b && b.detail) detail = b.detail;
+                } catch (_) { /* ignore */ }
+                if (errEl) errEl.textContent = detail;
+                return;
+            }
+            const body = await res.json();
+            if (okEl) okEl.textContent = `Saved. Nova will use ${body.filename || "this model"} when the GGUF provider is active.`;
+            renderGgufCard(body);
+            // Refresh the library so the selected badge moves to the new pick.
+            loadGgufModels().catch(() => {});
+        } catch (e) {
+            if (errEl) errEl.textContent = "Network error while selecting the model.";
+        } finally {
+            if (btn) { btn.disabled = false; btn.textContent = original || "Use this model"; }
         }
     }
 

--- a/tests/test_gguf_library.py
+++ b/tests/test_gguf_library.py
@@ -1,0 +1,527 @@
+"""Tests for the local GGUF model library (Phase 3).
+
+Pinned contracts (see ``core/gguf_settings.py`` and the
+``/admin/provider/gguf/models`` + ``/admin/provider/gguf/select``
+endpoints):
+
+* :func:`list_local_models` lists ``.gguf`` files **inside**
+  ``NOVA_MODEL_DIR`` with safe metadata (name, relative path, size,
+  ISO-8601 UTC mtime, selected flag) and:
+
+    - finds models in subdirectories (bounded recursion),
+    - skips non-``.gguf`` files, hidden files, and hidden directories,
+    - never follows a symlinked directory out of the model dir, and omits
+      a symlinked *file* whose target escapes the model dir,
+    - reports only relative paths (no unrelated absolute paths leak),
+    - degrades to a calm empty list + warning when the dir is missing /
+      not a directory, and never raises;
+
+* :func:`select_local_model` resolves a *relative* path against
+  ``NOVA_MODEL_DIR`` and persists it through the Phase-2 boundary —
+  refusing an absolute path, ``..`` traversal, a missing file, or a
+  non-``.gguf`` file with a sanitised :class:`GgufModelPathError` and
+  writing nothing;
+
+* both endpoints are admin-only and Ollama stays the default throughout.
+
+No real ``llama-cpp-python`` wheel or real ``.gguf`` weights are needed —
+a tiny dummy file stands in for a model.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import sqlite3
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod in ("ddgs", "duckduckgo_search", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import gguf_settings as gs  # noqa: E402
+from core import memory as core_memory, users  # noqa: E402
+from core.gguf_settings import GgufModelPathError  # noqa: E402
+from core.model_providers import reset as reset_registry  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+_ISO_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def _write_gguf(path, payload=b"GGUF\x00 not real weights"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return path
+
+
+@pytest.fixture
+def model_dir(tmp_path):
+    d = tmp_path / "nova-models"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def no_db(monkeypatch, tmp_path):
+    """Point the DB at a non-existent file so persisted reads are skipped."""
+    monkeypatch.setattr(core_memory, "DB_PATH", str(tmp_path / "absent.db"))
+
+
+# ── list_local_models ────────────────────────────────────────────────
+
+
+class TestListLocalModels:
+    def test_lists_root_file_with_safe_metadata(
+        self, monkeypatch, no_db, model_dir
+    ):
+        f = _write_gguf(model_dir / "model.gguf", b"GGUF" + b"x" * 100)
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert out["model_dir"] == str(model_dir)
+        assert out["model_dir_exists"] is True
+        assert out["count"] == 1
+        assert out["truncated"] is False
+        entry = out["models"][0]
+        assert entry["name"] == "model.gguf"
+        assert entry["relative_path"] == "model.gguf"
+        assert entry["size_bytes"] == f.stat().st_size
+        assert _ISO_Z.match(entry["modified_at"]), entry["modified_at"]
+        # Parses as a real timestamp.
+        datetime.strptime(entry["modified_at"], "%Y-%m-%dT%H:%M:%SZ")
+        assert entry["selected"] is False
+
+    def test_finds_models_in_subdirectories(self, monkeypatch, no_db, model_dir):
+        _write_gguf(model_dir / "a.gguf")
+        _write_gguf(model_dir / "team-a" / "b.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        rels = {m["relative_path"] for m in out["models"]}
+        assert rels == {"a.gguf", "team-a/b.gguf"}
+
+    def test_skips_non_gguf_files(self, monkeypatch, no_db, model_dir):
+        _write_gguf(model_dir / "real.gguf")
+        (model_dir / "notes.txt").write_text("hi")
+        (model_dir / "weights.bin").write_bytes(b"nope")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert [m["name"] for m in out["models"]] == ["real.gguf"]
+
+    def test_skips_hidden_files_and_dirs(self, monkeypatch, no_db, model_dir):
+        _write_gguf(model_dir / "visible.gguf")
+        _write_gguf(model_dir / ".hidden.gguf")
+        _write_gguf(model_dir / ".cache" / "secret.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert [m["name"] for m in out["models"]] == ["visible.gguf"]
+
+    def test_uppercase_extension_is_listed(self, monkeypatch, no_db, model_dir):
+        _write_gguf(model_dir / "Model.GGUF")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert [m["name"] for m in out["models"]] == ["Model.GGUF"]
+
+    def test_relative_paths_only_no_absolute_leak(
+        self, monkeypatch, no_db, model_dir
+    ):
+        _write_gguf(model_dir / "sub" / "m.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        for m in out["models"]:
+            assert not m["relative_path"].startswith("/")
+            assert str(model_dir) not in m["relative_path"]
+
+    def test_selected_flag_tracks_configured_model(
+        self, monkeypatch, no_db, model_dir
+    ):
+        chosen = _write_gguf(model_dir / "chosen.gguf")
+        _write_gguf(model_dir / "other.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(chosen))
+        out = gs.list_local_models()
+        by_name = {m["name"]: m for m in out["models"]}
+        assert by_name["chosen.gguf"]["selected"] is True
+        assert by_name["other.gguf"]["selected"] is False
+
+    def test_missing_model_dir_is_calm_empty(self, monkeypatch, no_db, tmp_path):
+        monkeypatch.setattr(
+            "config.NOVA_MODEL_DIR", str(tmp_path / "does-not-exist")
+        )
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert out["models"] == []
+        assert out["model_dir_exists"] is False
+        assert out["warnings"]
+
+    def test_model_dir_that_is_a_file_is_calm(self, monkeypatch, no_db, tmp_path):
+        f = tmp_path / "not-a-dir"
+        f.write_text("x")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(f))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert out["models"] == []
+        assert any("not a directory" in w for w in out["warnings"])
+
+    def test_empty_dir_warns_no_models(self, monkeypatch, no_db, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert out["models"] == []
+        assert any(".gguf" in w for w in out["warnings"])
+
+    def test_does_not_follow_symlinked_dir_escaping(
+        self, monkeypatch, no_db, tmp_path, model_dir
+    ):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        _write_gguf(outside / "escaped.gguf")
+        link = model_dir / "linked"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+        _write_gguf(model_dir / "inside.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        names = {m["name"] for m in out["models"]}
+        assert "inside.gguf" in names
+        assert "escaped.gguf" not in names
+
+    def test_omits_symlinked_file_escaping(
+        self, monkeypatch, no_db, tmp_path, model_dir
+    ):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = _write_gguf(outside / "real.gguf")
+        link = model_dir / "link.gguf"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert [m["name"] for m in out["models"]] == []
+
+    def test_depth_bound_excludes_very_deep_file(
+        self, monkeypatch, no_db, model_dir
+    ):
+        # Far below MAX_SCAN_DEPTH levels: must not be listed.
+        deep = model_dir
+        for i in range(gs.MAX_SCAN_DEPTH + 2):
+            deep = deep / f"d{i}"
+        _write_gguf(deep / "deep.gguf")
+        _write_gguf(model_dir / "shallow.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        names = {m["name"] for m in out["models"]}
+        assert "shallow.gguf" in names
+        assert "deep.gguf" not in names
+
+    def test_truncates_at_model_cap(self, monkeypatch, no_db, model_dir):
+        monkeypatch.setattr(gs, "MAX_LIBRARY_MODELS", 3)
+        for i in range(6):
+            _write_gguf(model_dir / f"m{i}.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.list_local_models()
+        assert out["count"] == 3
+        assert out["truncated"] is True
+        assert any("only the first" in w for w in out["warnings"])
+
+
+# ── select_local_model ───────────────────────────────────────────────
+
+
+class TestSelectLocalModel:
+    @pytest.fixture
+    def db(self, monkeypatch, tmp_path):
+        path = str(tmp_path / "nova.db")
+        monkeypatch.setattr(core_memory, "DB_PATH", path)
+        monkeypatch.setattr(natural_store, "DB_PATH", path)
+        core_memory.initialize_db()
+        reset_registry()
+        yield path
+        reset_registry()
+
+    def test_valid_relative_path_persists(self, db, monkeypatch, model_dir):
+        f = _write_gguf(model_dir / "sub" / "m.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        out = gs.select_local_model("sub/m.gguf")
+        assert out["configured_path"] == str(f.resolve())
+        assert out["path_source"] == "custom"
+        assert out["path_valid"] is True
+        assert gs.resolve_gguf_model_path() == str(f.resolve())
+
+    def test_select_then_list_marks_selected(self, db, monkeypatch, model_dir):
+        _write_gguf(model_dir / "a.gguf")
+        _write_gguf(model_dir / "b.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        gs.select_local_model("b.gguf")
+        out = gs.list_local_models()
+        by_name = {m["name"]: m["selected"] for m in out["models"]}
+        assert by_name == {"a.gguf": False, "b.gguf": True}
+
+    def test_absolute_path_refused(self, db, monkeypatch, model_dir):
+        f = _write_gguf(model_dir / "m.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.select_local_model(str(f))
+        assert "absolute" in str(exc.value)
+        assert gs.resolve_gguf_model_path() == ""
+
+    def test_traversal_refused(self, db, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.select_local_model("../secret.gguf")
+        assert ".." in str(exc.value)
+        assert gs.resolve_gguf_model_path() == ""
+
+    def test_missing_file_refused(self, db, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.select_local_model("absent.gguf")
+        assert "No file exists" in str(exc.value)
+
+    def test_non_gguf_refused(self, db, monkeypatch, model_dir):
+        (model_dir / "model.bin").write_bytes(b"nope")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        with pytest.raises(GgufModelPathError) as exc:
+            gs.select_local_model("model.bin")
+        assert ".gguf" in str(exc.value)
+
+    def test_empty_refused(self, db, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        with pytest.raises(GgufModelPathError):
+            gs.select_local_model("   ")
+
+    def test_tilde_refused(self, db, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        with pytest.raises(GgufModelPathError):
+            gs.select_local_model("~/m.gguf")
+
+
+# ── Endpoint wiring ──────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    from fastapi.testclient import TestClient
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def admin_token(db_path, web_client):
+    _make_user(db_path, "alice", role=users.ROLE_ADMIN)
+    return _login(web_client, "alice")
+
+
+@pytest.fixture
+def user_token(db_path, web_client):
+    _make_user(db_path, "bob")
+    return _login(web_client, "bob")
+
+
+@pytest.fixture
+def restricted_token(db_path, web_client):
+    _make_user(db_path, "kid", is_restricted=True)
+    return _login(web_client, "kid")
+
+
+_ENDPOINTS = [
+    ("GET", "/admin/provider/gguf/models", None),
+    ("POST", "/admin/provider/gguf/select", {"relative_path": "m.gguf"}),
+]
+
+
+class TestLibraryEndpointsAuth:
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_non_admin_forbidden(self, web_client, user_token, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(user_token))
+        else:
+            resp = web_client.post(path, headers=_h(user_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_restricted_forbidden(self, web_client, restricted_token, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path, headers=_h(restricted_token))
+        else:
+            resp = web_client.post(path, headers=_h(restricted_token), json=body)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path,body", _ENDPOINTS)
+    def test_unauthenticated_blocked(self, web_client, method, path, body):
+        if method == "GET":
+            resp = web_client.get(path)
+        else:
+            resp = web_client.post(path, json=body)
+        assert resp.status_code in (401, 403)
+
+
+class TestModelsEndpoint:
+    def test_lists_models_with_selected_flag(
+        self, web_client, admin_token, monkeypatch, model_dir
+    ):
+        chosen = _write_gguf(model_dir / "chosen.gguf")
+        _write_gguf(model_dir / "team" / "other.gguf")
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", str(chosen))
+        resp = web_client.get("/admin/provider/gguf/models", headers=_h(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["model_dir"] == str(model_dir)
+        assert body["model_dir_exists"] is True
+        by_name = {m["name"]: m for m in body["models"]}
+        assert set(by_name) == {"chosen.gguf", "other.gguf"}
+        assert by_name["chosen.gguf"]["selected"] is True
+        assert by_name["other.gguf"]["relative_path"] == "team/other.gguf"
+
+    def test_missing_dir_is_calm_200(self, web_client, admin_token, monkeypatch, tmp_path):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(tmp_path / "nope"))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.get("/admin/provider/gguf/models", headers=_h(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["models"] == []
+        assert body["warnings"]
+
+
+class TestSelectEndpoint:
+    def test_valid_select_persists(self, web_client, admin_token, monkeypatch, model_dir):
+        f = _write_gguf(model_dir / "pick.gguf")
+        monkeypatch.setattr("config.MODEL_PROVIDER", "llamacpp")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/select",
+            headers=_h(admin_token),
+            json={"relative_path": "pick.gguf"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["configured_path"] == str(f.resolve())
+        assert body["path_source"] == "custom"
+        assert body["path_valid"] is True
+        # The library now marks it selected.
+        listing = web_client.get(
+            "/admin/provider/gguf/models", headers=_h(admin_token)
+        ).json()
+        assert listing["models"][0]["selected"] is True
+
+    def test_absolute_path_is_400(self, web_client, admin_token, monkeypatch, model_dir):
+        f = _write_gguf(model_dir / "m.gguf")
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/select",
+            headers=_h(admin_token),
+            json={"relative_path": str(f)},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "absolute" in resp.json()["detail"]
+
+    def test_traversal_is_400(self, web_client, admin_token, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/select",
+            headers=_h(admin_token),
+            json={"relative_path": "../secret.gguf"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert ".." in resp.json()["detail"]
+
+    def test_missing_file_is_400(self, web_client, admin_token, monkeypatch, model_dir):
+        monkeypatch.setattr("config.NOVA_MODEL_DIR", str(model_dir))
+        monkeypatch.setattr("config.NOVA_GGUF_MODEL_PATH", "")
+        resp = web_client.post(
+            "/admin/provider/gguf/select",
+            headers=_h(admin_token),
+            json={"relative_path": "absent.gguf"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "No file exists" in resp.json()["detail"]
+
+    def test_empty_relative_path_is_422(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/provider/gguf/select",
+            headers=_h(admin_token),
+            json={"relative_path": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_extra_field_is_422(self, web_client, admin_token):
+        resp = web_client.post(
+            "/admin/provider/gguf/select",
+            headers=_h(admin_token),
+            json={"relative_path": "m.gguf", "provider": "evil"},
+        )
+        assert resp.status_code == 422

--- a/web.py
+++ b/web.py
@@ -3308,6 +3308,66 @@ def provider_gguf_test_endpoint(_: CurrentUser = Depends(require_admin)):
     return _gguf_settings.test_gguf_provider()
 
 
+# ── ADMIN: LOCAL GGUF MODEL LIBRARY (GGUF provider, Phase 3) ──────────
+# Lets an admin discover the ``.gguf`` files already inside NOVA_MODEL_DIR
+# and pick one as the model path without typing it. Both endpoints are
+# ``require_admin``. Safety, enforced in ``core.gguf_settings``:
+#
+#   * the listing is read-only and confined to NOVA_MODEL_DIR — a bounded,
+#     non-recursive-beyond-a-cap walk that never touches the wider
+#     filesystem, never follows symlinks out of the directory, skips
+#     hidden/system entries, only reports ``.gguf`` files, and returns
+#     relative paths + safe metadata (no unrelated absolute paths);
+#   * selecting reuses the Phase-2 write boundary: the chosen relative
+#     path is joined to NOVA_MODEL_DIR and re-validated (containment,
+#     ``.gguf``, readable regular file, no ``..``) before the single
+#     host-wide setting is persisted — a bad selection is a sanitised 400
+#     and nothing is written;
+#   * no shell, no download, no deletion, no overwrite; Ollama is
+#     untouched and stays the default.
+
+
+@app.get("/admin/provider/gguf/models")
+def provider_gguf_models_endpoint(_: CurrentUser = Depends(require_admin)):
+    """Read-only listing of local ``.gguf`` models inside NOVA_MODEL_DIR.
+
+    Returns ``{model_dir, model_dir_exists, models, count, truncated,
+    warnings}`` where each model carries its ``name``, ``relative_path``,
+    ``size_bytes``, ``modified_at`` (ISO-8601 UTC) and whether it is the
+    currently ``selected`` model. The scan is bounded and confined to the
+    one allowed directory; a missing directory is a calm 200 with an empty
+    list and a warning, never a 500. Nothing is scanned outside
+    NOVA_MODEL_DIR, downloaded, or modified.
+    """
+    return _gguf_settings.list_local_models()
+
+
+class SelectGgufModelRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+    relative_path: str = Field(min_length=1, max_length=_gguf_settings.MAX_PATH_LEN)
+
+
+@app.post("/admin/provider/gguf/select")
+def provider_gguf_select_endpoint(
+    req: SelectGgufModelRequest,
+    _: CurrentUser = Depends(require_admin),
+):
+    """Select a listed local model (by ``relative_path``) as the GGUF model.
+
+    The relative path is resolved against NOVA_MODEL_DIR and re-validated
+    through the same Phase-2 boundary as a pasted path before the
+    host-wide setting is persisted and the cached provider dropped. On
+    success the new GGUF status is returned. A path that is absolute,
+    contains ``..``, escapes the model directory, is not a readable
+    ``.gguf`` file, or does not exist is a 400 with a short, sanitised
+    message and **nothing is written**.
+    """
+    try:
+        return _gguf_settings.select_local_model(req.relative_path)
+    except _gguf_settings.GgufModelPathError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
 @app.get("/channel")
 def get_channel():
     return {"channel": NOVA_CHANNEL, "branch": NOVA_BRANCH}


### PR DESCRIPTION
## Summary

GGUF Provider **Phase 3 — Local Model Directory / Model Library.** Lets an admin discover and pick a local `.gguf` model from the configured model directory instead of typing its full path. Builds directly on the Phase-2 validation/persistence boundary; **Ollama remains the default and is untouched**.

- **`core/gguf_settings.py`**
  - `list_local_models()` — a **read-only, bounded** walk **confined to `NOVA_MODEL_DIR`**. Caps depth / directories visited / result count (`MAX_SCAN_DEPTH`, `MAX_DIRS_SCANNED`, `MAX_LIBRARY_MODELS`), skips hidden/system entries, never follows a symlink out of the directory (`followlinks=False`; symlinked files whose target escapes are omitted), lists **only `.gguf`** files, and returns **only relative paths + safe metadata** (`name`, `relative_path`, `size_bytes`, ISO-8601 UTC `modified_at`, `selected`). Every candidate is re-validated through the Phase-2 `validate_gguf_model_path`, so **the listed set is exactly the selectable set**.
  - `select_local_model(relative_path)` — refuses an absolute path, `..`, `~`, or NUL/newline up front, then joins the relative path to `NOVA_MODEL_DIR` and persists it through the same Phase-2 write boundary (`set_gguf_model_path`) — re-validating containment, `.gguf`, readable regular file before writing.
- **`web.py`** — two admin-only endpoints:
  - `GET /admin/provider/gguf/models` (listing; a missing directory is a calm 200 with an empty list + warning, never a 500)
  - `POST /admin/provider/gguf/select` (pick one by relative path; a bad selection is a sanitised 400 and nothing is written)
- **`static/index.html`** — a "Local model library" panel on the existing Settings → Models card: list button, per-model rows (name, relative path, size, modified, `selected` badge), and "Use this model". Selection uses a `data-rel` attribute + programmatic click binding (no inline-handler injection from filenames). Hidden for non-admins.
- **Docs/config** — `docs/local-gguf.md` (new Phase 3 section + status), `README.md`, `.env.example`, `config.py` comment, and `CHANGELOG.md`. Prior "never lists/scans" wording is corrected to accurately describe the bounded read-only listing.

### Safety
Admin-only · read-only · confined to `NOVA_MODEL_DIR` · no filesystem-wide scan · bounded recursion · no hidden/system dirs · no symlink escape · no shell · no download · no deletion · no overwrite · only `.gguf` · relative paths + sanitised errors only · Ollama not removed.

## Test plan

- [x] `tests/test_gguf_library.py` (36 tests): metadata shape & ISO-8601 `modified_at`, subdirectory recursion, non-`.gguf`/hidden-file/hidden-dir exclusion, no-absolute-path leak, `selected` flag, symlinked-dir + symlinked-file escape exclusion, depth bound, `MAX_LIBRARY_MODELS` truncation; select persists / marks selected; absolute / `..` / missing / non-`.gguf` / empty / `~` refused; both endpoints admin-only (non-admin & restricted 403, unauthenticated 401/403); `relative_path` empty → 422, extra field → 422.
- [x] Existing GGUF/provider/model suites still green (`test_gguf_settings.py`, `test_gguf_endpoints.py`, `test_llamacpp_provider.py`, `test_provider_*`, `test_model_*` — 199 passing).
- [x] Python (`core/gguf_settings.py`, `web.py`, `config.py`) and extracted inline JS syntax-checked.
- [ ] Manual UI smoke (browser) not run in this environment.

https://claude.ai/code/session_01VpSe8JBXV9UDMb1fJBYsF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpSe8JBXV9UDMb1fJBYsF5)_