### PR TITLE
Add Nova Memory Pack: portable per-user export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 # Changelog
 
 ## Unreleased
+### Added
+- **Nova Memory Pack — portable chat/memory export & import.** Nova can
+  now export a `.zip` of *structured JSON* (not a raw database dump) so a
+  user can carry their useful context to another install or device and
+  have the assistant "remember them". New module
+  [`core/memory_pack.py`](core/memory_pack.py) builds and validates the
+  pack; three authenticated FastAPI endpoints wire it up in `web.py`:
+  `POST /memory-pack/export` (streams the `.zip` download and writes a
+  copy to `NOVA_DATA_DIR/memory-packs/`), `POST /memory-pack/import/preview`
+  (dry-run that counts new vs. duplicate items and writes nothing), and
+  `POST /memory-pack/import?confirm=true` (the confirmed, merge-only
+  import). A new **Settings → Data** pane adds "Export Nova Memory Pack"
+  and "Import Nova Memory Pack" (preview-first, confirm-before-write)
+  controls for every authenticated user — **not** admin/alpha-gated, and
+  distinct from the admin-only `/admin/storage/*` raw-`nova.db` export.
+  The pack contains `manifest.json`, `profile.json`, `memories.json`
+  (classic + natural memories, **no embeddings**), `conversations.json`
+  (conversations with nested messages), `summaries.json` (a generated
+  session-continuity recap), and `settings.json` (safe per-user
+  preferences). It **never** contains password hashes, API keys,
+  GitHub/OAuth tokens, the JWT secret, session cookies, or the host
+  `settings` table; per-user settings additionally pass a secret-shaped
+  key/value denylist so a future sensitive key cannot leak. Import is
+  **merge by default** (keeps existing data, adds only what is missing,
+  de-duplicates classic memories on `(category, content)`, natural
+  memories on `(kind, topic, content)`, conversations on
+  `(title, created)`, and fills only missing settings), runs inside a
+  single SQLite transaction (any failure rolls back and the database is
+  left untouched), and validates the archive for path traversal (`../`,
+  absolute paths, drive letters, symlinks), member count, zip-bomb size,
+  per-file JSON validity, and a manifest `format_version` this build
+  understands before writing anything. Uploads over 50 MB are rejected
+  with `413`. Forward-compatible: every file carries a `version`, unknown
+  files/keys are ignored, optional files may be missing, and a
+  newer-than-supported pack is refused with a clear message. Under Docker
+  the exported copy lands on the mounted `nova-data` volume at
+  `/data/memory-packs/`. Fully covered by
+  [`tests/test_memory_pack.py`](tests/test_memory_pack.py) (manifest
+  generation, secret exclusion, invalid-zip / traversal / symlink /
+  zip-bomb rejection, merge + duplicate handling, transactional
+  rollback, Docker data path, and the HTTP endpoints). See
+  [docs/nova-memory-pack.md](docs/nova-memory-pack.md).
+
 ### Changed
 - **Removed the Tone Profile selector from the Settings UI.** Because
   Nova is now warm, patient, and emotionally aware by default (the

--- a/core/memory_pack.py
+++ b/core/memory_pack.py
@@ -1,0 +1,1303 @@
+"""Nova Memory Pack — portable, structured, per-user export / import.
+
+A **Nova Memory Pack** is a small ``.zip`` archive of *structured JSON*
+that lets a user carry their useful Nova context — long-term memories,
+conversations, generated summaries, and safe preferences — from one
+Nova instance to another so the assistant can "remember them" across
+installs and devices.
+
+This module is deliberately distinct from the two adjacent features:
+
+* :mod:`core.data_export` ships the **raw ``nova.db``** in a ``tar.gz``
+  for whole-host migration. It is **admin-only** and is a database
+  dump, not a curated per-user pack.
+* :mod:`core.memory_importer` ingests a **Markdown** memory pack
+  (memories only, no conversations, no export side).
+
+The Memory Pack is **per-user, authenticated (not admin), structured
+JSON, and round-trippable** (export ⇄ import). The contract:
+
+* **Local-only.** No network, no cloud, no account linking. Pure
+  functions over bytes + the local SQLite database.
+* **Secret-free.** Password hashes, JWT secrets, OAuth/GitHub tokens,
+  API keys, session cookies, and the host ``settings`` table are
+  never written. Per-user settings pass a secret-shaped denylist as
+  defense-in-depth so a *future* sensitive key cannot leak.
+* **Merge by default.** Import keeps existing data and only adds what
+  is missing, de-duplicating on content so re-importing the same pack
+  is a no-op.
+* **Transactional.** The whole import runs inside one SQLite
+  transaction; any failure rolls back and the existing database is
+  left exactly as it was.
+* **Hostile-input safe.** Import validates the archive structure
+  (path traversal, symlinks, member count, zip-bomb size, per-file
+  JSON validity, manifest format / version) before writing anything.
+
+The format is forward-compatible: every file carries a ``version``
+field, unknown files / keys are ignored, optional files may be
+missing, and an archive whose ``format_version`` is *newer* than this
+build understands is refused with a clear message rather than
+mis-read.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import re
+import sqlite3
+import stat
+import uuid
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Format identity ─────────────────────────────────────────────────
+
+#: Pack format identifier — pinned in every manifest so a future format
+#: change is detected explicitly instead of silently mis-read.
+FORMAT_ID = "nova-memory-pack"
+FORMAT_VERSION = 1
+
+#: File layout inside the archive. Everything is JSON at the archive
+#: root except the reserved ``attachments/`` directory (unused in v1
+#: but accepted on import so a future pack stays loadable here).
+MANIFEST_NAME = "manifest.json"
+PROFILE_NAME = "profile.json"
+MEMORIES_NAME = "memories.json"
+CONVERSATIONS_NAME = "conversations.json"
+SUMMARIES_NAME = "summaries.json"
+SETTINGS_NAME = "settings.json"
+ATTACHMENTS_PREFIX = "attachments/"
+
+#: Every JSON file the exporter writes, in a stable order.
+_EXPORT_FILES = (
+    MANIFEST_NAME, PROFILE_NAME, MEMORIES_NAME,
+    CONVERSATIONS_NAME, SUMMARIES_NAME, SETTINGS_NAME,
+)
+
+#: Top-level names an import tolerates without a warning.
+_KNOWN_TOP_LEVEL = frozenset(_EXPORT_FILES)
+
+#: Default filename stem for a freshly built pack. The timestamp is
+#: appended so packs sort lexicographically by creation time.
+DEFAULT_PACK_STEM = "nova-memory-pack"
+
+
+# ── Import safety caps ──────────────────────────────────────────────
+
+#: Largest upload the API will read into memory (compressed bytes).
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+#: Largest total *uncompressed* size we will accept — zip-bomb guard.
+MAX_TOTAL_UNCOMPRESSED_BYTES = 500 * 1024 * 1024
+#: Largest single member (uncompressed) we will accept.
+MAX_MEMBER_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
+#: Largest number of archive members we will enumerate.
+MAX_MEMBERS = 10_000
+#: Hard cap when actually decompressing one JSON file from the archive.
+MAX_JSON_BYTES = 64 * 1024 * 1024
+
+_HASH_CHUNK_BYTES = 64 * 1024
+
+
+# ── Secret filtering (defense-in-depth) ─────────────────────────────
+
+#: Per-user setting keys are already a safe allowlist today, but a
+#: future key could hold a credential. Any key containing one of these
+#: substrings is dropped from the export and ignored on import.
+_SECRET_KEY_SUBSTRINGS: tuple[str, ...] = (
+    "token", "secret", "password", "passwd", "api_key", "apikey",
+    "credential", "oauth", "jwt", "client_secret", "private_key",
+    "privatekey", "webhook", "cookie", "session", "access_key",
+    "refresh_token", "bearer",
+)
+
+#: A whitespace-free run this long that looks like base64 / hex is
+#: treated as a secret-shaped value and the setting is dropped.
+_LONG_TOKEN_RE = re.compile(r"[A-Za-z0-9_\-]{40,}")
+
+#: Allowed natural-memory ``kind`` values. Mirrors
+#: :data:`memory.schema.VALID_KINDS`; imported rows with an unknown
+#: kind are coerced to ``general`` rather than rejected.
+try:  # pragma: no cover - trivial import guard
+    from memory.schema import VALID_KINDS as _VALID_KINDS
+except Exception:  # pragma: no cover
+    _VALID_KINDS = frozenset({
+        "preference", "project", "hardware", "software",
+        "workflow", "constraint", "avoid", "general",
+    })
+
+
+# ── Result dataclasses ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MemoryPackResult:
+    """Outcome of :func:`build_memory_pack`.
+
+    ``data`` is the raw ``.zip`` bytes; ``filename`` is the suggested
+    download name; ``manifest`` is the parsed manifest body; ``counts``
+    is the per-section item count. ``as_dict`` omits the raw bytes so
+    it is safe to log or return as JSON.
+    """
+
+    filename: str
+    data: bytes
+    manifest: dict
+    counts: dict
+
+    def as_dict(self) -> dict:
+        return {
+            "filename": self.filename,
+            "size": len(self.data),
+            "manifest": self.manifest,
+            "counts": self.counts,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryPackInspection:
+    """Read-only structural report on an uploaded pack."""
+
+    valid: bool
+    manifest: Optional[dict]
+    counts: dict
+    files: tuple[str, ...]
+    errors: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "valid": self.valid,
+            "manifest": self.manifest,
+            "counts": self.counts,
+            "files": list(self.files),
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryPackImportPreview:
+    """Dry-run preview: what an import *would* do. Writes nothing."""
+
+    valid: bool
+    counts: dict
+    manifest: Optional[dict]
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "valid": self.valid,
+            "counts": self.counts,
+            "manifest": self.manifest,
+            "warnings": list(self.warnings),
+            "errors": list(self.errors),
+        }
+
+
+#: Stable wire-format strings for ``MemoryPackImportResult.outcome``.
+OUTCOME_IMPORTED = "imported"
+OUTCOME_UNCONFIRMED = "unconfirmed"
+OUTCOME_REFUSED = "refused"
+OUTCOME_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class MemoryPackImportResult:
+    """Outcome of :func:`import_memory_pack`."""
+
+    outcome: str
+    imported: dict
+    skipped: dict
+    manifest: Optional[dict]
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict:
+        return {
+            "outcome": self.outcome,
+            "imported": self.imported,
+            "skipped": self.skipped,
+            "manifest": self.manifest,
+            "warnings": list(self.warnings),
+            "errors": list(self.errors),
+        }
+
+
+# ── Small helpers ───────────────────────────────────────────────────
+
+
+def _resolve_db_path(db_path: Optional[str]) -> str:
+    """Return ``db_path`` or the live ``core.memory.DB_PATH``.
+
+    Resolved at call time (not import time) so tests that
+    ``monkeypatch.setattr(core.memory, "DB_PATH", ...)`` are honoured.
+    """
+    if db_path is not None:
+        return db_path
+    from core.memory import DB_PATH
+    return DB_PATH
+
+
+def _now(now: Optional[datetime]) -> datetime:
+    return now or datetime.now(timezone.utc)
+
+
+def _normalize(text: str) -> str:
+    """Lowercase + collapse whitespace for content de-duplication."""
+    return " ".join((text or "").lower().split())
+
+
+def _nova_version() -> str:
+    """Best-effort Nova version from the CHANGELOG heading, else ``""``."""
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        changelog = repo_root / "CHANGELOG.md"
+        if changelog.is_file():
+            for line in changelog.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()[:20]:
+                m = re.match(r"^##\s*\[?(\d+\.\d+(?:\.\d+)?)\]?", line.strip())
+                if m:
+                    return m.group(1)
+    except OSError:
+        return ""
+    return ""
+
+
+def _is_secret_setting(key: str, value: str) -> bool:
+    """True when a per-user setting looks like it carries a secret."""
+    low = (key or "").lower()
+    if any(sub in low for sub in _SECRET_KEY_SUBSTRINGS):
+        return True
+    if value and _LONG_TOKEN_RE.search(value):
+        return True
+    return False
+
+
+def _is_safe_member_name(name: str) -> bool:
+    """Reject path traversal / absolute / drive / control-char names."""
+    if not name or name.startswith("/") or name.startswith("\\"):
+        return False
+    if "\x00" in name or "\\" in name:
+        return False
+    if re.match(r"^[A-Za-z]:", name):
+        return False
+    for part in PurePosixPath(name).parts:
+        if part == "..":
+            return False
+    return True
+
+
+def _is_symlink_member(info: zipfile.ZipInfo) -> bool:
+    """True when a zip entry encodes a Unix symlink in its mode bits."""
+    mode = (info.external_attr >> 16) & 0xFFFF
+    return stat.S_ISLNK(mode)
+
+
+# ── Export ──────────────────────────────────────────────────────────
+
+
+def build_memory_pack(
+    user_id: int,
+    *,
+    db_path: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> MemoryPackResult:
+    """Build a Memory Pack ``.zip`` for ``user_id`` (in memory).
+
+    Reads only data owned by ``user_id``. Never touches the network,
+    never writes a file (the caller persists / streams the bytes), and
+    never includes a secret. The output is deterministic for a fixed
+    ``now`` and database state, which keeps the tests honest.
+    """
+    db = _resolve_db_path(db_path)
+    created = _now(now)
+    created_iso = created.isoformat()
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        project_names = _load_project_names(conn, user_id)
+        profile = _export_profile(conn, user_id)
+        classic, natural = _export_memories(conn, user_id, project_names)
+        conversations = _export_conversations(conn, user_id, project_names)
+        settings_payload, dropped_secret = _export_settings(conn, user_id)
+    finally:
+        conn.close()
+
+    # Summaries are generated, not stored — build one from the user's
+    # recent conversations at export time.
+    summary = _export_summary(user_id, created)
+
+    msg_count = sum(len(c["messages"]) for c in conversations)
+    counts = {
+        "memories": len(classic),
+        "natural_memories": len(natural),
+        "conversations": len(conversations),
+        "messages": msg_count,
+        "settings": len(settings_payload),
+        "summaries": 1 if summary.get("has_continuity") else 0,
+        "projects": len(project_names),
+    }
+
+    profile_doc = {"version": 1, **profile}
+    memories_doc = {"version": 1, "classic": classic, "natural": natural}
+    conversations_doc = {"version": 1, "conversations": conversations}
+    summaries_doc = {"version": 1, "session_continuity": summary}
+    settings_doc = {"version": 1, "user_settings": settings_payload}
+
+    # Hash the data files so the manifest can record integrity digests
+    # and an importer (or a human) can verify the archive contents.
+    file_bodies: dict[str, bytes] = {
+        PROFILE_NAME: _dumps(profile_doc),
+        MEMORIES_NAME: _dumps(memories_doc),
+        CONVERSATIONS_NAME: _dumps(conversations_doc),
+        SUMMARIES_NAME: _dumps(summaries_doc),
+        SETTINGS_NAME: _dumps(settings_doc),
+    }
+    files_meta = [
+        {"name": name, "size": len(body),
+         "sha256": hashlib.sha256(body).hexdigest()}
+        for name, body in file_bodies.items()
+    ]
+
+    warnings: list[str] = []
+    if dropped_secret:
+        warnings.append(
+            f"{dropped_secret} setting(s) were excluded because they "
+            "looked like a secret."
+        )
+
+    manifest = {
+        "format": FORMAT_ID,
+        "format_version": FORMAT_VERSION,
+        "app": "Nova",
+        "kind": "memory-pack",
+        "created_at": created_iso,
+        "nova_version": _nova_version(),
+        "counts": counts,
+        "files": files_meta,
+        "excluded": [
+            "password hashes",
+            "API keys",
+            "GitHub / OAuth tokens and client secrets",
+            "JWT signing secret",
+            "session cookies",
+            "the host (global) settings table",
+            "memory embeddings (regenerated locally on use)",
+            "per-user settings whose key or value looked secret-shaped",
+        ],
+        "privacy_notice": (
+            "This pack may contain personal conversation history and "
+            "long-term memories. Treat it like private data: store it "
+            "somewhere safe and only import it into a Nova instance you "
+            "trust."
+        ),
+        "warnings": warnings,
+    }
+    manifest_body = _dumps(manifest)
+
+    bio = io.BytesIO()
+    with zipfile.ZipFile(bio, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        _add_member(zf, MANIFEST_NAME, manifest_body, created)
+        for name in (PROFILE_NAME, MEMORIES_NAME, CONVERSATIONS_NAME,
+                     SUMMARIES_NAME, SETTINGS_NAME):
+            _add_member(zf, name, file_bodies[name], created)
+
+    stamp = created.strftime("%Y%m%dT%H%M%SZ")
+    filename = f"{DEFAULT_PACK_STEM}-{stamp}.zip"
+    return MemoryPackResult(
+        filename=filename,
+        data=bio.getvalue(),
+        manifest=manifest,
+        counts=counts,
+    )
+
+
+def _dumps(doc: dict) -> bytes:
+    """Serialise ``doc`` deterministically as UTF-8 JSON bytes."""
+    return json.dumps(
+        doc, indent=2, sort_keys=True, ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _add_member(
+    zf: zipfile.ZipFile, name: str, body: bytes, when: datetime,
+) -> None:
+    """Write ``body`` to ``name`` with a stable, traversal-safe header."""
+    info = zipfile.ZipInfo(
+        filename=name,
+        date_time=when.timetuple()[:6],
+    )
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o644 << 16
+    zf.writestr(info, body)
+
+
+def _load_project_names(
+    conn: sqlite3.Connection, user_id: int,
+) -> dict[int, str]:
+    """Map the user's project ids → names (for inline export labels)."""
+    try:
+        rows = conn.execute(
+            "SELECT id, name FROM projects WHERE user_id = ?", (user_id,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    return {int(r["id"]): r["name"] for r in rows}
+
+
+def _export_profile(conn: sqlite3.Connection, user_id: int) -> dict:
+    """Return the safe profile block (never the password hash)."""
+    user: dict = {}
+    try:
+        row = conn.execute(
+            "SELECT username, role, created_at FROM users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+        if row is not None:
+            user = {
+                "username": row["username"],
+                "role": row["role"],
+                "created_at": row["created_at"],
+            }
+    except sqlite3.OperationalError:
+        user = {}
+
+    # Personalization preferences via the canonical helper so defaults
+    # and key names never drift from the settings module.
+    try:
+        from core.settings import get_personalization
+        personalization = get_personalization(user_id)
+    except Exception:  # pragma: no cover - defensive
+        personalization = {}
+
+    return {"user": user, "personalization": personalization}
+
+
+def _export_memories(
+    conn: sqlite3.Connection, user_id: int, project_names: dict[int, str],
+) -> tuple[list[dict], list[dict]]:
+    """Return ``(classic, natural)`` memory rows owned by ``user_id``."""
+    classic: list[dict] = []
+    try:
+        rows = conn.execute(
+            "SELECT category, content, created, project_id FROM memories "
+            "WHERE user_id = ? ORDER BY created ASC",
+            (user_id,),
+        ).fetchall()
+        for r in rows:
+            classic.append({
+                "category": r["category"],
+                "content": r["content"],
+                "created": r["created"],
+                "project": project_names.get(r["project_id"]),
+            })
+    except sqlite3.OperationalError:
+        pass
+
+    natural: list[dict] = []
+    try:
+        rows = conn.execute(
+            "SELECT kind, topic, content, confidence, source, created_at, "
+            "updated_at, last_seen_at, project_id FROM natural_memories "
+            "WHERE user_id = ? ORDER BY created_at ASC",
+            (user_id,),
+        ).fetchall()
+        for r in rows:
+            natural.append({
+                "kind": r["kind"],
+                "topic": r["topic"],
+                "content": r["content"],
+                "confidence": r["confidence"],
+                "source": r["source"],
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"],
+                "last_seen_at": r["last_seen_at"],
+                "project": project_names.get(r["project_id"]),
+            })
+    except sqlite3.OperationalError:
+        pass
+
+    return classic, natural
+
+
+def _export_conversations(
+    conn: sqlite3.Connection, user_id: int, project_names: dict[int, str],
+) -> list[dict]:
+    """Return conversations (with nested messages) owned by ``user_id``."""
+    out: list[dict] = []
+    try:
+        convs = conn.execute(
+            "SELECT id, title, created, updated, project_id FROM conversations "
+            "WHERE user_id = ? ORDER BY created ASC",
+            (user_id,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return out
+
+    for c in convs:
+        try:
+            msgs = conn.execute(
+                "SELECT role, content, model, created FROM messages "
+                "WHERE conversation_id = ? ORDER BY created ASC, id ASC",
+                (c["id"],),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            msgs = []
+        out.append({
+            "title": c["title"],
+            "created": c["created"],
+            "updated": c["updated"],
+            "project": project_names.get(c["project_id"]),
+            "messages": [
+                {
+                    "role": m["role"],
+                    "content": m["content"],
+                    "model": m["model"],
+                    "created": m["created"],
+                }
+                for m in msgs
+            ],
+        })
+    return out
+
+
+def _export_settings(
+    conn: sqlite3.Connection, user_id: int,
+) -> tuple[dict, int]:
+    """Return ``(safe_settings, dropped_secret_count)`` for ``user_id``."""
+    safe: dict[str, str] = {}
+    dropped = 0
+    try:
+        rows = conn.execute(
+            "SELECT key, value FROM user_settings WHERE user_id = ? "
+            "ORDER BY key ASC",
+            (user_id,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return safe, dropped
+    for r in rows:
+        key, value = r["key"], r["value"]
+        if _is_secret_setting(key, value):
+            dropped += 1
+            continue
+        safe[key] = value
+    return safe, dropped
+
+
+def _export_summary(user_id: int, created: datetime) -> dict:
+    """Build a generated session-continuity summary (never stored)."""
+    try:
+        from core.session_continuity import build_session_continuity
+        # ``build_session_continuity`` compares naive timestamps from
+        # the store; pass a naive ``now`` to avoid tz subtraction errors.
+        naive = created.replace(tzinfo=None)
+        return build_session_continuity(user_id, now=naive)
+    except Exception:  # pragma: no cover - summary is best-effort
+        return {"has_continuity": False}
+
+
+# ── Inspection / validation ─────────────────────────────────────────
+
+
+def inspect_memory_pack(zip_bytes: bytes) -> MemoryPackInspection:
+    """Validate ``zip_bytes`` structurally. Never writes, never raises.
+
+    Checks (in order): non-empty; real ZIP; member count cap; every
+    member name safe (no traversal / absolute / drive / symlink);
+    declared sizes within the zip-bomb caps; a parseable
+    ``manifest.json`` with the expected format and a ``format_version``
+    this build understands; and every present data file is valid JSON
+    of the expected shape. Returns counts derived from the parsed
+    files so a caller can render a preview without a second parse.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    files: list[str] = []
+    counts = _empty_counts()
+
+    if not zip_bytes:
+        return MemoryPackInspection(
+            False, None, counts, (), ("The uploaded file is empty.",),
+        )
+
+    bio = io.BytesIO(zip_bytes)
+    if not zipfile.is_zipfile(bio):
+        return MemoryPackInspection(
+            False, None, counts, (),
+            ("The uploaded file is not a valid .zip archive.",),
+        )
+
+    try:
+        with zipfile.ZipFile(bio) as zf:
+            infos = zf.infolist()
+            if len(infos) > MAX_MEMBERS:
+                return MemoryPackInspection(
+                    False, None, counts, (),
+                    (f"Archive has too many entries (> {MAX_MEMBERS}).",),
+                )
+            total_uncompressed = 0
+            for info in infos:
+                name = info.filename
+                if name.endswith("/"):
+                    continue  # directory entry
+                if not _is_safe_member_name(name):
+                    errors.append(f"Unsafe archive entry: {name!r}.")
+                    continue
+                if _is_symlink_member(info):
+                    errors.append(f"Archive contains a symlink: {name!r}.")
+                    continue
+                if info.file_size > MAX_MEMBER_UNCOMPRESSED_BYTES:
+                    errors.append(f"Archive entry {name!r} is too large.")
+                    continue
+                total_uncompressed += int(info.file_size)
+                files.append(name)
+                top = PurePosixPath(name).parts[0]
+                if top not in _KNOWN_TOP_LEVEL \
+                        and not name.startswith(ATTACHMENTS_PREFIX):
+                    warnings.append(f"Ignoring unexpected entry: {name!r}.")
+
+            if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
+                return MemoryPackInspection(
+                    False, None, counts, tuple(files),
+                    ("Archive is too large when uncompressed "
+                     "(possible zip bomb).",),
+                )
+            if errors:
+                # A traversal / symlink / oversize member is fatal — do
+                # not go on to parse anything from a hostile archive.
+                return MemoryPackInspection(
+                    False, None, counts, tuple(files),
+                    tuple(errors), tuple(warnings),
+                )
+
+            manifest, m_errors = _read_manifest(zf)
+            errors.extend(m_errors)
+
+            payload, p_errors, p_warnings = _read_payload(zf)
+            errors.extend(p_errors)
+            warnings.extend(p_warnings)
+            counts = _count_payload(payload)
+    except zipfile.BadZipFile:
+        return MemoryPackInspection(
+            False, None, counts, tuple(files),
+            ("Archive could not be read (corrupt zip).",),
+        )
+
+    return MemoryPackInspection(
+        valid=not errors,
+        manifest=manifest,
+        counts=counts,
+        files=tuple(files),
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+def _empty_counts() -> dict:
+    return {
+        "memories": 0, "natural_memories": 0, "conversations": 0,
+        "messages": 0, "settings": 0, "summaries": 0, "projects": 0,
+    }
+
+
+def _read_member_json(
+    zf: zipfile.ZipFile, name: str,
+) -> tuple[Optional[object], Optional[str]]:
+    """Decompress + parse one JSON member with a hard size cap.
+
+    Returns ``(parsed, error)``. ``parsed`` is ``None`` when the member
+    is absent (no error) or unreadable (with an error string).
+    """
+    try:
+        info = zf.getinfo(name)
+    except KeyError:
+        return None, None
+    if info.file_size > MAX_JSON_BYTES:
+        return None, f"{name} is too large to read."
+    try:
+        with zf.open(name) as fh:
+            raw = fh.read(MAX_JSON_BYTES + 1)
+    except (zipfile.BadZipFile, OSError):
+        return None, f"{name} could not be read."
+    if len(raw) > MAX_JSON_BYTES:
+        return None, f"{name} is too large to read."
+    try:
+        return json.loads(raw.decode("utf-8")), None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None, f"{name} is not valid JSON."
+
+
+def _read_manifest(
+    zf: zipfile.ZipFile,
+) -> tuple[Optional[dict], list[str]]:
+    """Read + validate the manifest. Returns ``(manifest, errors)``."""
+    errors: list[str] = []
+    manifest, err = _read_member_json(zf, MANIFEST_NAME)
+    if err:
+        return None, [err]
+    if manifest is None:
+        return None, ["Archive is missing manifest.json."]
+    if not isinstance(manifest, dict):
+        return None, ["manifest.json is not a JSON object."]
+    if manifest.get("format") != FORMAT_ID:
+        errors.append(
+            f"Unexpected pack format {manifest.get('format')!r} "
+            f"(expected {FORMAT_ID!r})."
+        )
+    ver = manifest.get("format_version")
+    if not isinstance(ver, int):
+        errors.append("manifest.json has no integer format_version.")
+    elif ver > FORMAT_VERSION:
+        errors.append(
+            f"This pack was created by a newer Nova (format_version "
+            f"{ver}); this instance supports up to {FORMAT_VERSION}. "
+            "Update Nova and try again."
+        )
+    return manifest, errors
+
+
+def _read_payload(
+    zf: zipfile.ZipFile,
+) -> tuple[dict, list[str], list[str]]:
+    """Read + shape-check the data files. Returns ``(payload, errs, warns)``."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    payload: dict = {}
+
+    def _grab(name: str, key: str, kind: type):
+        parsed, err = _read_member_json(zf, name)
+        if err:
+            errors.append(err)
+            return
+        if parsed is None:
+            return  # optional file absent
+        if not isinstance(parsed, dict):
+            errors.append(f"{name} is not a JSON object.")
+            return
+        value = parsed.get(key)
+        if value is None:
+            return
+        if not isinstance(value, kind):
+            errors.append(f"{name} field {key!r} has the wrong type.")
+            return
+        payload[key] = value
+
+    _grab(PROFILE_NAME, "user", dict)
+    _grab(PROFILE_NAME, "personalization", dict)
+    _grab(MEMORIES_NAME, "classic", list)
+    _grab(MEMORIES_NAME, "natural", list)
+    _grab(CONVERSATIONS_NAME, "conversations", list)
+    _grab(SETTINGS_NAME, "user_settings", dict)
+    _grab(SUMMARIES_NAME, "session_continuity", dict)
+
+    return payload, errors, warnings
+
+
+def _count_payload(payload: dict) -> dict:
+    counts = _empty_counts()
+    counts["memories"] = len(payload.get("classic", []) or [])
+    counts["natural_memories"] = len(payload.get("natural", []) or [])
+    convs = payload.get("conversations", []) or []
+    counts["conversations"] = len(convs)
+    counts["messages"] = sum(
+        len(c.get("messages", []) or [])
+        for c in convs if isinstance(c, dict)
+    )
+    counts["settings"] = len(payload.get("user_settings", {}) or {})
+    sc = payload.get("session_continuity", {}) or {}
+    counts["summaries"] = 1 if sc.get("has_continuity") else 0
+    counts["projects"] = len(_payload_project_names(payload))
+    return counts
+
+
+def _payload_project_names(payload: dict) -> set[str]:
+    """Distinct, non-empty project names referenced anywhere in a pack."""
+    names: set[str] = set()
+    for row in payload.get("classic", []) or []:
+        _maybe_add_name(names, row)
+    for row in payload.get("natural", []) or []:
+        _maybe_add_name(names, row)
+    for row in payload.get("conversations", []) or []:
+        _maybe_add_name(names, row)
+    return names
+
+
+def _maybe_add_name(names: set[str], row: object) -> None:
+    if isinstance(row, dict):
+        p = row.get("project")
+        if isinstance(p, str) and p.strip():
+            names.add(p.strip())
+
+
+# ── Import preview (dry-run) ────────────────────────────────────────
+
+
+def build_import_preview(
+    zip_bytes: bytes,
+    user_id: int,
+    *,
+    db_path: Optional[str] = None,
+) -> MemoryPackImportPreview:
+    """Validate the pack and report what a merge would add vs. skip.
+
+    Writes nothing. Counts are split into ``new`` / ``duplicate`` so
+    the UI can show "X new memories, Y already known" before the user
+    confirms.
+    """
+    inspection = inspect_memory_pack(zip_bytes)
+    if not inspection.valid:
+        return MemoryPackImportPreview(
+            False, inspection.counts, inspection.manifest,
+            inspection.warnings, inspection.errors,
+        )
+
+    payload = _parse_payload(zip_bytes)
+    db = _resolve_db_path(db_path)
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        existing = _load_existing_signatures(conn, user_id)
+    finally:
+        conn.close()
+
+    counts = _preview_counts(payload, existing)
+    return MemoryPackImportPreview(
+        valid=True,
+        counts=counts,
+        manifest=inspection.manifest,
+        warnings=inspection.warnings,
+        errors=(),
+    )
+
+
+def _preview_counts(payload: dict, existing: dict) -> dict:
+    classic = payload.get("classic", []) or []
+    natural = payload.get("natural", []) or []
+    convs = payload.get("conversations", []) or []
+    settings = payload.get("user_settings", {}) or {}
+
+    classic_new = sum(
+        1 for r in classic
+        if isinstance(r, dict)
+        and (str(r.get("category", "")), _normalize(str(r.get("content", ""))))
+        not in existing["classic"]
+        and str(r.get("content", "")).strip()
+    )
+    natural_new = sum(
+        1 for r in natural
+        if isinstance(r, dict)
+        and (str(r.get("kind", "")), str(r.get("topic", "")),
+             _normalize(str(r.get("content", ""))))
+        not in existing["natural"]
+        and str(r.get("content", "")).strip()
+    )
+    conv_new_rows = [
+        c for c in convs
+        if isinstance(c, dict)
+        and (str(c.get("title", "")), str(c.get("created", "")))
+        not in existing["conversations"]
+    ]
+    conv_new = len(conv_new_rows)
+    msgs_new = sum(len(c.get("messages", []) or []) for c in conv_new_rows)
+
+    settings_safe = {
+        k: v for k, v in settings.items()
+        if not _is_secret_setting(str(k), str(v))
+    }
+    settings_apply = sum(
+        1 for k in settings_safe if k not in existing["settings"]
+    )
+    settings_secret = len(settings) - len(settings_safe)
+
+    pack_projects = _payload_project_names(payload)
+    projects_new = len(pack_projects - existing["projects"])
+
+    return {
+        "memories": {
+            "total": len(classic), "new": classic_new,
+            "duplicate": len(classic) - classic_new,
+        },
+        "natural_memories": {
+            "total": len(natural), "new": natural_new,
+            "duplicate": len(natural) - natural_new,
+        },
+        "conversations": {
+            "total": len(convs), "new": conv_new,
+            "duplicate": len(convs) - conv_new,
+        },
+        "messages": {"total": msgs_new},
+        "settings": {
+            "total": len(settings), "applicable": settings_apply,
+            "skipped_existing": len(settings_safe) - settings_apply,
+            "skipped_secret": settings_secret,
+        },
+        "summaries": {
+            "present": bool(
+                (payload.get("session_continuity", {}) or {})
+                .get("has_continuity")
+            )
+        },
+        "projects": {
+            "total": len(pack_projects), "new": projects_new,
+            "existing": len(pack_projects) - projects_new,
+        },
+    }
+
+
+# ── Import (merge, transactional) ───────────────────────────────────
+
+
+def import_memory_pack(
+    zip_bytes: bytes,
+    user_id: int,
+    *,
+    confirm: bool = False,
+    mode: str = "merge",
+    db_path: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> MemoryPackImportResult:
+    """Merge a Memory Pack into ``user_id``'s data inside one transaction.
+
+    With ``confirm=False`` nothing is written (the caller is expected
+    to show a preview first). ``mode`` must be ``"merge"`` in v1 — the
+    only mode that exists; it keeps every existing row and adds only
+    what is missing. On *any* error the transaction is rolled back so
+    the database is left exactly as it was.
+    """
+    inspection = inspect_memory_pack(zip_bytes)
+    if not inspection.valid:
+        return MemoryPackImportResult(
+            OUTCOME_REFUSED, {}, {}, inspection.manifest,
+            inspection.warnings, inspection.errors,
+        )
+    if mode != "merge":
+        return MemoryPackImportResult(
+            OUTCOME_REFUSED, {}, {}, inspection.manifest, (),
+            (f"Unsupported import mode {mode!r}; only 'merge' is "
+             "available.",),
+        )
+    if not confirm:
+        return MemoryPackImportResult(
+            OUTCOME_UNCONFIRMED, {}, {}, inspection.manifest,
+            ("Import not confirmed — nothing was written.",), (),
+        )
+
+    payload = _parse_payload(zip_bytes)
+    db = _resolve_db_path(db_path)
+    when = _now(now).isoformat()
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN")
+        imported, skipped, warnings = _apply_merge(
+            conn, user_id, payload, when,
+        )
+        conn.commit()
+    except Exception as exc:  # noqa: BLE001 - we must never leave a half import
+        conn.rollback()
+        logger.warning("Memory pack import failed and was rolled back: %s", exc)
+        return MemoryPackImportResult(
+            OUTCOME_FAILED, {}, {}, inspection.manifest, (),
+            ("Import failed; no changes were made to your data.",),
+        )
+    finally:
+        conn.close()
+
+    return MemoryPackImportResult(
+        outcome=OUTCOME_IMPORTED,
+        imported=imported,
+        skipped=skipped,
+        manifest=inspection.manifest,
+        warnings=tuple(warnings),
+        errors=(),
+    )
+
+
+def _apply_merge(
+    conn: sqlite3.Connection, user_id: int, payload: dict, when: str,
+) -> tuple[dict, dict, list[str]]:
+    """Insert missing rows on ``conn`` (already inside a transaction)."""
+    existing = _load_existing_signatures(conn, user_id)
+    project_ids = _load_existing_project_ids(conn, user_id)
+    warnings: list[str] = []
+    imported = {
+        "memories": 0, "natural_memories": 0, "conversations": 0,
+        "messages": 0, "settings": 0, "projects": 0,
+    }
+    skipped = {
+        "memories_duplicate": 0, "natural_memories_duplicate": 0,
+        "conversations_duplicate": 0, "settings_existing": 0,
+        "settings_secret": 0,
+    }
+
+    def _project_id(name: object) -> Optional[int]:
+        if not isinstance(name, str) or not name.strip():
+            return None
+        key = name.strip()
+        if key in project_ids:
+            return project_ids[key]
+        cur = conn.execute(
+            "INSERT INTO projects (user_id, name, description, "
+            "created_at, updated_at) VALUES (?, ?, '', ?, ?)",
+            (user_id, key, when, when),
+        )
+        new_id = int(cur.lastrowid)
+        project_ids[key] = new_id
+        imported["projects"] += 1
+        return new_id
+
+    # ── classic memories ──
+    for row in payload.get("classic", []) or []:
+        if not isinstance(row, dict):
+            continue
+        category = str(row.get("category", "") or "general")
+        content = str(row.get("content", "") or "")
+        if not content.strip():
+            continue
+        sig = (category, _normalize(content))
+        if sig in existing["classic"]:
+            skipped["memories_duplicate"] += 1
+            continue
+        conn.execute(
+            "INSERT INTO memories (category, content, created, user_id, "
+            "project_id) VALUES (?, ?, ?, ?, ?)",
+            (category, content, str(row.get("created") or when), user_id,
+             _project_id(row.get("project"))),
+        )
+        existing["classic"].add(sig)
+        imported["memories"] += 1
+
+    # ── natural memories ──
+    for row in payload.get("natural", []) or []:
+        if not isinstance(row, dict):
+            continue
+        content = str(row.get("content", "") or "")
+        if not content.strip():
+            continue
+        kind = str(row.get("kind", "") or "general")
+        if kind not in _VALID_KINDS:
+            kind = "general"
+        topic = str(row.get("topic", "") or "")
+        sig = (kind, topic, _normalize(content))
+        if sig in existing["natural"]:
+            skipped["natural_memories_duplicate"] += 1
+            continue
+        try:
+            confidence = float(row.get("confidence", 0.8))
+        except (TypeError, ValueError):
+            confidence = 0.8
+        conn.execute(
+            "INSERT INTO natural_memories (id, kind, topic, content, "
+            "confidence, source, created_at, updated_at, last_seen_at, "
+            "embedding, user_id, project_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+            (str(uuid.uuid4()), kind, topic, content, confidence,
+             str(row.get("source") or "import"),
+             str(row.get("created_at") or when),
+             str(row.get("updated_at") or when),
+             str(row.get("last_seen_at") or when),
+             user_id, _project_id(row.get("project"))),
+        )
+        existing["natural"].add(sig)
+        imported["natural_memories"] += 1
+
+    # ── conversations + messages ──
+    for conv in payload.get("conversations", []) or []:
+        if not isinstance(conv, dict):
+            continue
+        title = str(conv.get("title", "") or "Imported conversation")
+        created = str(conv.get("created") or when)
+        sig = (title, created)
+        if sig in existing["conversations"]:
+            skipped["conversations_duplicate"] += 1
+            continue
+        cur = conn.execute(
+            "INSERT INTO conversations (user_id, title, created, updated, "
+            "project_id) VALUES (?, ?, ?, ?, ?)",
+            (user_id, title, created, str(conv.get("updated") or created),
+             _project_id(conv.get("project"))),
+        )
+        conv_id = int(cur.lastrowid)
+        existing["conversations"].add(sig)
+        imported["conversations"] += 1
+        for msg in conv.get("messages", []) or []:
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role", "") or "user")
+            content = str(msg.get("content", "") or "")
+            conn.execute(
+                "INSERT INTO messages (conversation_id, role, content, "
+                "model, created) VALUES (?, ?, ?, ?, ?)",
+                (conv_id, role, content,
+                 (msg.get("model") if isinstance(msg.get("model"), str)
+                  else None),
+                 str(msg.get("created") or created)),
+            )
+            imported["messages"] += 1
+
+    # ── settings (fill missing only; never overwrite) ──
+    _merge_settings(conn, user_id, payload, existing, imported, skipped,
+                    warnings)
+
+    return imported, skipped, warnings
+
+
+def _merge_settings(
+    conn, user_id, payload, existing, imported, skipped, warnings,
+) -> None:
+    """Apply safe, non-existing per-user settings inside the transaction."""
+    settings = payload.get("user_settings", {}) or {}
+    if not settings:
+        return
+    try:
+        from core.settings import (
+            PERSONALIZATION_ENUMS, CUSTOM_INSTRUCTIONS_MAX_LEN,
+        )
+    except Exception:  # pragma: no cover - defensive
+        PERSONALIZATION_ENUMS, CUSTOM_INSTRUCTIONS_MAX_LEN = {}, 1000
+
+    for key, value in settings.items():
+        key = str(key)
+        value = "" if value is None else str(value)
+        if _is_secret_setting(key, value):
+            skipped["settings_secret"] += 1
+            continue
+        if key in existing["settings"]:
+            skipped["settings_existing"] += 1
+            continue
+        # Validate known personalization values; skip anything invalid
+        # rather than poisoning a column the UI cannot render.
+        if key in PERSONALIZATION_ENUMS and value not in PERSONALIZATION_ENUMS[key]:
+            warnings.append(f"Skipped setting {key!r}: value not recognised.")
+            continue
+        if key == "custom_instructions" and len(value) > CUSTOM_INSTRUCTIONS_MAX_LEN:
+            value = value[:CUSTOM_INSTRUCTIONS_MAX_LEN]
+        conn.execute(
+            "INSERT INTO user_settings (user_id, key, value) "
+            "VALUES (?, ?, ?) ON CONFLICT(user_id, key) DO NOTHING",
+            (user_id, key, value),
+        )
+        existing["settings"].add(key)
+        imported["settings"] += 1
+
+
+def _load_existing_signatures(
+    conn: sqlite3.Connection, user_id: int,
+) -> dict:
+    """Read content signatures of the user's current data for dedup."""
+    out = {
+        "classic": set(), "natural": set(), "conversations": set(),
+        "settings": set(), "projects": set(),
+    }
+    try:
+        for r in conn.execute(
+            "SELECT category, content FROM memories WHERE user_id = ?",
+            (user_id,),
+        ):
+            out["classic"].add((str(r["category"]), _normalize(str(r["content"]))))
+    except sqlite3.OperationalError:
+        pass
+    try:
+        for r in conn.execute(
+            "SELECT kind, topic, content FROM natural_memories "
+            "WHERE user_id = ?", (user_id,),
+        ):
+            out["natural"].add(
+                (str(r["kind"]), str(r["topic"]), _normalize(str(r["content"])))
+            )
+    except sqlite3.OperationalError:
+        pass
+    try:
+        for r in conn.execute(
+            "SELECT title, created FROM conversations WHERE user_id = ?",
+            (user_id,),
+        ):
+            out["conversations"].add((str(r["title"]), str(r["created"])))
+    except sqlite3.OperationalError:
+        pass
+    try:
+        for r in conn.execute(
+            "SELECT key FROM user_settings WHERE user_id = ?", (user_id,),
+        ):
+            out["settings"].add(str(r["key"]))
+    except sqlite3.OperationalError:
+        pass
+    try:
+        for r in conn.execute(
+            "SELECT name FROM projects WHERE user_id = ?", (user_id,),
+        ):
+            out["projects"].add(str(r["name"]))
+    except sqlite3.OperationalError:
+        pass
+    return out
+
+
+def _load_existing_project_ids(
+    conn: sqlite3.Connection, user_id: int,
+) -> dict[str, int]:
+    try:
+        rows = conn.execute(
+            "SELECT id, name FROM projects WHERE user_id = ?", (user_id,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    return {str(r["name"]): int(r["id"]) for r in rows}
+
+
+def _parse_payload(zip_bytes: bytes) -> dict:
+    """Re-open a validated pack and return its parsed data files.
+
+    Assumes the archive already passed :func:`inspect_memory_pack`;
+    used by preview / import after validation so a hostile archive can
+    never reach this point.
+    """
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        payload, _, _ = _read_payload(zf)
+    return payload
+
+
+# ── Persistence helper (Docker-friendly) ────────────────────────────
+
+
+def write_pack_to_data_dir(
+    result: MemoryPackResult,
+    *,
+    dest_dir: Optional[str] = None,
+) -> Optional[Path]:
+    """Write the pack into ``NOVA_DATA_DIR/memory-packs`` (best effort).
+
+    Returns the written path, or ``None`` if persistence failed (the
+    caller still streams the bytes to the user, so a read-only data
+    directory is non-fatal). Under Docker ``NOVA_DATA_DIR=/data`` so
+    the file lands on the mounted ``nova-data`` volume.
+    """
+    try:
+        from core import paths as _paths
+        if dest_dir is not None:
+            target_dir = Path(dest_dir)
+        else:
+            target_dir = _paths.memory_packs_dir()
+            if not target_dir.is_absolute():
+                target_dir = _paths.effective_data_root() / target_dir.name
+        target_dir.mkdir(parents=True, exist_ok=True)
+        out = target_dir / result.filename
+        tmp = target_dir / (result.filename + ".partial")
+        tmp.write_bytes(result.data)
+        tmp.replace(out)
+        return out
+    except OSError as exc:
+        logger.warning("Could not persist memory pack to data dir: %s", exc)
+        return None

--- a/docs/nova-memory-pack.md
+++ b/docs/nova-memory-pack.md
@@ -1,0 +1,182 @@
+# Nova Memory Pack
+
+A **Nova Memory Pack** is a small, portable `.zip` of *structured JSON*
+that lets a user carry their useful Nova context — long-term memories,
+conversations, generated summaries, and safe preferences — from one
+Nova instance to another so the assistant can "remember them" across
+installs and devices.
+
+It is **local-only**, **authenticated** (every signed-in user can
+export/import their *own* data), **preview-first**, and
+**merge-by-default**. It never leaves the host on its own and it never
+contains secrets.
+
+## How it differs from the other export features
+
+Nova ships three related-but-distinct features. Don't confuse them:
+
+| Feature | Module | Scope | Format | Who |
+|---|---|---|---|---|
+| **Nova Memory Pack** (this doc) | `core/memory_pack.py` | one user's curated data | `.zip` of JSON | any authenticated user |
+| Data export / migration | `core/data_export.py` | the whole host (`nova.db` + dirs) | `.tar.gz` raw DB | **admin only** (`/admin/storage/*`) |
+| Markdown memory pack import | `core/memory_importer.py` | memories only, import side | Markdown text | any user (programmatic) |
+
+The Memory Pack is the right tool for *"move me to a new laptop"*. The
+admin data export is the right tool for *"migrate the whole server to a
+new disk"*.
+
+## Using it (Settings → Data)
+
+Open **Settings → Data**. There are two controls, available to every
+authenticated user (they are **not** admin/alpha gated):
+
+* **Export Nova Memory Pack** — confirms a privacy warning, then
+  downloads `nova-memory-pack-<timestamp>.zip`. A copy is also written
+  into `NOVA_DATA_DIR/memory-packs/` so Docker installs keep one on the
+  persistent volume.
+* **Import Nova Memory Pack** — pick a `.zip`. Nova shows a **preview**
+  ("would add N new memories, M new conversations, …") and writes
+  nothing until you click **Merge into my account**.
+
+## What the ZIP contains
+
+```
+manifest.json        format id + version, counts, file hashes, exclusions
+profile.json         { user: {username, role, created_at}, personalization }
+memories.json        { classic: [...], natural: [...] }   (no embeddings)
+conversations.json   { conversations: [ {title, created, updated, project,
+                                         messages: [...] } ] }
+summaries.json       { session_continuity: <generated recap> }
+settings.json        { user_settings: { key: value } }    (safe keys only)
+attachments/         reserved for a future version (unused in v1)
+```
+
+### Data sources exported (scoped to the signed-in `user_id`)
+
+| File | Table / source |
+|---|---|
+| `profile.json` | `users` (no `password_hash`) + `core.settings.get_personalization()` |
+| `memories.json` → `classic` | `memories` (`category, content, created, project`) |
+| `memories.json` → `natural` | `natural_memories` (`kind, topic, content, confidence, source, timestamps, project`; **embeddings dropped**) |
+| `conversations.json` | `conversations` + `messages` (messages nested per conversation) |
+| `summaries.json` | `core.session_continuity.build_session_continuity()` — generated at export time, not stored |
+| `settings.json` | `user_settings` (secret-filtered) |
+
+Project grouping is preserved by **name**: a memory/conversation tied to
+a project records the project name inline, and import get-or-creates a
+project of that name for the target user.
+
+## What is intentionally excluded
+
+The pack **never** contains:
+
+* password hashes (`users.password_hash`),
+* API keys, GitHub / OAuth tokens and client secrets, the JWT signing
+  secret, session cookies — none of which live in the user-scoped tables
+  anyway (they are environment configuration),
+* the host (global) `settings` table,
+* memory embeddings (regenerated locally on use),
+* any per-user setting whose **key or value looks secret-shaped**
+  (substrings like `token`, `secret`, `password`, `api_key`,
+  `oauth`, `client_secret`, … or a 40+ char base64/hex-looking run).
+  This is defense-in-depth so a *future* sensitive per-user key cannot
+  leak through the export.
+
+The `manifest.json` lists these exclusions and carries a
+`privacy_notice` reminding the user the pack may hold personal
+conversation history.
+
+## Import: merge & de-duplication
+
+Import is **merge-only** in v1 and **non-destructive**:
+
+* **keep existing data** — nothing the target already has is changed,
+* **import what's missing** — only new items are added,
+* **de-duplicate** on content so re-importing the same pack is a no-op:
+  * classic memories on `(category, normalized content)`,
+  * natural memories on `(kind, topic, normalized content)`,
+  * conversations on `(title, created)` (and their messages come with
+    them only when the conversation itself is new),
+  * settings: a key is applied **only if the user does not already have
+    it** — an existing preference is never overwritten,
+  * projects: get-or-created by name.
+
+A **preview / dry-run** step (`/memory-pack/import/preview`, and the UI
+preview) reports `new` vs. `duplicate` counts plus warnings, and writes
+nothing. The real import requires explicit confirmation
+(`?confirm=true`).
+
+The entire merge runs inside **one SQLite transaction**. If anything
+fails part-way, the transaction is rolled back and the existing database
+is left exactly as it was — a failed import never corrupts your data.
+
+## Security & validation
+
+The import path is built for hostile input. Before writing anything it:
+
+* rejects non-zip / empty uploads,
+* rejects **path traversal** (`../`), absolute paths, Windows drive
+  letters, backslashes, and **symlink** members,
+* caps the member count, the per-file size, and the total uncompressed
+  size (**zip-bomb** guard),
+* rejects a missing / non-JSON / wrong-format `manifest.json`,
+* rejects a `format_version` newer than this build understands (with a
+  clear "update Nova" message — forward-compatible rather than
+  mis-reading a future format),
+* parses every data file as JSON with a hard size cap and shape check.
+
+Uploads larger than **50 MB** are rejected with `413` before being
+buffered. Importing honours the same per-account memory-save policy gate
+as the manual "add memory" action.
+
+## API
+
+All endpoints require a normal Bearer token (any authenticated user);
+none are admin-gated. The `.zip` is sent as the **raw request body**
+(no multipart), which lets the server enforce a strict size cap.
+
+| Method & path | Purpose |
+|---|---|
+| `POST /memory-pack/export` | Build + download the pack. Streams `application/zip` with `Content-Disposition` and `X-Nova-Memory-Pack-*` count headers; also writes a copy to `NOVA_DATA_DIR/memory-packs/`. |
+| `POST /memory-pack/import/preview` | Validate an uploaded pack and return new/duplicate counts + warnings. Writes nothing. |
+| `POST /memory-pack/import?confirm=true` | Merge the uploaded pack. Requires `confirm=true`. |
+
+## Docker
+
+Under the bundled Compose stack `NOVA_DATA_DIR=/data` is a mounted
+volume (`nova-data`). Exported packs are written to
+`/data/memory-packs/`, so they survive `docker compose down` and image
+rebuilds (removed only by `docker compose down -v`). Nothing about this
+feature changes the schema or the Docker deployment.
+
+## Compatibility & forward-compatibility
+
+* `manifest.json` pins `format` (`nova-memory-pack`) and an integer
+  `format_version` (currently `1`); each data file also carries its own
+  `version`.
+* Unknown files and unknown JSON keys are ignored on import, and
+  optional files may be absent — so a newer pack remains loadable by an
+  older reader for the parts it understands, and an older pack always
+  loads.
+* A pack whose `format_version` is **newer** than the running Nova is
+  refused with a clear message instead of being mis-read.
+* The existing database schema is unchanged; the feature only reads and
+  inserts rows through the established tables.
+
+## Limitations & follow-ups
+
+* **No attachments yet.** `attachments/` is reserved; chat images are
+  not packed in v1.
+* **Embeddings are not exported.** Imported natural memories start
+  without an embedding and rely on keyword similarity until they are
+  next saved; this is intentional (embeddings are large and
+  host-specific).
+* **Merge only.** There is no "replace/overwrite" mode — by design, so
+  an import can never destroy existing data. A future version could add
+  an explicit, confirmation-gated replace mode.
+* **`message_feedback` is not exported** (it references message ids that
+  do not survive a cross-instance remap). Personalization preferences in
+  `settings.json` capture the user-facing tone choices.
+* Conversation summaries are **generated at export time** from recent
+  conversation titles; they are a convenience snapshot, not a stored
+  artifact.

--- a/static/index.html
+++ b/static/index.html
@@ -3437,6 +3437,7 @@
                 <button class="settings-nav-btn" data-pane="memory" onclick="switchSettingsPane('memory')" id="settings-nav-memory">Memory</button>
                 <button class="settings-nav-btn" data-pane="voice" onclick="switchSettingsPane('voice')" id="settings-nav-voice">Voice</button>
                 <button class="settings-nav-btn" data-pane="models" onclick="switchSettingsPane('models')" id="settings-nav-models">Models</button>
+                <button class="settings-nav-btn" data-pane="data" onclick="switchSettingsPane('data')" id="settings-nav-data">Data</button>
                 <button class="settings-nav-btn" data-pane="admin" onclick="switchSettingsPane('admin')" id="settings-nav-admin" style="display:none;">Admin</button>
                 <div class="settings-nav-divider"></div>
                 <button class="settings-nav-btn" data-pane="account" onclick="switchSettingsPane('account')" id="settings-nav-account">Account</button>
@@ -3905,6 +3906,40 @@
                             </div>
                             <div id="maintenance-detail-status" style="margin-top:8px;color:var(--text);"></div>
                         </div>
+                    </div>
+                </section>
+
+                <!-- DATA — Nova Memory Pack (portable export / import) -->
+                <section class="settings-pane" id="settings-pane-data">
+                    <div class="settings-section-title" id="settings-data-title">Data — Nova Memory Pack</div>
+                    <div class="settings-row-hint" id="settings-data-note">
+                        Carry your Nova context to another install or device. A Memory Pack is a <code>.zip</code> of structured JSON — your memories, conversations, generated summaries, and safe preferences. It never contains passwords, API keys, or tokens.
+                    </div>
+
+                    <!-- Export -->
+                    <div class="settings-row">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="memory-pack-export-title">Export Nova Memory Pack</span>
+                                <span class="settings-row-hint" id="memory-pack-export-hint">Download a <code>.zip</code> of your data. ⚠ It may contain personal conversation history — store it somewhere safe.</span>
+                            </div>
+                            <button class="memory-btn" id="memory-pack-export-btn" onclick="exportMemoryPack()">Export</button>
+                        </div>
+                        <div id="memory-pack-export-status" class="settings-row-hint" style="min-height:0;"></div>
+                    </div>
+
+                    <!-- Import -->
+                    <div class="settings-row">
+                        <div class="settings-row-head">
+                            <div class="settings-row-label">
+                                <span class="settings-row-title" id="memory-pack-import-title">Import Nova Memory Pack</span>
+                                <span class="settings-row-hint" id="memory-pack-import-hint">Merge a pack into this account. Existing data is kept; only missing memories and conversations are added. You'll see a preview before anything is saved.</span>
+                            </div>
+                            <button class="memory-btn" id="memory-pack-import-btn" onclick="document.getElementById('memory-pack-file').click()">Choose .zip…</button>
+                        </div>
+                        <input type="file" id="memory-pack-file" accept=".zip,application/zip" style="display:none" onchange="onMemoryPackFileSelected(event)" />
+                        <div id="memory-pack-import-error" class="settings-row-hint" style="color:var(--danger);min-height:0;"></div>
+                        <div id="memory-pack-import-preview" style="display:none;"></div>
                     </div>
                 </section>
 
@@ -8910,6 +8945,9 @@
             loadDefaultModelCard().catch(() => {});
             loadGgufCard().catch(() => {});
         }
+        if (pane === "data") {
+            resetMemoryPackUI();
+        }
     }
 
     function applySettingsAdminVisibility() {
@@ -8919,6 +8957,193 @@
         navAdmin.style.display = isAdmin ? "" : "none";
         if (!isAdmin && settingsCurrentPane === "admin") {
             settingsCurrentPane = "general";
+        }
+    }
+
+    // ── Nova Memory Pack (portable export / import) ──────────────────
+    // Available to every authenticated user (NOT admin-gated). Export
+    // streams a .zip download; import is a preview-first, merge-only,
+    // confirm-before-write flow. The server enforces all the real
+    // safety rules — this is just calm UI on top of it.
+
+    let _memoryPackFile = null;
+
+    function resetMemoryPackUI() {
+        _memoryPackFile = null;
+        const err = document.getElementById("memory-pack-import-error");
+        if (err) err.textContent = "";
+        const status = document.getElementById("memory-pack-export-status");
+        if (status) { status.textContent = ""; status.style.color = ""; }
+        const box = document.getElementById("memory-pack-import-preview");
+        if (box) { box.style.display = "none"; box.innerHTML = ""; }
+    }
+
+    async function exportMemoryPack() {
+        const btn = document.getElementById("memory-pack-export-btn");
+        const status = document.getElementById("memory-pack-export-status");
+        if (!confirm(
+            "Export a Nova Memory Pack?\n\n" +
+            "The .zip may contain personal conversation history and " +
+            "long-term memories. Keep it somewhere safe and only import " +
+            "it into a Nova you trust. It never contains passwords, API " +
+            "keys, or tokens."
+        )) return;
+        const token = localStorage.getItem("nova_token");
+        btn.disabled = true;
+        status.style.color = "";
+        status.textContent = "Building your Memory Pack…";
+        try {
+            const res = await fetch("/memory-pack/export", {
+                method: "POST",
+                headers: { "Authorization": `Bearer ${token}` },
+            });
+            if (res.status === 401) { logout(); return; }
+            if (!res.ok) {
+                let detail = "Export failed.";
+                try { const b = await res.json(); if (b && b.detail) detail = b.detail; } catch {}
+                status.style.color = "var(--danger)";
+                status.textContent = detail;
+                return;
+            }
+            const mems = res.headers.get("x-nova-memory-pack-memories") || "0";
+            const convs = res.headers.get("x-nova-memory-pack-conversations") || "0";
+            let fname = "nova-memory-pack.zip";
+            const cd = res.headers.get("content-disposition") || "";
+            const m = cd.match(/filename="?([^"]+)"?/);
+            if (m) fname = m[1];
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = fname;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+            status.style.color = "";
+            status.textContent = `Exported ${mems} memories and ${convs} conversations to ${fname}.`;
+        } catch (e) {
+            status.style.color = "var(--danger)";
+            status.textContent = "Export failed. Please try again.";
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    function onMemoryPackFileSelected(event) {
+        const file = event.target.files && event.target.files[0];
+        event.target.value = "";  // allow re-selecting the same file later
+        if (!file) return;
+        _memoryPackFile = file;
+        memoryPackPreview(file);
+    }
+
+    async function memoryPackPreview(file) {
+        const errEl = document.getElementById("memory-pack-import-error");
+        const box = document.getElementById("memory-pack-import-preview");
+        errEl.textContent = "";
+        box.style.display = "none";
+        box.innerHTML = "";
+        const token = localStorage.getItem("nova_token");
+        try {
+            const res = await fetch("/memory-pack/import/preview", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/zip",
+                },
+                body: file,
+            });
+            if (res.status === 401) { logout(); return; }
+            const body = await res.json().catch(() => null);
+            if (!res.ok) {
+                errEl.textContent = (body && body.detail) ? body.detail : "Could not read that file.";
+                return;
+            }
+            if (!body || !body.valid) {
+                const why = (body && body.errors && body.errors.length)
+                    ? body.errors.join("; ") : "it is not a valid Nova Memory Pack.";
+                errEl.textContent = "Cannot import: " + why;
+                return;
+            }
+            renderMemoryPackPreview(body);
+        } catch (e) {
+            errEl.textContent = "Could not read that file.";
+        }
+    }
+
+    function renderMemoryPackPreview(preview) {
+        const box = document.getElementById("memory-pack-import-preview");
+        const c = preview.counts || {};
+        const memNew = ((c.memories && c.memories.new) || 0) +
+            ((c.natural_memories && c.natural_memories.new) || 0);
+        const convNew = (c.conversations && c.conversations.new) || 0;
+        const setNew = (c.settings && c.settings.applicable) || 0;
+        const warnings = preview.warnings || [];
+        let html = '<div class="settings-row" style="margin-top:10px;">';
+        html += '<div class="settings-row-hint" style="color:var(--text);">This pack would add:</div>';
+        html += '<ul style="margin:6px 0 0 18px;padding:0;">';
+        html += `<li>${memNew} new memories</li>`;
+        html += `<li>${convNew} new conversations</li>`;
+        html += `<li>${setNew} new settings</li>`;
+        html += '</ul>';
+        if (warnings.length) {
+            html += '<div class="settings-row-hint" style="color:var(--danger);margin-top:6px;">' +
+                warnings.map(escapeHtml).join("<br>") + '</div>';
+        }
+        html += '<div class="settings-row-hint" style="margin-top:6px;">Existing data is kept and duplicates are skipped (merge).</div>';
+        html += '<div style="display:flex;gap:8px;margin-top:10px;">';
+        html += '<button class="memory-btn" id="memory-pack-confirm-btn" onclick="confirmMemoryPackImport()">Merge into my account</button>';
+        html += '<button class="memory-btn" onclick="cancelMemoryPackImport()">Cancel</button>';
+        html += '</div></div>';
+        box.innerHTML = html;
+        box.style.display = "block";
+    }
+
+    function cancelMemoryPackImport() {
+        _memoryPackFile = null;
+        const box = document.getElementById("memory-pack-import-preview");
+        box.style.display = "none";
+        box.innerHTML = "";
+    }
+
+    async function confirmMemoryPackImport() {
+        if (!_memoryPackFile) return;
+        const errEl = document.getElementById("memory-pack-import-error");
+        const box = document.getElementById("memory-pack-import-preview");
+        const token = localStorage.getItem("nova_token");
+        errEl.textContent = "";
+        box.innerHTML = '<div class="settings-row-hint">Importing…</div>';
+        try {
+            const res = await fetch("/memory-pack/import?confirm=true", {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${token}`,
+                    "Content-Type": "application/zip",
+                },
+                body: _memoryPackFile,
+            });
+            if (res.status === 401) { logout(); return; }
+            const body = await res.json().catch(() => null);
+            if (!res.ok) {
+                box.style.display = "none";
+                box.innerHTML = "";
+                errEl.textContent = (body && body.detail) ? body.detail : "Import failed.";
+                return;
+            }
+            const imp = (body && body.imported) || {};
+            const memCount = (imp.memories || 0) + (imp.natural_memories || 0);
+            box.innerHTML = '<div class="settings-row-hint" style="color:var(--text);">' +
+                `Imported ${memCount} memories, ${imp.conversations || 0} conversations, ` +
+                `and ${imp.settings || 0} settings. ✓</div>`;
+            _memoryPackFile = null;
+            // Refresh the views that now have new data.
+            try { if (typeof loadMemories === "function") loadMemories(); } catch {}
+            try { if (typeof loadConversations === "function") loadConversations(); } catch {}
+        } catch (e) {
+            box.style.display = "none";
+            box.innerHTML = "";
+            errEl.textContent = "Import failed. Your existing data was not changed.";
         }
     }
 

--- a/tests/test_memory_pack.py
+++ b/tests/test_memory_pack.py
@@ -1,0 +1,605 @@
+"""Tests for the Nova Memory Pack (portable per-user export / import).
+
+Covers the contract from the feature request:
+
+* manifest generation (format id / version, counts, file hashes),
+* export excludes secrets (password hash, secret-shaped settings,
+  embeddings, the host settings table),
+* import rejects invalid ZIPs (not a zip, empty, missing/!json
+  manifest, newer format_version, zip-bomb size),
+* import rejects path traversal / absolute / symlink members,
+* import merge behaviour + duplicate handling (re-import is a no-op),
+* settings merge never overwrites existing preferences,
+* the import runs in a transaction (a mid-import failure rolls back),
+* the export lands under NOVA_DATA_DIR/memory-packs (Docker path),
+* the authenticated HTTP endpoints (export / preview / import).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sqlite3
+import sys
+import uuid
+import zipfile
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod in ("ddgs", "ollama", "sgmllib", "feedparser"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core import memory as core_memory  # noqa: E402
+from core import memory_pack as mp  # noqa: E402
+from core import paths as core_paths  # noqa: E402
+from core import settings as core_settings  # noqa: E402
+from core import users  # noqa: E402
+from memory import store as natural_store  # noqa: E402
+
+
+# ── fixtures / helpers ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    monkeypatch.setenv(core_paths.ENV_VAR, str(tmp_path))
+    path = str(tmp_path / "nova.db")
+    monkeypatch.setattr(core_memory, "DB_PATH", path)
+    monkeypatch.setattr(natural_store, "DB_PATH", path)
+    core_memory.initialize_db()
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM users")
+    return path
+
+
+def _make_user(db_path, username, password="pw", role=users.ROLE_USER,
+               is_restricted=False):
+    with sqlite3.connect(db_path) as conn:
+        return users.create_user(
+            conn, username, password, role=role, is_restricted=is_restricted,
+        )
+
+
+def _add_natural_memory(db_path, user_id, kind, topic, content,
+                        project_id=None):
+    """Insert a natural_memories row directly (no embedding / ollama)."""
+    now = datetime.now().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO natural_memories (id, kind, topic, content, "
+            "confidence, source, created_at, updated_at, last_seen_at, "
+            "embedding, user_id, project_id) "
+            "VALUES (?, ?, ?, ?, 0.9, 'extractor', ?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), kind, topic, content, now, now, now,
+             json.dumps([0.1, 0.2, 0.3]), user_id, project_id),
+        )
+
+
+def _seed_user_with_data(db_path, username="alice"):
+    """Create a user with memories, a conversation, and settings."""
+    uid = _make_user(db_path, username)
+    core_memory.save_memory("preferences", "Alice prefers tea over coffee", uid)
+    core_memory.save_memory("facts", "Alice lives in Berlin", uid)
+    _add_natural_memory(db_path, uid, "preference", "editor", "Uses Neovim daily")
+    cid = core_memory.create_conversation("Trip planning", uid)
+    core_memory.save_message(cid, "user", "Help me plan a trip to Japan")
+    core_memory.save_message(cid, "assistant", "Of course!", "test-model")
+    core_settings.save_user_setting(uid, "response_style", "concise")
+    # A secret-shaped per-user setting that must never be exported.
+    core_settings.save_user_setting(
+        uid, "github_token", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab",
+    )
+    return uid
+
+
+def _read_zip(data: bytes) -> dict:
+    out = {}
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for name in zf.namelist():
+            out[name] = zf.read(name)
+    return out
+
+
+def _manifest_bytes(version=mp.FORMAT_VERSION, fmt=mp.FORMAT_ID):
+    return json.dumps(
+        {"format": fmt, "format_version": version, "counts": {}}
+    ).encode("utf-8")
+
+
+def _make_zip(members: dict, symlinks: dict | None = None) -> bytes:
+    bio = io.BytesIO()
+    with zipfile.ZipFile(bio, "w") as zf:
+        for name, body in members.items():
+            zf.writestr(name, body)
+        for name, target in (symlinks or {}).items():
+            info = zipfile.ZipInfo(name)
+            info.external_attr = 0o120777 << 16  # S_IFLNK | 0777
+            zf.writestr(info, target)
+    return bio.getvalue()
+
+
+# ── export: manifest + structure ────────────────────────────────────
+
+
+class TestExportManifest:
+    def test_build_produces_zip_with_expected_files(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        assert result.filename.endswith(".zip")
+        assert result.filename.startswith("nova-memory-pack-")
+        files = _read_zip(result.data)
+        for name in (mp.MANIFEST_NAME, mp.PROFILE_NAME, mp.MEMORIES_NAME,
+                     mp.CONVERSATIONS_NAME, mp.SUMMARIES_NAME,
+                     mp.SETTINGS_NAME):
+            assert name in files
+
+    def test_manifest_format_and_counts(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        manifest = result.manifest
+        assert manifest["format"] == mp.FORMAT_ID
+        assert manifest["format_version"] == mp.FORMAT_VERSION
+        assert manifest["counts"]["memories"] == 2
+        assert manifest["counts"]["natural_memories"] == 1
+        assert manifest["counts"]["conversations"] == 1
+        assert manifest["counts"]["messages"] == 2
+        assert "privacy_notice" in manifest
+        assert "personal conversation history" in manifest["privacy_notice"]
+
+    def test_manifest_files_have_hashes(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        files = _read_zip(result.data)
+        import hashlib
+        for entry in result.manifest["files"]:
+            body = files[entry["name"]]
+            assert entry["size"] == len(body)
+            assert entry["sha256"] == hashlib.sha256(body).hexdigest()
+
+    def test_export_is_deterministic_for_fixed_now(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        when = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        a = mp.build_memory_pack(uid, now=when)
+        b = mp.build_memory_pack(uid, now=when)
+        # The data files are byte-identical (zip mtimes are pinned to now).
+        assert _read_zip(a.data)[mp.MEMORIES_NAME] == \
+            _read_zip(b.data)[mp.MEMORIES_NAME]
+
+
+# ── export: secret exclusion ────────────────────────────────────────
+
+
+class TestExportExcludesSecrets:
+    def test_password_hash_never_appears(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT password_hash FROM users WHERE id = ?", (uid,),
+            ).fetchone()
+        password_hash = row[0].encode("utf-8")
+        result = mp.build_memory_pack(uid)
+        assert password_hash not in result.data
+        profile = json.loads(_read_zip(result.data)[mp.PROFILE_NAME])
+        assert "password_hash" not in profile["user"]
+
+    def test_secret_shaped_setting_excluded(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        settings = json.loads(_read_zip(result.data)[mp.SETTINGS_NAME])
+        assert "response_style" in settings["user_settings"]
+        assert "github_token" not in settings["user_settings"]
+        assert b"ghp_ABCDEFG" not in result.data
+
+    def test_embeddings_excluded(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        memories = json.loads(_read_zip(result.data)[mp.MEMORIES_NAME])
+        for row in memories["natural"]:
+            assert "embedding" not in row
+
+    def test_profile_contains_safe_fields(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        profile = json.loads(_read_zip(result.data)[mp.PROFILE_NAME])
+        assert profile["user"]["username"] == "alice"
+        assert "personalization" in profile
+        assert profile["personalization"]["response_style"] == "concise"
+
+
+# ── inspect / validation ────────────────────────────────────────────
+
+
+class TestInspectValid:
+    def test_valid_pack_inspects_clean(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        report = mp.inspect_memory_pack(result.data)
+        assert report.valid is True
+        assert report.errors == ()
+        assert report.counts["memories"] == 2
+        assert report.counts["conversations"] == 1
+
+
+class TestInspectRejectsInvalid:
+    def test_empty_bytes(self):
+        report = mp.inspect_memory_pack(b"")
+        assert report.valid is False
+
+    def test_not_a_zip(self):
+        report = mp.inspect_memory_pack(b"this is not a zip file")
+        assert report.valid is False
+        assert "not a valid .zip" in report.errors[0]
+
+    def test_missing_manifest(self):
+        data = _make_zip({mp.PROFILE_NAME: b'{"version": 1}'})
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("manifest" in e for e in report.errors)
+
+    def test_manifest_not_json(self):
+        data = _make_zip({mp.MANIFEST_NAME: b"{ this is not json"})
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("not valid JSON" in e for e in report.errors)
+
+    def test_wrong_format(self):
+        data = _make_zip({mp.MANIFEST_NAME: _manifest_bytes(fmt="something-else")})
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("format" in e for e in report.errors)
+
+    def test_newer_format_version_refused(self):
+        data = _make_zip({mp.MANIFEST_NAME: _manifest_bytes(version=999)})
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("newer Nova" in e for e in report.errors)
+
+    def test_data_file_not_json(self):
+        data = _make_zip({
+            mp.MANIFEST_NAME: _manifest_bytes(),
+            mp.MEMORIES_NAME: b"{ broken",
+        })
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+
+    def test_zip_bomb_size_rejected(self, monkeypatch):
+        monkeypatch.setattr(mp, "MAX_TOTAL_UNCOMPRESSED_BYTES", 5)
+        data = _make_zip({mp.MANIFEST_NAME: _manifest_bytes()})
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("zip bomb" in e.lower() or "too large" in e.lower()
+                   for e in report.errors)
+
+    def test_too_many_members_rejected(self, monkeypatch):
+        monkeypatch.setattr(mp, "MAX_MEMBERS", 1)
+        data = _make_zip({
+            mp.MANIFEST_NAME: _manifest_bytes(),
+            mp.PROFILE_NAME: b'{"version": 1}',
+        })
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+
+
+class TestInspectRejectsTraversal:
+    def test_parent_traversal(self):
+        data = _make_zip({
+            mp.MANIFEST_NAME: _manifest_bytes(),
+            "../evil.json": b"{}",
+        })
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("Unsafe" in e for e in report.errors)
+
+    def test_absolute_path(self):
+        data = _make_zip({
+            mp.MANIFEST_NAME: _manifest_bytes(),
+            "/etc/passwd": b"x",
+        })
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+
+    def test_symlink_member(self):
+        data = _make_zip(
+            {mp.MANIFEST_NAME: _manifest_bytes()},
+            symlinks={"link.json": "/etc/passwd"},
+        )
+        report = mp.inspect_memory_pack(data)
+        assert report.valid is False
+        assert any("symlink" in e.lower() for e in report.errors)
+
+
+# ── import: merge + dedup ───────────────────────────────────────────
+
+
+class TestImportMerge:
+    def test_round_trip_into_fresh_instance(self, tmp_path, monkeypatch):
+        db1 = str(tmp_path / "a.db")
+        db2 = str(tmp_path / "b.db")
+
+        monkeypatch.setattr(core_memory, "DB_PATH", db1)
+        monkeypatch.setattr(natural_store, "DB_PATH", db1)
+        core_memory.initialize_db()
+        uid_a = _seed_user_with_data(db1, "alice")
+        pack = mp.build_memory_pack(uid_a)
+
+        monkeypatch.setattr(core_memory, "DB_PATH", db2)
+        monkeypatch.setattr(natural_store, "DB_PATH", db2)
+        core_memory.initialize_db()
+        uid_b = _make_user(db2, "bob")
+
+        result = mp.import_memory_pack(pack.data, uid_b, confirm=True)
+        assert result.outcome == mp.OUTCOME_IMPORTED
+        assert result.imported["memories"] == 2
+        assert result.imported["natural_memories"] == 1
+        assert result.imported["conversations"] == 1
+        assert result.imported["messages"] == 2
+
+        mems = core_memory.list_memories(uid_b)
+        assert any("tea" in m["content"] for m in mems)
+        convs = core_memory.load_conversations(uid_b)
+        assert any(c["title"] == "Trip planning" for c in convs)
+        nat = natural_store.list_memories(uid_b, db_path=db2)
+        assert any("Neovim" in m.content for m in nat)
+
+    def test_unconfirmed_writes_nothing(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)
+        target = _make_user(db_path, "bob")
+        result = mp.import_memory_pack(pack.data, target, confirm=False)
+        assert result.outcome == mp.OUTCOME_UNCONFIRMED
+        assert core_memory.list_memories(target) == []
+
+    def test_reimport_is_deduplicated(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)
+        target = _make_user(db_path, "bob")
+
+        first = mp.import_memory_pack(pack.data, target, confirm=True)
+        assert first.imported["memories"] == 2
+        assert first.imported["conversations"] == 1
+
+        second = mp.import_memory_pack(pack.data, target, confirm=True)
+        assert second.imported["memories"] == 0
+        assert second.imported["conversations"] == 0
+        assert second.skipped["memories_duplicate"] == 2
+        assert second.skipped["conversations_duplicate"] == 1
+        # No duplicate rows landed in the database.
+        assert len(core_memory.list_memories(target)) == 2
+        assert len(core_memory.load_conversations(target)) == 1
+
+    def test_partial_overlap_imports_only_missing(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)
+        target = _make_user(db_path, "bob")
+        # Bob already knows one of the facts verbatim.
+        core_memory.save_memory("preferences", "Alice prefers tea over coffee",
+                                target)
+        result = mp.import_memory_pack(pack.data, target, confirm=True)
+        assert result.imported["memories"] == 1
+        assert result.skipped["memories_duplicate"] == 1
+
+    def test_settings_merge_never_overwrites(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)  # exports response_style=concise
+        target = _make_user(db_path, "bob")
+        core_settings.save_user_setting(target, "response_style", "technical")
+
+        result = mp.import_memory_pack(pack.data, target, confirm=True)
+        # Existing preference preserved; never clobbered by the pack.
+        assert core_settings.get_user_setting(target, "response_style") == \
+            "technical"
+        assert result.skipped["settings_existing"] >= 1
+
+    def test_import_drops_secret_settings(self, db_path):
+        # Defense-in-depth: even a hand-crafted pack carrying a secret
+        # setting must never land that value in the database.
+        target = _make_user(db_path, "bob")
+        data = _make_zip({
+            mp.MANIFEST_NAME: _manifest_bytes(),
+            mp.SETTINGS_NAME: json.dumps({"version": 1, "user_settings": {
+                "warmth_level": "high",
+                "api_key": "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef",
+            }}).encode("utf-8"),
+        })
+        result = mp.import_memory_pack(data, target, confirm=True)
+        assert result.outcome == mp.OUTCOME_IMPORTED
+        assert result.imported["settings"] == 1
+        assert result.skipped["settings_secret"] >= 1
+        assert core_settings.get_user_setting(target, "warmth_level") == "high"
+        assert core_settings.get_user_setting(
+            target, "api_key", "MISSING") == "MISSING"
+
+    def test_projects_recreated_by_name(self, db_path):
+        uid = _make_user(db_path, "alice")
+        from core import projects as projects_mod
+        pid = projects_mod.create_project("Nova", uid)["id"]
+        core_memory.save_memory("facts", "Project fact about Nova", uid,
+                                project_id=pid)
+        pack = mp.build_memory_pack(uid)
+
+        target = _make_user(db_path, "bob")
+        result = mp.import_memory_pack(pack.data, target, confirm=True)
+        assert result.imported["projects"] == 1
+        bob_projects = projects_mod.list_projects(target)
+        assert any(p["name"] == "Nova" for p in bob_projects)
+
+
+class TestImportTransaction:
+    def test_failure_rolls_back(self, db_path, monkeypatch):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)
+        target = _make_user(db_path, "bob")
+
+        # Force a failure *after* memories/conversations are inserted but
+        # before commit. The whole transaction must roll back.
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated failure")
+
+        monkeypatch.setattr(mp, "_merge_settings", _boom)
+        result = mp.import_memory_pack(pack.data, target, confirm=True)
+        assert result.outcome == mp.OUTCOME_FAILED
+        # Database is untouched: no memories, no conversations imported.
+        assert core_memory.list_memories(target) == []
+        assert core_memory.load_conversations(target) == []
+
+
+# ── preview ─────────────────────────────────────────────────────────
+
+
+class TestImportPreview:
+    def test_preview_reports_new_counts(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)
+        target = _make_user(db_path, "bob")
+        preview = mp.build_import_preview(pack.data, target)
+        assert preview.valid is True
+        assert preview.counts["memories"]["new"] == 2
+        assert preview.counts["conversations"]["new"] == 1
+        # The secret-shaped setting was already stripped at export time, so
+        # the safe preference is the only applicable setting here.
+        assert preview.counts["settings"]["applicable"] >= 1
+
+    def test_preview_marks_duplicates(self, db_path):
+        uid = _seed_user_with_data(db_path)
+        pack = mp.build_memory_pack(uid)
+        target = _make_user(db_path, "bob")
+        mp.import_memory_pack(pack.data, target, confirm=True)
+        preview = mp.build_import_preview(pack.data, target)
+        assert preview.counts["memories"]["new"] == 0
+        assert preview.counts["memories"]["duplicate"] == 2
+
+    def test_preview_invalid_pack(self):
+        preview = mp.build_import_preview(b"not a zip", 1)
+        assert preview.valid is False
+
+
+# ── Docker data path ────────────────────────────────────────────────
+
+
+class TestDockerDataPath:
+    def test_pack_written_under_memory_packs(self, db_path, tmp_path,
+                                             monkeypatch):
+        root = tmp_path / "NovaData"
+        root.mkdir()
+        monkeypatch.setenv(core_paths.ENV_VAR, str(root))
+        uid = _seed_user_with_data(db_path)
+        result = mp.build_memory_pack(uid)
+        out = mp.write_pack_to_data_dir(result)
+        assert out is not None
+        assert out.parent == root / core_paths.MEMORY_PACKS_SUBDIR
+        assert out.is_file()
+        assert out.name == result.filename
+
+
+# ── HTTP endpoints ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def web_client(db_path, monkeypatch):
+    monkeypatch.setattr(core_memory, "DB_PATH", db_path)
+    monkeypatch.setattr(natural_store, "DB_PATH", db_path)
+    from core.rate_limiter import _login_limiter
+    _login_limiter._store.clear()
+
+    import web
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("web.initialize_db"))
+        stack.enter_context(patch("web.learn_from_feeds"))
+        stack.enter_context(patch("web.scheduler", MagicMock()))
+        with TestClient(web.app, raise_server_exceptions=True) as client:
+            yield client
+
+
+def _login(client, username, password="pw"):
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _h(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestEndpointsAuth:
+    def test_export_requires_auth(self, web_client):
+        resp = web_client.post("/memory-pack/export")
+        assert resp.status_code in (401, 403)
+
+    def test_import_requires_auth(self, web_client):
+        resp = web_client.post("/memory-pack/import?confirm=true", content=b"x")
+        assert resp.status_code in (401, 403)
+
+
+class TestExportEndpoint:
+    def test_export_downloads_zip(self, db_path, web_client):
+        _seed_user_with_data(db_path)
+        token = _login(web_client, "alice")
+        resp = web_client.post("/memory-pack/export", headers=_h(token))
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/zip"
+        assert "attachment" in resp.headers["content-disposition"]
+        assert resp.headers["x-nova-memory-pack-conversations"] == "1"
+        # Body is a real pack.
+        report = mp.inspect_memory_pack(resp.content)
+        assert report.valid is True
+
+
+class TestImportEndpoints:
+    def test_preview_then_import(self, db_path, web_client, tmp_path,
+                                 monkeypatch):
+        # Build a pack as alice via the export endpoint.
+        _seed_user_with_data(db_path)
+        alice = _login(web_client, "alice")
+        pack = web_client.post(
+            "/memory-pack/export", headers=_h(alice),
+        ).content
+
+        # Import it into a second user.
+        _make_user(db_path, "bob")
+        bob = _login(web_client, "bob")
+
+        preview = web_client.post(
+            "/memory-pack/import/preview", headers=_h(bob), content=pack,
+        )
+        assert preview.status_code == 200, preview.text
+        assert preview.json()["counts"]["memories"]["new"] == 2
+
+        done = web_client.post(
+            "/memory-pack/import?confirm=true", headers=_h(bob), content=pack,
+        )
+        assert done.status_code == 200, done.text
+        assert done.json()["outcome"] == "imported"
+        assert done.json()["imported"]["conversations"] == 1
+
+    def test_import_requires_confirm(self, db_path, web_client):
+        _make_user(db_path, "bob")
+        bob = _login(web_client, "bob")
+        resp = web_client.post(
+            "/memory-pack/import", headers=_h(bob), content=b"PK\x03\x04",
+        )
+        assert resp.status_code == 400
+
+    def test_import_rejects_invalid_zip(self, db_path, web_client):
+        _make_user(db_path, "bob")
+        bob = _login(web_client, "bob")
+        resp = web_client.post(
+            "/memory-pack/import?confirm=true", headers=_h(bob),
+            content=b"definitely not a zip",
+        )
+        assert resp.status_code == 400
+
+    def test_import_rejects_oversize(self, db_path, web_client, monkeypatch):
+        monkeypatch.setattr(mp, "MAX_UPLOAD_BYTES", 16)
+        _make_user(db_path, "bob")
+        bob = _login(web_client, "bob")
+        resp = web_client.post(
+            "/memory-pack/import?confirm=true", headers=_h(bob),
+            content=b"x" * 64,
+        )
+        assert resp.status_code == 413

--- a/web.py
+++ b/web.py
@@ -75,6 +75,7 @@ from core import provider_status as _provider_status
 from core import model_settings as _model_settings
 from core import gguf_settings as _gguf_settings
 from core import data_export as _data_export
+from core import memory_pack as _memory_pack
 from core import voice as _voice
 import sqlite3 as _sqlite3
 from core import users as _users_mod
@@ -1397,6 +1398,129 @@ def add_memory(
         )
     save_memory(request.category, request.content, user.id)
     return {"ok": True}
+
+
+# ── NOVA MEMORY PACK (portable export / import) ──
+#
+# A Memory Pack is a per-user .zip of structured JSON (memories,
+# conversations, generated summaries, and safe preferences) so a user
+# can carry their Nova context to another install/device. Unlike the
+# admin-only /admin/storage/* endpoints (which ship the raw nova.db),
+# these are available to any authenticated user and operate only on
+# that user's own data. The pack never contains secrets.
+
+async def _read_pack_upload(request: Request) -> bytes:
+    """Read a raw ``.zip`` upload body with a hard size cap.
+
+    The pack is sent as the raw request body (no multipart) so we can
+    enforce a strict in-memory size limit before doing any work.
+    Returns the bytes or raises 413 (too large) / 400 (empty).
+    """
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > _memory_pack.MAX_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=413, detail="Memory pack is too large.",
+                )
+        except ValueError:
+            pass
+    body = await request.body()
+    if len(body) > _memory_pack.MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Memory pack is too large.")
+    if not body:
+        raise HTTPException(status_code=400, detail="No file was uploaded.")
+    return body
+
+
+@app.post("/memory-pack/export")
+def memory_pack_export(user: CurrentUser = Depends(get_current_user)):
+    """Build and download a Nova Memory Pack for the current user.
+
+    Streams a ``.zip`` of structured JSON and also writes a copy into
+    ``NOVA_DATA_DIR/memory-packs`` (best effort) so Docker installs keep
+    one on the persistent volume. The pack never contains secrets.
+    """
+    try:
+        result = _memory_pack.build_memory_pack(user.id)
+    except Exception:  # noqa: BLE001 - surface a safe 500, never a stack trace
+        raise HTTPException(
+            status_code=500, detail="Could not build the memory pack.",
+        )
+    # Persist a copy to the data volume; a read-only data dir is not fatal.
+    _memory_pack.write_pack_to_data_dir(result)
+    counts = result.counts
+    headers = {
+        "Content-Disposition": f'attachment; filename="{result.filename}"',
+        "Cache-Control": "no-store",
+        "X-Nova-Memory-Pack-Memories": str(
+            counts["memories"] + counts["natural_memories"]
+        ),
+        "X-Nova-Memory-Pack-Conversations": str(counts["conversations"]),
+        "X-Nova-Memory-Pack-Settings": str(counts["settings"]),
+    }
+    return Response(
+        content=result.data, media_type="application/zip", headers=headers,
+    )
+
+
+@app.post("/memory-pack/import/preview")
+async def memory_pack_import_preview(
+    request: Request,
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Validate an uploaded pack and report what a merge would do.
+
+    Writes nothing — this is the dry-run step the UI shows before the
+    user confirms. Returns counts (new vs. duplicate), warnings, and
+    the pack manifest.
+    """
+    body = await _read_pack_upload(request)
+    return _memory_pack.build_import_preview(body, user.id).as_dict()
+
+
+@app.post("/memory-pack/import")
+async def memory_pack_import(
+    request: Request,
+    confirm: bool = False,
+    mode: str = "merge",
+    user: CurrentUser = Depends(get_current_user),
+):
+    """Merge an uploaded pack into the current user's data.
+
+    Requires ``?confirm=true`` (never imports blindly). Importing
+    writes memories/conversations, so it honours the same per-account
+    policy gate as the manual "add memory" endpoint. The merge runs in
+    a single transaction; on any failure the database is unchanged.
+    """
+    policy = get_policy(user)
+    if not policy.memory_save_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="Memory saving is disabled for this account.",
+        )
+    if not confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Import requires explicit confirmation (?confirm=true).",
+        )
+    body = await _read_pack_upload(request)
+    result = _memory_pack.import_memory_pack(
+        body, user.id, confirm=True, mode=mode,
+    )
+    if result.outcome == _memory_pack.OUTCOME_REFUSED:
+        raise HTTPException(
+            status_code=400,
+            detail="; ".join(result.errors)
+            or "The memory pack could not be imported.",
+        )
+    if result.outcome == _memory_pack.OUTCOME_FAILED:
+        raise HTTPException(
+            status_code=500,
+            detail="; ".join(result.errors)
+            or "Import failed; no changes were made.",
+        )
+    return result.as_dict()
 
 
 # ── FEEDBACK ENDPOINTS ──


### PR DESCRIPTION
## Nova Memory Pack

Adds a per-user, **structured-JSON `.zip`** export/import so a user can carry their useful Nova context — long-term memories, conversations, generated summaries, and safe preferences — to another Nova instance and have the assistant "remember them" across installs/devices.

This is deliberately distinct from the two existing features:
- `core/data_export.py` — **admin-only** `tar.gz` of the **raw `nova.db`** (whole-host migration).
- `core/memory_importer.py` — **Markdown** memories-only importer.

The Memory Pack is **per-user, authenticated (not admin), structured JSON, round-trippable, secret-free, merge-by-default, and transactional.**

### What's in the box (ZIP)
`manifest.json`, `profile.json`, `memories.json` (classic + natural memories, **no embeddings**), `conversations.json` (conversations with nested messages), `summaries.json` (generated session-continuity recap), `settings.json` (safe per-user preferences). `attachments/` is reserved for later.

### Data sources exported (scoped to the signed-in `user_id`)
`users` (no `password_hash`) + personalization → `profile.json`; `memories` + `natural_memories` → `memories.json`; `conversations` + `messages` → `conversations.json`; `core.session_continuity` → `summaries.json`; `user_settings` (secret-filtered) → `settings.json`. Project grouping is preserved **by name** (get-or-created on import).

### Intentionally excluded (never written)
Password hashes, API keys, GitHub/OAuth tokens & client secrets, the JWT secret, session cookies, the **host `settings` table**, memory embeddings, and any per-user setting whose **key/value looks secret-shaped** (forward-compat defense-in-depth).

### Import: merge + dedup (non-destructive, transactional)
Keeps existing data, adds only what's missing, de-dups classic memories on `(category, content)`, natural on `(kind, topic, content)`, conversations on `(title, created)`, and fills only **missing** settings (never overwrites). A **preview/dry-run** step reports new vs. duplicate counts and writes nothing; the real import requires `?confirm=true`. The whole merge runs in **one SQLite transaction** — any failure rolls back and the DB is left untouched.

### Security
Validates uploads for path traversal (`../`), absolute paths, drive letters, **symlinks**, member count, **zip-bomb** size, per-file JSON validity, and a manifest `format_version` this build understands. Raw-body upload capped at **50 MB → 413**. Authenticated, not admin/alpha; import honors the per-account memory-save policy.

### UI
New **Settings → Data** pane with *Export Nova Memory Pack* (privacy-warned download) and *Import Nova Memory Pack* (preview-first, confirm-before-write). Not admin-gated.

### Docker
Export streams the download **and** writes a copy to `NOVA_DATA_DIR/memory-packs/` → `/data/memory-packs/` on the mounted `nova-data` volume. No schema change, no Docker deployment change.

## Files
- **new** `core/memory_pack.py` — build/inspect/preview/import engine
- `web.py` — `POST /memory-pack/export`, `/memory-pack/import/preview`, `/memory-pack/import`
- `static/index.html` — Settings → Data pane + JS handlers
- **new** `tests/test_memory_pack.py` — 40 tests
- **new** `docs/nova-memory-pack.md`, `CHANGELOG.md`

## Testing
- `tests/test_memory_pack.py`: **40 passed** (manifest generation, secret exclusion, invalid/traversal/symlink/zip-bomb rejection, merge + duplicate handling, transactional rollback, Docker data path, HTTP endpoints).
- Regression sweep across touched surfaces (auth, conversations, memory/settings scoping, admin users, message edit/delete, storage endpoints): **all green**.
- `flake8` clean; inline JS passes `node --check`.

### Manual test
1. Settings → Data → **Export** → downloads `nova-memory-pack-*.zip` (a copy also appears in `NOVA_DATA_DIR/memory-packs/`).
2. On another account/instance → Settings → Data → **Import** → pick the zip → review the preview → **Merge into my account** → memories & conversations appear; re-importing is a no-op.

## Limitations / follow-ups
Merge-only (no destructive replace mode by design); embeddings regenerate locally; `message_feedback` not exported; attachments reserved for a future version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D4rcJf3TTSXT2Q2tL8jqo

---
_Generated by [Claude Code](https://claude.ai/code/session_019D4rcJf3TTSXT2Q2tL8jqo)_