### PR TITLE
feat(docker): full Docker Compose stack with bundled Ollama

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,45 @@
+# ====================================================================
+#  Nova environment configuration
+#
+#  Docker (recommended):  cp .env.example .env  &&  docker compose up -d
+#                         then open http://localhost:8000
+#
+#  The defaults below bring the stack up immediately. Change the
+#  credentials before exposing Nova beyond your own machine.
+# ====================================================================
+
+# ── Docker Compose: networking ────────────────────────────────────
+# Host port Nova is published on. Reach it at http://localhost:<port>
+# and, from other LAN machines, http://<host-ip>:<port>. Change this if
+# 8000 is already taken on the host. NOVA_PORT is the in-container port;
+# leave both at 8000 unless you have a reason to change them.
+NOVA_HOST_PORT=8000
+NOVA_PORT=8000
+
+# ── Model provider URL (Ollama) ───────────────────────────────────
+# Leave commented for the default setups:
+#   * Docker Compose      → Nova uses the bundled `ollama` container
+#                           (http://ollama:11434) automatically.
+#   * Local (non-Docker)  → Nova uses http://localhost:11434.
+# Uncomment and set it only to point Nova at an Ollama elsewhere, e.g.
+# another LAN machine or your NAS:
+#   OLLAMA_HOST=http://192.168.1.50:11434
+# OLLAMA_HOST=
+
 # ── Nova credentials ────────────────────────────────────────────
-# IMPORTANT: Change both values before any deployment.
-# Defaults (nova / nova) are intentionally weak and must not be used in production.
+# The first start seeds the admin account from these values. CHANGE
+# THEM before exposing Nova beyond localhost — the defaults are weak.
 NOVA_USERNAME=admin
 NOVA_PASSWORD=changeme
-NOVA_SECRET_KEY=change-this-to-a-long-random-string
+
+# ── Session signing key (JWT) ─────────────────────────────────────
+# Signs login sessions. Leave it UNSET (commented) for Docker: the
+# container generates a strong per-install key on first start and keeps
+# it in the data volume, so logins survive restarts without a known key
+# being shipped in this file. For a non-Docker deployment that must keep
+# sessions across restarts, set your own long random value:
+#   NOVA_SECRET_KEY=$(openssl rand -hex 32)
+# NOVA_SECRET_KEY=
 
 # ── Nova data directory ───────────────────────────────────────────
 # Where Nova stores its runtime state (nova.db, backups, exports,
@@ -32,6 +68,9 @@ NOVA_SECRET_KEY=change-this-to-a-long-random-string
 # NOVA_DATA_DIR and now want the new directory, stop Nova, copy
 # nova.db manually (see docs/data-directory.md), then start Nova.
 # Nova never deletes or overwrites an existing database on startup.
+#
+# Under Docker Compose this value is ignored: the container always uses
+# /data (a persistent named volume), so leave it blank here.
 NOVA_DATA_DIR=
 
 # ── Release channel ───────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 # syntax=docker/dockerfile:1.7
 
 # Nova — self-hosted local AI assistant
-# Build: docker build -t nova .
-# Run:   docker run -p 8080:8080 --env-file .env -v nova-data:/data nova
+#
+# Build:  docker build -t nova .
+# Run:    docker compose up -d           (recommended — see docker-compose.yml)
 #
 # This image bundles only the application code and Python dependencies.
 # It contains NO secrets, NO database, and NO Ollama models.
-#   - Credentials are passed at runtime via environment variables.
-#   - The SQLite database is stored on a host-managed volume (/data).
-#   - Ollama runs externally and is reached over the network via OLLAMA_HOST.
+#   - Credentials are passed at runtime via environment variables (.env).
+#   - All runtime data (nova.db, logs, exports, backups) lives on the
+#     /data volume, never in the disposable container layer.
+#   - Ollama runs as its own container and is reached over the Docker
+#     network via OLLAMA_HOST (see docker-compose.yml).
 
 FROM python:3.11-slim AS base
 
@@ -16,6 +19,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Persist all runtime state under /data by default so a stock
+# `docker run -v nova-data:/data nova` keeps nothing important in the
+# container layer. core/paths.py reads NOVA_DATA_DIR and places nova.db +
+# backups/exports/memory-packs/logs underneath it. NOVA_PORT is the port
+# uvicorn binds inside the container; both are overridable at runtime.
+ENV NOVA_DATA_DIR=/data \
+    NOVA_PORT=8000
 
 WORKDIR /app
 
@@ -32,8 +43,8 @@ RUN pip install -r requirements.txt
 # __pycache__, tests, and other local artefacts from entering the image.
 COPY . .
 
-# Drop privileges. The /data volume is chowned by the entrypoint at runtime
-# so a host bind-mount with arbitrary ownership still works.
+# Drop privileges. /data is created and chowned here; the entrypoint also
+# ensures it exists at runtime so a host bind-mount still works.
 RUN useradd --system --create-home --uid 1000 nova \
     && mkdir -p /data \
     && chown -R nova:nova /app /data
@@ -43,9 +54,19 @@ RUN chmod +x /usr/local/bin/nova-entrypoint
 
 USER nova
 
-EXPOSE 8080
+EXPOSE 8000
 
 VOLUME ["/data"]
 
+# Liveness check: uvicorn is serving the web UI. Uses only the stdlib so
+# no extra packages are needed. A <500 response means the app is up.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
+    CMD python -c "import os,sys,urllib.request; \
+url='http://127.0.0.1:'+os.environ.get('NOVA_PORT','8000')+'/'; \
+sys.exit(0 if urllib.request.urlopen(url, timeout=3).status < 500 else 1)" \
+    || exit 1
+
 ENTRYPOINT ["tini", "--", "/usr/local/bin/nova-entrypoint"]
-CMD ["uvicorn", "web:app", "--host", "0.0.0.0", "--port", "8080"]
+# Shell form so ${NOVA_PORT} is expanded at runtime; `exec` keeps uvicorn
+# as the child tini supervises so signals propagate cleanly.
+CMD ["sh", "-c", "exec uvicorn web:app --host 0.0.0.0 --port ${NOVA_PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -925,13 +925,27 @@ For the broader deployment story (LAN-only, VPN / Zero-Trust gateway,
 backups, and the explicit list of things Nova will never do) see
 [docs/secure-deployment.md](docs/secure-deployment.md).
 
-### Docker
+### Docker (recommended)
 
-A `Dockerfile` and `docker-compose.yml` are included. The compose
-stack persists `nova.db` in a Docker volume, keeps Ollama external
-(reachable via `OLLAMA_HOST`), and supports clean updates via
-`docker compose pull`. See [docs/docker.md](docs/docker.md) for the
-full guide.
+The fastest way to run Nova — nothing to install on the host but Docker
+itself. The included `Dockerfile` and `docker-compose.yml` bring up the
+whole stack: the Nova web app **and** a bundled Ollama model server. All
+runtime data (database, memory, settings, logs, exports) is persisted on
+a `nova-data` volume and models on an `ollama-models` volume, so rebuilds
+and updates never lose data.
+
+```bash
+cp .env.example .env
+docker compose up -d
+# pull at least one model, then open http://localhost:8000
+docker compose exec ollama ollama pull gemma3:1b
+```
+
+Nova is reachable at `http://localhost:8000`, and from other LAN machines
+(including Windows browsers) at `http://<host-ip>:8000`. See
+[docs/docker.md](docs/docker.md) for first-run, starting/stopping, logs,
+updates, backups, resetting, pulling models, optional NVIDIA GPU, and
+using Nova from a Windows browser.
 
 ### Portable workspace (systemd or Docker)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,62 +1,99 @@
-# Nova — Docker Compose deployment
+# Nova — full Docker Compose stack (self-hosted / local).
 #
-# Usage:
-#   1. Copy .env.example to .env and set NOVA_USERNAME / NOVA_PASSWORD /
-#      NOVA_SECRET_KEY before the first start.
-#   2. Make sure Ollama is running and reachable via OLLAMA_HOST below.
-#   3. docker compose up -d
+# Runs everything Nova needs in containers: the Nova web app and a local
+# Ollama model server. No Python, Ollama, or dependencies are installed on
+# the host. There is no cloud component and no remote sync.
 #
-# Updates:
-#   docker compose pull && docker compose up -d
+# Quick start:
+#   cp .env.example .env      # then edit credentials
+#   docker compose up -d
+#   open http://localhost:8000
 #
-# Data location:
-#   The named volume `nova-data` holds nova.db. List with `docker volume ls`,
-#   inspect with `docker volume inspect nova-data`. See docs/docker.md for
-#   backup guidance.
-#
-# This is a LOCAL / SELF-HOSTED deployment. There is no cloud component.
+# See docs/docker.md for the full guide (first-run, updates, backups,
+# pulling models, GPU, Windows browser access).
 
 services:
+  # ── Nova web application ──────────────────────────────────────────
   nova:
-    # Use the prebuilt image from GHCR for `docker compose pull`-based updates,
-    # or comment `image:` and uncomment `build:` to build from this checkout.
-    image: ghcr.io/thezupzup/nova:latest
-    # build: .
+    # Build the image from this checkout. To use a prebuilt image instead,
+    # comment `build:` and uncomment the `image:` line below.
+    build:
+      context: .
+    # image: ghcr.io/thezupzup/nova:latest
+    image: nova:local
     container_name: nova
     restart: unless-stopped
-    ports:
-      # Host:Container — change the host side if 8080 is already in use.
-      - "8080:8080"
+
+    # All variables from .env are passed to the container. Docker-specific
+    # values are overridden in `environment:` below (which wins over the
+    # env file) so the in-container paths/URLs are always correct.
+    env_file:
+      - .env
     environment:
-      # ── Credentials (REQUIRED) ─────────────────────────────────────
-      # Set these in .env. Defaults in .env.example are intentionally weak
-      # and must be overridden before the first start.
-      NOVA_USERNAME: ${NOVA_USERNAME:?set NOVA_USERNAME in .env}
-      NOVA_PASSWORD: ${NOVA_PASSWORD:?set NOVA_PASSWORD in .env}
-      NOVA_SECRET_KEY: ${NOVA_SECRET_KEY:?set NOVA_SECRET_KEY in .env}
+      # Persist all runtime state on the /data volume (mounted below).
+      NOVA_DATA_DIR: /data
+      # Reach the bundled Ollama container over the compose network.
+      # Override OLLAMA_HOST in .env to point at an external Ollama
+      # (e.g. http://192.168.1.50:11434) and Nova will use that instead.
+      OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
+      # Port uvicorn binds inside the container.
+      NOVA_PORT: ${NOVA_PORT:-8000}
 
-      # ── Ollama endpoint ────────────────────────────────────────────
-      # Default points at the host machine. On Linux, host.docker.internal
-      # only resolves thanks to the extra_hosts entry below. If Ollama runs
-      # on a different machine, set OLLAMA_HOST=http://<lan-ip>:11434.
-      OLLAMA_HOST: ${OLLAMA_HOST:-http://host.docker.internal:11434}
+    ports:
+      # host:container. Reach Nova at http://localhost:8000 and, from
+      # other LAN machines, http://<host-ip>:8000. Change the host side
+      # with NOVA_HOST_PORT in .env if 8000 is already taken.
+      - "${NOVA_HOST_PORT:-8000}:${NOVA_PORT:-8000}"
 
-      # ── Release channel (optional) ─────────────────────────────────
-      NOVA_CHANNEL: ${NOVA_CHANNEL:-stable}
-
-      # ── Other optional toggles, forwarded only if set in .env ──────
-      NOVA_BRANCH: ${NOVA_BRANCH:-main}
-      NOVA_ADMIN_UI: ${NOVA_ADMIN_UI:-false}
-      NOVA_AUTO_WEB_LEARNING: ${NOVA_AUTO_WEB_LEARNING:-false}
     volumes:
-      # Persistent storage for nova.db. Survives `docker compose down` and
-      # `docker compose pull`. Removed only by `docker volume rm nova-data`
-      # or `docker compose down -v` (destructive).
+      # Persistent app data: nova.db (database + memory + settings +
+      # conversations) plus backups/, exports/, memory-packs/, logs/ and
+      # the auto-generated secret_key. Survives `docker compose down` and
+      # rebuilds; removed only by `docker compose down -v`.
       - nova-data:/data
-    extra_hosts:
-      # Lets the container reach an Ollama running on the Docker host on
-      # Linux, matching the Mac/Windows behaviour. Harmless on other OSes.
-      - "host.docker.internal:host-gateway"
+
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+  # ── Ollama local model server ─────────────────────────────────────
+  ollama:
+    image: ollama/ollama:latest
+    container_name: nova-ollama
+    restart: unless-stopped
+
+    volumes:
+      # Pulled models + manifests live here, NOT in the container layer,
+      # so they survive image updates and `docker compose down`.
+      - ollama-models:/root/.ollama
+
+    # Ollama is reached by Nova over the internal compose network and does
+    # not need to be published to the host. Uncomment to also expose the
+    # API on the host (e.g. to run `ollama` commands from the host or share
+    # the model server with other machines):
+    # ports:
+    #   - "11434:11434"
+
+    healthcheck:
+      # `ollama list` returns 0 once the daemon is accepting requests.
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+    # ── Optional NVIDIA GPU acceleration ─────────────────────────────
+    # Requires the NVIDIA driver + nvidia-container-toolkit on the host.
+    # Uncomment the block below, then `docker compose up -d`. CPU-only
+    # works out of the box without this. See docs/docker.md (GPU section).
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
 
 volumes:
   nova-data:
+  ollama-models:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,25 +1,42 @@
 #!/bin/sh
 # Nova container entrypoint.
 #
-# Nova's code uses a relative DB_PATH ("nova.db" in the working directory).
-# To persist the database across container rebuilds without modifying app
-# code, we mount a Docker volume at /data and symlink /app/nova.db to it.
-# The first time the app writes to nova.db, the file is created inside the
-# volume and survives container replacement.
+# Responsibilities (all idempotent — safe to re-run on every start):
+#   1. Make sure the persistent data directory exists and is usable.
+#   2. Migrate a legacy baked-in nova.db into the volume, once, if present.
+#   3. Provide a stable per-install JWT secret when the operator did not
+#      set one, so logins survive restarts without shipping a known key.
+#
+# All real runtime state (nova.db, backups/, exports/, memory-packs/,
+# logs/) is written under $NOVA_DATA_DIR by the application itself
+# (see core/paths.py), which is why this script does NOT symlink nova.db
+# anymore: NOVA_DATA_DIR=/data makes the app read/write the volume path
+# directly.
 set -eu
 
 DATA_DIR="${NOVA_DATA_DIR:-/data}"
 mkdir -p "$DATA_DIR"
 
-# If a legacy nova.db was baked into the image (it shouldn't be, but be safe)
-# and the volume is empty, migrate it once. Otherwise the volume copy wins.
+# One-time migration: if an older image baked nova.db into /app and the
+# volume has no database yet, move it across so history is not lost. New
+# images never bake nova.db (see .dockerignore), so this is a no-op for
+# fresh installs.
 if [ -f /app/nova.db ] && [ ! -L /app/nova.db ] && [ ! -e "$DATA_DIR/nova.db" ]; then
     mv /app/nova.db "$DATA_DIR/nova.db"
 fi
 
-# Always replace /app/nova.db with a symlink into the volume so the running
-# app reads/writes through to persistent storage.
-rm -f /app/nova.db
-ln -s "$DATA_DIR/nova.db" /app/nova.db
+# Persist a per-install JWT signing secret. We deliberately do NOT ship a
+# default NOVA_SECRET_KEY: a known key would let anyone on the network
+# forge session tokens. When the operator has not supplied one (unset or
+# empty), generate a random key once and keep it on the data volume so
+# sessions remain valid across restarts and rebuilds.
+if [ -z "${NOVA_SECRET_KEY:-}" ]; then
+    KEY_FILE="$DATA_DIR/secret_key"
+    if [ ! -f "$KEY_FILE" ]; then
+        ( umask 077; python -c "import secrets; print(secrets.token_hex(32))" > "$KEY_FILE" )
+    fi
+    NOVA_SECRET_KEY="$(cat "$KEY_FILE")"
+    export NOVA_SECRET_KEY
+fi
 
 exec "$@"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,190 +1,361 @@
 # Running Nova with Docker
 
-Nova ships with a `Dockerfile` and `docker-compose.yml` for self-hosted deployments. This is a **local / self-hosted** setup: there is no cloud component, no remote sync, and no auto-deploy. You run Nova on a machine you control, talking to an Ollama you control.
+Nova ships a complete Docker Compose stack so you can run it **without
+installing Python, Ollama, or any dependencies on the host**. Everything
+runs in containers:
 
-> **Want one parent folder per install?** If you'd rather use **host
-> bind mounts** under a single workspace directory (so the data,
-> config, logs, and backups all live next to each other and move as
-> one unit), see [`docs/portable-workspace.md`](portable-workspace.md)
-> and the ready-to-edit
-> [`deploy/docker/docker-compose.portable.yml`](../deploy/docker/docker-compose.portable.yml).
-> The quickstart on this page uses a named Docker volume instead;
-> both are supported.
+| Container | Image | Role |
+|---|---|---|
+| `nova` | built from this repo's `Dockerfile` | Nova backend + web UI |
+| `nova-ollama` | `ollama/ollama` | local model server |
 
-> **Warning.** The container exposes Nova's web UI on the network. Do not publish port 8080 to the public internet without a reverse proxy and TLS in front of it. Defaults in `.env.example` are intentionally weak; change them before the first start.
+This is a **local / self-hosted** setup: no cloud component, no remote
+sync, no auto-deploy. It is designed for a Linux AI/project PC, a NAS
+that runs Docker, and Windows machines that connect to Nova through a
+browser.
+
+> **Heads-up on exposure.** The stack publishes Nova's web UI on your
+> LAN (`http://<host-ip>:8000`). Change `NOVA_USERNAME` / `NOVA_PASSWORD`
+> before exposing it, and do **not** forward port 8000 to the public
+> internet without a reverse proxy and TLS in front of it. Admin-only and
+> alpha-only features are **off by default** and stay off unless you opt
+> in (see [Admin / alpha features](#admin--alpha-features-stay-off)).
+
+---
 
 ## What ends up where
 
-| Component | Location |
-|---|---|
-| Application code | Inside the image at `/app` |
-| SQLite database (`nova.db`) | Docker volume `nova-data`, mounted at `/data` |
-| Credentials | `.env` on the host, passed in via `docker compose` |
-| Ollama models | **Outside the container.** Nova calls Ollama over the network. |
+Nova keeps **all** of its runtime state on Docker volumes, never in the
+disposable container layer:
 
-The image contains no secrets and no database. Pulling a new version cannot overwrite your data.
+| Data | Volume | Path in container |
+|---|---|---|
+| Database — incl. **memory, settings, conversations** (`nova.db`) | `nova-data` | `/data/nova.db` |
+| Logs | `nova-data` | `/data/logs/` |
+| Exports / user-generated files | `nova-data` | `/data/exports/` |
+| Memory packs | `nova-data` | `/data/memory-packs/` |
+| Backups (sidecar) | `nova-data` | `/data/backups/` |
+| Auto-generated session key | `nova-data` | `/data/secret_key` |
+| **Ollama models** | `ollama-models` | `/root/.ollama` |
+
+> **Why one volume for the database, memory, and settings?** In Nova,
+> memory, settings, and conversations are not separate folders — they are
+> tables **inside the single `nova.db` SQLite file**. So one `nova-data`
+> volume cleanly persists the database + memory + settings + logs + user
+> files together. Chat image attachments are stored inside `nova.db`
+> (base64), so there is no separate uploads directory to mount.
+
+The image contains **no secrets, no database, and no models**. Pulling or
+rebuilding a new version cannot overwrite your data.
+
+---
 
 ## Prerequisites
 
-- Docker Engine 24+ and the `docker compose` plugin
-- An Ollama instance reachable from the container (see [Connecting to Ollama](#connecting-to-ollama))
-- The Ollama models referenced in `config.py` already pulled on that Ollama instance
+- Docker Engine 24+ with the `docker compose` plugin (Docker Desktop on
+  Windows/macOS already includes it).
+- Enough disk for the models you pull (see
+  [Pulling Ollama models](#pulling--downloading-ollama-models)).
 
-## First run
+No Python, no Ollama, and no other host packages are required.
+
+---
+
+## First-time setup
 
 ```bash
 git clone https://github.com/TheZupZup/Nova.git
 cd Nova
 
 cp .env.example .env
-# Edit .env and set:
-#   NOVA_USERNAME       — your login
-#   NOVA_PASSWORD       — your password (change before first start)
-#   NOVA_SECRET_KEY     — a long random string used to sign JWTs
-#   OLLAMA_HOST         — see "Connecting to Ollama" below
-# Optionally set NOVA_CHANNEL=stable|beta|alpha.
+# Edit .env and set at least:
+#   NOVA_USERNAME   — your admin login
+#   NOVA_PASSWORD   — change it from the default
+# Everything else has working defaults.
 
 docker compose up -d
 ```
 
-Nova is now reachable at `http://<host>:8080`. Log in with the credentials you set in `.env`.
+The first `up`:
 
-To follow logs:
+1. builds the `nova` image from this checkout,
+2. starts the `ollama` model server (waits until it's healthy),
+3. starts Nova and creates the admin account from `.env`.
+
+Open **http://localhost:8000** and log in. From another machine on the
+same network use **http://&lt;host-ip&gt;:8000**.
+
+Then pull at least one model so Nova can reply — see
+[Pulling Ollama models](#pulling--downloading-ollama-models).
+
+> The session signing key is generated automatically on first start and
+> stored at `/data/secret_key`, so you don't have to set `NOVA_SECRET_KEY`
+> yourself. Logins survive restarts and rebuilds.
+
+---
+
+## Everyday operations
+
+### Starting Nova
 
 ```bash
-docker compose logs -f nova
-```
-
-## Updating
-
-The image is published to GHCR as `ghcr.io/thezupzup/nova:latest`. To update:
-
-```bash
-docker compose pull
 docker compose up -d
 ```
 
-This replaces the container but leaves the `nova-data` volume — and therefore `nova.db` — untouched.
-
-If you'd rather build from your local checkout, edit `docker-compose.yml`: comment the `image:` line and uncomment `build: .`, then:
+### Stopping Nova
 
 ```bash
-docker compose build
+docker compose stop          # stop containers, keep them
+# or
+docker compose down          # stop and remove containers (data volumes kept)
+```
+
+`down` removes the containers but **not** the `nova-data` /
+`ollama-models` volumes — your database and models are safe.
+
+### Viewing logs
+
+```bash
+docker compose logs -f            # both services, follow
+docker compose logs -f nova       # just Nova
+docker compose logs -f ollama     # just the model server
+docker compose logs --tail=200 nova
+```
+
+### Checking status
+
+```bash
+docker compose ps                 # health/status of both containers
+```
+
+### Updating Nova
+
+Because the image is built from this checkout, update the code and
+rebuild:
+
+```bash
+git pull
+docker compose up -d --build      # rebuild Nova, restart, keep all data
+```
+
+To also update the model server image:
+
+```bash
+docker compose pull ollama
 docker compose up -d
 ```
 
-## Where data is stored
+> **Prefer a prebuilt image?** Edit `docker-compose.yml`: comment the
+> `build:` block and uncomment `image: ghcr.io/thezupzup/nova:latest`.
+> Then update with `docker compose pull && docker compose up -d`.
 
-`nova.db` lives in the named Docker volume `nova-data`, mounted inside the container at `/data`. The application's relative `nova.db` path is symlinked into that volume by the entrypoint, so app code sees it at the usual location without any code change.
+### Resetting containers without deleting data
 
-To find the path on disk:
+Recreate the containers from scratch while keeping the database and
+models:
 
 ```bash
-docker volume inspect nova-data --format '{{ .Mountpoint }}'
+docker compose down               # removes containers only (NOT volumes)
+docker compose up -d --force-recreate
 ```
 
-On a default Linux Docker install this is typically `/var/lib/docker/volumes/nova-data/_data`.
+Your `nova-data` and `ollama-models` volumes are untouched. The
+**destructive** variant is `docker compose down -v`, which deletes the
+volumes (database, conversations, and downloaded models). Only use it
+when you truly want a clean slate.
 
-### Backing up `nova.db`
+---
 
-Stop the container before copying the file to avoid catching it mid-write:
+## Pulling / downloading Ollama models
+
+No models are bundled. Pull the ones Nova uses into the running `ollama`
+container — they land in the `ollama-models` volume and persist across
+rebuilds:
+
+```bash
+# Lightweight router/classifier + general chat (start here):
+docker compose exec ollama ollama pull gemma3:1b
+docker compose exec ollama ollama pull gemma4
+
+# Optional, for coding and "advanced" requests (larger downloads):
+docker compose exec ollama ollama pull deepseek-coder-v2
+docker compose exec ollama ollama pull qwen2.5:32b
+```
+
+These are the model names Nova references in `config.py`. `qwen2.5:32b`
+needs significant disk and RAM; if your hardware is constrained, skip it
+— the router falls back to `gemma4` for advanced requests.
+
+List and remove models:
+
+```bash
+docker compose exec ollama ollama list
+docker compose exec ollama ollama rm <model>
+```
+
+Because models live in the `ollama-models` volume, you only download them
+once. `docker compose down`, `up --build`, and image updates do not delete
+them — only `docker compose down -v` does.
+
+---
+
+## Backing up persistent data
+
+Everything important is in two volumes. Stop the app first so the SQLite
+file is copied in a consistent state.
+
+**Back up the Nova database + files (`nova-data`):**
 
 ```bash
 docker compose stop nova
 docker run --rm -v nova-data:/data -v "$PWD":/backup alpine \
-    cp /data/nova.db /backup/nova.db.$(date +%Y%m%d-%H%M%S)
+    tar czf /backup/nova-data-$(date +%Y%m%d-%H%M%S).tar.gz -C /data .
 docker compose start nova
 ```
 
-Restore by copying a backup back into the volume the same way before starting the container.
-
-> **Backup note.** `nova.db` is a single SQLite file. Copy it while the app is stopped, or use SQLite's `.backup` command against a live DB. Don't copy it under load — you may capture an inconsistent snapshot.
-
-## Connecting to Ollama
-
-Nova does **not** bundle Ollama. The container reaches Ollama over the network via `OLLAMA_HOST`. Three common setups:
-
-### 1. Ollama on the same host as Docker (Linux)
-
-Use the `host.docker.internal` alias wired up by the `extra_hosts` entry in `docker-compose.yml`:
-
-```env
-OLLAMA_HOST=http://host.docker.internal:11434
-```
-
-Make sure Ollama is listening on an interface the container can reach. By default `ollama serve` binds to `127.0.0.1`, which is **not** reachable from inside the container. Bind to all interfaces:
+**Back up the Ollama models (`ollama-models`, optional — they can be
+re-pulled):**
 
 ```bash
-OLLAMA_HOST=0.0.0.0 ollama serve
+docker run --rm -v ollama-models:/models -v "$PWD":/backup alpine \
+    tar czf /backup/ollama-models-$(date +%Y%m%d-%H%M%S).tar.gz -C /models .
 ```
 
-(or set `Environment=OLLAMA_HOST=0.0.0.0` in your Ollama systemd unit).
+**Restore** by extracting an archive back into the volume while the
+stack is stopped:
 
-### 2. Ollama on the same host (Docker Desktop, macOS / Windows)
+```bash
+docker compose down
+docker run --rm -v nova-data:/data -v "$PWD":/backup alpine \
+    sh -c "rm -rf /data/* && tar xzf /backup/nova-data-YYYYMMDD-HHMMSS.tar.gz -C /data"
+docker compose up -d
+```
 
-`host.docker.internal` resolves natively. The same `OLLAMA_HOST=http://host.docker.internal:11434` works without extra setup.
+> Nova also keeps an in-app export/restore flow (Settings → admin) that
+> writes to `/data/exports`. The volume-level backup above is the
+> simplest full-image snapshot.
 
-### 3. Ollama on a different machine
+---
 
-Point `OLLAMA_HOST` at that machine's LAN IP:
+## Using Nova from Windows as a browser client
+
+You do **not** install Nova on Windows. Run the stack on your Linux PC or
+NAS, then just open a browser on the Windows machine:
+
+1. Start the stack on the host (`docker compose up -d`).
+2. Find the host's LAN IP (on Linux: `ip addr` / `hostname -I`).
+3. On the Windows machine, browse to **`http://<host-ip>:8000`** — for
+   example `http://192.168.1.42:8000`.
+4. Log in with your `NOVA_USERNAME` / `NOVA_PASSWORD`.
+
+If it doesn't load from Windows but works as `http://localhost:8000` on
+the host:
+
+- Make sure the host firewall allows inbound TCP **8000**
+  (e.g. `sudo firewall-cmd --add-port=8000/tcp` on Fedora, or
+  `sudo ufw allow 8000/tcp` on Ubuntu).
+- Confirm both machines are on the same network/subnet.
+- The container publishes on all interfaces by default, so no Nova-side
+  change is needed.
+
+You can pin Nova to a different host port by setting `NOVA_HOST_PORT` in
+`.env` (e.g. `NOVA_HOST_PORT=9000` → browse to `:9000`).
+
+---
+
+## Connecting to an external Ollama instead of the bundled one
+
+By default Nova talks to the bundled `ollama` container. To use an Ollama
+running elsewhere (another machine, your NAS, a GPU box), set `OLLAMA_HOST`
+in `.env`:
 
 ```env
 OLLAMA_HOST=http://192.168.1.50:11434
 ```
 
-The other machine must be running Ollama with `OLLAMA_HOST=0.0.0.0` so the port is reachable across the network.
+That other Ollama must listen on a reachable interface
+(`OLLAMA_HOST=0.0.0.0 ollama serve`). You can also stop the bundled model
+server with `docker compose stop ollama` if you don't need it.
 
-## Changing the password before first start
+---
 
-Always set `NOVA_PASSWORD` in `.env` before the first `docker compose up`. The very first start creates the admin record from these environment variables.
+## Optional: NVIDIA GPU acceleration
 
-If you've already started the container with the default password and want to rotate it before exposing Nova:
+CPU works out of the box. To let Ollama use an NVIDIA GPU:
 
-```bash
-docker compose down
-# Edit .env, set the new NOVA_PASSWORD
-docker volume rm nova-data    # destructive: wipes nova.db, including conversations
-docker compose up -d
-```
+1. Install the NVIDIA driver and the
+   [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+   on the host.
+2. In `docker-compose.yml`, uncomment the `deploy:` GPU block under the
+   `ollama` service.
+3. `docker compose up -d` and verify with:
 
-If you don't want to wipe the database, change the password from inside Nova's settings UI after logging in instead.
+   ```bash
+   docker compose exec ollama nvidia-smi
+   ```
 
-## Environment variables forwarded to the container
+Only the `ollama` container needs the GPU — Nova itself is CPU-only.
 
-| Variable | Required | Purpose |
-|---|---|---|
-| `NOVA_USERNAME` | yes | Admin login |
-| `NOVA_PASSWORD` | yes | Admin password (change before first start) |
-| `NOVA_SECRET_KEY` | yes | JWT signing secret — long random string |
-| `OLLAMA_HOST` | yes | URL of your Ollama instance |
-| `NOVA_CHANNEL` | no | `stable` (default), `beta`, or `alpha` |
-| `NOVA_BRANCH` | no | Display-only branch label |
-| `NOVA_ADMIN_UI` | no | `true` to expose admin-only UI controls |
-| `NOVA_AUTO_WEB_LEARNING` | no | `true` to enable background RSS learning |
+---
 
-The `alpha` channel additionally requires `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `NOVA_ALPHA_ALLOWED_USERS`. See `.env.example` for details — add them under `environment:` in `docker-compose.yml` if you use that channel.
+## Admin / alpha features stay off
 
-## What this deployment does NOT do
+The default Docker configuration does **not** expose admin-only or
+alpha-only functionality:
 
-- No bundled Ollama. Models are not downloaded by the image.
-- No automatic updates. You run `docker compose pull` when you want to update.
-- No remote deploy hook. Nothing in this repo will push to your server for you.
-- No telemetry, cloud sync, or third-party calls beyond Nova's existing optional integrations.
+- `NOVA_ADMIN_UI=false` — admin-only UI controls are hidden.
+- `NOVA_CHANNEL=stable` — the alpha GitHub-OAuth gate is inactive.
+- Maintenance Center, Dev Workspace, and all integrations
+  (SilentGuard, NexaNote, GitHub, Jellyfin) default to **off**.
+
+Leave these as-is unless you intentionally opt in. See `.env.example` for
+each switch.
+
+---
 
 ## Troubleshooting
 
-**`Cannot connect to Ollama`**
-Check `OLLAMA_HOST` from inside the container:
+**Nova replies with a model/connection error.**
+You probably haven't pulled a model yet, or the model name Nova requested
+isn't present. Check:
+
 ```bash
-docker compose exec nova python -c "import os, httpx; print(httpx.get(os.environ['OLLAMA_HOST']+'/api/tags').text)"
+docker compose exec ollama ollama list
+docker compose exec nova python -c \
+  "import os,urllib.request; print(urllib.request.urlopen(os.environ['OLLAMA_HOST']+'/api/tags',timeout=5).read()[:200])"
 ```
-If this fails, Ollama is either not running, not bound to a reachable interface, or blocked by a firewall.
 
-**`docker compose pull` says credentials are missing**
-The compose file requires `NOVA_USERNAME`, `NOVA_PASSWORD`, and `NOVA_SECRET_KEY` to be set. They live in `.env` next to `docker-compose.yml`. They are not needed for `docker compose pull` itself, but `docker compose up` validates them.
+**`docker compose up` fails saying `.env` is missing.**
+Run `cp .env.example .env` first.
 
-**Want to start over from a clean state**
+**Port 8000 is already in use.**
+Set `NOVA_HOST_PORT` to a free port in `.env`, then `docker compose up -d`.
+
+**Permission errors on the data volume.**
+The default named volume is initialised with the right ownership
+automatically. If you switched `nova-data` to a host **bind mount**, make
+the host directory writable by UID 1000 (the `nova` user):
+`sudo chown -R 1000:1000 /your/host/path`.
+
+**Start over completely (deletes data).**
+
 ```bash
-docker compose down -v   # removes the nova-data volume — DESTRUCTIVE
+docker compose down -v
 docker compose up -d
 ```
+
+---
+
+## What this deployment does NOT do
+
+- No telemetry, cloud sync, or third-party calls beyond Nova's existing
+  optional integrations.
+- No automatic model downloads — you pull models explicitly.
+- No automatic updates — you run `docker compose up -d --build` when you
+  want to update.
+- No reverse proxy or TLS is bundled. Add your own if you expose Nova
+  beyond a trusted LAN (see [`docs/secure-deployment.md`](secure-deployment.md)).
+
+For a host-bind-mount layout where data/config/logs live under one parent
+folder, see [`docs/portable-workspace.md`](portable-workspace.md) and
+[`deploy/docker/docker-compose.portable.yml`](../deploy/docker/docker-compose.portable.yml).

--- a/tests/test_docker_stack.py
+++ b/tests/test_docker_stack.py
@@ -1,0 +1,162 @@
+"""Contract tests for the top-level Docker Compose stack.
+
+These tests pin the behaviour requested for the full Docker deployment:
+a self-contained stack (Nova + bundled Ollama) reachable on port 8000,
+with every kind of runtime data on a persistent volume and admin/alpha
+features left off by default.
+
+The compose / Dockerfile / entrypoint files are read as **plain text** so
+the suite does not depend on PyYAML being installed — matching the style
+of ``tests/test_paths.py::TestPortableDockerComposeExample`` and
+``tests/test_systemd_unit.py``. Each assertion encodes a requirement from
+the Docker-based deployment, not an incidental formatting choice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (_REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def _uncommented_lines(body: str) -> list[str]:
+    """Return stripped, non-comment, non-blank lines.
+
+    Used for negative assertions so a rule that *mentions* something in a
+    comment (e.g. "do not expose admin") never trips a check that the
+    thing is not actually configured.
+    """
+    return [
+        line.strip()
+        for line in body.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+# ── docker-compose.yml ──────────────────────────────────────────────
+
+
+class TestComposeStack:
+    def test_compose_file_exists(self):
+        assert (_REPO_ROOT / "docker-compose.yml").is_file()
+
+    def test_defines_both_services(self):
+        # The stack must run Nova *and* a bundled Ollama, so a user needs
+        # neither Python nor Ollama on the host.
+        body = _read("docker-compose.yml")
+        assert "\n  nova:" in body
+        assert "\n  ollama:" in body
+        assert "ollama/ollama" in body
+
+    def test_nova_built_from_repo(self):
+        # Default path builds the image from this checkout so
+        # `docker compose up -d` works without a published image.
+        body = _read("docker-compose.yml")
+        assert "build:" in body
+        assert "context: ." in body
+
+    def test_published_on_port_8000(self):
+        # Host-reachable at :8000 (localhost and LAN). Host side is
+        # overridable via NOVA_HOST_PORT; container side defaults to 8000.
+        body = _read("docker-compose.yml")
+        assert "${NOVA_HOST_PORT:-8000}:${NOVA_PORT:-8000}" in body
+
+    def test_data_dir_pinned_to_container_data(self):
+        # core/paths.py persists nova.db + subdirs under NOVA_DATA_DIR.
+        assert "NOVA_DATA_DIR: /data" in _read("docker-compose.yml")
+
+    def test_defaults_to_bundled_ollama(self):
+        # Nova reaches the Ollama container over the compose network, and
+        # the value is overridable from .env for an external Ollama.
+        body = _read("docker-compose.yml")
+        assert "OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}" in body
+
+    def test_persistent_volumes_for_data_and_models(self):
+        # Nova data (db/memory/settings/logs/exports) and Ollama models
+        # each live on a named volume — never only in the container layer.
+        body = _read("docker-compose.yml")
+        assert "nova-data:/data" in body
+        assert "ollama-models:/root/.ollama" in body
+        # Both named volumes are declared in the top-level volumes block.
+        assert "\nvolumes:" in body
+        assert "\n  nova-data:" in body
+        assert "\n  ollama-models:" in body
+
+    def test_passes_env_file(self):
+        # All required environment variables flow in from .env.
+        body = _read("docker-compose.yml")
+        assert "env_file:" in body
+        assert "- .env" in body
+
+    def test_does_not_mount_docker_socket(self):
+        assert "docker.sock" not in _read("docker-compose.yml")
+
+    def test_does_not_run_privileged(self):
+        body = _read("docker-compose.yml")
+        assert "privileged: true" not in body
+        assert "cap_add" not in body
+
+    def test_does_not_force_enable_admin_or_alpha(self):
+        # Requirement: never expose admin/alpha-only functionality by
+        # default. The compose file must not hardcode any of these on.
+        joined = "\n".join(_uncommented_lines(_read("docker-compose.yml")))
+        for forbidden in (
+            'NOVA_ADMIN_UI: "true"',
+            "NOVA_ADMIN_UI: true",
+            "NOVA_ADMIN_UI=true",
+            "NOVA_CHANNEL: alpha",
+            "NOVA_CHANNEL=alpha",
+            'NOVA_MAINTENANCE_ENABLED: "true"',
+            "NOVA_MAINTENANCE_ENABLED: true",
+        ):
+            assert forbidden not in joined, (
+                f"compose must not force-enable admin/alpha: {forbidden!r}"
+            )
+
+
+# ── Dockerfile ──────────────────────────────────────────────────────
+
+
+class TestDockerfile:
+    def test_exposes_8000(self):
+        assert "EXPOSE 8000" in _read("Dockerfile")
+
+    def test_persists_under_data_by_default(self):
+        assert "NOVA_DATA_DIR=/data" in _read("Dockerfile")
+
+    def test_runs_as_non_root(self):
+        assert "USER nova" in _read("Dockerfile")
+
+    def test_no_secrets_or_db_baked(self):
+        # The image should not COPY an .env or a database in (comments may
+        # mention nova.db, so check only the real instruction lines).
+        body = _read("Dockerfile")
+        assert "COPY .env" not in body
+        assert "nova.db" not in "\n".join(_uncommented_lines(body))
+
+
+# ── docker/entrypoint.sh ────────────────────────────────────────────
+
+
+class TestEntrypoint:
+    def test_generates_and_persists_secret_key_when_unset(self):
+        # No known default key is shipped; one is generated on first run
+        # and kept on the data volume so logins survive restarts.
+        body = _read("docker/entrypoint.sh")
+        assert 'if [ -z "${NOVA_SECRET_KEY:-}" ]' in body
+        assert "secret_key" in body
+        assert "token_hex" in body
+        assert "export NOVA_SECRET_KEY" in body
+
+    def test_ensures_data_dir(self):
+        body = _read("docker/entrypoint.sh")
+        assert 'DATA_DIR="${NOVA_DATA_DIR:-/data}"' in body
+        assert 'mkdir -p "$DATA_DIR"' in body
+
+    def test_execs_final_command(self):
+        # tini supervises the real process; signals must propagate.
+        assert 'exec "$@"' in _read("docker/entrypoint.sh")


### PR DESCRIPTION
## Summary

Makes Nova **fully Docker-based**. A user can now run the whole thing with:

```bash
cp .env.example .env
docker compose up -d
```

…with no Python, Ollama, dependencies, or runtime services installed on the host. The stack is two containers on a private Compose network:

| Container | Image | Role |
|---|---|---|
| `nova` | built from this repo's `Dockerfile` | Nova backend + web UI |
| `nova-ollama` | `ollama/ollama` | local model server |

Nova is reachable at `http://localhost:8000` and, from other LAN machines (including a Windows browser), at `http://<host-ip>:8000`.

## What changed

- **`docker-compose.yml`** (rewrite) — `nova` (built from the checkout) + bundled `ollama`. Nova talks to Ollama at `http://ollama:11434` by default (overridable via `OLLAMA_HOST` for an external instance). Publishes `:8000` (host port via `NOVA_HOST_PORT`). `depends_on` waits for Ollama's healthcheck. Commented NVIDIA GPU block.
- **`Dockerfile`** — serve on `8000` (`NOVA_PORT`); bake `NOVA_DATA_DIR=/data` so all runtime state lives on the volume, never in the container layer; stdlib-only healthcheck; keeps tini + non-root `nova` user.
- **`docker/entrypoint.sh`** — auto-generates and persists a per-install JWT secret to `/data/secret_key` when `NOVA_SECRET_KEY` is unset (no known default key is shipped); drops the obsolete `nova.db` symlink (the app now writes the volume path directly). Upgrades from the old image are seamless — the DB already lived at `/data/nova.db`.
- **`.env.example`** — adds a Docker section (host port, Ollama URL handling, secret-key guidance) without changing non-Docker local-dev defaults.
- **`docs/docker.md`** (rewrite) — covers first-run, start/stop, logs, updates, backups, resetting without data loss, pulling models, connecting to an external Ollama, optional NVIDIA GPU, and using Nova from a Windows browser.
- **`README.md`** — refreshed Docker section.
- **`tests/test_docker_stack.py`** (new) — text-based contract tests for the compose file, Dockerfile, and entrypoint (no PyYAML dependency), mirroring the repo's existing deployment-artifact test style.

## How the services communicate

Both containers share the default Compose network. Nova resolves Ollama by service name (`http://ollama:11434`). Only Nova's `8000` is published to the host; Ollama's `11434` stays internal (a commented `ports:` line exposes it if wanted).

## Where persistent data lives

Two named volumes — nothing important is left in the disposable container layer:

| Data | Volume → path |
|---|---|
| Database incl. **memory, settings, conversations** (`nova.db`) | `nova-data` → `/data/nova.db` |
| Logs / exports / memory-packs / backups / session key | `nova-data` → `/data/...` |
| User-generated chat images | inside `nova.db` (base64) |
| **Ollama models** | `ollama-models` → `/root/.ollama` |

In Nova, memory/settings/conversations are tables **inside the single `nova.db` SQLite file**, so one `nova-data` volume cleanly persists DB + memory + settings + logs + user files. Models persist across rebuilds because they live in the separate `ollama-models` volume — `down`, `up --build`, and image updates never touch it (only `down -v` does).

## Commands to test locally

```bash
# Static validation (no Docker daemon needed):
docker compose config -q                 # render/validate the stack
sh -n docker/entrypoint.sh               # entrypoint shell syntax

# Contract + regression tests:
python -m pytest tests/test_docker_stack.py tests/test_paths.py -q

# End-to-end (with a Docker daemon):
cp .env.example .env
docker compose up -d
docker compose exec ollama ollama pull gemma3:1b
curl -fsS http://localhost:8000/ >/dev/null && echo "Nova up on :8000"
```

## Docker Compose usage

```bash
docker compose up -d                 # start
docker compose logs -f nova          # logs
docker compose down                  # stop (keeps volumes/data)
git pull && docker compose up -d --build   # update
docker compose down && docker compose up -d --force-recreate   # reset, keep data
docker compose exec ollama ollama pull gemma4   # pull a model
```

Full walkthrough (backups, Windows client, external Ollama, GPU): [`docs/docker.md`](docs/docker.md).

## Behavior preserved

- Non-Docker `python web.py` still runs on `:8080` against `localhost` Ollama — unchanged.
- No Python source files were modified; no UI/app behavior changes.
- Admin-only and alpha-only features stay **off** by default (`NOVA_ADMIN_UI=false`, `NOVA_CHANNEL=stable`, maintenance/integrations disabled), and the compose file never force-enables them (guarded by a test).
- The existing `deploy/docker/docker-compose.portable.yml` and systemd unit are untouched.

## Known limitations

- No `docker build` / `docker compose up` could be executed in the authoring environment (no Docker daemon). Validation was via `docker compose config`, app import, an entrypoint simulation (secret-key gen/reuse/override verified), the healthcheck snippet, and the test suite. A real build/run is recommended before merging out of draft.
- No models are bundled; the first chat requires `ollama pull` (documented). `qwen2.5:32b` is large — optional.
- `depends_on: condition: service_healthy` requires Compose v2 (Docker Engine 24+ / `docker compose` plugin).
- No reverse proxy/TLS bundled (by design). Don't expose `:8000` to the public internet without one.

## Follow-up recommendations (GPU / NVIDIA)

GPU is intentionally **commented, not enabled**, to keep the first implementation simple. To turn it on later:

1. Install the NVIDIA driver + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on the host.
2. Uncomment the `deploy.resources.reservations.devices` block under the `ollama` service.
3. `docker compose up -d`, verify with `docker compose exec ollama nvidia-smi`.

Possible future PRs: a `docker-compose.gpu.yml` override file, an optional model-preload init step, and a non-default Nova-side healthcheck for the alpha channel.

https://claude.ai/code/session_01QZLtagHLc5u2vrtRifoWmk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZLtagHLc5u2vrtRifoWmk)_