### PR TITLE
Feature/backend chat cancellation

### DIFF
--- a/core/active_generation_tracker.py
+++ b/core/active_generation_tracker.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+import threading
+import secrets as _secrets
+
+@dataclass(slots=True)
+class ActiveGeneration:
+    user_id: int
+    conversation_id: int
+    cancel_event: threading.Event
+
+
+class ActiveGenerationTracker:
+    """
+    Thread-safe registry for tracking active model generations, allowing for cancellation and cleanup. 
+    Each active generation is associated with a unique request ID, user ID, conversation ID
+    """
+
+    def __init__(self) -> None:
+        self._active_generations: dict[str, ActiveGeneration] = {}
+        self._lock = threading.Lock()
+    
+    def _request_id(self) -> str:
+        """Generate a new unique request ID for tracking an active generation."""
+        return _secrets.token_urlsafe(32)
+    
+    def _register_active_generation(self, request_id: str, user_id: int, conversation_id: int,) -> threading.Event:
+        """ Register a new active generation and return its cancellation event. """
+        cancel_event = threading.Event()
+        generation = ActiveGeneration(user_id=user_id, 
+                                      conversation_id=conversation_id, 
+                                      cancel_event=cancel_event)
+        
+        with self._lock:
+            self._active_generations[request_id] = generation
+        
+        return cancel_event
+
+    def _get_active_generation(self, request_id: str) -> dict | None:
+        """ Retrieve the active generation associated with the given request ID, if it exists. """
+        with self._lock:
+            return self._active_generations.get(request_id)
+
+    def _unregister_active_generation(self, request_id: str) -> None:
+        """ Unregister generation after completion or cancellation to free up resources. """
+        with self._lock:
+            self._active_generations.pop(request_id, None)
+
+tracker = ActiveGenerationTracker()

--- a/core/active_generation_tracker.py
+++ b/core/active_generation_tracker.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import threading
 import secrets as _secrets
 
+
 @dataclass(slots=True)
 class ActiveGeneration:
     user_id: int
@@ -11,28 +12,28 @@ class ActiveGeneration:
 
 class ActiveGenerationTracker:
     """
-    Thread-safe registry for tracking active model generations, allowing for cancellation and cleanup. 
+    Thread-safe registry for tracking active model generations, allowing for cancellation and cleanup.
     Each active generation is associated with a unique request ID, user ID, conversation ID
     """
 
     def __init__(self) -> None:
         self._active_generations: dict[str, ActiveGeneration] = {}
         self._lock = threading.Lock()
-    
+
     def _request_id(self) -> str:
         """Generate a new unique request ID for tracking an active generation."""
         return _secrets.token_urlsafe(32)
-    
+
     def _register_active_generation(self, request_id: str, user_id: int, conversation_id: int,) -> threading.Event:
         """ Register a new active generation and return its cancellation event. """
         cancel_event = threading.Event()
-        generation = ActiveGeneration(user_id=user_id, 
-                                      conversation_id=conversation_id, 
+        generation = ActiveGeneration(user_id=user_id,
+                                      conversation_id=conversation_id,
                                       cancel_event=cancel_event)
-        
+
         with self._lock:
             self._active_generations[request_id] = generation
-        
+
         return cancel_event
 
     def _get_active_generation(self, request_id: str) -> dict | None:
@@ -44,5 +45,6 @@ class ActiveGenerationTracker:
         """ Unregister generation after completion or cancellation to free up resources. """
         with self._lock:
             self._active_generations.pop(request_id, None)
+
 
 tracker = ActiveGenerationTracker()

--- a/core/chat.py
+++ b/core/chat.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from typing import Iterator
 from config import NOVA_SYSTEM_PROMPT, CHAT_HISTORY_LIMIT
 from core.model_providers import (
@@ -45,6 +46,15 @@ logger = logging.getLogger(__name__)
 
 OLLAMA_UNAVAILABLE = "Ollama is unreachable. Make sure Ollama is running, then try again."
 
+
+class RequestCancelled(Exception):
+    """Raised when users cancel request aborts a generation."""
+
+def _check_cancellation(cancel_event: threading.Event | None) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise RequestCancelled()
+
+
 # Phrases that, when present in a first-pass reply, mean Nova does not
 # actually know the answer. The non-streaming chat() retries with web
 # search; chat_stream() emits a `replace` event then re-streams. Kept
@@ -64,7 +74,9 @@ def _reply_is_uncertain(reply: str) -> bool:
     return any(trigger in lowered for trigger in UNCERTAINTY_TRIGGERS)
 
 
-def _generate(model: str, messages: list[dict]) -> str:
+def _generate(model: str, messages: list[dict], 
+              request_id: str | None = None,
+              cancel_event: threading.Event | None = None,) -> str:
     """One non-streamed generation through the active model provider.
 
     Nova core no longer talks to any concrete client library: it asks the
@@ -74,9 +86,18 @@ def _generate(model: str, messages: list[dict]) -> str:
     own transport failures to :class:`ModelProviderError`, which the chat
     entrypoints translate to the existing user-facing "unreachable" reply.
     """
+    _check_cancellation(cancel_event)
     response = get_provider().generate(
-        ModelRequest(model=model, messages=messages)
+        ModelRequest(
+            model=model,
+            messages=messages,
+            options={
+                "request_id": request_id,
+                "cancel_event": cancel_event,
+            },
+        )
     )
+    _check_cancellation(cancel_event)
     return response.content
 
 
@@ -354,7 +375,19 @@ def build_image_messages(user_input: str, image: str) -> list[dict]:
     }]
 
 
-def chat(history: list[dict], user_input: str, memories: list[dict], user_id: int, forced_model: str = None, force_search: bool = False, image: str = None, policy: Policy | None = None, project_id: int | None = None) -> tuple[str, str]:  # noqa: E501
+def chat(
+    history: list[dict],
+    user_input: str,
+    memories: list[dict],
+    user_id: int,
+    forced_model: str = None,
+    force_search: bool = False,
+    image: str = None,
+    policy: Policy | None = None,
+    project_id: int | None = None,
+    request_id: str | None = None,
+    cancel_event: threading.Event | None = None,
+) -> tuple[str, str]:  # noqa: E501
     """
     Envoie un message à Nova et retourne sa réponse et le modèle utilisé.
 
@@ -383,7 +416,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             logger.debug("Processing image request, encoded length=%d", len(image))
             messages = build_image_messages(user_input, image)
             default_model = resolve_default_model()
-            reply = _generate(default_model, messages)
+            reply = _generate(
+                default_model,
+                messages,
+                request_id=request_id,
+                cancel_event=cancel_event,
+            )
+            _check_cancellation(cancel_event)
             if _autosave_allowed(policy, user_input, reply):
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
@@ -428,7 +467,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                     personalization=personalization,
                     feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
-                reply = _generate(model, messages)
+                reply = _generate(
+                    model,
+                    messages,
+                    request_id=request_id,
+                    cancel_event=cancel_event,
+                )
+                _check_cancellation(cancel_event)
                 return reply, model
 
             if weather_result in ("no_city", "multiple"):
@@ -448,7 +493,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                     personalization=personalization,
                     feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
-                reply = _generate(model, messages)
+                reply = _generate(
+                    model,
+                    messages,
+                    request_id=request_id,
+                    cancel_event=cancel_event,
+                )
+                _check_cancellation(cancel_event)
                 return reply, model
 
         # Web search — both the explicit `force_search` flag and the
@@ -460,7 +511,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                 personalization=personalization,
                 feedback_preferences=feedback_prefs, companion_mode=companion_mode,
             )
-            reply = _generate(model, messages)
+            reply = _generate(
+                model,
+                messages,
+                request_id=request_id,
+                cancel_event=cancel_event,
+            )
+            _check_cancellation(cancel_event)
             return reply, model
 
         # Chat normal — inject relevant natural memories into context
@@ -470,7 +527,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
             personalization=personalization,
             feedback_preferences=feedback_prefs, companion_mode=companion_mode,
         )
-        reply = _generate(model, messages)
+        reply = _generate(
+            model,
+            messages,
+            request_id=request_id,
+            cancel_event=cancel_event,
+        )
+        _check_cancellation(cancel_event)
 
         # Si Nova sait pas → cherche sur le web automatiquement
         if policy.web_search_enabled and _reply_is_uncertain(reply):
@@ -481,7 +544,13 @@ def chat(history: list[dict], user_input: str, memories: list[dict], user_id: in
                     personalization=personalization,
                     feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
-                reply = _generate(model, messages)
+                reply = _generate(
+                    model,
+                    messages,
+                    request_id=request_id,
+                    cancel_event=cancel_event,
+                )
+                _check_cancellation(cancel_event)
 
         if _autosave_allowed(policy, user_input, reply):
             extract_and_save_memory(user_input, reply, user_id, project_id)
@@ -505,6 +574,8 @@ def chat_stream(
     image: str = None,
     policy: Policy | None = None,
     project_id: int | None = None,
+    request_id: str | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> Iterator[dict]:
     """Generator twin of :func:`chat` that yields incremental events.
 
@@ -537,7 +608,13 @@ def chat_stream(
             logger.debug("Processing streaming-image request, encoded length=%d", len(image))
             messages = build_image_messages(user_input, image)
             default_model = resolve_default_model()
-            reply = _generate(default_model, messages)
+            reply = _generate(
+                default_model,
+                messages,
+                request_id=request_id,
+                cancel_event=cancel_event,
+            )
+            _check_cancellation(cancel_event)
             if _autosave_allowed(policy, user_input, reply):
                 extract_and_save_memory(
                     user_input or "image", reply, user_id, project_id
@@ -584,7 +661,10 @@ def chat_stream(
                     "weather", personalization=personalization,
                     feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
-                reply = yield from _stream_and_accumulate(model, messages)
+                reply = yield from _stream_and_accumulate(
+                    model, messages, request_id=request_id,
+                    cancel_event=cancel_event,
+                )
                 yield {"type": "done", "reply": reply, "model": model}
                 return
 
@@ -609,7 +689,10 @@ def chat_stream(
                     "security", personalization=personalization,
                     feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
-                reply = yield from _stream_and_accumulate(model, messages)
+                reply = yield from _stream_and_accumulate(
+                    model, messages, request_id=request_id,
+                    cancel_event=cancel_event,
+                )
                 yield {"type": "done", "reply": reply, "model": model}
                 return
 
@@ -621,7 +704,10 @@ def chat_stream(
                 "search", personalization=personalization,
                 feedback_preferences=feedback_prefs, companion_mode=companion_mode,
             )
-            reply = yield from _stream_and_accumulate(model, messages)
+            reply = yield from _stream_and_accumulate(
+                model, messages, request_id=request_id,
+                cancel_event=cancel_event,
+            )
             yield {"type": "done", "reply": reply, "model": model}
             return
 
@@ -631,7 +717,15 @@ def chat_stream(
             natural_memories=natural_mems, personalization=personalization,
             feedback_preferences=feedback_prefs, companion_mode=companion_mode,
         )
-        reply = yield from _stream_and_accumulate(model, messages)
+        reply = yield from _stream_and_accumulate(
+            model,
+            messages,
+            request_id=request_id,
+            cancel_event=cancel_event,
+        )
+        if cancel_event is not None and cancel_event.is_set():
+            yield {"type": "error", "detail": "generation cancelled"}
+            return
 
         # Uncertainty fallback (same trigger set as the non-streaming
         # path). We clear the bubble via `replace` then stream the
@@ -646,7 +740,19 @@ def chat_stream(
                     "search", personalization=personalization,
                     feedback_preferences=feedback_prefs, companion_mode=companion_mode,
                 )
-                reply = yield from _stream_and_accumulate(model, messages)
+                reply = yield from _stream_and_accumulate(
+                    model,
+                    messages,
+                    request_id=request_id,
+                    cancel_event=cancel_event,
+                )
+                if cancel_event is not None and cancel_event.is_set():
+                    yield {"type": "error", "detail": "generation cancelled"}
+                    return
+
+        if cancel_event is not None and cancel_event.is_set():
+            yield {"type": "error", "detail": "generation cancelled"}
+            return
 
         if _autosave_allowed(policy, user_input, reply):
             extract_and_save_memory(user_input, reply, user_id, project_id)
@@ -661,7 +767,8 @@ def chat_stream(
         yield {"type": "error", "detail": OLLAMA_UNAVAILABLE}
 
 
-def _stream_and_accumulate(model: str, messages: list[dict]) -> Iterator[dict]:
+def _stream_and_accumulate(model: str, messages: list[dict],
+                           request_id: str | None = None, cancel_event: threading.Event | None = None,) -> Iterator[dict]:
     """Stream one generation through the provider, re-emitting each token.
 
     The generator behaves as a coroutine: ``reply = yield from
@@ -676,7 +783,10 @@ def _stream_and_accumulate(model: str, messages: list[dict]) -> Iterator[dict]:
     wrapper turns into the existing `error` event.
     """
     parts: list[str] = []
-    request = ModelRequest(model=model, messages=messages, stream=True)
+    # request_id and cancel_event are passed a new stream is initiated to support mid-stream cancellation
+    request = ModelRequest(model=model, messages=messages, stream=True, 
+                           options={"request_id": request_id,
+                                    "cancel_event": cancel_event,},)
     for chunk in get_provider().stream(request):
         if not chunk.content:
             continue

--- a/core/chat.py
+++ b/core/chat.py
@@ -50,6 +50,7 @@ OLLAMA_UNAVAILABLE = "Ollama is unreachable. Make sure Ollama is running, then t
 class RequestCancelled(Exception):
     """Raised when users cancel request aborts a generation."""
 
+
 def _check_cancellation(cancel_event: threading.Event | None) -> None:
     if cancel_event is not None and cancel_event.is_set():
         raise RequestCancelled()
@@ -74,7 +75,7 @@ def _reply_is_uncertain(reply: str) -> bool:
     return any(trigger in lowered for trigger in UNCERTAINTY_TRIGGERS)
 
 
-def _generate(model: str, messages: list[dict], 
+def _generate(model: str, messages: list[dict],
               request_id: str | None = None,
               cancel_event: threading.Event | None = None,) -> str:
     """One non-streamed generation through the active model provider.
@@ -784,9 +785,9 @@ def _stream_and_accumulate(model: str, messages: list[dict],
     """
     parts: list[str] = []
     # request_id and cancel_event are passed a new stream is initiated to support mid-stream cancellation
-    request = ModelRequest(model=model, messages=messages, stream=True, 
+    request = ModelRequest(model=model, messages=messages, stream=True,
                            options={"request_id": request_id,
-                                    "cancel_event": cancel_event,},)
+                                    "cancel_event": cancel_event},)
     for chunk in get_provider().stream(request):
         if not chunk.content:
             continue

--- a/core/model_providers/ollama.py
+++ b/core/model_providers/ollama.py
@@ -167,81 +167,13 @@ class OllamaProvider(ModelProvider):
                 if content:
                     yield ModelChunk(content=content)
                 return
-            # Iterate upstream chunks but try to close the upstream
-            # stream/response when the cancel_event is set so the
-            # underlying transport can be aborted early (best-effort).
-            # Some upstream stream implementations do not expose a
-            # synchronous ``close`` / ``aclose`` API. Iterating such a
-            # stream can block the current thread; to ensure the web
-            # generator can return promptly on cancellation we run the
-            # upstream iterator in a background producer thread and
-            # shuttle chunks via a Queue. The main thread polls the
-            # queue and stops immediately when ``cancel_event`` is set,
-            # ensuring the request handler unblocks and the result is
-            # not persisted. This does not forcibly abort the Ollama
-            # worker process in every environment (that would require
-            # transport-level abort support), but it isolates the
-            # blocking I/O from the request thread.
-            from queue import Queue, Empty
-
-            q: "Queue[object]" = Queue()
-            _SENTINEL = object()
-
-            def _producer():
-                try:
-                    for c in _iter_content_chunks(upstream):
-                        q.put(c)
-                except Exception as exc:  # put the exception for consumer
-                    q.put(exc)
-                finally:
-                    q.put(_SENTINEL)
-
-            prod_thread = threading.Thread(target=_producer, daemon=True)
-            prod_thread.start()
-
-            try:
-                while True:
-                    # Short timeout so we can react to cancel_event
-                    try:
-                        item = q.get(timeout=0.1)
-                    except Empty:
-                        if cancel_event is not None and cancel_event.is_set():
-                            # Best-effort attempt to close upstream if it
-                            # exposes a close hook. If it doesn't, simply
-                            # return so the request handler unblocks.
-                            try:
-                                aclose = getattr(upstream, "aclose", None)
-                                if callable(aclose):
-                                    try:
-                                        aclose()
-                                    except TypeError:
-                                        pass
-                                else:
-                                    close = getattr(upstream, "close", None)
-                                    if callable(close):
-                                        try:
-                                            close()
-                                        except Exception:
-                                            pass
-                            except Exception:
-                                pass
-                            return
-                        continue
-
-                    if item is _SENTINEL:
-                        break
-                    if isinstance(item, Exception):
-                        raise item
-
-                    if cancel_event is not None and cancel_event.is_set():
-                        return
-
-                    yield ModelChunk(content=item)
-            finally:
-                # Ensure the producer thread is not left blocked; if it
-                # is still running give it a moment to finish and move
-                # on — it's daemonized so it won't prevent shutdown.
-                prod_thread.join(timeout=0.01)
+            for chunk in _iter_content_chunks(upstream):
+                if cancel_event is not None and cancel_event.is_set():
+                    # Ollama's native Python client does not expose a cancel
+                    # hook for the stream object. We stop consuming and let
+                    # the caller treat the request as aborted.
+                    return
+                yield ModelChunk(content=chunk)
                 
         except _TRANSPORT_ERRORS as exc:
             raise ModelProviderError(str(exc) or "Ollama unreachable") from exc

--- a/core/model_providers/ollama.py
+++ b/core/model_providers/ollama.py
@@ -21,7 +21,7 @@ process restart.
 """
 
 from __future__ import annotations
-
+import threading
 from typing import Iterator, Optional
 
 import httpx
@@ -61,6 +61,13 @@ def _safe_get(obj, key: str):
         except TypeError:
             pass
     return getattr(obj, key, None)
+
+
+def _get_cancel_event(request: ModelRequest) -> threading.Event | None:
+    if not request.options:
+        return None
+    cancel_event = request.options.get("cancel_event")
+    return cancel_event if isinstance(cancel_event, threading.Event) else None
 
 
 def _iter_content_chunks(stream) -> Iterator[str]:
@@ -137,7 +144,10 @@ class OllamaProvider(ModelProvider):
 
     def stream(self, request: ModelRequest) -> Iterator[ModelChunk]:
         client = self._client()
+        cancel_event = _get_cancel_event(request)
         try:
+            if cancel_event is not None and cancel_event.is_set():
+                return
             try:
                 upstream = client.chat(
                     model=request.model,
@@ -157,8 +167,82 @@ class OllamaProvider(ModelProvider):
                 if content:
                     yield ModelChunk(content=content)
                 return
-            for chunk in _iter_content_chunks(upstream):
-                yield ModelChunk(content=chunk)
+            # Iterate upstream chunks but try to close the upstream
+            # stream/response when the cancel_event is set so the
+            # underlying transport can be aborted early (best-effort).
+            # Some upstream stream implementations do not expose a
+            # synchronous ``close`` / ``aclose`` API. Iterating such a
+            # stream can block the current thread; to ensure the web
+            # generator can return promptly on cancellation we run the
+            # upstream iterator in a background producer thread and
+            # shuttle chunks via a Queue. The main thread polls the
+            # queue and stops immediately when ``cancel_event`` is set,
+            # ensuring the request handler unblocks and the result is
+            # not persisted. This does not forcibly abort the Ollama
+            # worker process in every environment (that would require
+            # transport-level abort support), but it isolates the
+            # blocking I/O from the request thread.
+            from queue import Queue, Empty
+
+            q: "Queue[object]" = Queue()
+            _SENTINEL = object()
+
+            def _producer():
+                try:
+                    for c in _iter_content_chunks(upstream):
+                        q.put(c)
+                except Exception as exc:  # put the exception for consumer
+                    q.put(exc)
+                finally:
+                    q.put(_SENTINEL)
+
+            prod_thread = threading.Thread(target=_producer, daemon=True)
+            prod_thread.start()
+
+            try:
+                while True:
+                    # Short timeout so we can react to cancel_event
+                    try:
+                        item = q.get(timeout=0.1)
+                    except Empty:
+                        if cancel_event is not None and cancel_event.is_set():
+                            # Best-effort attempt to close upstream if it
+                            # exposes a close hook. If it doesn't, simply
+                            # return so the request handler unblocks.
+                            try:
+                                aclose = getattr(upstream, "aclose", None)
+                                if callable(aclose):
+                                    try:
+                                        aclose()
+                                    except TypeError:
+                                        pass
+                                else:
+                                    close = getattr(upstream, "close", None)
+                                    if callable(close):
+                                        try:
+                                            close()
+                                        except Exception:
+                                            pass
+                            except Exception:
+                                pass
+                            return
+                        continue
+
+                    if item is _SENTINEL:
+                        break
+                    if isinstance(item, Exception):
+                        raise item
+
+                    if cancel_event is not None and cancel_event.is_set():
+                        return
+
+                    yield ModelChunk(content=item)
+            finally:
+                # Ensure the producer thread is not left blocked; if it
+                # is still running give it a moment to finish and move
+                # on — it's daemonized so it won't prevent shutdown.
+                prod_thread.join(timeout=0.01)
+                
         except _TRANSPORT_ERRORS as exc:
             raise ModelProviderError(str(exc) or "Ollama unreachable") from exc
         except Exception as exc:  # noqa: BLE001 — narrowed below

--- a/core/model_providers/ollama.py
+++ b/core/model_providers/ollama.py
@@ -174,7 +174,6 @@ class OllamaProvider(ModelProvider):
                     # the caller treat the request as aborted.
                     return
                 yield ModelChunk(content=chunk)
-                
         except _TRANSPORT_ERRORS as exc:
             raise ModelProviderError(str(exc) or "Ollama unreachable") from exc
         except Exception as exc:  # noqa: BLE001 — narrowed below

--- a/static/index.html
+++ b/static/index.html
@@ -4625,6 +4625,7 @@
     let activeChatController = null;
     let activeThinkingRow = null;
     let activeStreamBubble = null;
+    let activeRequestId = null;
     let userCancelledChat = false;
     let allConversations = [];
     let convSearchQuery = "";
@@ -4711,9 +4712,33 @@
         messagesEl.scrollTop = messagesEl.scrollHeight;
     }
 
+    async function cancelGeneration() {
+        try {
+            const res = await fetch(`/chat/cancel/${encodeURIComponent(activeRequestId)}`, {
+                method: "POST",
+                headers: { "Authorization": `Bearer ${token}` }
+            });
+            if (!res.ok) {
+                let detail = "";
+                try { 
+                    detail = (await res.json())?.detail || ""; 
+                } catch {}
+                return;
+            }
+        } catch (e) {
+            appendMessage("nova", "Unable to cancel generation (network error).");
+        }
+    }
+
     function stopMessage() {
         if (!isThinking) return;
         userCancelledChat = true;
+        // If the server knows about this generation, ask it to cancel
+        // so provider-side work can be interrupted. Otherwise fall back
+        // to the local abort behavior.
+        if (activeRequestId) {
+            cancelGeneration();
+        }
         if (activeChatController) {
             activeChatController.abort();
         }
@@ -4731,6 +4756,7 @@
         appendStoppedNotice();
         isThinking = false;
         activeChatController = null;
+        activeRequestId = null;
         setSendButtonToSend();
         document.getElementById("user-input")?.focus();
     }
@@ -7800,6 +7826,7 @@
             activeChatController = null;
             activeStreamBubble = null;
             setSendButtonToSend();
+            activeRequestId = null;
             searchEnabled = false;
             document.getElementById("search-btn").classList.remove("active");
             removeImage();
@@ -7835,6 +7862,9 @@
                         result.conversationId = event.conversation_id;
                     }
                     if (event.model) result.model = event.model;
+                    if (event.request_id) {
+                        activeRequestId = event.request_id;
+                    }
                     break;
                 }
                 case "delta": {
@@ -7897,6 +7927,8 @@
                         result.model,
                         result.assistantMessageId || null,
                     );
+                    // generation finished — clear any server-side cancel handle
+                    activeRequestId = null;
                     break;
                 }
                 case "error": {
@@ -7908,6 +7940,7 @@
                     }
                     if (thinkingRow.isConnected) thinkingRow.remove();
                     activeThinkingRow = null;
+                    activeRequestId = null;
                     break;
                 }
                 default:
@@ -7962,6 +7995,8 @@
                     || "Nova didn't produce a reply. Please try again.";
             }
         }
+        // Clear any server-side cancel handle
+        activeRequestId = null;
         if (thinkingRow.isConnected) thinkingRow.remove();
         activeThinkingRow = null;
         return result;

--- a/tests/test_cancel_endpoint.py
+++ b/tests/test_cancel_endpoint.py
@@ -111,6 +111,7 @@ def test_cancel_endpoint_returns_404_for_other_user(db_path, web_client):
     import web
 
     alice = _make_user(db_path, "alice")
+    _make_user(db_path, "bob")
     b_token = _login(web_client, "bob")
 
     request_id = web.tracker._request_id()

--- a/tests/test_cancel_endpoint.py
+++ b/tests/test_cancel_endpoint.py
@@ -2,19 +2,17 @@ import contextlib
 import json
 import sqlite3
 import sys
-import threading
-from unittest.mock import MagicMock, patch
-
 import pytest
+
+from unittest.mock import MagicMock, patch
+from core import chat as chat_module, memory as core_memory, ollama_client, users
+from memory import store as natural_store
 from fastapi.testclient import TestClient
+
 
 for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock()
-
-from core import chat as chat_module, memory as core_memory, ollama_client, users
-from core.model_providers import ModelRequest, OllamaProvider
-from memory import store as natural_store
 
 
 @pytest.fixture
@@ -113,8 +111,6 @@ def test_cancel_endpoint_returns_404_for_other_user(db_path, web_client):
     import web
 
     alice = _make_user(db_path, "alice")
-    bob = _make_user(db_path, "bob")
-    a_token = _login(web_client, "alice")
     b_token = _login(web_client, "bob")
 
     request_id = web.tracker._request_id()
@@ -129,7 +125,6 @@ def test_cancel_endpoint_returns_404_for_other_user(db_path, web_client):
 
 def test_cancelled_stream_does_not_persist(db_path, web_client):
     """When a stream is cancelled mid-generation, nothing gets persisted.
-    
     Simulates the scenario where:
     1. Client calls /chat/stream and streaming begins
     2. Provider's cancellation check catches the cancel_event being set
@@ -169,16 +164,13 @@ def test_cancelled_stream_does_not_persist(db_path, web_client):
             json={"message": "hi", "mode": "chat"},
             headers=_h(token),
         )
-    
     # Verify the stream ended with error, not done
     assert resp.status_code == 200
     events = _decode_ndjson(resp.content)
     types = [e["type"] for e in events]
-    
     # Should have error event, NOT done (because generation was cancelled)
     assert "error" in types, f"Expected 'error' in event types, got: {types}"
-    assert "done" not in types, f"Cancelled stream should not have 'done' event"
-    
+    assert "done" not in types, "Cancelled stream should not have 'done' event"
     # Critically: verify nothing was persisted
     with sqlite3.connect(db_path) as conn:
         count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]

--- a/tests/test_cancel_endpoint.py
+++ b/tests/test_cancel_endpoint.py
@@ -1,0 +1,207 @@
+import contextlib
+import json
+import sqlite3
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from core import chat as chat_module, memory as core_memory, ollama_client, users
+from core.model_providers import ModelRequest, OllamaProvider
+from memory import store as natural_store
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(conn, username, password, role=role)
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class _SubscriptableEvent:
+    """Stand-in for ``ollama.ChatResponse`` (a ``SubscriptableBaseModel``).
+
+    Real ollama-python streams Pydantic objects that expose ``.get()``
+    and ``[key]`` access but are **not** ``dict`` instances. The plain
+    dict mocks elsewhere in this file happen to satisfy any
+    ``isinstance(event, dict)`` filter; production ``ChatResponse``
+    objects do not — that mismatch was the root cause of empty replies
+    in production. Using this shape in regression tests pins the
+    contract without importing the live ollama package.
+    """
+
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def get(self, key, default=None):
+        return self._fields.get(key, default)
+
+    def __getitem__(self, key):
+        return self._fields[key]
+
+
+def _decode_ndjson(body: bytes) -> list[dict]:
+    """Decode NDJSON response body into list of dicts."""
+    out = []
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+def test_cancel_endpoint_sets_event_and_requires_owner(db_path, web_client):
+    # Create a user and register a synthetic active generation.
+    import web
+
+    alice = _make_user(db_path, "alice")
+    token = _login(web_client, "alice")
+
+    request_id = web.tracker._request_id()
+    cancel_event = web.tracker._register_active_generation(request_id, alice, 1)
+
+    resp = web_client.post(f"/chat/cancel/{request_id}", headers=_h(token))
+    assert resp.status_code == 200
+    assert resp.json().get("cancelled") is True
+    assert cancel_event.is_set()
+
+    # Cleanup
+    web.tracker._unregister_active_generation(request_id)
+
+
+def test_cancel_endpoint_returns_404_for_other_user(db_path, web_client):
+    import web
+
+    alice = _make_user(db_path, "alice")
+    bob = _make_user(db_path, "bob")
+    a_token = _login(web_client, "alice")
+    b_token = _login(web_client, "bob")
+
+    request_id = web.tracker._request_id()
+    cancel_event = web.tracker._register_active_generation(request_id, alice, 1)
+
+    resp = web_client.post(f"/chat/cancel/{request_id}", headers=_h(b_token))
+    assert resp.status_code == 404
+    assert not cancel_event.is_set()
+
+    web.tracker._unregister_active_generation(request_id)
+
+
+def test_cancelled_stream_does_not_persist(db_path, web_client):
+    """When a stream is cancelled mid-generation, nothing gets persisted.
+    
+    Simulates the scenario where:
+    1. Client calls /chat/stream and streaming begins
+    2. Provider's cancellation check catches the cancel_event being set
+    3. Generation stops mid-stream with RequestCancelled
+    4. Endpoint catches the exception and doesn't persist any messages
+    """
+    _make_user(db_path, "alice")
+    token = _login(web_client, "alice")
+
+    def fake_chat_raises_cancelled(*args, **kwargs):
+        """Generator that yields one chunk then raises RequestCancelled."""
+        if kwargs.get("stream"):
+            def gen():
+                # Yield one chunk to show generation started
+                yield _SubscriptableEvent(
+                    message=_SubscriptableEvent(content="hel"), done=False
+                )
+                # Then cancel is detected and RequestCancelled is raised
+                from core.chat import RequestCancelled
+                raise RequestCancelled()
+            return gen()
+        return {"message": {"content": "hello"}}
+
+    with patch.object(ollama_client.client, "chat", side_effect=fake_chat_raises_cancelled), \
+            patch.object(chat_module, "route", lambda _msg: "default"), \
+            patch.object(chat_module, "should_search", lambda _msg: False), \
+            patch.object(chat_module, "is_security_query", lambda _msg: False), \
+            patch.object(chat_module, "detect_weather_city", lambda _msg: None), \
+            patch.object(chat_module, "get_relevant_memories", lambda *_a, **_k: []), \
+            patch.object(chat_module, "extract_and_save_memory", lambda *_a, **_k: None), \
+            patch.object(
+                chat_module, "_extract_and_save_natural_memories",
+                lambda *_a, **_k: None,
+            ):
+        resp = web_client.post(
+            "/chat/stream",
+            json={"message": "hi", "mode": "chat"},
+            headers=_h(token),
+        )
+    
+    # Verify the stream ended with error, not done
+    assert resp.status_code == 200
+    events = _decode_ndjson(resp.content)
+    types = [e["type"] for e in events]
+    
+    # Should have error event, NOT done (because generation was cancelled)
+    assert "error" in types, f"Expected 'error' in event types, got: {types}"
+    assert "done" not in types, f"Cancelled stream should not have 'done' event"
+    
+    # Critically: verify nothing was persisted
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    assert count == 0, "Cancelled stream should not persist any messages"
+
+
+def test_cancelled_chat_does_not_persist(db_path, web_client):
+    _make_user(db_path, "alice")
+    token = _login(web_client, "alice")
+
+    def fake_chat(*args, **kwargs):
+        from core.chat import RequestCancelled
+        raise RequestCancelled()
+
+    import web
+    with patch.object(web, "chat", side_effect=fake_chat):
+        resp = web_client.post(
+            "/chat",
+            json={"message": "hi", "mode": "chat"},
+            headers=_h(token),
+        )
+
+    assert resp.status_code == 503
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    assert count == 0, "Cancelled /chat request should not persist any messages"

--- a/web.py
+++ b/web.py
@@ -9,6 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field, field_validator
 
+from core.active_generation_tracker import tracker
 from core.auth import (
     CurrentUser,
     authenticate,
@@ -19,7 +20,7 @@ from core.rate_limiter import check_login_rate_limit
 from apscheduler.schedulers.background import BackgroundScheduler
 from core.learner import learn_from_feeds
 from core.updater import check_and_update_models
-from core.chat import chat, chat_stream
+from core.chat import RequestCancelled, chat, chat_stream
 from core.memory_command import handle_manual_memory_command
 from core.session_continuity import build_session_continuity
 from core.memory import (
@@ -174,7 +175,6 @@ scheduler = BackgroundScheduler()
 if NOVA_AUTO_WEB_LEARNING:
     scheduler.add_job(learn_from_feeds, "interval", hours=1)
 scheduler.add_job(check_and_update_models, "interval", weeks=1)
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -1083,10 +1083,6 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         }
 
     conversation_id = _resolve_conversation_id(request, user)
-    # The conversation is the single source of truth for the active
-    # project: a new thread was just created in the validated project,
-    # an existing one keeps its own. Memory is scoped to it so a project
-    # session sees global + that project's memory and nothing else.
     active_project_id = get_conversation_project_id(conversation_id, user.id)
     memories = load_memories(user.id, project_scope=active_project_id)
 
@@ -1098,14 +1094,25 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
     forced_model = _resolve_forced_model(request, user)
     _check_forced_model_access(forced_model, user)
 
-    response, model_used = chat(
-        history, request.message, memories, user.id,
-        forced_model=forced_model,
-        force_search=request.search,
-        image=request.image,
-        policy=policy,
-        project_id=active_project_id,
+    request_id = tracker._request_id()
+    cancel_event = tracker._register_active_generation(
+        request_id, user.id, conversation_id
     )
+    try:
+        response, model_used = chat(
+            history, request.message, memories, user.id,
+            forced_model=forced_model,
+            force_search=request.search,
+            image=request.image,
+            policy=policy,
+            project_id=active_project_id,
+            request_id=request_id,
+            cancel_event=cancel_event,
+        )
+    except RequestCancelled:
+        raise HTTPException(status_code=503, detail="Chat generation cancelled.")
+    finally:
+        tracker._unregister_active_generation(request_id)
 
     user_message_id = save_message(
         conversation_id, "user", request.message
@@ -1121,6 +1128,7 @@ def chat_endpoint(request: ChatRequest, user: CurrentUser = Depends(get_current_
         "response": response,
         "model": model_used,
         "conversation_id": conversation_id,
+        "request_id": request_id,
         "user_message_id": user_message_id,
         "assistant_message_id": assistant_message_id,
     }
@@ -1162,6 +1170,7 @@ def chat_stream_endpoint(
     conversation never shows a half-baked response.
     """
     policy, short_reply, short_model = _chat_preflight(request, user)
+    request_id = tracker._request_id()
 
     if short_reply is not None:
         # Short-circuit replies (memory commands, "what do you remember")
@@ -1170,11 +1179,19 @@ def chat_stream_endpoint(
         conv_id = request.conversation_id
 
         def _short_circuit():
-            yield _stream_event({"type": "meta", "model": short_model,
-                                 "conversation_id": conv_id})
+            yield _stream_event({
+                "type": "meta",
+                "model": short_model,
+                "conversation_id": conv_id,
+                "request_id": request_id,
+            })
             yield _stream_event({"type": "delta", "content": short_reply})
-            yield _stream_event({"type": "done", "model": short_model,
-                                 "conversation_id": conv_id})
+            yield _stream_event({
+                "type": "done",
+                "model": short_model,
+                "conversation_id": conv_id,
+                "request_id": request_id,
+            })
 
         return StreamingResponse(_short_circuit(), media_type="application/x-ndjson")
 
@@ -1193,6 +1210,10 @@ def chat_stream_endpoint(
     forced_model = _resolve_forced_model(request, user)
     _check_forced_model_access(forced_model, user)
 
+    cancel_event = tracker._register_active_generation(
+        request_id, user.id, conversation_id
+    )
+
     def _generate():
         # `chat_stream` mirrors the synchronous `chat()` path: it does
         # routing, weather/search/security gating, and uncertainty
@@ -1204,6 +1225,8 @@ def chat_stream_endpoint(
             image=request.image,
             policy=policy,
             project_id=active_project_id,
+            request_id=request_id,
+            cancel_event=cancel_event,
         )
 
         final_reply = ""
@@ -1218,6 +1241,7 @@ def chat_stream_endpoint(
                         "type": "meta",
                         "model": final_model,
                         "conversation_id": conversation_id,
+                        "request_id": request_id,
                     })
                 elif etype == "delta":
                     yield _stream_event(event)
@@ -1238,6 +1262,7 @@ def chat_stream_endpoint(
                         yield _stream_event({
                             "type": "error",
                             "detail": EMPTY_REPLY_DETAIL,
+                            "request_id": request_id,
                         })
                         return
                     # Persist only once we know the full reply landed
@@ -1263,6 +1288,7 @@ def chat_stream_endpoint(
                         "type": "done",
                         "model": final_model,
                         "conversation_id": conversation_id,
+                        "request_id": request_id,
                         "user_message_id": user_message_id,
                         "assistant_message_id": assistant_message_id,
                     })
@@ -1271,13 +1297,27 @@ def chat_stream_endpoint(
                     yield _stream_event({
                         "type": "error",
                         "detail": event.get("detail", "stream error"),
+                        "request_id": request_id,
                     })
                     return
+        except RequestCancelled:
+            yield _stream_event({
+                "type": "error",
+                "detail": "generation cancelled",
+                "request_id": request_id,
+            })
+            return
         except Exception as exc:  # pragma: no cover — defensive
             # Whatever happens we must terminate the stream tidily so
             # the client unblocks and shows a calm error state.
-            yield _stream_event({"type": "error", "detail": str(exc) or "stream error"})
+            yield _stream_event({
+                "type": "error",
+                "detail": str(exc) or "stream error",
+                "request_id": request_id,
+            })
             return
+        finally:
+            tracker._unregister_active_generation(request_id)
 
         # Defensive fallthrough — chat_stream should always end with
         # either `done` or `error`. If it does not (e.g. generator
@@ -1300,6 +1340,18 @@ def chat_stream_endpoint(
         media_type="application/x-ndjson",
         headers=headers,
     )
+
+
+@app.post("/chat/cancel/{request_id}")
+def cancel_chat_endpoint(
+    request_id: str,
+    user: CurrentUser = Depends(get_current_user),
+):
+    active = tracker._get_active_generation(request_id)
+    if not active or active.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Generation not found.")
+    active.cancel_event.set()
+    return {"request_id": request_id, "cancelled": True}
 
 
 # ── MEMORY ENDPOINTS ──

--- a/web.py
+++ b/web.py
@@ -176,6 +176,7 @@ if NOVA_AUTO_WEB_LEARNING:
     scheduler.add_job(learn_from_feeds, "interval", hours=1)
 scheduler.add_job(check_and_update_models, "interval", weeks=1)
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     initialize_db()


### PR DESCRIPTION
Issue #96 

Changes:
Adds `active_generation_tracker.py` to track and cancel generation during the login session
Updates `core/ollama.py` and `core/chat.py` to integrate cancellation methods for models and chat stream
Updates `web.py` with a formal `POST /chat/cancel/{request_id}` endpoint
Adds frontend support `index.html` for canceling active requests
Includes a new test suite `test_cancel_endpoint.py` that includes tests for canceled requests not being persisted. 

Notes:
Current cancellation is only best-effort in the sense of stopping Nova’s processing/streaming. It does not guarantee early release of Ollama CPU/GPU resources.