### PR TITLE
docker: make the stack zero-setup + add dev/prod and auto-update overlays

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # ====================================================================
 #  Nova environment configuration
 #
-#  Docker (recommended):  cp .env.example .env  &&  docker compose up -d
-#                         then open http://localhost:8000
+#  Docker (recommended):  docker compose up -d   ->   http://localhost:8000
+#
+#  This file is OPTIONAL. The Docker stack starts with safe built-in
+#  defaults (admin / changeme) and needs no .env at all. Copy it to .env
+#  only to OVERRIDE those defaults:  cp .env.example .env
 #
 #  The defaults below bring the stack up immediately. Change the
 #  credentials before exposing Nova beyond your own machine.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Cross-platform line-ending normalization.
+#
+# Without this, a Windows checkout with core.autocrlf=true rewrites shell
+# scripts to CRLF. The Linux container then can't run docker/entrypoint.sh
+# (/bin/sh chokes on the trailing \r — you get a confusing "no such file or
+# directory" on `docker compose up`). Forcing LF keeps the exact same bytes
+# on Linux, macOS, and Windows so the stack is truly plug-and-play anywhere.
+
+# Default: treat files as text, auto-detect, and always store/check out LF.
+* text=auto eol=lf
+
+# Files that MUST stay LF — they run inside Linux containers / POSIX shells.
+*.sh                 text eol=lf
+*.py                 text eol=lf
+*.yml                text eol=lf
+*.yaml               text eol=lf
+*.env                text eol=lf
+.env.example         text eol=lf
+Dockerfile           text eol=lf
+docker/entrypoint.sh text eol=lf
+
+# Windows-only helpers (if ever added) should keep CRLF.
+*.bat                text eol=crlf
+*.ps1                text eol=crlf
+
+# Binary assets — never normalize or diff as text.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.gguf  binary
+*.onnx  binary
+*.db    binary
+*.gz    binary
+*.zip   binary

--- a/README.md
+++ b/README.md
@@ -935,11 +935,15 @@ a `nova-data` volume and models on an `ollama-models` volume, so rebuilds
 and updates never lose data.
 
 ```bash
-cp .env.example .env
 docker compose up -d
-# pull at least one model, then open http://localhost:8000
+# pull at least one model, then open http://localhost:8000 (admin / changeme)
 docker compose exec ollama ollama pull gemma3:1b
 ```
+
+No `.env` is required — the stack starts with safe defaults. Copy
+`.env.example` to `.env` only when you want to change the admin login,
+ports, or enable integrations (and **do** change the admin password before
+exposing Nova beyond localhost).
 
 **Don't want to build?** A prebuilt image is published to the GitHub
 Container Registry on every push to `main` and every release tag, so you
@@ -947,7 +951,6 @@ can deploy without cloning or building the repo. Use the bundled
 `docker-compose.ghcr.yml`, which pulls `ghcr.io/thezupzup/nova:latest`:
 
 ```bash
-cp .env.example .env
 docker compose -f docker-compose.ghcr.yml up -d
 docker compose -f docker-compose.ghcr.yml exec ollama ollama pull gemma3:1b
 # update later: docker compose -f docker-compose.ghcr.yml pull && \
@@ -961,8 +964,9 @@ between build and prebuilt keeps your data.
 Nova is reachable at `http://localhost:8000`, and from other LAN machines
 (including Windows browsers) at `http://<host-ip>:8000`. See
 [docs/docker.md](docs/docker.md) for first-run, starting/stopping, logs,
-updates, backups, resetting, pulling models, optional NVIDIA GPU, and
-using Nova from a Windows browser.
+updates (incl. optional auto-update), production vs development, backups,
+resetting, pulling models, optional NVIDIA GPU, and using Nova from a
+Windows browser.
 
 ### Portable workspace (systemd or Docker)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,44 @@
+# Nova — development overlay (opt-in).
+#
+# Layer this ON TOP of docker-compose.yml for live code-reload while you
+# edit Nova on the host. The base compose file stays production-shaped;
+# this overlay only applies when you ask for it explicitly:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Tip: set it once for the shell and plain `docker compose up` uses both —
+#   export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+#
+# What it changes vs the production default:
+#   * Bind-mounts your working copy over /app, so source edits are visible
+#     inside the container immediately.
+#   * Runs uvicorn with --reload, so the server restarts on code changes.
+#   * Drops restart: unless-stopped, so a dev container never fights you.
+#
+# Your data still lives on the nova-data volume from the base file, so the
+# database survives restarts. To keep dev data fully separate from a
+# production stack on the same host, give dev its own project name:
+#   docker compose -p nova-dev -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# After changing requirements.txt, rebuild the image: add --build to `up`.
+
+services:
+  nova:
+    build:
+      context: .
+    # Shadow the baked-in /app with your live checkout. Python dependencies
+    # were installed into the image's site-packages at build time, so only
+    # the source is overlaid here. nova.db is NOT in /app — it stays on the
+    # /data volume (NOVA_DATA_DIR=/data is inherited from the base file), so
+    # reloading never writes the database into your host checkout.
+    volumes:
+      - ./:/app
+
+    # Live reload. uvicorn watches /app and restarts on .py changes. The
+    # container entrypoint still runs first (data-dir prep + secret-key
+    # generation); this only replaces the command it execs. ${NOVA_PORT} is
+    # substituted by Compose at `up` time, mirroring the base image's CMD.
+    command: ["sh", "-c", "exec uvicorn web:app --host 0.0.0.0 --port ${NOVA_PORT:-8000} --reload --reload-dir /app"]
+
+    # You drive a dev container's lifecycle; don't auto-restart it.
+    restart: "no"

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -5,10 +5,13 @@
 # Registry. Use it to *deploy* Nova without cloning or building the whole
 # repository.
 #
-# Quick start (no `git clone` required — just this file + an .env):
-#   # download this file and create an .env (see docs/docker.md)
+# Quick start (no `git clone` required — just this one file):
 #   docker compose -f docker-compose.ghcr.yml up -d
 #   open http://localhost:8000
+#
+# Comes up with safe defaults (admin login: admin / changeme) and needs no
+# manual setup. Drop an .env next to this file to override credentials,
+# ports, or the image tag (NOVA_IMAGE_TAG).
 #
 # Update to the newest published image:
 #   docker compose -f docker-compose.ghcr.yml pull
@@ -28,11 +31,15 @@ services:
     container_name: nova
     restart: unless-stopped
 
-    # All variables from .env are passed to the container. Docker-specific
-    # values are overridden in `environment:` below (which wins over the
-    # env file) so the in-container paths/URLs are always correct.
+    # Load overrides from .env WHEN PRESENT. `required: false` keeps the
+    # stack working with zero setup: with no .env the container falls back
+    # to the defaults in `environment:` below (which always win over the
+    # env file, so the in-container paths/URLs stay correct).
+    # Needs Docker Compose v2.24+ (Docker Desktop / Engine shipped it in
+    # early 2024); upgrade Docker if you see an "unexpected key" error here.
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       # Persist all runtime state on the /data volume (mounted below).
       NOVA_DATA_DIR: /data
@@ -42,6 +49,12 @@ services:
       OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
       # Port uvicorn binds inside the container.
       NOVA_PORT: ${NOVA_PORT:-8000}
+      # First-run admin account. These defaults let the stack come up with
+      # zero configuration; the app seeds this login into the database on
+      # the very first start. CHANGE THEM in .env (or your shell) BEFORE
+      # exposing Nova beyond localhost — the defaults are deliberately weak.
+      NOVA_USERNAME: ${NOVA_USERNAME:-admin}
+      NOVA_PASSWORD: ${NOVA_PASSWORD:-changeme}
 
     ports:
       # host:container. Reach Nova at http://localhost:8000 and, from

--- a/docker-compose.watchtower.yml
+++ b/docker-compose.watchtower.yml
@@ -1,0 +1,41 @@
+# Nova — automatic-updates overlay (opt-in, prebuilt image only).
+#
+# Adds Watchtower, a small companion that periodically checks GHCR for a
+# newer Nova image, pulls it, and recreates the container — WITHOUT touching
+# your nova-data or ollama-models volumes, so no data is lost on update.
+#
+# Use it ONLY with the prebuilt (GHCR) stack. Watchtower pulls published
+# images; it cannot rebuild Nova from source:
+#
+#   docker compose -f docker-compose.ghcr.yml -f docker-compose.watchtower.yml up -d
+#
+# Notes:
+#   * Pin a release (NOVA_IMAGE_TAG=1.2.3 in .env) and Watchtower only moves
+#     you within that tag; leave it at `latest` to track main automatically.
+#   * Only the nova container is auto-updated (via the label below). Ollama
+#     and Watchtower itself are left alone — update those deliberately.
+#   * Default poll interval is 24h; override WATCHTOWER_POLL_INTERVAL (sec).
+
+services:
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: nova-watchtower
+    restart: unless-stopped
+    environment:
+      # Only manage containers that opt in via the label below, so Watchtower
+      # never touches unrelated containers on the same host.
+      WATCHTOWER_LABEL_ENABLE: "true"
+      # Delete the superseded image after a successful update to save disk.
+      WATCHTOWER_CLEANUP: "true"
+      # How often to check for a newer image, in seconds (default 24h).
+      WATCHTOWER_POLL_INTERVAL: ${WATCHTOWER_POLL_INTERVAL:-86400}
+    volumes:
+      # Watchtower drives the Docker Engine API through this socket, which is
+      # effectively full control of the host's containers. Only enable it on
+      # a host you trust; put a socket-proxy in front to narrow the surface.
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  # Opt the Nova container in to Watchtower-managed updates.
+  nova:
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,14 @@
 # the host. There is no cloud component and no remote sync.
 #
 # Quick start (build from source — the default developer workflow):
-#   cp .env.example .env      # then edit credentials
 #   docker compose up -d
 #   open http://localhost:8000
+#
+# That's the whole setup — no file copying, no manual steps. The stack
+# comes up with safe defaults (admin login: admin / changeme). To change
+# credentials, ports, or enable integrations, copy the sample env file
+# and edit it first (entirely optional):
+#   cp .env.example .env      # optional — only to override the defaults
 #
 # Don't want to build? Deploy the prebuilt image from GHCR instead with
 # docker-compose.ghcr.yml (no checkout/build needed):
@@ -31,11 +36,15 @@ services:
     container_name: nova
     restart: unless-stopped
 
-    # All variables from .env are passed to the container. Docker-specific
-    # values are overridden in `environment:` below (which wins over the
-    # env file) so the in-container paths/URLs are always correct.
+    # Load overrides from .env WHEN PRESENT. `required: false` keeps a
+    # fresh clone working with zero setup: with no .env the container falls
+    # back to the defaults in `environment:` below (which always win over
+    # the env file, so the in-container paths/URLs stay correct).
+    # Needs Docker Compose v2.24+ (Docker Desktop / Engine shipped it in
+    # early 2024); upgrade Docker if you see an "unexpected key" error here.
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       # Persist all runtime state on the /data volume (mounted below).
       NOVA_DATA_DIR: /data
@@ -45,6 +54,12 @@ services:
       OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
       # Port uvicorn binds inside the container.
       NOVA_PORT: ${NOVA_PORT:-8000}
+      # First-run admin account. These defaults let the stack come up with
+      # zero configuration; the app seeds this login into the database on
+      # the very first start. CHANGE THEM in .env (or your shell) BEFORE
+      # exposing Nova beyond localhost — the defaults are deliberately weak.
+      NOVA_USERNAME: ${NOVA_USERNAME:-admin}
+      NOVA_PASSWORD: ${NOVA_PASSWORD:-changeme}
 
     ports:
       # host:container. Reach Nova at http://localhost:8000 and, from

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -75,24 +75,30 @@ No Python, no Ollama, and no other host packages are required.
 ```bash
 git clone https://github.com/TheZupZup/Nova.git
 cd Nova
-
-cp .env.example .env
-# Edit .env and set at least:
-#   NOVA_USERNAME   — your admin login
-#   NOVA_PASSWORD   — change it from the default
-# Everything else has working defaults.
-
 docker compose up -d
 ```
+
+That's the whole setup — **no file copying and no manual configuration.**
+The stack comes up with safe built-in defaults, including an admin login of
+`admin` / `changeme`.
 
 The first `up`:
 
 1. builds the `nova` image from this checkout,
 2. starts the `ollama` model server (waits until it's healthy),
-3. starts Nova and creates the admin account from `.env`.
+3. starts Nova, which on first boot creates `nova.db`, seeds the admin
+   account, and generates a per-install session key — all automatically.
 
-Open **http://localhost:8000** and log in. From another machine on the
-same network use **http://&lt;host-ip&gt;:8000**.
+Open **http://localhost:8000** and log in with `admin` / `changeme`. From
+another machine on the same network use **http://&lt;host-ip&gt;:8000**.
+
+> **Change the admin password before exposing Nova beyond localhost.**
+> Copy the sample env file and edit it — this is the *only* reason you need
+> an `.env`, and it stays optional:
+> ```bash
+> cp .env.example .env     # then set NOVA_USERNAME / NOVA_PASSWORD, etc.
+> docker compose up -d     # picks up the new values
+> ```
 
 Then pull at least one model so Nova can reply — see
 [Pulling Ollama models](#pulling--downloading-ollama-models).
@@ -124,18 +130,23 @@ this one file and an `.env`.
 # Fetch the compose file (or copy it out of the repo):
 curl -fsSLO https://raw.githubusercontent.com/TheZupZup/Nova/main/docker-compose.ghcr.yml
 
-# Create a minimal .env next to it (only credentials are required):
-cat > .env <<'EOF'
-NOVA_USERNAME=admin
-NOVA_PASSWORD=change-me-please
-EOF
-
-# Pull the image + Ollama, then start the stack:
+# Pull the image + Ollama and start the stack. No .env is needed — it comes
+# up with admin / changeme by default:
 docker compose -f docker-compose.ghcr.yml up -d
 
 # Pull at least one model, then open http://localhost:8000
 docker compose -f docker-compose.ghcr.yml exec ollama ollama pull gemma3:1b
 ```
+
+> **Set real credentials before exposing it.** Create an `.env` next to the
+> compose file and re-run `up -d`:
+> ```bash
+> cat > .env <<'EOF'
+> NOVA_USERNAME=admin
+> NOVA_PASSWORD=change-me-please
+> EOF
+> docker compose -f docker-compose.ghcr.yml up -d
+> ```
 
 Open **http://localhost:8000** and log in. From another machine on the
 same network use **http://&lt;host-ip&gt;:8000** (see
@@ -251,6 +262,85 @@ Your `nova-data` and `ollama-models` volumes are untouched. The
 **destructive** variant is `docker compose down -v`, which deletes the
 volumes (database, conversations, and downloaded models). Only use it
 when you truly want a clean slate.
+
+---
+
+## Production vs development
+
+The default `docker compose up -d` is the **production-shaped** setup: a
+self-contained image that runs as a non-root user, restarts automatically,
+and serves the code baked in at build time. That's what you want on a
+server or NAS.
+
+For **active development** — editing Nova's source and seeing changes live —
+layer the opt-in dev overlay on top. It bind-mounts your checkout into the
+container and runs uvicorn with `--reload`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+The overlay only changes the `nova` service (live source mount, `--reload`,
+no auto-restart); Ollama, the volumes, and the database are untouched. Set
+it once for your shell so plain `docker compose` commands pick up both files:
+
+```bash
+export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+docker compose up        # now runs with live reload
+```
+
+To keep development data completely separate from a production stack on the
+same host, give the dev stack its own project name (separate containers and
+volumes):
+
+```bash
+docker compose -p nova-dev -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+After changing `requirements.txt`, rebuild: add `--build` to the `up`
+command.
+
+---
+
+## Automatic updates (optional)
+
+Updates are **manual by default** — nothing changes under you. To update
+deliberately:
+
+```bash
+# Prebuilt (GHCR) stack:
+docker compose -f docker-compose.ghcr.yml pull
+docker compose -f docker-compose.ghcr.yml up -d
+
+# Build-from-source stack:
+git pull
+docker compose up -d --build
+```
+
+Your `nova-data` and `ollama-models` volumes are never touched by an
+update, so the database, conversations, and downloaded models survive.
+
+If you'd rather Nova update **itself**, the repo ships an opt-in Watchtower
+overlay for the prebuilt stack. Watchtower periodically checks GHCR, pulls a
+newer image, and recreates the container — keeping your volumes intact:
+
+```bash
+docker compose -f docker-compose.ghcr.yml -f docker-compose.watchtower.yml up -d
+```
+
+Trade-offs to understand before enabling it:
+
+- **Prebuilt image only.** Watchtower pulls published images; it cannot
+  rebuild the build-from-source stack.
+- **Pin for stability.** With `NOVA_IMAGE_TAG=latest` (the default)
+  Watchtower tracks `main`. Pin a release (`NOVA_IMAGE_TAG=1.2.3` in `.env`)
+  to receive only patches within that line, or to freeze entirely.
+- **It needs the Docker socket** — host-level container control. Only
+  enable it on a host you trust; a socket-proxy can narrow the surface.
+- Tune the cadence with `WATCHTOWER_POLL_INTERVAL` (seconds; default 24h).
+
+Only the `nova` container opts in (via a label); Ollama and Watchtower
+itself are never auto-updated.
 
 ---
 
@@ -413,8 +503,11 @@ docker compose exec nova python -c \
   "import os,urllib.request; print(urllib.request.urlopen(os.environ['OLLAMA_HOST']+'/api/tags',timeout=5).read()[:200])"
 ```
 
-**`docker compose up` fails saying `.env` is missing.**
-Run `cp .env.example .env` first.
+**`docker compose up` errors on the `env_file` / `.env` entry.**
+`.env` is optional — the stack runs without it. This error means your
+Docker Compose predates the `required: false` field (added in Compose
+v2.24, early 2024). Upgrade Docker Desktop / the Compose plugin, or just
+create the file once: `cp .env.example .env`.
 
 **Port 8000 is already in use.**
 Set `NOVA_HOST_PORT` to a free port in `.env`, then `docker compose up -d`.

--- a/tests/test_docker_stack.py
+++ b/tests/test_docker_stack.py
@@ -86,11 +86,23 @@ class TestComposeStack:
         assert "\n  nova-data:" in body
         assert "\n  ollama-models:" in body
 
-    def test_passes_env_file(self):
-        # All required environment variables flow in from .env.
+    def test_passes_env_file_optionally(self):
+        # Overrides flow in from .env WHEN PRESENT, but the file is optional
+        # so a fresh clone comes up with zero setup. The long-form
+        # `required: false` is what lets `docker compose up` work with no
+        # .env on disk (Compose v2.24+).
         body = _read("docker-compose.yml")
         assert "env_file:" in body
-        assert "- .env" in body
+        assert "path: .env" in body
+        assert "required: false" in body
+
+    def test_seeds_admin_login_defaults_for_zero_setup(self):
+        # With no .env the stack must still have admin credentials so
+        # first-run seeding works out of the box. Defaults are deliberately
+        # weak and overridable from .env / the shell.
+        body = _read("docker-compose.yml")
+        assert "NOVA_USERNAME: ${NOVA_USERNAME:-admin}" in body
+        assert "NOVA_PASSWORD: ${NOVA_PASSWORD:-changeme}" in body
 
     def test_does_not_mount_docker_socket(self):
         assert "docker.sock" not in _read("docker-compose.yml")
@@ -221,10 +233,19 @@ class TestGhcrComposeStack:
         assert "\n  nova-data:" in body
         assert "\n  ollama-models:" in body
 
-    def test_passes_env_file(self):
+    def test_passes_env_file_optionally(self):
+        # Same optional-.env contract as the build stack: loaded when
+        # present, but not required, so the prebuilt stack also starts with
+        # no manual setup.
         body = _read(self.PATH)
         assert "env_file:" in body
-        assert "- .env" in body
+        assert "path: .env" in body
+        assert "required: false" in body
+
+    def test_seeds_admin_login_defaults_for_zero_setup(self):
+        body = _read(self.PATH)
+        assert "NOVA_USERNAME: ${NOVA_USERNAME:-admin}" in body
+        assert "NOVA_PASSWORD: ${NOVA_PASSWORD:-changeme}" in body
 
     def test_does_not_mount_docker_socket(self):
         assert "docker.sock" not in _read(self.PATH)


### PR DESCRIPTION
## Goal

Make Nova truly plug-and-play: `git clone && docker compose up -d` should just work, with **no manual setup**.

## The one real blocker

The app already self-initializes on first boot — `initialize_db()` → `core/users.py:migrate()` seeds the admin account, and `docker/entrypoint.sh` generates a per-install session key. Persistence, port mapping, and update-safety were already solid (named `nova-data`/`ollama-models` volumes, `${NOVA_HOST_PORT:-8000}:${NOVA_PORT:-8000}`, idempotent entrypoint).

The **only** thing breaking a clean first run was that Compose hard-required a `.env` file and errored when it was absent — the repo's own docs even documented the workaround (`cp .env.example .env`). This PR removes that friction.

## Changes

**Zero-setup boot (the core fix)**
- `docker-compose.yml` + `docker-compose.ghcr.yml`: `.env` is now **optional** via `env_file: [{ path: .env, required: false }]`, and `NOVA_USERNAME` / `NOVA_PASSWORD` defaults (`admin` / `changeme`) are added to `environment:`. A fresh clone boots with safe defaults; a present `.env` still overrides everything as before.

**Cross-platform safety (Linux/Windows/Mac)**
- `.gitattributes` (new): forces **LF** on shell scripts and `docker/entrypoint.sh`, so a Windows checkout with `core.autocrlf=true` can't corrupt the container entrypoint and break `docker compose up`.

**Production vs development separation**
- `docker-compose.dev.yml` (new): opt-in overlay that bind-mounts the checkout and runs `uvicorn --reload`. The base file stays production-shaped; dev is explicit: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`.

**Optional auto-update strategy**
- `docker-compose.watchtower.yml` (new): opt-in Watchtower overlay for the prebuilt (GHCR) stack. Only the `nova` container opts in (via label); volumes are never touched. Trade-offs (socket access, pinning) are documented.

**Docs**
- `docs/docker.md`: zero-setup first-run, fixed the now-obsolete ".env is missing" troubleshooting entry, and added **Production vs development** and **Automatic updates (optional)** sections.
- `README.md` + `.env.example`: present `.env` as optional, used only to override defaults.

## What I deliberately did *not* change
The `Dockerfile` is already optimized and simple (slim base, non-root user, `tini` PID-1, healthcheck, layer-cached deps, `/data` volume), so I left it alone rather than churn it.

## Validation
No Docker daemon is available in this environment, so I validated statically with `docker compose config` (daemon-less). All four combinations parse, and:
- **no `.env`** → resolves to `admin` / `changeme` on `:8000`, both named volumes present;
- **with `.env`** → values override correctly (`alice` / `s3cret-pw`, host port `9000`).

```
-f docker-compose.yml                                        VALID
-f docker-compose.ghcr.yml                                   VALID
-f docker-compose.yml -f docker-compose.dev.yml              VALID
-f docker-compose.ghcr.yml -f docker-compose.watchtower.yml  VALID
```

> Note: first-run still needs a model pulled for chat to reply (`docker compose exec ollama ollama pull gemma3:1b`) — this is inherent to a local-LLM app and is left manual on purpose (auto-pulling would download GBs on first boot). It's documented in `docs/docker.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JccnpY4oQexgK2xxCEv3fo

---
_Generated by [Claude Code](https://claude.ai/code/session_01JccnpY4oQexgK2xxCEv3fo)_